### PR TITLE
Global platform settings (OpenRouter, SAML SP, feature flags)

### DIFF
--- a/clients/web/src/components/layout/side-nav-path-utils.ts
+++ b/clients/web/src/components/layout/side-nav-path-utils.ts
@@ -7,13 +7,20 @@ export type SettingsNavView =
   | 'notifications'
   | 'roles'
   | 'lti-tools'
+  | 'platform'
 
 export function settingsViewFromPathname(pathname: string): SettingsNavView {
   if (pathname.startsWith('/settings/ai/system-prompts')) return 'ai-prompts'
   if (pathname.startsWith('/settings/ai/models')) return 'ai-models'
   const m = matchPath({ path: '/settings/:tab', end: true }, pathname)
   const raw = m?.params.tab
-  if (raw === 'account' || raw === 'notifications' || raw === 'roles' || raw === 'lti-tools')
+  if (
+    raw === 'account' ||
+    raw === 'notifications' ||
+    raw === 'roles' ||
+    raw === 'lti-tools' ||
+    raw === 'platform'
+  )
     return raw
   return 'account'
 }

--- a/clients/web/src/components/layout/side-nav-settings-links.tsx
+++ b/clients/web/src/components/layout/side-nav-settings-links.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { NavLink, useLocation } from 'react-router-dom'
-import { ArrowLeft, Bell, Bot, ChevronDown, Plug, Shield, User } from 'lucide-react'
+import { ArrowLeft, Bell, Bot, ChevronDown, Plug, Settings2, Shield, User } from 'lucide-react'
 import { usePermissions } from '../../context/use-permissions'
 import { PERM_RBAC_MANAGE } from '../../lib/rbac-api'
 import { settingsViewFromPathname } from './side-nav-path-utils'
