### PR TITLE
Add Go script to hydrate Lextures welcome onboarding course

### DIFF
--- a/server-new/cmd/hydrate-welcome-course/main.go
+++ b/server-new/cmd/hydrate-welcome-course/main.go
@@ -1,0 +1,72 @@
+// Command hydrate-welcome-course creates the default "Getting started with Lextures" onboarding course
+// for a user (student enrollment), optional staff teachers, module content, assignment, quiz,
+// per-course permission grants, and baseline Student / Teacher app role links.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+	serverdata "github.com/lextures/lextures/server-new"
+	"github.com/lextures/lextures/server-new/internal/db"
+	"github.com/lextures/lextures/server-new/internal/migrate"
+	"github.com/lextures/lextures/server-new/internal/scripts/welcomecourse"
+)
+
+func main() {
+	dsn := strings.TrimSpace(os.Getenv("DATABASE_URL"))
+	runMig := flag.Bool("migrate", false, "apply embedded SQL migrations before hydrating (uses DATABASE_URL)")
+	student := flag.String("student-user-id", "", "UUID of the learner to enroll as student (required)")
+	teachers := flag.String("teacher-user-ids", "", "comma-separated teacher UUIDs for roster + grants; omit to use the student in solo mode")
+	flag.Parse()
+
+	if dsn == "" {
+		log.Fatal("DATABASE_URL is required")
+	}
+	sid, err := uuid.Parse(strings.TrimSpace(*student))
+	if err != nil || sid == uuid.Nil {
+		log.Fatal("-student-user-id must be a non-empty UUID")
+	}
+
+	ctx := context.Background()
+	if *runMig {
+		if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+			log.Fatalf("migrate: %v", err)
+		}
+	}
+
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		log.Fatalf("db: %v", err)
+	}
+	defer pool.Close()
+
+	var teacherIDs []uuid.UUID
+	for _, part := range strings.Split(*teachers, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		tid, perr := uuid.Parse(part)
+		if perr != nil {
+			log.Fatalf("invalid teacher uuid %q: %v", part, perr)
+		}
+		teacherIDs = append(teacherIDs, tid)
+	}
+
+	res, err := welcomecourse.Hydrate(ctx, pool, sid, teacherIDs)
+	if err != nil {
+		log.Fatalf("hydrate: %v", err)
+	}
+
+	action := "reused existing"
+	if res.Created {
+		action = "created"
+	}
+	fmt.Printf("%s welcome course %s (course_code=%s course_id=%s)\n", action, welcomecourse.DefaultTitle(), res.CourseCode, res.CourseID)
+}

--- a/server-new/internal/scripts/welcomecourse/welcomecourse.go
+++ b/server-new/internal/scripts/welcomecourse/welcomecourse.go
@@ -1,0 +1,397 @@
+// Package welcomecourse creates (or reuses) the default “Getting started with Lextures” course:
+// content pages, a short assignment, and a knowledge-check quiz, plus roster and RBAC-aligned grants for staff.
+package welcomecourse
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	defaultCourseTitle       = "Getting started with Lextures"
+	defaultCourseDescription = "Short tour of Lextures after your first sign-in: navigation, learning activities, and where to get help."
+)
+
+// DefaultTitle is the canonical title used to detect an existing welcome course for a user.
+func DefaultTitle() string { return defaultCourseTitle }
+
+// Result is returned after a successful hydrate (new or existing).
+type Result struct {
+	CourseID   uuid.UUID
+	CourseCode string
+	Created    bool
+}
+
+type quizQuestionJSON struct {
+	ID                 string          `json:"id"`
+	Prompt             string          `json:"prompt"`
+	QuestionType       string          `json:"questionType"`
+	Choices            []string        `json:"choices"`
+	ChoiceIDs          []string        `json:"choiceIds"`
+	TypeConfig         json.RawMessage `json:"typeConfig"`
+	CorrectChoiceIndex *uint           `json:"correctChoiceIndex"`
+	MultipleAnswer     bool            `json:"multipleAnswer"`
+	AnswerWithImage    bool            `json:"answerWithImage"`
+	Required           bool            `json:"required"`
+	Points             int32           `json:"points"`
+	EstimatedMinutes   int32           `json:"estimatedMinutes"`
+	ConceptIDs         []string        `json:"conceptIds"`
+	SrsEligible        bool            `json:"srsEligible"`
+}
+
+// Hydrate ensures the welcome course exists for studentUserID and returns its identifiers.
+// teacherUserIDs are enrolled as teachers and receive the same per-course permission grants as migrations seed for staff.
+func Hydrate(ctx context.Context, pool *pgxpool.Pool, studentUserID uuid.UUID, teacherUserIDs []uuid.UUID) (*Result, error) {
+	if studentUserID == uuid.Nil {
+		return nil, fmt.Errorf("student user id is required")
+	}
+	teachers := normalizeTeacherIDs(teacherUserIDs, studentUserID)
+
+	var existingID uuid.UUID
+	var existingCode string
+	err := pool.QueryRow(ctx, `
+SELECT c.id, c.course_code
+FROM course.courses c
+INNER JOIN course.course_enrollments se
+  ON se.course_id = c.id AND se.user_id = $1 AND se.role = 'student'
+WHERE c.title = $2
+LIMIT 1
+`, studentUserID, defaultCourseTitle).Scan(&existingID, &existingCode)
+	if err == nil {
+		return &Result{CourseID: existingID, CourseCode: existingCode, Created: false}, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, err
+	}
+
+	const maxCodeAttempts = 8
+	primaryTeacher := teachers[0]
+
+	for attempt := 0; attempt < maxCodeAttempts; attempt++ {
+		code, gerr := randomCourseCode()
+		if gerr != nil {
+			return nil, gerr
+		}
+		tx, berr := pool.BeginTx(ctx, pgx.TxOptions{})
+		if berr != nil {
+			return nil, berr
+		}
+
+		var courseID uuid.UUID
+		if ierr := tx.QueryRow(ctx, `
+INSERT INTO course.courses (
+	course_code, title, description, course_type, created_by_user_id, published
+)
+VALUES ($1, $2, $3, 'traditional', $4, TRUE)
+RETURNING id
+`, code, defaultCourseTitle, defaultCourseDescription, primaryTeacher).Scan(&courseID); ierr != nil {
+			_ = tx.Rollback(ctx)
+			var pgErr *pgconn.PgError
+			if errors.As(ierr, &pgErr) && pgErr.Code == "23505" {
+				continue
+			}
+			return nil, ierr
+		}
+
+		if _, ierr := tx.Exec(ctx, `
+INSERT INTO course.assignment_groups (course_id, sort_order, name, weight_percent)
+VALUES ($1, 0, 'Assignments', 100.0)
+`, courseID); ierr != nil {
+			_ = tx.Rollback(ctx)
+			return nil, ierr
+		}
+
+		for _, uid := range teachers {
+			if _, ierr := tx.Exec(ctx, `
+INSERT INTO course.course_enrollments (course_id, user_id, role)
+VALUES ($1, $2, 'teacher')
+ON CONFLICT (course_id, user_id, role) DO NOTHING
+`, courseID, uid); ierr != nil {
+				_ = tx.Rollback(ctx)
+				return nil, ierr
+			}
+		}
+		if _, ierr := tx.Exec(ctx, `
+INSERT INTO course.course_enrollments (course_id, user_id, role)
+VALUES ($1, $2, 'student')
+ON CONFLICT (course_id, user_id, role) DO NOTHING
+`, courseID, studentUserID); ierr != nil {
+			_ = tx.Rollback(ctx)
+			return nil, ierr
+		}
+
+		permPrefix := "course:" + code + ":"
+		grantSQL := `INSERT INTO course.user_course_grants (user_id, course_id, permission_string) VALUES ($1, $2, $3) ON CONFLICT (user_id, course_id, permission_string) DO NOTHING`
+		for _, uid := range teachers {
+			for _, perm := range []string{
+				permPrefix + "item:create",
+				permPrefix + "items:create",
+				permPrefix + "enrollments:read",
+				permPrefix + "enrollments:update",
+				permPrefix + "gradebook:view",
+			} {
+				if _, ierr := tx.Exec(ctx, grantSQL, uid, courseID, perm); ierr != nil {
+					_ = tx.Rollback(ctx)
+					return nil, ierr
+				}
+			}
+		}
+
+		var modID uuid.UUID
+		if ierr := tx.QueryRow(ctx, `
+INSERT INTO course.course_structure_items (course_id, sort_order, kind, title, parent_id, published)
+VALUES ($1, 0, 'module', 'Welcome to Lextures', NULL, TRUE)
+RETURNING id
+`, courseID).Scan(&modID); ierr != nil {
+			_ = tx.Rollback(ctx)
+			return nil, ierr
+		}
+
+		pageIntro := introPageMarkdown()
+		if ierr := insertContentPage(ctx, tx, courseID, modID, 0, "Open Lextures and find your way around", pageIntro); ierr != nil {
+			_ = tx.Rollback(ctx)
+			return nil, ierr
+		}
+
+		pageActivities := activitiesPageMarkdown()
+		if ierr := insertContentPage(ctx, tx, courseID, modID, 1, "Assignments, quizzes, and your grades", pageActivities); ierr != nil {
+			_ = tx.Rollback(ctx)
+			return nil, ierr
+		}
+
+		if ierr := insertAssignment(ctx, tx, courseID, modID, 2, "Try a practice check-in", practiceAssignmentMarkdown()); ierr != nil {
+			_ = tx.Rollback(ctx)
+			return nil, ierr
+		}
+
+		qs := []quizQuestionJSON{
+			{
+				ID:           "welcome-q1",
+				Prompt:       "Where do you primarily open a course after signing in to Lextures?",
+				QuestionType: "multiple_choice",
+				Choices: []string{
+					"From the course picker on my home dashboard",
+					"Only through an external LMS launch link",
+					"In System Settings, under Courses",
+					"In the question bank editor",
+				},
+				ChoiceIDs:          []string{},
+				TypeConfig:         json.RawMessage(`{}`),
+				CorrectChoiceIndex: uintPtr(0),
+				Points:             1,
+				Required:           true,
+			},
+		}
+		qBytes, jerr := json.Marshal(qs)
+		if jerr != nil {
+			_ = tx.Rollback(ctx)
+			return nil, jerr
+		}
+		if ierr := insertQuiz(ctx, tx, courseID, modID, 3, "Quick check: Lextures basics", quickCheckIntroMarkdown(), qBytes); ierr != nil {
+			_ = tx.Rollback(ctx)
+			return nil, ierr
+		}
+
+		if ierr := ensureUserAppRoles(ctx, tx, studentUserID, teachers); ierr != nil {
+			_ = tx.Rollback(ctx)
+			return nil, ierr
+		}
+
+		if cerr := tx.Commit(ctx); cerr != nil {
+			return nil, cerr
+		}
+		return &Result{CourseID: courseID, CourseCode: code, Created: true}, nil
+	}
+	return nil, fmt.Errorf("failed to allocate unique course code after %d attempts", maxCodeAttempts)
+}
+
+const (
+	courseCodePrefix = "C-"
+	courseCodeRand   = 6
+)
+
+func randomCourseCode() (string, error) {
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, courseCodeRand)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	out := make([]byte, courseCodeRand)
+	for i := range b {
+		out[i] = alphabet[int(b[i])%len(alphabet)]
+	}
+	return courseCodePrefix + string(out), nil
+}
+
+// ensureUserAppRoles links baseline global app roles so authorization matches course enrollment intent.
+func ensureUserAppRoles(ctx context.Context, tx pgx.Tx, student uuid.UUID, teachers []uuid.UUID) error {
+	if _, err := tx.Exec(ctx, `
+INSERT INTO "user".user_app_roles (user_id, role_id)
+SELECT $1, r.id FROM "user".app_roles r WHERE r.name = 'Student'
+ON CONFLICT (user_id, role_id) DO NOTHING
+`, student); err != nil {
+		return err
+	}
+	for _, uid := range teachers {
+		if _, err := tx.Exec(ctx, `
+INSERT INTO "user".user_app_roles (user_id, role_id)
+SELECT $1, r.id FROM "user".app_roles r WHERE r.name = 'Teacher'
+ON CONFLICT (user_id, role_id) DO NOTHING
+`, uid); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func normalizeTeacherIDs(ids []uuid.UUID, student uuid.UUID) []uuid.UUID {
+	seen := make(map[uuid.UUID]struct{})
+	var out []uuid.UUID
+	for _, id := range ids {
+		if id == uuid.Nil {
+			continue
+		}
+		if id == student {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	if len(out) == 0 && student != uuid.Nil {
+		// Solo mode: same user teaches and takes the tour.
+		return []uuid.UUID{student}
+	}
+	return out
+}
+
+func insertContentPage(ctx context.Context, tx pgx.Tx, courseID, moduleID uuid.UUID, sort int, title, markdown string) error {
+	var id uuid.UUID
+	q := `
+INSERT INTO course.course_structure_items (course_id, sort_order, kind, title, parent_id, published)
+VALUES ($1, $2, 'content_page', $3, $4, TRUE)
+RETURNING id`
+	if err := tx.QueryRow(ctx, q, courseID, sort, title, moduleID).Scan(&id); err != nil {
+		return err
+	}
+	_, err := tx.Exec(ctx, `INSERT INTO course.module_content_pages (structure_item_id, markdown) VALUES ($1, $2)`, id, markdown)
+	return err
+}
+
+func insertAssignment(ctx context.Context, tx pgx.Tx, courseID, moduleID uuid.UUID, sort int, title, markdown string) error {
+	var id uuid.UUID
+	q := `
+INSERT INTO course.course_structure_items (course_id, sort_order, kind, title, parent_id, published)
+VALUES ($1, $2, 'assignment', $3, $4, TRUE)
+RETURNING id`
+	if err := tx.QueryRow(ctx, q, courseID, sort, title, moduleID).Scan(&id); err != nil {
+		return err
+	}
+	_, err := tx.Exec(ctx, `INSERT INTO course.module_assignments (structure_item_id, markdown) VALUES ($1, $2)`, id, markdown)
+	return err
+}
+
+func insertQuiz(ctx context.Context, tx pgx.Tx, courseID, moduleID uuid.UUID, sort int, title, markdown string, questionsJSON []byte) error {
+	var id uuid.UUID
+	q := `
+INSERT INTO course.course_structure_items (course_id, sort_order, kind, title, parent_id, published)
+VALUES ($1, $2, 'quiz', $3, $4, TRUE)
+RETURNING id`
+	if err := tx.QueryRow(ctx, q, courseID, sort, title, moduleID).Scan(&id); err != nil {
+		return err
+	}
+	_, err := tx.Exec(ctx, `INSERT INTO course.module_quizzes (structure_item_id, markdown, questions_json) VALUES ($1, $2, $3::jsonb)`, id, markdown, questionsJSON)
+	return err
+}
+
+func uintPtr(u uint) *uint { return &u }
+
+func introPageMarkdown() string {
+	return strings.TrimSpace(`
+## You're in the right place
+
+This short course is shown after your first sign-in so you can learn Lextures in context instead of reading a static manual.
+
+### Home and courses
+
+- After you sign in, open **Courses** (or your dashboard) to see everything you are enrolled in.
+- Each **course card** opens that course’s outline, syllabus, announcements, and activities.
+
+### Course layout
+
+Inside a course you typically see:
+
+- **Modules** — ordered lessons, readings, videos, assignments, and quizzes.
+- **Grades** — scores and feedback your instructors release (names vary by institution).
+
+### Mobile app
+
+If you installed the Lextures mobile app, you are using the same account as the web app. Complete activities the same way; drafts and submissions sync when you are online.
+
+### Need help?
+
+Use **your institution’s help link** or instructor syllabus for local support. Lextures also surfaces context-sensitive help where product teams have wired it in.
+
+When you are ready, go to the next page and try the sample assignment and quiz.
+`)
+}
+
+func activitiesPageMarkdown() string {
+	return strings.TrimSpace(`
+## Assignments
+
+**Assignments** ask you to submit work: text, files, or both, depending on how your instructor configured the activity.
+
+1. Open the assignment from the course outline.
+2. Read the instructions and rubric (if provided).
+3. Compose your answer and attach any required files.
+4. Submit before the due date. You may be allowed to resubmit if your instructor turns that on.
+
+## Quizzes
+
+**Quizzes** are auto-graded checks for understanding. Some quizzes shuffle questions or impose a time limit; follow on-screen guidance.
+
+- Select **Submit** when you are finished, not only when the timer ends.
+- After submit, review rules determine whether you can see correct answers immediately, after the due date, or never.
+
+## Grades
+
+Open **Grades** from the course menu to see released scores. Some items stay hidden until the instructor posts grades for everyone.
+
+---
+
+Try the practice items in this module to confirm everything works on your device.
+`)
+}
+
+func practiceAssignmentMarkdown() string {
+	return strings.TrimSpace(`
+### Practice check-in (not graded)
+
+Reply in a sentence or two:
+
+1. What device are you using right now (web browser vs. mobile app)?
+2. What is one goal you have for using Lextures this term?
+
+This item exists only so you can see how assignment submission works. Your instructor may not leave feedback here.
+`)
+}
+
+func quickCheckIntroMarkdown() string {
+	return strings.TrimSpace(`
+### Quick knowledge check
+
+One multiple-choice question below. Select the answer that best matches how Lextures is usually used.
+`)
+}

--- a/server-new/internal/scripts/welcomecourse/welcomecourse_db_test.go
+++ b/server-new/internal/scripts/welcomecourse/welcomecourse_db_test.go
@@ -1,0 +1,97 @@
+package welcomecourse
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	serverdata "github.com/lextures/lextures/server-new"
+	"github.com/lextures/lextures/server-new/internal/auth"
+	"github.com/lextures/lextures/server-new/internal/db"
+	"github.com/lextures/lextures/server-new/internal/migrate"
+	"github.com/lextures/lextures/server-new/internal/repos/user"
+)
+
+func TestHydrate_Pg(t *testing.T) {
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	dsn := os.Getenv("DATABASE_URL")
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	ph, err := auth.HashPassword("password1230")
+	if err != nil {
+		t.Fatal(err)
+	}
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 10)
+	stu, err := user.InsertUser(ctx, pool, "welcome-stu-"+suffix+"@t.com", ph, nil)
+	if err != nil {
+		t.Fatalf("insert student: %v", err)
+	}
+	tch, err := user.InsertUser(ctx, pool, "welcome-tch-"+suffix+"@t.org", ph, nil)
+	if err != nil {
+		t.Fatalf("insert teacher: %v", err)
+	}
+
+	stuID := uuid.MustParse(stu.ID)
+	tchID := uuid.MustParse(tch.ID)
+
+	res1, err := Hydrate(ctx, pool, stuID, []uuid.UUID{tchID})
+	if err != nil {
+		t.Fatalf("hydrate 1: %v", err)
+	}
+	if !res1.Created {
+		t.Fatalf("first hydrate: want created true")
+	}
+
+	res2, err := Hydrate(ctx, pool, stuID, []uuid.UUID{tchID})
+	if err != nil {
+		t.Fatalf("hydrate 2: %v", err)
+	}
+	if res2.Created {
+		t.Fatalf("second hydrate: want created false")
+	}
+	if res2.CourseID != res1.CourseID || res2.CourseCode != res1.CourseCode {
+		t.Fatalf("id mismatch: %+v vs %+v", res1, res2)
+	}
+
+	var nPages, nAssign, nQuiz int
+	_ = pool.QueryRow(ctx, `
+SELECT
+  (SELECT COUNT(*) FROM course.course_structure_items i
+   INNER JOIN course.module_content_pages p ON p.structure_item_id = i.id
+   WHERE i.course_id = $1 AND i.kind = 'content_page'),
+  (SELECT COUNT(*) FROM course.course_structure_items i
+   INNER JOIN course.module_assignments a ON a.structure_item_id = i.id
+   WHERE i.course_id = $1 AND i.kind = 'assignment'),
+  (SELECT COUNT(*) FROM course.course_structure_items i
+   INNER JOIN course.module_quizzes q ON q.structure_item_id = i.id
+   WHERE i.course_id = $1 AND i.kind = 'quiz')
+`, res1.CourseID).Scan(&nPages, &nAssign, &nQuiz)
+	if nPages != 2 || nAssign != 1 || nQuiz != 1 {
+		t.Fatalf("structure counts: pages=%d assign=%d quiz=%d", nPages, nAssign, nQuiz)
+	}
+
+	var grantCount int
+	err = pool.QueryRow(ctx, `
+SELECT COUNT(*) FROM course.user_course_grants WHERE course_id = $1 AND user_id = $2
+`, res1.CourseID, tchID).Scan(&grantCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grantCount < 5 {
+		t.Fatalf("teacher grants: got %d want >= 5", grantCount)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a small Go package plus CLI to provision the default **Getting started with Lextures** course after first install or first sign-in: two content pages (navigation and activities), a practice assignment, a one-question quiz, default assignment group, enrollments, per-course permission grants consistent with existing migrations, and baseline **Student** / **Teacher** app role links.

## Usage

From `server-new`:

```bash
go run ./cmd/hydrate-welcome-course -student-user-id=<UUID> [-teacher-user-ids=<uuid,uuid>] [-migrate]
```

- **`-migrate`**: runs embedded SQL migrations first (optional; production usually runs migrations separately).
- **`DATABASE_URL`** is required.

The library entry point is `welcomecourse.Hydrate` for calling from signup or mobile backend code.

## Testing

- `go test ./...` passes.
- `TestHydrate_Pg` runs when `DATABASE_URL` is set (same pattern as other DB tests).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99b05af1-8ea6-403e-8337-806b1d8dad01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99b05af1-8ea6-403e-8337-806b1d8dad01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