@@ -65,6 +65,13 @@ export function SideNavSettingsLinks() {
           >
             <Plug className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
             LTI tools
+          </NavLink>
+          <NavLink
+            to="/settings/platform"
+            className={() => `${sideNavLinkClass} ${view === 'platform' ? sideNavActiveClass : ''}`}
+          >
+            <Settings2 className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+            Global platform
           </NavLink>
           <div className="flex flex-col gap-0.5">
             <button

--- a/clients/web/src/components/settings/platform-settings-panel.tsx
+++ b/clients/web/src/components/settings/platform-settings-panel.tsx
@@ -1,0 +1,490 @@
+import { type FormEvent, useCallback, useEffect, useState } from 'react'
+import { authorizedFetch } from '../../lib/api'
+import { readApiErrorMessage } from '../../lib/errors'
+import { PLATFORM_SECRET_PLACEHOLDER } from '../../lib/platform-settings'
+import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
+
+type FieldSource = 'environment' | 'database'
+
+export type PlatformSettingsPayload = {
+  openRouterApiKey: string
+  samlSsoEnabled: boolean
+  samlPublicBaseUrl: string
+  samlSpEntityId: string
+  samlSpX509Pem: string
+  samlSpPrivateKeyPem: string
+  annotationEnabled: boolean
+  feedbackMediaEnabled: boolean
+  blindGradingEnabled: boolean
+  moderatedGradingEnabled: boolean
+  originalityDetectionEnabled: boolean
+  originalityStubExternal: boolean
+  gradePostingPoliciesEnabled: boolean
+  gradebookCsvEnabled: boolean
+  resubmissionWorkflowEnabled: boolean
+  ltiEnabled: boolean
+  oneRosterEnabled: boolean
+  sources: {
+    openRouterApiKey: FieldSource
+    samlSsoEnabled: FieldSource
+    samlPublicBaseUrl: FieldSource
+    samlSpEntityId: FieldSource
+    samlSpX509Pem: FieldSource
+    samlSpPrivateKeyPem: FieldSource
+    annotationEnabled: FieldSource
+    feedbackMediaEnabled: FieldSource
+    blindGradingEnabled: FieldSource
+    moderatedGradingEnabled: FieldSource
+    originalityDetectionEnabled: FieldSource
+    originalityStubExternal: FieldSource
+    gradePostingPoliciesEnabled: FieldSource
+    gradebookCsvEnabled: FieldSource
+    resubmissionWorkflowEnabled: FieldSource
+    ltiEnabled: FieldSource
+    oneRosterEnabled: FieldSource
+  }
+}
+
+function emptyForm(): PlatformSettingsPayload {
+  return {
+    openRouterApiKey: '',
+    samlSsoEnabled: false,
+    samlPublicBaseUrl: '',
+    samlSpEntityId: '',
+    samlSpX509Pem: '',
+    samlSpPrivateKeyPem: '',
+    annotationEnabled: false,
+    feedbackMediaEnabled: false,
+    blindGradingEnabled: true,
+    moderatedGradingEnabled: false,
+    originalityDetectionEnabled: false,
+    originalityStubExternal: false,
+    gradePostingPoliciesEnabled: true,
+    gradebookCsvEnabled: false,
+    resubmissionWorkflowEnabled: false,
+    ltiEnabled: false,
+    oneRosterEnabled: false,
+    sources: {
+      openRouterApiKey: 'environment',
+      samlSsoEnabled: 'environment',
+      samlPublicBaseUrl: 'environment',
+      samlSpEntityId: 'environment',
+      samlSpX509Pem: 'environment',
+      samlSpPrivateKeyPem: 'environment',
+      annotationEnabled: 'environment',
+      feedbackMediaEnabled: 'environment',
+      blindGradingEnabled: 'environment',
+      moderatedGradingEnabled: 'environment',
+      originalityDetectionEnabled: 'environment',
+      originalityStubExternal: 'environment',
+      gradePostingPoliciesEnabled: 'environment',
+      gradebookCsvEnabled: 'environment',
+      resubmissionWorkflowEnabled: 'environment',
+      ltiEnabled: 'environment',
+      oneRosterEnabled: 'environment',
+    },
+  }
+}
+
+function sourceBadge(src: FieldSource) {
+  if (src === 'database') {
+    return (
+      <span className="ml-2 rounded-md bg-indigo-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-indigo-800 dark:bg-indigo-950/80 dark:text-indigo-200">
+        Database
+      </span>
+    )
+  }
+  return (
+    <span className="ml-2 rounded-md bg-slate-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-600 dark:bg-neutral-700 dark:text-neutral-300">
+      Environment
+    </span>
+  )
+}
+
+export function PlatformSettingsPanel() {
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [form, setForm] = useState<PlatformSettingsPayload>(() => emptyForm())
+  const [baseline, setBaseline] = useState<PlatformSettingsPayload>(() => emptyForm())
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await authorizedFetch('/api/v1/settings/platform')
+      const raw: unknown = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        throw new Error(readApiErrorMessage(raw))
+      }
+      const data = raw as PlatformSettingsPayload
+      setForm(data)
+      setBaseline(data)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load platform settings.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  function update<K extends keyof PlatformSettingsPayload>(key: K, value: PlatformSettingsPayload[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }))
+  }
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault()
+    setSaving(true)
+    setError(null)
+    try {
+      const mask: string[] = []
+      const body: Record<string, unknown> = {}
+
+      const maybe = (field: string, before: unknown, after: unknown, apply: () => void) => {
+        if (before !== after) {
+          mask.push(field)
+          apply()
+        }
+      }
+
+      maybe(
+        'openRouterApiKey',
+        baseline.openRouterApiKey,
+        form.openRouterApiKey,
+        () => {
+          const v = form.openRouterApiKey.trim()
+          if (v && v !== PLATFORM_SECRET_PLACEHOLDER) {
+            body.openRouterApiKey = v
+          }
+        },
+      )
+
+      if (
+        baseline.sources.openRouterApiKey === 'database' &&
+        form.openRouterApiKey.trim() === '' &&
+        baseline.openRouterApiKey !== form.openRouterApiKey
+      ) {
+        mask.push('clearOpenRouterApiKey')
+        body.clearOpenRouterApiKey = true
+      }
+
+      maybe('samlSsoEnabled', baseline.samlSsoEnabled, form.samlSsoEnabled, () => {
+        body.samlSsoEnabled = form.samlSsoEnabled
+      })
+      maybe('samlPublicBaseUrl', baseline.samlPublicBaseUrl, form.samlPublicBaseUrl, () => {
+        body.samlPublicBaseUrl = form.samlPublicBaseUrl.trim()
+      })
+      maybe('samlSpEntityId', baseline.samlSpEntityId, form.samlSpEntityId, () => {
+        body.samlSpEntityId = form.samlSpEntityId.trim()
+      })
+      maybe('samlSpX509Pem', baseline.samlSpX509Pem, form.samlSpX509Pem, () => {
+        const v = form.samlSpX509Pem.trim()
+        if (v && v !== PLATFORM_SECRET_PLACEHOLDER) {
+          body.samlSpX509Pem = v
+        }
+      })
+      maybe('samlSpPrivateKeyPem', baseline.samlSpPrivateKeyPem, form.samlSpPrivateKeyPem, () => {
+        const v = form.samlSpPrivateKeyPem.trim()
+        if (v && v !== PLATFORM_SECRET_PLACEHOLDER) {
+          body.samlSpPrivateKeyPem = v
+        }
+      })
+
+      maybe('annotationEnabled', baseline.annotationEnabled, form.annotationEnabled, () => {
+        body.annotationEnabled = form.annotationEnabled
+      })
+      maybe('feedbackMediaEnabled', baseline.feedbackMediaEnabled, form.feedbackMediaEnabled, () => {
+        body.feedbackMediaEnabled = form.feedbackMediaEnabled
+      })
+      maybe('blindGradingEnabled', baseline.blindGradingEnabled, form.blindGradingEnabled, () => {
+        body.blindGradingEnabled = form.blindGradingEnabled
+      })
+      maybe('moderatedGradingEnabled', baseline.moderatedGradingEnabled, form.moderatedGradingEnabled, () => {
+        body.moderatedGradingEnabled = form.moderatedGradingEnabled
+      })
+      maybe(
+        'originalityDetectionEnabled',
+        baseline.originalityDetectionEnabled,
+        form.originalityDetectionEnabled,
+        () => {
+          body.originalityDetectionEnabled = form.originalityDetectionEnabled
+        },
+      )
+      maybe('originalityStubExternal', baseline.originalityStubExternal, form.originalityStubExternal, () => {
+        body.originalityStubExternal = form.originalityStubExternal
+      })
+      maybe(
+        'gradePostingPoliciesEnabled',
+        baseline.gradePostingPoliciesEnabled,
+        form.gradePostingPoliciesEnabled,
+        () => {
+          body.gradePostingPoliciesEnabled = form.gradePostingPoliciesEnabled
+        },
+      )
+      maybe('gradebookCsvEnabled', baseline.gradebookCsvEnabled, form.gradebookCsvEnabled, () => {
+        body.gradebookCsvEnabled = form.gradebookCsvEnabled
+      })
+      maybe(
+        'resubmissionWorkflowEnabled',
+        baseline.resubmissionWorkflowEnabled,
+        form.resubmissionWorkflowEnabled,
+        () => {
+          body.resubmissionWorkflowEnabled = form.resubmissionWorkflowEnabled
+        },
+      )
+      maybe('ltiEnabled', baseline.ltiEnabled, form.ltiEnabled, () => {
+        body.ltiEnabled = form.ltiEnabled
+      })
+      maybe('oneRosterEnabled', baseline.oneRosterEnabled, form.oneRosterEnabled, () => {
+        body.oneRosterEnabled = form.oneRosterEnabled
+      })
+
+      if (mask.length === 0) {
+        toastSaveOk('No changes to save.')
+        setSaving(false)
+        return
+      }
+
+      body.updateMask = mask
+
+      const res = await authorizedFetch('/api/v1/settings/platform', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      const raw: unknown = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        toastMutationError(readApiErrorMessage(raw))
+        return
+      }
+      const data = raw as PlatformSettingsPayload
+      setForm(data)
+      setBaseline(data)
+      toastSaveOk('Platform settings saved.')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const chk =
+    'rounded border border-slate-200 bg-white text-indigo-600 focus:ring-indigo-500 dark:border-neutral-600 dark:bg-neutral-800'
+
+  if (loading) {
+    return <p className="mt-4 text-sm text-slate-500 dark:text-neutral-400">Loading platform settings…</p>
+  }
+
+  return (
+    <div>
+      <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+        Values stored here override the server process environment when set. Requires{' '}
+        <code className="rounded bg-slate-100 px-1 font-mono text-xs dark:bg-neutral-800">global:app:rbac:manage</code>.
+        Secrets are never returned in plain text after save.
+      </p>
+
+      {error && (
+        <p className="mt-4 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-200">
+          {error}
+        </p>
+      )}
+
+      <form className="mt-8 space-y-10" onSubmit={onSubmit}>
+        <section>
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">AI — OpenRouter</h3>
+          <p className="mt-1 text-xs text-slate-500 dark:text-neutral-400">
+            Used for AI generation (models list, notebook RAG, etc.). Leave unchanged to keep the current key.
+          </p>
+          <label className="mt-4 block text-sm font-medium text-slate-700 dark:text-neutral-200">
+            API key {sourceBadge(form.sources.openRouterApiKey)}
+          </label>
+          <input
+            type="password"
+            autoComplete="off"
+            value={form.openRouterApiKey}
+            onChange={(e) => update('openRouterApiKey', e.target.value)}
+            placeholder={PLATFORM_SECRET_PLACEHOLDER}
+            className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 font-mono text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+          />
+        </section>
+
+        <section>
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">SAML service provider</h3>
+          <p className="mt-1 text-xs text-slate-500 dark:text-neutral-400">
+            Browser SSO endpoints use these SP settings (IdP metadata remains under Admin SAML).
+          </p>
+          <div className="mt-4 space-y-4">
+            <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-neutral-200">
+              <input
+                type="checkbox"
+                checked={form.samlSsoEnabled}
+                onChange={(e) => update('samlSsoEnabled', e.target.checked)}
+                className={chk}
+              />
+              Enable SAML SSO {sourceBadge(form.sources.samlSsoEnabled)}
+            </label>
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-neutral-200">
+                Public base URL {sourceBadge(form.sources.samlPublicBaseUrl)}
+              </label>
+              <input
+                type="url"
+                value={form.samlPublicBaseUrl}
+                onChange={(e) => update('samlPublicBaseUrl', e.target.value)}
+                className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-neutral-200">
+                SP entity ID {sourceBadge(form.sources.samlSpEntityId)}
+              </label>
+              <input
+                type="text"
+                value={form.samlSpEntityId}
+                onChange={(e) => update('samlSpEntityId', e.target.value)}
+                className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-neutral-200">
+                SP X.509 certificate (PEM) {sourceBadge(form.sources.samlSpX509Pem)}
+              </label>
+              <textarea
+                rows={5}
+                spellCheck={false}
+                value={form.samlSpX509Pem}
+                onChange={(e) => update('samlSpX509Pem', e.target.value)}
+                className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 font-mono text-xs dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-neutral-200">
+                SP private key (PEM) {sourceBadge(form.sources.samlSpPrivateKeyPem)}
+              </label>
+              <textarea
+                rows={4}
+                spellCheck={false}
+                placeholder={PLATFORM_SECRET_PLACEHOLDER}
+                value={form.samlSpPrivateKeyPem}
+                onChange={(e) => update('samlSpPrivateKeyPem', e.target.value)}
+                className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 font-mono text-xs dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+              />
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Platform feature flags</h3>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <FlagRow
+              label="Annotations"
+              src={form.sources.annotationEnabled}
+              checked={form.annotationEnabled}
+              onChange={(v) => update('annotationEnabled', v)}
+            />
+            <FlagRow
+              label="Feedback media"
+              src={form.sources.feedbackMediaEnabled}
+              checked={form.feedbackMediaEnabled}
+              onChange={(v) => update('feedbackMediaEnabled', v)}
+            />
+            <FlagRow
+              label="Blind grading"
+              src={form.sources.blindGradingEnabled}
+              checked={form.blindGradingEnabled}
+              onChange={(v) => update('blindGradingEnabled', v)}
+            />
+            <FlagRow
+              label="Moderated grading"
+              src={form.sources.moderatedGradingEnabled}
+              checked={form.moderatedGradingEnabled}
+              onChange={(v) => update('moderatedGradingEnabled', v)}
+            />
+            <FlagRow
+              label="Originality detection"
+              src={form.sources.originalityDetectionEnabled}
+              checked={form.originalityDetectionEnabled}
+              onChange={(v) => update('originalityDetectionEnabled', v)}
+            />
+            <FlagRow
+              label="Originality stub external"
+              src={form.sources.originalityStubExternal}
+              checked={form.originalityStubExternal}
+              onChange={(v) => update('originalityStubExternal', v)}
+            />
+            <FlagRow
+              label="Grade posting policies"
+              src={form.sources.gradePostingPoliciesEnabled}
+              checked={form.gradePostingPoliciesEnabled}
+              onChange={(v) => update('gradePostingPoliciesEnabled', v)}
+            />
+            <FlagRow
+              label="Gradebook CSV export"
+              src={form.sources.gradebookCsvEnabled}
+              checked={form.gradebookCsvEnabled}
+              onChange={(v) => update('gradebookCsvEnabled', v)}
+            />
+            <FlagRow
+              label="Resubmission workflow"
+              src={form.sources.resubmissionWorkflowEnabled}
+              checked={form.resubmissionWorkflowEnabled}
+              onChange={(v) => update('resubmissionWorkflowEnabled', v)}
+            />
+            <FlagRow
+              label="LTI"
+              src={form.sources.ltiEnabled}
+              checked={form.ltiEnabled}
+              onChange={(v) => update('ltiEnabled', v)}
+            />
+            <FlagRow
+              label="OneRoster API"
+              src={form.sources.oneRosterEnabled}
+              checked={form.oneRosterEnabled}
+              onChange={(v) => update('oneRosterEnabled', v)}
+            />
+          </div>
+        </section>
+
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white"
+          >
+            {saving ? 'Saving…' : 'Save changes'}
+          </button>
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={saving || loading}
+            className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+          >
+            Reload
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+function FlagRow(props: {
+  label: string
+  src: FieldSource
+  checked: boolean
+  onChange: (v: boolean) => void
+}) {
+  const chk =
+    'rounded border border-slate-200 bg-white text-indigo-600 focus:ring-indigo-500 dark:border-neutral-600 dark:bg-neutral-800'
+  return (
+    <label className="flex items-start gap-2 rounded-xl border border-slate-100 bg-slate-50/80 px-3 py-2.5 dark:border-neutral-700 dark:bg-neutral-800/40">
+      <input type="checkbox" checked={props.checked} onChange={(e) => props.onChange(e.target.checked)} className={chk} />
+      <span className="text-sm text-slate-800 dark:text-neutral-100">
+        {props.label}
+        {sourceBadge(props.src)}
+      </span>
+    </label>
+  )
+}

--- a/clients/web/src/lib/__tests__/build-search-items.test.ts
+++ b/clients/web/src/lib/__tests__/build-search-items.test.ts
@@ -153,6 +153,7 @@ describe('buildSearchItems', () => {
     const allowed = (p: string) => p === PERM_RBAC_MANAGE
     const items = buildSearchItems([], [], allowed)
     expect(items.some((i) => i.path === '/settings/roles')).toBe(true)
+    expect(items.some((i) => i.path === '/settings/platform')).toBe(true)
     expect(items.some((i) => i.path === '/settings/ai/models')).toBe(true)
     expect(items.some((i) => i.path === '/settings/ai/system-prompts')).toBe(true)
   })
@@ -161,7 +162,7 @@ describe('buildSearchItems', () => {
     const items = buildSearchItems([], [], allowsNone)
     expect(items.some((i) => i.path === '/settings/roles')).toBe(false)
     expect(items.some((i) => i.path === '/settings/ai/models')).toBe(false)
-    expect(items.some((i) => i.path === '/settings/ai/system-prompts')).toBe(false)
+    expect(items.some((i) => i.path === '/settings/platform')).toBe(false)
   })
 
   it('adds Create course action when PERM_COURSE_CREATE is allowed', () => {
@@ -339,6 +340,7 @@ describe('buildSearchItems with full permissions', () => {
   it('includes rbac page and create course when allows returns true', () => {
     const items = buildSearchItems([], [], allowsAll)
     expect(items.some((i) => i.path === '/settings/roles')).toBe(true)
+    expect(items.some((i) => i.path === '/settings/platform')).toBe(true)
     expect(items.some((i) => i.path === '/settings/ai/models')).toBe(true)
     expect(items.some((i) => i.id === 'action:/courses/create')).toBe(true)
   })

--- a/clients/web/src/lib/build-search-items.ts
+++ b/clients/web/src/lib/build-search-items.ts
@@ -122,6 +122,14 @@ export function buildSearchItems(
 
   if (allows(PERM_RBAC_MANAGE)) {
     items.push({
+      id: 'page:/settings/platform',
+      group: 'page',
+      title: 'Global platform',
+      subtitle: 'System settings',
+      path: '/settings/platform',
+      haystack: 'openrouter saml feature flags lti oneroster platform environment database admin page'.toLowerCase(),
+    })
+    items.push({
       id: 'page:/settings/ai/models',
       group: 'page',
       title: 'AI models',

--- a/clients/web/src/lib/platform-settings.ts
+++ b/clients/web/src/lib/platform-settings.ts
@@ -1,0 +1,2 @@
+/** Matches server `placeholderSecretResponse` for masked API keys in settings responses. */
+export const PLATFORM_SECRET_PLACEHOLDER = '••••••••••••'

--- a/clients/web/src/pages/lms/settings.tsx
+++ b/clients/web/src/pages/lms/settings.tsx
@@ -5,6 +5,7 @@ import { settingsViewFromPathname } from '../../components/layout/side-nav-path-
 import { ImageModelPicker } from '../../components/image-model-picker'
 import { RequirePermission } from '../../components/require-permission'
 import { LtiToolsSettingsPanel } from '../../components/settings/lti-tools-settings-panel'
+import { PlatformSettingsPanel } from '../../components/settings/platform-settings-panel'
 import { RolesPermissionsPanel } from '../../components/settings/roles-permissions-panel'
 import { usePermissions } from '../../context/use-permissions'
 import { PERM_RBAC_MANAGE } from '../../lib/rbac-api'
@@ -19,7 +20,11 @@ import { useUiDensityControls } from '../../context/ui-density-context'
 
 function isSystemSettingsPath(pathname: string): boolean {
   if (pathname.startsWith('/settings/ai/')) return true
-  return pathname === '/settings/roles' || pathname === '/settings/lti-tools'
+  return (
+    pathname === '/settings/roles' ||
+    pathname === '/settings/lti-tools' ||
+    pathname === '/settings/platform'
+  )
 }
 
 type SystemPromptItem = {
@@ -519,7 +524,7 @@ export default function Settings() {
     <LmsPage title="Settings" description="Account and learning preferences.">
       <div
         className={`mt-8 ${
-          activeView === 'roles' || activeView === 'lti-tools'
+          activeView === 'roles' || activeView === 'lti-tools' || activeView === 'platform'
             ? 'max-w-4xl'
             : activeView === 'ai-prompts'
               ? 'max-w-3xl'
@@ -553,9 +558,10 @@ export default function Settings() {
 
             {!modelsConfigured && !aiLoading && (
               <p className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
-                Set <code className="rounded bg-amber-100/80 px-1.5 py-0.5 font-mono text-xs">OPENROUTER_API_KEY</code> or{' '}
-                <code className="rounded bg-amber-100/80 px-1.5 py-0.5 font-mono text-xs">OPEN_ROUTER_API_KEY</code> in the
-                server environment so AI image generation can call OpenRouter.
+                Configure an OpenRouter API key under{' '}
+                <span className="font-medium">Settings → Global platform</span>, or set{' '}
+                <code className="rounded bg-amber-100/80 px-1.5 py-0.5 font-mono text-xs">OPENROUTER_API_KEY</code> in the
+                server environment, so AI features can call OpenRouter.
               </p>
             )}
 
@@ -940,6 +946,23 @@ export default function Settings() {
           >
             <LtiToolsSettingsPanel />
           </RequirePermission>
+        )}
+
+        {activeView === 'platform' && (
+          <div>
+            <h2 className="text-base font-semibold text-slate-900 dark:text-neutral-100">Global platform</h2>
+            <RequirePermission
+              permission={PERM_RBAC_MANAGE}
+              fallback={
+                <p className="mt-6 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-300">
+                  You need permission to edit platform configuration (
+                  <code className="font-mono text-xs">{PERM_RBAC_MANAGE}</code>).
+                </p>
+              }
+            >
+              <PlatformSettingsPanel />
+            </RequirePermission>
+          </div>
         )}
       </div>
 

--- a/server-new/internal/app/app.go
+++ b/server-new/internal/app/app.go
@@ -19,8 +19,9 @@ import (
 	"github.com/lextures/lextures/server-new/internal/httpserver"
 	"github.com/lextures/lextures/server-new/internal/lti"
 	"github.com/lextures/lextures/server-new/internal/migrate"
+	"github.com/lextures/lextures/server-new/internal/platformstate"
+	"github.com/lextures/lextures/server-new/internal/repos/platformconfig"
 	"github.com/lextures/lextures/server-new/internal/service/oidcauth"
-	"github.com/lextures/lextures/server-new/internal/service/openrouter"
 )
 
 // Run starts the API. Pass the migration file tree (e.g. serverdata.Migrations from the module root).
@@ -39,19 +40,27 @@ func Run(ctx context.Context, fsys fs.FS) error {
 			return err
 		}
 	}
-	background.Start(ctx, pool, cfg)
 
-	ltiRT := lti.NewFromConfig(cfg)
+	dbPlatform, err := platformconfig.Get(ctx, pool)
+	if err != nil {
+		return fmt.Errorf("app: platform settings: %w", err)
+	}
+	merged := platformconfig.Merge(cfg, dbPlatform)
+	if err := merged.Validate(); err != nil {
+		return fmt.Errorf("app: effective configuration invalid (environment + database settings): %w", err)
+	}
+
+	background.Start(ctx, pool, merged)
+
+	ltiRT := lti.NewFromConfig(merged)
 	deps := httpserver.Deps{
 		Pool:      pool,
 		JWTSigner: auth.NewJWTSigner(cfg.JWTSecret),
 		Config:    cfg,
-		OIDC:      oidcauth.NewService(cfg),
+		Platform:  platformstate.New(merged),
+		OIDC:      oidcauth.NewService(merged),
 		Comm:      commevents.New(),
 		Lti:       ltiRT,
-	}
-	if k := strings.TrimSpace(cfg.OpenRouterAPIKey); k != "" {
-		deps.OpenRouter = openrouter.NewClient(k)
 	}
 	srv := &http.Server{
 		Addr:    cfg.HTTPAddr,

--- a/server-new/internal/app/app.go
+++ b/server-new/internal/app/app.go
@@ -3,6 +3,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -10,6 +11,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/lextures/lextures/server-new/internal/auth"
 	"github.com/lextures/lextures/server-new/internal/background"
@@ -43,7 +46,13 @@ func Run(ctx context.Context, fsys fs.FS) error {
 
 	dbPlatform, err := platformconfig.Get(ctx, pool)
 	if err != nil {
-		return fmt.Errorf("app: platform settings: %w", err)
+		// Integration tests (and some local workflows) set RUN_MIGRATIONS=false against an
+		// empty database, so migration 118 never creates settings.platform_app_settings.
+		// Treat a missing table like "no DB overrides" instead of failing startup.
+		if cfg.RunMigrations || !isUndefinedTable(err) {
+			return fmt.Errorf("app: platform settings: %w", err)
+		}
+		dbPlatform = nil
 	}
 	merged := platformconfig.Merge(cfg, dbPlatform)
 	if err := merged.Validate(); err != nil {
@@ -82,4 +91,9 @@ func Run(ctx context.Context, fsys fs.FS) error {
 		}
 		return nil
 	}
+}
+
+func isUndefinedTable(err error) bool {
+	var pg *pgconn.PgError
+	return errors.As(err, &pg) && pg.Code == "42P01"
 }

--- a/server-new/internal/httpserver/admin_nodb_test.go
+++ b/server-new/internal/httpserver/admin_nodb_test.go
@@ -6,6 +6,24 @@ import (
 	"testing"
 )
 
+func TestAdmin_PlatformSettings_Unauthorized(t *testing.T) {
+	h := NewHandler(Deps{Pool: nil, JWTSigner: nil})
+	for _, p := range []struct {
+		path   string
+		method string
+	}{
+		{"/api/v1/settings/platform", http.MethodGet},
+		{"/api/v1/settings/platform", http.MethodPut},
+	} {
+		srr := httptest.NewRecorder()
+		r := httptest.NewRequest(p.method, p.path, nil)
+		h.ServeHTTP(srr, r)
+		if srr.Code != http.StatusUnauthorized {
+			t.Fatalf("platform %s %s: %d", p.method, p.path, srr.Code)
+		}
+	}
+}
+
 func TestAdmin_OIDCList_Unauthorized(t *testing.T) {
 	h := NewHandler(Deps{Pool: nil, JWTSigner: nil})
 	rr := httptest.NewRecorder()

--- a/server-new/internal/httpserver/auth.go
+++ b/server-new/internal/httpserver/auth.go
@@ -96,7 +96,7 @@ func (d Deps) handleForgotPassword() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
 			return
 		}
-		res, err := authservice.RequestPasswordReset(r.Context(), d.Pool, d.Config, b.Email)
+		res, err := authservice.RequestPasswordReset(r.Context(), d.Pool, d.effectiveConfig(), b.Email)
 		if err != nil {
 			writeAuthErr(w, err)
 			return
@@ -140,7 +140,7 @@ func (d Deps) handleSAMLStatus() http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		if !d.Config.SAMLSSOEnabled {
+		if !d.effectiveConfig().SAMLSSOEnabled {
 			_, _ = w.Write([]byte(`{"enabled":false}`))
 			return
 		}
@@ -184,7 +184,7 @@ func (d Deps) handleOIDCStatus() http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		if !d.Config.OIDCSSOEnabled {
+		if !d.effectiveConfig().OIDCSSOEnabled {
 			_, _ = w.Write([]byte(`{"enabled":false,"providers":[],"custom":[]}`))
 			return
 		}
@@ -205,7 +205,7 @@ func (d Deps) handleOIDCStatus() http.HandlerFunc {
 		for _, c := range customRows {
 			custom = append(custom, customInfo{ID: c.ID, DisplayName: c.DisplayName})
 		}
-		base := strings.TrimRight(d.Config.OIDCPublicBaseURL, "/")
+		base := strings.TrimRight(d.effectiveConfig().OIDCPublicBaseURL, "/")
 		_ = json.NewEncoder(w).Encode(struct {
 			Enabled   bool   `json:"enabled"`
 			APIBase   string `json:"apiBase"`
@@ -216,9 +216,9 @@ func (d Deps) handleOIDCStatus() http.HandlerFunc {
 		}{
 			Enabled:   true,
 			APIBase:   base,
-			Google:    d.Config.OIDCGoogleConfigured(),
-			Microsoft: d.Config.OIDCMicrosoftConfigured(),
-			Apple:     d.Config.OIDCAppleConfigured(),
+			Google:    d.effectiveConfig().OIDCGoogleConfigured(),
+			Microsoft: d.effectiveConfig().OIDCMicrosoftConfigured(),
+			Apple:     d.effectiveConfig().OIDCAppleConfigured(),
 			Custom:    custom,
 		})
 	}
@@ -255,7 +255,7 @@ func (d Deps) handleOIDCLink() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
 			return
 		}
-		if !d.Config.OIDCSSOEnabled {
+		if !d.effectiveConfig().OIDCSSOEnabled {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "OpenID Connect is not enabled on this server.")
 			return
 		}
@@ -289,7 +289,7 @@ func (d Deps) handleOIDCLink() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInvalidInput, "Failed to start OIDC link flow.")
 			return
 		}
-		public := strings.TrimRight(d.Config.OIDCPublicBaseURL, "/")
+		public := strings.TrimRight(d.effectiveConfig().OIDCPublicBaseURL, "/")
 		var path string
 		if p == "custom" {
 			cid := *customID

--- a/server-new/internal/httpserver/canvas_import_ws.go
+++ b/server-new/internal/httpserver/canvas_import_ws.go
@@ -152,7 +152,7 @@ func (d Deps) runCanvasImport(
 	if mode != "erase" && mode != "mergeAdd" && mode != "overwrite" {
 		return errors.New("Invalid import mode.")
 	}
-	canvasBase, err := normalizeCanvasBaseURL(canvasBaseURL, d.Config.CanvasAllowedHostSuffixes)
+	canvasBase, err := normalizeCanvasBaseURL(canvasBaseURL, d.effectiveConfig().CanvasAllowedHostSuffixes)
 	if err != nil {
 		return err
 	}

--- a/server-new/internal/httpserver/course_factory_reset.go
+++ b/server-new/internal/httpserver/course_factory_reset.go
@@ -48,7 +48,7 @@ func (d Deps) handlePostFactoryResetCourse() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
 			return
 		}
-		coursefiles.RemoveStoredBlobs(d.Config.CourseFilesRoot, courseCode, outcome.RemovedCourseFileStorageKeys)
+		coursefiles.RemoveStoredBlobs(d.effectiveConfig().CourseFilesRoot, courseCode, outcome.RemovedCourseFileStorageKeys)
 		log.Printf(
 			"factory-reset: success course=%q viewer=%s removed_file_blobs=%d",
 			courseCode,

--- a/server-new/internal/httpserver/course_file_content.go
+++ b/server-new/internal/httpserver/course_file_content.go
@@ -42,7 +42,7 @@ func (d Deps) handleGetCourseFileContent() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Not found.")
 			return
 		}
-		root := strings.TrimSpace(d.Config.CourseFilesRoot)
+		root := strings.TrimSpace(d.effectiveConfig().CourseFilesRoot)
 		if root == "" {
 			root = "data/course-files"
 		}

--- a/server-new/internal/httpserver/course_get.go
+++ b/server-new/internal/httpserver/course_get.go
@@ -82,9 +82,9 @@ func (d Deps) handleGetCourse() http.HandlerFunc {
 			CoursePublic:                *crow,
 			ViewerEnrollmentRoles:        roles,
 			ViewerStudentEnrollmentID:    stuStr,
-			AnnotationsEnabled:            d.Config.AnnotationEnabled,
-			FeedbackMediaEnabled:          d.Config.FeedbackMediaEnabled,
-			ResubmissionWorkflowEnabled:  d.Config.ResubmissionWorkflowEnabled,
+			AnnotationsEnabled:            d.effectiveConfig().AnnotationEnabled,
+			FeedbackMediaEnabled:          d.effectiveConfig().FeedbackMediaEnabled,
+			ResubmissionWorkflowEnabled:  d.effectiveConfig().ResubmissionWorkflowEnabled,
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(resp)

--- a/server-new/internal/httpserver/gradebook_grid.go
+++ b/server-new/internal/httpserver/gradebook_grid.go
@@ -333,7 +333,7 @@ func (d Deps) handleGradebookGrid() http.HandlerFunc {
 			DroppedGrades:        droppedByStudent,
 			ExcusedGrades:        excused,
 			GradingScheme:        schemePtr,
-			GradebookCsvEnabled: d.Config.GradebookCSVEnabled,
+			GradebookCsvEnabled: d.effectiveConfig().GradebookCSVEnabled,
 		})
 	}
 }

--- a/server-new/internal/httpserver/lti_http.go
+++ b/server-new/internal/httpserver/lti_http.go
@@ -233,7 +233,7 @@ func (d Deps) handleLtiProviderLaunch() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Could not issue session token.")
 			return
 		}
-		public := strings.TrimRight(strings.TrimSpace(d.Config.PublicWebOrigin), "/")
+		public := strings.TrimRight(strings.TrimSpace(d.effectiveConfig().PublicWebOrigin), "/")
 		escTok, _ := json.Marshal(appTok)
 		escURL, _ := json.Marshal(public + "/")
 		html := fmt.Sprintf(`<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><title>Signing in…</title></head>

--- a/server-new/internal/httpserver/me_notebook.go
+++ b/server-new/internal/httpserver/me_notebook.go
@@ -24,7 +24,7 @@ func (d Deps) handleNotebookQuery() http.HandlerFunc {
 			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 			return
 		}
-		if d.OpenRouter == nil {
+		if d.openRouterClient() == nil {
 			w.Header().Set("Content-Type", "application/json; charset=utf-8")
 			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeAiNotConfigured, "AI features are not configured on this server.")
 			return
@@ -47,7 +47,7 @@ func (d Deps) handleNotebookQuery() http.HandlerFunc {
 			})
 		}
 		docs = notebookrag.FilterDocs(docs)
-		resp, err := notebookrag.Answer(r.Context(), d.Pool, d.OpenRouter, userID, body.Question, docs)
+		resp, err := notebookrag.Answer(r.Context(), d.Pool, d.openRouterClient(), userID, body.Question, docs)
 		if err != nil {
 			if notebookrag.IsValidationError(err) {
 				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())

--- a/server-new/internal/httpserver/me_notebook_test.go
+++ b/server-new/internal/httpserver/me_notebook_test.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/lextures/lextures/server-new/internal/auth"
 	"github.com/lextures/lextures/server-new/internal/config"
-	"github.com/lextures/lextures/server-new/internal/service/openrouter"
+	"github.com/lextures/lextures/server-new/internal/platformstate"
 )
 
 func TestNotebookQuery_AINotConfigured(t *testing.T) {
 	signer := auth.NewJWTSigner("01234567890123456789012345678901")
-	h := NewHandler(Deps{JWTSigner: signer, OpenRouter: nil, Config: config.Config{}})
+	h := NewHandler(Deps{JWTSigner: signer, Platform: platformstate.New(config.Config{}), Config: config.Config{}})
 	tok, err := signer.Sign("a0000000-0000-4000-8000-000000000002", "x@y.com")
 	if err != nil {
 		t.Fatal(err)
@@ -29,7 +29,7 @@ func TestNotebookQuery_AINotConfigured(t *testing.T) {
 }
 
 func TestNotebookQuery_Unauthorized(t *testing.T) {
-	h := NewHandler(Deps{OpenRouter: openrouter.NewClient("k")})
+	h := NewHandler(Deps{Platform: platformstate.New(config.Config{OpenRouterAPIKey: "k"}), Config: config.Config{OpenRouterAPIKey: "k"}})
 	rr := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/me/notebooks/query", strings.NewReader(`{"question":"q","notebooks":[]}`))
 	h.ServeHTTP(rr, r)
@@ -41,7 +41,7 @@ func TestNotebookQuery_Unauthorized(t *testing.T) {
 func TestNotebookQuery_Method(t *testing.T) {
 	signer := auth.NewJWTSigner("01234567890123456789012345678901")
 	tok, _ := signer.Sign("a0000000-0000-4000-8000-000000000002", "x@y.com")
-	h := NewHandler(Deps{JWTSigner: signer, OpenRouter: openrouter.NewClient("k")})
+	h := NewHandler(Deps{JWTSigner: signer, Platform: platformstate.New(config.Config{OpenRouterAPIKey: "k"}), Config: config.Config{OpenRouterAPIKey: "k"}})
 	rr := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/me/notebooks/query", nil)
 	r.Header.Set("Authorization", "Bearer "+tok)
@@ -54,7 +54,7 @@ func TestNotebookQuery_Method(t *testing.T) {
 func TestNotebookQuery_PoolNotConfigured(t *testing.T) {
 	signer := auth.NewJWTSigner("01234567890123456789012345678901")
 	tok, _ := signer.Sign("a0000000-0000-4000-8000-000000000002", "x@y.com")
-	h := NewHandler(Deps{Pool: nil, JWTSigner: signer, OpenRouter: openrouter.NewClient("k")})
+	h := NewHandler(Deps{Pool: nil, JWTSigner: signer, Platform: platformstate.New(config.Config{OpenRouterAPIKey: "k"}), Config: config.Config{OpenRouterAPIKey: "k"}})
 	rr := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/me/notebooks/query", bytes.NewReader([]byte(`{"question":"q","notebooks":[{"courseCode":"C","markdown":"m"}]}`)))
 	r.Header.Set("Authorization", "Bearer "+tok)
@@ -67,7 +67,7 @@ func TestNotebookQuery_PoolNotConfigured(t *testing.T) {
 func TestNotebookQuery_InvalidJSON(t *testing.T) {
 	signer := auth.NewJWTSigner("01234567890123456789012345678901")
 	tok, _ := signer.Sign("a0000000-0000-4000-8000-000000000002", "x@y.com")
-	h := NewHandler(Deps{JWTSigner: signer, OpenRouter: openrouter.NewClient("k"), Config: config.Config{}})
+	h := NewHandler(Deps{JWTSigner: signer, Platform: platformstate.New(config.Config{OpenRouterAPIKey: "k"}), Config: config.Config{OpenRouterAPIKey: "k"}})
 	rr := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/me/notebooks/query", bytes.NewReader([]byte("notjson")))
 	r.Header.Set("Authorization", "Bearer "+tok)

--- a/server-new/internal/httpserver/oidc_routes.go
+++ b/server-new/internal/httpserver/oidc_routes.go
@@ -25,7 +25,7 @@ func (d Deps) handleOIDCLogin() http.HandlerFunc {
 			return
 		}
 		if d.OIDC == nil {
-			d.OIDC = oidcauth.NewService(d.Config)
+			d.OIDC = oidcauth.NewService(d.effectiveConfig())
 		}
 		prov := strings.ToLower(strings.TrimSpace(chi.URLParam(r, "provider")))
 		q := r.URL.Query()
@@ -83,7 +83,7 @@ func (d Deps) handleOIDCCallback() http.HandlerFunc {
 			return
 		}
 		if d.OIDC == nil {
-			d.OIDC = oidcauth.NewService(d.Config)
+			d.OIDC = oidcauth.NewService(d.effectiveConfig())
 		}
 		prov := strings.ToLower(strings.TrimSpace(chi.URLParam(r, "provider")))
 		q := r.URL.Query()

--- a/server-new/internal/httpserver/oneroster_admin.go
+++ b/server-new/internal/httpserver/oneroster_admin.go
@@ -25,7 +25,7 @@ func (d Deps) handleAdminOneRosterUpload() http.HandlerFunc {
 			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 			return
 		}
-		if !d.Config.OneRosterEnabled {
+		if !d.effectiveConfig().OneRosterEnabled {
 			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeInvalidInput, "OneRoster is not enabled.")
 			return
 		}
@@ -95,7 +95,7 @@ func (d Deps) handleAdminOneRosterSyncRunsList() http.HandlerFunc {
 			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 			return
 		}
-		if !d.Config.OneRosterEnabled {
+		if !d.effectiveConfig().OneRosterEnabled {
 			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeInvalidInput, "OneRoster is not enabled.")
 			return
 		}
@@ -164,7 +164,7 @@ func (d Deps) handleAdminOneRosterSyncRunDetail() http.HandlerFunc {
 			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 			return
 		}
-		if !d.Config.OneRosterEnabled {
+		if !d.effectiveConfig().OneRosterEnabled {
 			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeInvalidInput, "OneRoster is not enabled.")
 			return
 		}
@@ -222,7 +222,7 @@ func (d Deps) handleAdminOneRosterBearerPost() http.HandlerFunc {
 			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 			return
 		}
-		if !d.Config.OneRosterEnabled {
+		if !d.effectiveConfig().OneRosterEnabled {
 			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeInvalidInput, "OneRoster is not enabled.")
 			return
 		}
@@ -259,7 +259,7 @@ func (d Deps) handleAdminOneRosterBearerPost() http.HandlerFunc {
 
 func (d Deps) handleOneRosterV1P2() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !d.Config.OneRosterEnabled {
+		if !d.effectiveConfig().OneRosterEnabled {
 			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeInvalidInput, "OneRoster is not enabled.")
 			return
 		}
@@ -269,7 +269,7 @@ func (d Deps) handleOneRosterV1P2() http.HandlerFunc {
 			return
 		}
 		raw := r.Header.Get("Authorization")
-		instID, err := oneroster.ResolveInstitutionFromBearer(r.Context(), d.Pool, d.Config, raw)
+		instID, err := oneroster.ResolveInstitutionFromBearer(r.Context(), d.Pool, d.effectiveConfig(), raw)
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusUnauthorized, apierr.CodeUnauthorized, "Unauthorized.")
 			return

--- a/server-new/internal/httpserver/saml_lti.go
+++ b/server-new/internal/httpserver/saml_lti.go
@@ -20,17 +20,17 @@ func (d Deps) registerSAMLBrowserRoutes(r chi.Router) {
 
 func (d Deps) handleSAMLMetadata() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !d.Config.SAMLSSOEnabled {
+		if !d.effectiveConfig().SAMLSSOEnabled {
 			writeSAMLorLTIErr(w, http.StatusBadRequest, "SAML is not enabled on this server.")
 			return
 		}
-		browsersaml.HandleMetadata(d.Config, w, r)
+		browsersaml.HandleMetadata(d.effectiveConfig(), w, r)
 	}
 }
 
 func (d Deps) handleSAMLLoginGet() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !d.Config.SAMLSSOEnabled {
+		if !d.effectiveConfig().SAMLSSOEnabled {
 			writeSAMLorLTIErr(w, http.StatusBadRequest, "SAML is not enabled on this server.")
 			return
 		}
@@ -38,7 +38,7 @@ func (d Deps) handleSAMLLoginGet() http.HandlerFunc {
 			writeSAMLorLTIErr(w, http.StatusInternalServerError, "Database is not configured.")
 			return
 		}
-		err := browsersaml.HandleLoginRedirect(r.Context(), d.Pool, d.Config, w, r)
+		err := browsersaml.HandleLoginRedirect(r.Context(), d.Pool, d.effectiveConfig(), w, r)
 		if err == nil {
 			return
 		}
@@ -53,7 +53,7 @@ func (d Deps) handleSAMLLoginGet() http.HandlerFunc {
 
 func (d Deps) handleSAMLACS() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !d.Config.SAMLSSOEnabled {
+		if !d.effectiveConfig().SAMLSSOEnabled {
 			writeSAMLorLTIErr(w, http.StatusBadRequest, "SAML is not enabled on this server.")
 			return
 		}
@@ -61,7 +61,7 @@ func (d Deps) handleSAMLACS() http.HandlerFunc {
 			writeSAMLorLTIErr(w, http.StatusInternalServerError, "Server is not fully configured.")
 			return
 		}
-		err := browsersaml.HandleACS(r.Context(), d.Pool, d.Config, d.JWTSigner, d.Config.PublicWebOrigin, w, r)
+		err := browsersaml.HandleACS(r.Context(), d.Pool, d.effectiveConfig(), d.JWTSigner, d.effectiveConfig().PublicWebOrigin, w, r)
 		if err == nil {
 			return
 		}

--- a/server-new/internal/httpserver/server.go
+++ b/server-new/internal/httpserver/server.go
@@ -13,20 +13,36 @@ import (
 	"github.com/lextures/lextures/server-new/internal/config"
 	"github.com/lextures/lextures/server-new/internal/lti"
 	"github.com/lextures/lextures/server-new/internal/openapi"
+	"github.com/lextures/lextures/server-new/internal/platformstate"
 	"github.com/lextures/lextures/server-new/internal/service/oidcauth"
 	"github.com/lextures/lextures/server-new/internal/service/openrouter"
 )
 
 // Deps is the minimal set of server dependencies. Expand with auth, LTI, etc. during the migration.
 type Deps struct {
-	Pool       *pgxpool.Pool
-	Ready      ReadyChecker
-	JWTSigner  *auth.JWTSigner
-	Config     config.Config
-	OpenRouter *openrouter.Client
-	OIDC       *oidcauth.Service
-	Comm       *commevents.Hub
-	Lti        *lti.Runtime
+	Pool      *pgxpool.Pool
+	Ready     ReadyChecker
+	JWTSigner *auth.JWTSigner
+	// Config is the environment-only configuration (used with DB overrides in Platform).
+	Config   config.Config
+	Platform *platformstate.Platform
+	OIDC     *oidcauth.Service
+	Comm     *commevents.Hub
+	Lti      *lti.Runtime
+}
+
+func (d Deps) effectiveConfig() config.Config {
+	if d.Platform != nil {
+		return d.Platform.Config()
+	}
+	return d.Config
+}
+
+func (d Deps) openRouterClient() *openrouter.Client {
+	if d.Platform != nil {
+		return d.Platform.OpenRouter()
+	}
+	return nil
 }
 
 // NewHandler builds the HTTP API (routes only; does not start listening).
@@ -71,6 +87,8 @@ func NewHandler(d Deps) http.Handler {
 	r.Get("/api/v1/settings/ai/models", d.handleListAIModels())
 	r.Get("/api/v1/settings/ai", d.handleGetSettingsAI())
 	r.Put("/api/v1/settings/ai", d.handlePutSettingsAI())
+	r.Get("/api/v1/settings/platform", d.handleGetPlatformSettings())
+	r.Put("/api/v1/settings/platform", d.handlePutPlatformSettings())
 	r.Get("/api/v1/settings/system-prompts", d.handleListSystemPrompts())
 	r.Put("/api/v1/settings/system-prompts/{key}", d.handlePutSystemPrompt())
 	r.Get("/api/v1/search", d.handleSearchIndex())

--- a/server-new/internal/httpserver/settings_ai.go
+++ b/server-new/internal/httpserver/settings_ai.go
@@ -40,7 +40,7 @@ func (d Deps) handleListAIModels() http.HandlerFunc {
 				"Could not load models from OpenRouter. Try again. ("+err.Error()+")")
 			return
 		}
-		configured := d.OpenRouter != nil
+		configured := d.openRouterClient() != nil
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"configured": configured,

--- a/server-new/internal/httpserver/settings_platform.go
+++ b/server-new/internal/httpserver/settings_platform.go
@@ -1,0 +1,367 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/lextures/lextures/server-new/internal/apierr"
+	"github.com/lextures/lextures/server-new/internal/repos/platformconfig"
+)
+
+const placeholderSecretResponse = "••••••••••••"
+
+func maskSecret(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return ""
+	}
+	return placeholderSecretResponse
+}
+
+func maskPEMIfSet(pem string) string {
+	if strings.TrimSpace(pem) == "" {
+		return ""
+	}
+	return placeholderSecretResponse
+}
+
+type platformSettingsJSON struct {
+	OpenRouterAPIKey string `json:"openRouterApiKey"`
+
+	SAMLSSOEnabled      bool   `json:"samlSsoEnabled"`
+	SAMLPublicBaseURL   string `json:"samlPublicBaseUrl"`
+	SAMLSPEntityID      string `json:"samlSpEntityId"`
+	SAMLSPX509PEM       string `json:"samlSpX509Pem"`
+	SAMLSPPrivateKeyPEM string `json:"samlSpPrivateKeyPem"`
+
+	AnnotationEnabled           bool `json:"annotationEnabled"`
+	FeedbackMediaEnabled        bool `json:"feedbackMediaEnabled"`
+	BlindGradingEnabled         bool `json:"blindGradingEnabled"`
+	ModeratedGradingEnabled     bool `json:"moderatedGradingEnabled"`
+	OriginalityDetectionEnabled bool `json:"originalityDetectionEnabled"`
+	OriginalityStubExternal     bool `json:"originalityStubExternal"`
+	GradePostingPoliciesEnabled bool `json:"gradePostingPoliciesEnabled"`
+	GradebookCSVEnabled         bool `json:"gradebookCsvEnabled"`
+	ResubmissionWorkflowEnabled bool `json:"resubmissionWorkflowEnabled"`
+	LTIEnabled                  bool `json:"ltiEnabled"`
+	OneRosterEnabled            bool `json:"oneRosterEnabled"`
+
+	Sources platformSourcesJSON `json:"sources"`
+}
+
+type platformSourcesJSON struct {
+	OpenRouterAPIKey string `json:"openRouterApiKey"`
+
+	SAMLSSOEnabled      string `json:"samlSsoEnabled"`
+	SAMLPublicBaseURL   string `json:"samlPublicBaseUrl"`
+	SAMLSPEntityID      string `json:"samlSpEntityId"`
+	SAMLSPX509PEM       string `json:"samlSpX509Pem"`
+	SAMLSPPrivateKeyPEM string `json:"samlSpPrivateKeyPem"`
+
+	AnnotationEnabled           string `json:"annotationEnabled"`
+	FeedbackMediaEnabled        string `json:"feedbackMediaEnabled"`
+	BlindGradingEnabled         string `json:"blindGradingEnabled"`
+	ModeratedGradingEnabled     string `json:"moderatedGradingEnabled"`
+	OriginalityDetectionEnabled string `json:"originalityDetectionEnabled"`
+	OriginalityStubExternal     string `json:"originalityStubExternal"`
+	GradePostingPoliciesEnabled string `json:"gradePostingPoliciesEnabled"`
+	GradebookCSVEnabled         string `json:"gradebookCsvEnabled"`
+	ResubmissionWorkflowEnabled string `json:"resubmissionWorkflowEnabled"`
+	LTIEnabled                  string `json:"ltiEnabled"`
+	OneRosterEnabled            string `json:"oneRosterEnabled"`
+}
+
+func src(s platformconfig.Source) string {
+	return string(s)
+}
+
+// handleGetPlatformSettings is GET /api/v1/settings/platform
+func (d Deps) handleGetPlatformSettings() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+		ctx := r.Context()
+		var dbRow *platformconfig.Row
+		var err error
+		if d.Pool != nil {
+			dbRow, err = platformconfig.Get(ctx, d.Pool)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load platform settings.")
+				return
+			}
+		}
+		merged := platformconfig.Merge(d.Config, dbRow)
+		sources := platformconfig.ResolveSources(d.Config, dbRow)
+		out := platformSettingsJSON{
+			OpenRouterAPIKey:            maskSecret(merged.OpenRouterAPIKey),
+			SAMLSSOEnabled:              merged.SAMLSSOEnabled,
+			SAMLPublicBaseURL:           merged.SAMLPublicBaseURL,
+			SAMLSPEntityID:              merged.SAMLSPEntityID,
+			SAMLSPX509PEM:               merged.SAMLSPX509PEM,
+			SAMLSPPrivateKeyPEM:         maskPEMIfSet(merged.SAMLSPPrivateKeyPEM),
+			AnnotationEnabled:           merged.AnnotationEnabled,
+			FeedbackMediaEnabled:        merged.FeedbackMediaEnabled,
+			BlindGradingEnabled:         merged.BlindGradingEnabled,
+			ModeratedGradingEnabled:     merged.ModeratedGradingEnabled,
+			OriginalityDetectionEnabled: merged.OriginalityDetectionEnabled,
+			OriginalityStubExternal:     merged.OriginalityStubExternal,
+			GradePostingPoliciesEnabled: merged.GradePostingPoliciesEnabled,
+			GradebookCSVEnabled:         merged.GradebookCSVEnabled,
+			ResubmissionWorkflowEnabled: merged.ResubmissionWorkflowEnabled,
+			LTIEnabled:                  merged.LTIEnabled,
+			OneRosterEnabled:            merged.OneRosterEnabled,
+			Sources: platformSourcesJSON{
+				OpenRouterAPIKey:            src(sources.OpenRouterAPIKey),
+				SAMLSSOEnabled:              src(sources.SAMLSSOEnabled),
+				SAMLPublicBaseURL:           src(sources.SAMLPublicBaseURL),
+				SAMLSPEntityID:              src(sources.SAMLSPEntityID),
+				SAMLSPX509PEM:               src(sources.SAMLSPX509PEM),
+				SAMLSPPrivateKeyPEM:         src(sources.SAMLSPPrivateKeyPEM),
+				AnnotationEnabled:           src(sources.AnnotationEnabled),
+				FeedbackMediaEnabled:        src(sources.FeedbackMediaEnabled),
+				BlindGradingEnabled:         src(sources.BlindGradingEnabled),
+				ModeratedGradingEnabled:     src(sources.ModeratedGradingEnabled),
+				OriginalityDetectionEnabled: src(sources.OriginalityDetectionEnabled),
+				OriginalityStubExternal:     src(sources.OriginalityStubExternal),
+				GradePostingPoliciesEnabled: src(sources.GradePostingPoliciesEnabled),
+				GradebookCSVEnabled:         src(sources.GradebookCSVEnabled),
+				ResubmissionWorkflowEnabled: src(sources.ResubmissionWorkflowEnabled),
+				LTIEnabled:                  src(sources.LTIEnabled),
+				OneRosterEnabled:            src(sources.OneRosterEnabled),
+			},
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+type putPlatformBody struct {
+	OpenRouterAPIKey      *string `json:"openRouterApiKey"`
+	ClearOpenRouterAPIKey bool    `json:"clearOpenRouterApiKey"`
+
+	SAMLSSOEnabled      *bool   `json:"samlSsoEnabled"`
+	SAMLPublicBaseURL   *string `json:"samlPublicBaseUrl"`
+	SAMLSPEntityID      *string `json:"samlSpEntityId"`
+	SAMLSPX509PEM       *string `json:"samlSpX509Pem"`
+	SAMLSPPrivateKeyPEM *string `json:"samlSpPrivateKeyPem"`
+
+	AnnotationEnabled           *bool `json:"annotationEnabled"`
+	FeedbackMediaEnabled        *bool `json:"feedbackMediaEnabled"`
+	BlindGradingEnabled         *bool `json:"blindGradingEnabled"`
+	ModeratedGradingEnabled     *bool `json:"moderatedGradingEnabled"`
+	OriginalityDetectionEnabled *bool `json:"originalityDetectionEnabled"`
+	OriginalityStubExternal     *bool `json:"originalityStubExternal"`
+	GradePostingPoliciesEnabled *bool `json:"gradePostingPoliciesEnabled"`
+	GradebookCSVEnabled         *bool `json:"gradebookCsvEnabled"`
+	ResubmissionWorkflowEnabled *bool `json:"resubmissionWorkflowEnabled"`
+	LTIEnabled                  *bool `json:"ltiEnabled"`
+	OneRosterEnabled            *bool `json:"oneRosterEnabled"`
+
+	UpdateMask []string `json:"updateMask"`
+}
+
+// handlePutPlatformSettings is PUT /api/v1/settings/platform
+func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.Header().Set("Allow", http.MethodPut)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Database is not configured.")
+			return
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		var body putPlatformBody
+		if err := json.Unmarshal(b, &body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		mask := map[string]struct{}{}
+		for _, k := range body.UpdateMask {
+			k = strings.TrimSpace(k)
+			if k != "" {
+				mask[strings.ToLower(k)] = struct{}{}
+			}
+		}
+
+		wr := &platformconfig.Write{}
+		clearRouter := body.ClearOpenRouterAPIKey
+		if len(mask) > 0 {
+			clearRouter = false
+			if _, ok := mask["clearopenrouterapikey"]; ok {
+				clearRouter = true
+			}
+		}
+
+		set := func(field string, hasInput bool, apply func()) {
+			if len(mask) > 0 {
+				if _, ok := mask[strings.ToLower(field)]; !ok {
+					return
+				}
+			} else {
+				if !hasInput {
+					return
+				}
+			}
+			apply()
+		}
+
+		set("openrouterapikey", body.OpenRouterAPIKey != nil, func() {
+			s := strings.TrimSpace(*body.OpenRouterAPIKey)
+			if s != "" && s != placeholderSecretResponse {
+				wr.OpenRouterAPIKey = &s
+			}
+		})
+
+		if clearRouter && wr.OpenRouterAPIKey != nil && strings.TrimSpace(*wr.OpenRouterAPIKey) != "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Cannot set openRouterApiKey and clearOpenRouterApiKey together.")
+			return
+		}
+		if clearRouter {
+			if err := platformconfig.ClearOpenRouterAPIKey(r.Context(), d.Pool); err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to clear OpenRouter override.")
+				return
+			}
+		}
+		set("samlssoenabled", body.SAMLSSOEnabled != nil, func() {
+			v := *body.SAMLSSOEnabled
+			wr.SAMLSSOEnabled = &v
+		})
+		set("samlpublicbaseurl", body.SAMLPublicBaseURL != nil, func() {
+			s := strings.TrimSpace(*body.SAMLPublicBaseURL)
+			wr.SAMLPublicBaseURL = &s
+		})
+		set("samlspentityid", body.SAMLSPEntityID != nil, func() {
+			s := strings.TrimSpace(*body.SAMLSPEntityID)
+			wr.SAMLSPEntityID = &s
+		})
+		set("samlspx509pem", body.SAMLSPX509PEM != nil, func() {
+			s := strings.TrimSpace(*body.SAMLSPX509PEM)
+			if s != "" && s != placeholderSecretResponse {
+				wr.SAMLSPX509PEM = &s
+			}
+		})
+		set("samlprivatekeypem", body.SAMLSPPrivateKeyPEM != nil, func() {
+			s := strings.TrimSpace(*body.SAMLSPPrivateKeyPEM)
+			if s != "" && s != placeholderSecretResponse {
+				wr.SAMLSPPrivateKeyPEM = &s
+			}
+		})
+		set("annotationenabled", body.AnnotationEnabled != nil, func() {
+			v := *body.AnnotationEnabled
+			wr.AnnotationEnabled = &v
+		})
+		set("feedbackmediaenabled", body.FeedbackMediaEnabled != nil, func() {
+			v := *body.FeedbackMediaEnabled
+			wr.FeedbackMediaEnabled = &v
+		})
+		set("blindgradingenabled", body.BlindGradingEnabled != nil, func() {
+			v := *body.BlindGradingEnabled
+			wr.BlindGradingEnabled = &v
+		})
+		set("moderatedgradingenabled", body.ModeratedGradingEnabled != nil, func() {
+			v := *body.ModeratedGradingEnabled
+			wr.ModeratedGradingEnabled = &v
+		})
+		set("originalitydetectionenabled", body.OriginalityDetectionEnabled != nil, func() {
+			v := *body.OriginalityDetectionEnabled
+			wr.OriginalityDetectionEnabled = &v
+		})
+		set("originalitystubexternal", body.OriginalityStubExternal != nil, func() {
+			v := *body.OriginalityStubExternal
+			wr.OriginalityStubExternal = &v
+		})
+		set("gradepostingpoliciesenabled", body.GradePostingPoliciesEnabled != nil, func() {
+			v := *body.GradePostingPoliciesEnabled
+			wr.GradePostingPoliciesEnabled = &v
+		})
+		set("gradebookcsvenabled", body.GradebookCSVEnabled != nil, func() {
+			v := *body.GradebookCSVEnabled
+			wr.GradebookCSVEnabled = &v
+		})
+		set("resubmissionworkflowenabled", body.ResubmissionWorkflowEnabled != nil, func() {
+			v := *body.ResubmissionWorkflowEnabled
+			wr.ResubmissionWorkflowEnabled = &v
+		})
+		set("ltienabled", body.LTIEnabled != nil, func() {
+			v := *body.LTIEnabled
+			wr.LTIEnabled = &v
+		})
+		set("onerosterenabled", body.OneRosterEnabled != nil, func() {
+			v := *body.OneRosterEnabled
+			wr.OneRosterEnabled = &v
+		})
+
+		dbRow, err := platformconfig.Upsert(r.Context(), d.Pool, wr)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save platform settings.")
+			return
+		}
+		merged := platformconfig.Merge(d.Config, dbRow)
+		if err := merged.Validate(); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		if d.Platform != nil {
+			d.Platform.Reload(merged)
+		}
+		if d.OIDC != nil {
+			d.OIDC = nil
+		}
+
+		sources := platformconfig.ResolveSources(d.Config, dbRow)
+		out := platformSettingsJSON{
+			OpenRouterAPIKey:            maskSecret(merged.OpenRouterAPIKey),
+			SAMLSSOEnabled:              merged.SAMLSSOEnabled,
+			SAMLPublicBaseURL:           merged.SAMLPublicBaseURL,
+			SAMLSPEntityID:              merged.SAMLSPEntityID,
+			SAMLSPX509PEM:               merged.SAMLSPX509PEM,
+			SAMLSPPrivateKeyPEM:         maskPEMIfSet(merged.SAMLSPPrivateKeyPEM),
+			AnnotationEnabled:           merged.AnnotationEnabled,
+			FeedbackMediaEnabled:        merged.FeedbackMediaEnabled,
+			BlindGradingEnabled:         merged.BlindGradingEnabled,
+			ModeratedGradingEnabled:     merged.ModeratedGradingEnabled,
+			OriginalityDetectionEnabled: merged.OriginalityDetectionEnabled,
+			OriginalityStubExternal:     merged.OriginalityStubExternal,
+			GradePostingPoliciesEnabled: merged.GradePostingPoliciesEnabled,
+			GradebookCSVEnabled:         merged.GradebookCSVEnabled,
+			ResubmissionWorkflowEnabled: merged.ResubmissionWorkflowEnabled,
+			LTIEnabled:                  merged.LTIEnabled,
+			OneRosterEnabled:            merged.OneRosterEnabled,
+			Sources: platformSourcesJSON{
+				OpenRouterAPIKey:            src(sources.OpenRouterAPIKey),
+				SAMLSSOEnabled:              src(sources.SAMLSSOEnabled),
+				SAMLPublicBaseURL:           src(sources.SAMLPublicBaseURL),
+				SAMLSPEntityID:              src(sources.SAMLSPEntityID),
+				SAMLSPX509PEM:               src(sources.SAMLSPX509PEM),
+				SAMLSPPrivateKeyPEM:         src(sources.SAMLSPPrivateKeyPEM),
+				AnnotationEnabled:           src(sources.AnnotationEnabled),
+				FeedbackMediaEnabled:        src(sources.FeedbackMediaEnabled),
+				BlindGradingEnabled:         src(sources.BlindGradingEnabled),
+				ModeratedGradingEnabled:     src(sources.ModeratedGradingEnabled),
+				OriginalityDetectionEnabled: src(sources.OriginalityDetectionEnabled),
+				OriginalityStubExternal:     src(sources.OriginalityStubExternal),
+				GradePostingPoliciesEnabled: src(sources.GradePostingPoliciesEnabled),
+				GradebookCSVEnabled:         src(sources.GradebookCSVEnabled),
+				ResubmissionWorkflowEnabled: src(sources.ResubmissionWorkflowEnabled),
+				LTIEnabled:                  src(sources.LTIEnabled),
+				OneRosterEnabled:            src(sources.OneRosterEnabled),
+			},
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}

--- a/server-new/internal/httpserver/webhooks_originality.go
+++ b/server-new/internal/httpserver/webhooks_originality.go
@@ -36,7 +36,7 @@ func (d Deps) handleOriginalityWebhook() http.HandlerFunc {
 			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 			return
 		}
-		if !d.Config.OriginalityDetectionEnabled {
+		if !d.effectiveConfig().OriginalityDetectionEnabled {
 			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Not found.")
 			return
 		}

--- a/server-new/internal/platformstate/platformstate.go
+++ b/server-new/internal/platformstate/platformstate.go
@@ -1,0 +1,52 @@
+// Package platformstate holds the effective merged configuration and OpenRouter client (reloadable).
+package platformstate
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/lextures/lextures/server-new/internal/config"
+	"github.com/lextures/lextures/server-new/internal/service/openrouter"
+)
+
+// Platform is the request-time snapshot of env + DB merged settings.
+type Platform struct {
+	mu         sync.RWMutex
+	cfg        config.Config
+	openRouter *openrouter.Client
+}
+
+// New builds state from merged configuration (OpenRouter client only when API key is non-empty).
+func New(cfg config.Config) *Platform {
+	p := &Platform{cfg: cfg}
+	if k := strings.TrimSpace(cfg.OpenRouterAPIKey); k != "" {
+		p.openRouter = openrouter.NewClient(k)
+	}
+	return p
+}
+
+// Config returns the effective merged configuration.
+func (p *Platform) Config() config.Config {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.cfg
+}
+
+// OpenRouter returns the chat client, or nil when no API key is configured.
+func (p *Platform) OpenRouter() *openrouter.Client {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.openRouter
+}
+
+// Reload replaces configuration and rebuilds the OpenRouter client when the key changes.
+func (p *Platform) Reload(cfg config.Config) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cfg = cfg
+	var next *openrouter.Client
+	if k := strings.TrimSpace(cfg.OpenRouterAPIKey); k != "" {
+		next = openrouter.NewClient(k)
+	}
+	p.openRouter = next
+}

--- a/server-new/internal/repos/platformconfig/merge_test.go
+++ b/server-new/internal/repos/platformconfig/merge_test.go
@@ -1,0 +1,27 @@
+package platformconfig
+
+import (
+	"testing"
+
+	"github.com/lextures/lextures/server-new/internal/config"
+)
+
+func TestMerge_OpenRouterEmptyDBUsesEnv(t *testing.T) {
+	env := config.Config{OpenRouterAPIKey: "env-key"}
+	db := Row{OpenRouterAPIKey: ptr("")}
+	got := Merge(env, &db)
+	if got.OpenRouterAPIKey != "env-key" {
+		t.Fatalf("OpenRouter: got %q want env", got.OpenRouterAPIKey)
+	}
+}
+
+func TestMerge_OpenRouterNonEmptyDBOverrides(t *testing.T) {
+	env := config.Config{OpenRouterAPIKey: "env-key"}
+	db := Row{OpenRouterAPIKey: ptr("db-key")}
+	got := Merge(env, &db)
+	if got.OpenRouterAPIKey != "db-key" {
+		t.Fatalf("OpenRouter: got %q want db", got.OpenRouterAPIKey)
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/server-new/internal/repos/platformconfig/platformconfig.go
+++ b/server-new/internal/repos/platformconfig/platformconfig.go
@@ -1,0 +1,354 @@
+// Package platformconfig stores optional overrides for env-driven app settings (singleton row).
+package platformconfig
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/lextures/lextures/server-new/internal/config"
+)
+
+// Row is the optional DB override layer; nil pointers mean "use environment value".
+type Row struct {
+	OpenRouterAPIKey *string
+
+	SAMLSSOEnabled      *bool
+	SAMLPublicBaseURL   *string
+	SAMLSPEntityID      *string
+	SAMLSPX509PEM       *string
+	SAMLSPPrivateKeyPEM *string
+
+	AnnotationEnabled           *bool
+	FeedbackMediaEnabled        *bool
+	BlindGradingEnabled         *bool
+	ModeratedGradingEnabled     *bool
+	OriginalityDetectionEnabled *bool
+	OriginalityStubExternal     *bool
+	GradePostingPoliciesEnabled *bool
+	GradebookCSVEnabled         *bool
+	ResubmissionWorkflowEnabled *bool
+	LTIEnabled                  *bool
+	OneRosterEnabled            *bool
+
+	UpdatedAt time.Time
+}
+
+// Write is the upsert payload (nil pointer = leave column unchanged).
+type Write struct {
+	OpenRouterAPIKey *string
+
+	SAMLSSOEnabled      *bool
+	SAMLPublicBaseURL   *string
+	SAMLSPEntityID      *string
+	SAMLSPX509PEM       *string
+	SAMLSPPrivateKeyPEM *string
+
+	AnnotationEnabled           *bool
+	FeedbackMediaEnabled        *bool
+	BlindGradingEnabled         *bool
+	ModeratedGradingEnabled     *bool
+	OriginalityDetectionEnabled *bool
+	OriginalityStubExternal     *bool
+	GradePostingPoliciesEnabled *bool
+	GradebookCSVEnabled         *bool
+	ResubmissionWorkflowEnabled *bool
+	LTIEnabled                  *bool
+	OneRosterEnabled            *bool
+}
+
+// Get returns the singleton row or (nil, nil) if missing.
+func Get(ctx context.Context, pool *pgxpool.Pool) (*Row, error) {
+	var r Row
+	err := pool.QueryRow(ctx, `
+SELECT
+	openrouter_api_key,
+	saml_sso_enabled,
+	saml_public_base_url,
+	saml_sp_entity_id,
+	saml_sp_x509_pem,
+	saml_sp_private_key_pem,
+	annotation_enabled,
+	feedback_media_enabled,
+	blind_grading_enabled,
+	moderated_grading_enabled,
+	originality_detection_enabled,
+	originality_stub_external,
+	grade_posting_policies_enabled,
+	gradebook_csv_enabled,
+	resubmission_workflow_enabled,
+	lti_enabled,
+	oneroster_enabled,
+	updated_at
+FROM settings.platform_app_settings
+WHERE id = 1
+`).Scan(
+		&r.OpenRouterAPIKey,
+		&r.SAMLSSOEnabled,
+		&r.SAMLPublicBaseURL,
+		&r.SAMLSPEntityID,
+		&r.SAMLSPX509PEM,
+		&r.SAMLSPPrivateKeyPEM,
+		&r.AnnotationEnabled,
+		&r.FeedbackMediaEnabled,
+		&r.BlindGradingEnabled,
+		&r.ModeratedGradingEnabled,
+		&r.OriginalityDetectionEnabled,
+		&r.OriginalityStubExternal,
+		&r.GradePostingPoliciesEnabled,
+		&r.GradebookCSVEnabled,
+		&r.ResubmissionWorkflowEnabled,
+		&r.LTIEnabled,
+		&r.OneRosterEnabled,
+		&r.UpdatedAt,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+// ClearOpenRouterAPIKey removes the stored OpenRouter override so the environment key is used again.
+func ClearOpenRouterAPIKey(ctx context.Context, pool *pgxpool.Pool) error {
+	_, err := pool.Exec(ctx, `
+UPDATE settings.platform_app_settings
+SET openrouter_api_key = NULL, updated_at = NOW()
+WHERE id = 1
+`)
+	return err
+}
+
+// Upsert applies non-nil fields in w to the singleton row (COALESCE keeps existing values).
+func Upsert(ctx context.Context, pool *pgxpool.Pool, w *Write) (*Row, error) {
+	_, err := pool.Exec(ctx, `
+INSERT INTO settings.platform_app_settings (
+	id,
+	openrouter_api_key,
+	saml_sso_enabled,
+	saml_public_base_url,
+	saml_sp_entity_id,
+	saml_sp_x509_pem,
+	saml_sp_private_key_pem,
+	annotation_enabled,
+	feedback_media_enabled,
+	blind_grading_enabled,
+	moderated_grading_enabled,
+	originality_detection_enabled,
+	originality_stub_external,
+	grade_posting_policies_enabled,
+	gradebook_csv_enabled,
+	resubmission_workflow_enabled,
+	lti_enabled,
+	oneroster_enabled,
+	updated_at
+) VALUES (
+	1,
+	$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NOW()
+)
+ON CONFLICT (id) DO UPDATE SET
+	openrouter_api_key = COALESCE(EXCLUDED.openrouter_api_key, settings.platform_app_settings.openrouter_api_key),
+	saml_sso_enabled = COALESCE(EXCLUDED.saml_sso_enabled, settings.platform_app_settings.saml_sso_enabled),
+	saml_public_base_url = COALESCE(EXCLUDED.saml_public_base_url, settings.platform_app_settings.saml_public_base_url),
+	saml_sp_entity_id = COALESCE(EXCLUDED.saml_sp_entity_id, settings.platform_app_settings.saml_sp_entity_id),
+	saml_sp_x509_pem = COALESCE(EXCLUDED.saml_sp_x509_pem, settings.platform_app_settings.saml_sp_x509_pem),
+	saml_sp_private_key_pem = COALESCE(EXCLUDED.saml_sp_private_key_pem, settings.platform_app_settings.saml_sp_private_key_pem),
+	annotation_enabled = COALESCE(EXCLUDED.annotation_enabled, settings.platform_app_settings.annotation_enabled),
+	feedback_media_enabled = COALESCE(EXCLUDED.feedback_media_enabled, settings.platform_app_settings.feedback_media_enabled),
+	blind_grading_enabled = COALESCE(EXCLUDED.blind_grading_enabled, settings.platform_app_settings.blind_grading_enabled),
+	moderated_grading_enabled = COALESCE(EXCLUDED.moderated_grading_enabled, settings.platform_app_settings.moderated_grading_enabled),
+	originality_detection_enabled = COALESCE(EXCLUDED.originality_detection_enabled, settings.platform_app_settings.originality_detection_enabled),
+	originality_stub_external = COALESCE(EXCLUDED.originality_stub_external, settings.platform_app_settings.originality_stub_external),
+	grade_posting_policies_enabled = COALESCE(EXCLUDED.grade_posting_policies_enabled, settings.platform_app_settings.grade_posting_policies_enabled),
+	gradebook_csv_enabled = COALESCE(EXCLUDED.gradebook_csv_enabled, settings.platform_app_settings.gradebook_csv_enabled),
+	resubmission_workflow_enabled = COALESCE(EXCLUDED.resubmission_workflow_enabled, settings.platform_app_settings.resubmission_workflow_enabled),
+	lti_enabled = COALESCE(EXCLUDED.lti_enabled, settings.platform_app_settings.lti_enabled),
+	oneroster_enabled = COALESCE(EXCLUDED.oneroster_enabled, settings.platform_app_settings.oneroster_enabled),
+	updated_at = NOW()
+`,
+		w.OpenRouterAPIKey,
+		w.SAMLSSOEnabled,
+		w.SAMLPublicBaseURL,
+		w.SAMLSPEntityID,
+		w.SAMLSPX509PEM,
+		w.SAMLSPPrivateKeyPEM,
+		w.AnnotationEnabled,
+		w.FeedbackMediaEnabled,
+		w.BlindGradingEnabled,
+		w.ModeratedGradingEnabled,
+		w.OriginalityDetectionEnabled,
+		w.OriginalityStubExternal,
+		w.GradePostingPoliciesEnabled,
+		w.GradebookCSVEnabled,
+		w.ResubmissionWorkflowEnabled,
+		w.LTIEnabled,
+		w.OneRosterEnabled,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return Get(ctx, pool)
+}
+
+// Merge applies DB overrides on top of env-backed configuration.
+func Merge(env config.Config, db *Row) config.Config {
+	if db == nil {
+		return env
+	}
+	out := env
+	if db.OpenRouterAPIKey != nil {
+		if strings.TrimSpace(*db.OpenRouterAPIKey) != "" {
+			out.OpenRouterAPIKey = strings.TrimSpace(*db.OpenRouterAPIKey)
+		}
+	}
+	if db.SAMLSSOEnabled != nil {
+		out.SAMLSSOEnabled = *db.SAMLSSOEnabled
+	}
+	if db.SAMLPublicBaseURL != nil && strings.TrimSpace(*db.SAMLPublicBaseURL) != "" {
+		out.SAMLPublicBaseURL = strings.TrimRight(strings.TrimSpace(*db.SAMLPublicBaseURL), "/")
+	}
+	if db.SAMLSPEntityID != nil && strings.TrimSpace(*db.SAMLSPEntityID) != "" {
+		out.SAMLSPEntityID = strings.TrimSpace(*db.SAMLSPEntityID)
+	}
+	if db.SAMLSPX509PEM != nil && strings.TrimSpace(*db.SAMLSPX509PEM) != "" {
+		out.SAMLSPX509PEM = strings.TrimSpace(*db.SAMLSPX509PEM)
+	}
+	if db.SAMLSPPrivateKeyPEM != nil && strings.TrimSpace(*db.SAMLSPPrivateKeyPEM) != "" {
+		out.SAMLSPPrivateKeyPEM = strings.TrimSpace(*db.SAMLSPPrivateKeyPEM)
+	}
+	if db.AnnotationEnabled != nil {
+		out.AnnotationEnabled = *db.AnnotationEnabled
+	}
+	if db.FeedbackMediaEnabled != nil {
+		out.FeedbackMediaEnabled = *db.FeedbackMediaEnabled
+	}
+	if db.BlindGradingEnabled != nil {
+		out.BlindGradingEnabled = *db.BlindGradingEnabled
+	}
+	if db.ModeratedGradingEnabled != nil {
+		out.ModeratedGradingEnabled = *db.ModeratedGradingEnabled
+	}
+	if db.OriginalityDetectionEnabled != nil {
+		out.OriginalityDetectionEnabled = *db.OriginalityDetectionEnabled
+	}
+	if db.OriginalityStubExternal != nil {
+		out.OriginalityStubExternal = *db.OriginalityStubExternal
+	}
+	if db.GradePostingPoliciesEnabled != nil {
+		out.GradePostingPoliciesEnabled = *db.GradePostingPoliciesEnabled
+	}
+	if db.GradebookCSVEnabled != nil {
+		out.GradebookCSVEnabled = *db.GradebookCSVEnabled
+	}
+	if db.ResubmissionWorkflowEnabled != nil {
+		out.ResubmissionWorkflowEnabled = *db.ResubmissionWorkflowEnabled
+	}
+	if db.LTIEnabled != nil {
+		out.LTIEnabled = *db.LTIEnabled
+	}
+	if db.OneRosterEnabled != nil {
+		out.OneRosterEnabled = *db.OneRosterEnabled
+	}
+	return out
+}
+
+// Source describes whether the effective value came from the DB row or the environment.
+type Source string
+
+const (
+	SourceEnvironment Source = "environment"
+	SourceDatabase    Source = "database"
+)
+
+// Sources indicates which layer won for mergeable fields (for admin transparency).
+type Sources struct {
+	OpenRouterAPIKey Source
+
+	SAMLSSOEnabled      Source
+	SAMLPublicBaseURL   Source
+	SAMLSPEntityID      Source
+	SAMLSPX509PEM       Source
+	SAMLSPPrivateKeyPEM Source
+
+	AnnotationEnabled           Source
+	FeedbackMediaEnabled        Source
+	BlindGradingEnabled         Source
+	ModeratedGradingEnabled     Source
+	OriginalityDetectionEnabled Source
+	OriginalityStubExternal     Source
+	GradePostingPoliciesEnabled Source
+	GradebookCSVEnabled         Source
+	ResubmissionWorkflowEnabled Source
+	LTIEnabled                  Source
+	OneRosterEnabled            Source
+}
+
+// ResolveSources compares env vs DB row to label each field.
+func ResolveSources(env config.Config, db *Row) Sources {
+	var s Sources
+	if db == nil {
+		return sourcesAllEnvironment(env)
+	}
+	s.OpenRouterAPIKey = sourceString(env.OpenRouterAPIKey, db.OpenRouterAPIKey)
+	s.SAMLSSOEnabled = sourceBool(env.SAMLSSOEnabled, db.SAMLSSOEnabled)
+	s.SAMLPublicBaseURL = sourceString(env.SAMLPublicBaseURL, db.SAMLPublicBaseURL)
+	s.SAMLSPEntityID = sourceString(env.SAMLSPEntityID, db.SAMLSPEntityID)
+	s.SAMLSPX509PEM = sourceString(env.SAMLSPX509PEM, db.SAMLSPX509PEM)
+	s.SAMLSPPrivateKeyPEM = sourceString(env.SAMLSPPrivateKeyPEM, db.SAMLSPPrivateKeyPEM)
+	s.AnnotationEnabled = sourceBool(env.AnnotationEnabled, db.AnnotationEnabled)
+	s.FeedbackMediaEnabled = sourceBool(env.FeedbackMediaEnabled, db.FeedbackMediaEnabled)
+	s.BlindGradingEnabled = sourceBool(env.BlindGradingEnabled, db.BlindGradingEnabled)
+	s.ModeratedGradingEnabled = sourceBool(env.ModeratedGradingEnabled, db.ModeratedGradingEnabled)
+	s.OriginalityDetectionEnabled = sourceBool(env.OriginalityDetectionEnabled, db.OriginalityDetectionEnabled)
+	s.OriginalityStubExternal = sourceBool(env.OriginalityStubExternal, db.OriginalityStubExternal)
+	s.GradePostingPoliciesEnabled = sourceBool(env.GradePostingPoliciesEnabled, db.GradePostingPoliciesEnabled)
+	s.GradebookCSVEnabled = sourceBool(env.GradebookCSVEnabled, db.GradebookCSVEnabled)
+	s.ResubmissionWorkflowEnabled = sourceBool(env.ResubmissionWorkflowEnabled, db.ResubmissionWorkflowEnabled)
+	s.LTIEnabled = sourceBool(env.LTIEnabled, db.LTIEnabled)
+	s.OneRosterEnabled = sourceBool(env.OneRosterEnabled, db.OneRosterEnabled)
+	return s
+}
+
+func sourcesAllEnvironment(env config.Config) Sources {
+	_ = env
+	return Sources{
+		OpenRouterAPIKey:            SourceEnvironment,
+		SAMLSSOEnabled:              SourceEnvironment,
+		SAMLPublicBaseURL:           SourceEnvironment,
+		SAMLSPEntityID:              SourceEnvironment,
+		SAMLSPX509PEM:               SourceEnvironment,
+		SAMLSPPrivateKeyPEM:         SourceEnvironment,
+		AnnotationEnabled:           SourceEnvironment,
+		FeedbackMediaEnabled:        SourceEnvironment,
+		BlindGradingEnabled:         SourceEnvironment,
+		ModeratedGradingEnabled:     SourceEnvironment,
+		OriginalityDetectionEnabled: SourceEnvironment,
+		OriginalityStubExternal:     SourceEnvironment,
+		GradePostingPoliciesEnabled: SourceEnvironment,
+		GradebookCSVEnabled:         SourceEnvironment,
+		ResubmissionWorkflowEnabled: SourceEnvironment,
+		LTIEnabled:                  SourceEnvironment,
+		OneRosterEnabled:            SourceEnvironment,
+	}
+}
+
+func sourceString(envVal string, dbPtr *string) Source {
+	if dbPtr != nil {
+		if strings.TrimSpace(*dbPtr) != "" {
+			return SourceDatabase
+		}
+	}
+	return SourceEnvironment
+}
+
+func sourceBool(envVal bool, dbPtr *bool) Source {
+	if dbPtr != nil {
+		return SourceDatabase
+	}
+	return SourceEnvironment
+}

--- a/server-new/migrations/118_platform_app_settings.sql
+++ b/server-new/migrations/118_platform_app_settings.sql
@@ -1,0 +1,30 @@
+-- Singleton platform application settings (OpenRouter, SAML SP material, feature flags).
+-- Values override process environment when set; see internal/repos/platformconfig.
+CREATE TABLE IF NOT EXISTS settings.platform_app_settings (
+    id SMALLINT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+
+    openrouter_api_key TEXT,
+
+    saml_sso_enabled BOOLEAN,
+    saml_public_base_url TEXT,
+    saml_sp_entity_id TEXT,
+    saml_sp_x509_pem TEXT,
+    saml_sp_private_key_pem TEXT,
+
+    annotation_enabled BOOLEAN,
+    feedback_media_enabled BOOLEAN,
+    blind_grading_enabled BOOLEAN,
+    moderated_grading_enabled BOOLEAN,
+    originality_detection_enabled BOOLEAN,
+    originality_stub_external BOOLEAN,
+    grade_posting_policies_enabled BOOLEAN,
+    gradebook_csv_enabled BOOLEAN,
+    resubmission_workflow_enabled BOOLEAN,
+    lti_enabled BOOLEAN,
+    oneroster_enabled BOOLEAN,
+
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO settings.platform_app_settings (id) VALUES (1)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds database-backed **global platform settings** so administrators can configure OpenRouter, SAML service-provider material, and platform-wide feature flags from the LMS UI instead of relying only on process environment variables.

## Backend

- New migration `118_platform_app_settings.sql`: singleton table `settings.platform_app_settings`.
- At startup, env config is merged with the DB row and validated (same rules as env-only startup).
- If **`RUN_MIGRATIONS=false`** and the platform settings table does not exist yet (e.g. integration tests that skip migrations against an empty DB), startup treats that as **no DB overrides** instead of failing with “relation does not exist”.
- Introduces `platformstate.Platform` to hold the effective merged `config.Config` and reloadable OpenRouter client after PUT saves.
- New authenticated APIs (same permission as other admin settings): `GET /api/v1/settings/platform` and `PUT /api/v1/settings/platform` (`global:app:rbac:manage`). Responses mask secrets and include `sources` (`environment` vs `database`) per field.
- HTTP handlers that depended on `Deps.Config` now use merged effective config via `effectiveConfig()` so SAML, LTI, OneRoster gates, course flags, etc. respect DB overrides without restart after save.

## Frontend

- **Settings → Global platform** (`/settings/platform`) under System Settings, gated by `PERM_RBAC_MANAGE`.
- Form sections: OpenRouter API key, SAML SP toggles and PEM fields, platform feature flags (annotations, grading, originality, LTI, OneRoster, etc.).
- Clearing the OpenRouter field when the effective source was database sends `clearOpenRouterApiKey` to drop the DB override and fall back to the environment key.

## Demo / screenshots

Global platform form (masked secrets; Database vs Environment badges):

[Global platform settings demo](https://cursor.com/agents/bc-2e31944b-8969-52e7-9e6d-7814f01587ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fglobal-platform-settings-demo.png)

Settings sidebar entry under System Settings:

[Settings nav — Global platform](https://cursor.com/agents/bc-2e31944b-8969-52e7-9e6d-7814f01587ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsettings-nav-global-platform.png)

## Testing

- `go test ./...` (server-new)
- `npm test` (clients/web)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://lextures.slack.com/archives/D0B0KS3A9LM/p1777499975194459?thread_ts=1777499975.194459&cid=D0B0KS3A9LM)

<div><a href="https://cursor.com/agents/bc-2e31944b-8969-52e7-9e6d-7814f01587ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e31944b-8969-52e7-9e6d-7814f01587ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

