### PR TITLE
Clever and ClassLink K-12 OIDC Instant Login

### DIFF
--- a/clients/web/src/components/oidc-sign-in-buttons.tsx
+++ b/clients/web/src/components/oidc-sign-in-buttons.tsx
@@ -6,6 +6,8 @@ type OidcStatus = {
   google?: boolean
   microsoft?: boolean
   apple?: boolean
+  clever?: boolean
+  classlink?: boolean
   custom?: { id: string; displayName: string }[]
 }
 
@@ -71,6 +73,24 @@ export function OidcSignInButtons({ nextPath }: Props) {
           aria-label="Sign in with Apple"
         >
           Sign in with Apple
+        </a>
+      )}
+      {s.clever && (
+        <a
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-[#436CF2] bg-[#436CF2] px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-[#3558d4]"
+          href={p('/auth/oidc/clever/login')}
+          aria-label="Sign in using your Clever account"
+        >
+          Log in with Clever
+        </a>
+      )}
+      {s.classlink && (
+        <a
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-[#0B5FFF] bg-[#0B5FFF] px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-[#094bcc]"
+          href={p('/auth/oidc/classlink/login')}
+          aria-label="Sign in using your ClassLink account"
+        >
+          Log in with ClassLink
         </a>
       )}
       {s.custom?.map((c) => (

--- a/clients/web/src/pages/__tests__/login.test.tsx
+++ b/clients/web/src/pages/__tests__/login.test.tsx
@@ -61,6 +61,26 @@ describe('Login', () => {
     })
   })
 
+  it('shows Log in with Clever when the API reports Clever SSO is available', async () => {
+    server.use(
+      http.get('http://localhost:8080/api/v1/auth/oidc/status', () =>
+        HttpResponse.json({
+          enabled: true,
+          clever: true,
+          classlink: false,
+        }),
+      ),
+    )
+
+    renderWithRouter(<Login />, { route: '/login', path: '/login' })
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: /sign in using your clever account/i }),
+      ).toBeInTheDocument()
+    })
+  })
+
   it('shows a friendly error when the request fails at the network layer', async () => {
     server.use(
       http.post('http://localhost:8080/api/v1/auth/login', () => HttpResponse.error()),

--- a/docs/completed/4.4-clever-classlink.md
+++ b/docs/completed/4.4-clever-classlink.md
@@ -1,6 +1,8 @@
 # 4.4 — Clever / ClassLink
 
 > Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §4.4.
+>
+> **Shipped in repo:** Clever and ClassLink OIDC Instant Login via `/auth/oidc/clever|classlink/*`, env `CLEVER_*` / `CLASSLINK_*`, DB migration `120_clever_classlink_sso.sql`, login UI buttons, Clever `/v3.0/me` for email/role/COPPA. Clever Secure Sync and ClassLink OneRoster remain future work.
 
 ## Metadata
 
@@ -10,7 +12,7 @@
 | **Section** | Identity, SSO & Provisioning |
 | **Severity** | BLOCKER |
 | **Markets** | K12 |
-| **Status (today)** | MISSING |
+| **Status (today)** | SHIPPED (Instant Login + JIT fields; Secure Sync / roster TBD) |
 | **Estimated effort** | M (2–4 w) |
 | **Owner (proposed)** | Platform / Integrations team |
 | **Depends on** | 4.2 OIDC SSO (Clever uses OIDC), 4.3 OneRoster 1.2 (Clever delivers roster via OneRoster) |
@@ -178,4 +180,4 @@ Not applicable.
 - ClassLink Developer Documentation: https://www.classlink.com/developers
 - Clever Instant Login (OIDC): https://dev.clever.com/reference/oauth
 - COPPA 16 CFR Part 312; FERPA 34 CFR Part 99.
-- Related plans: `4.2-oidc-sso.md`, [`4.3-oneroster-1-2.md`](../../completed/4.3-oneroster-1-2.md) (complete).
+- Related plans: `4.2-oidc-sso.md`, [`4.3-oneroster-1-2.md`](./4.3-oneroster-1-2.md) (complete).

--- a/scripts/capture-k12-login-demo.sh
+++ b/scripts/capture-k12-login-demo.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Capture login page with Clever/ClassLink buttons (K-12 SSO demo).
+# Requires: clients/web/dist built with VITE_API_URL=http://127.0.0.1:9777, demo server script, Xvfb, ffmpeg, google-chrome.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEMO_PORT="${DEMO_PORT:-9777}"
+DISPLAY_NUM="${DISPLAY_NUM:-199}"
+export DISPLAY=":${DISPLAY_NUM}"
+SHOT="/opt/cursor/artifacts/screenshots/k12-login-clever-classlink.png"
+VID="/opt/cursor/artifacts/recordings/k12-login-clever-classlink-demo.mp4"
+
+mkdir -p "$(dirname "$SHOT")" "$(dirname "$VID")"
+
+node "$ROOT/scripts/k12-login-demo-server.mjs" "$DEMO_PORT" &
+DEMO_PID=$!
+cleanup() {
+  kill "$DEMO_PID" 2>/dev/null || true
+  kill "$XVFB_PID" 2>/dev/null || true
+  kill "$FF_PID" 2>/dev/null || true
+  kill "$CHROME_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for i in $(seq 1 50); do
+  if curl -fsS "http://127.0.0.1:${DEMO_PORT}/login" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+
+Xvfb ":${DISPLAY_NUM}" -screen 0 1280x900x24 &
+XVFB_PID=$!
+sleep 0.5
+
+ffmpeg -y -nostdin -f x11grab -video_size 1280x900 -draw_mouse 0 -i "${DISPLAY}.0" -t 12 -r 12 -pix_fmt yuv420p "$VID" &
+FF_PID=$!
+
+sleep 1
+google-chrome --no-sandbox --disable-gpu --disable-dev-shm-usage \
+  --window-size=1280,900 \
+  --app="http://127.0.0.1:${DEMO_PORT}/login" &
+CHROME_PID=$!
+
+sleep 9
+kill "$CHROME_PID" 2>/dev/null || true
+wait "$FF_PID" 2>/dev/null || true
+
+timeout 25 google-chrome --no-sandbox --disable-gpu --headless=new \
+  --window-size=1280,900 \
+  --screenshot="$SHOT" \
+  "http://127.0.0.1:${DEMO_PORT}/login" || true
+
+ls -la "$SHOT" "$VID"

--- a/scripts/k12-login-demo-server.mjs
+++ b/scripts/k12-login-demo-server.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Serves the Vite production build with mocked /api/v1/auth/* endpoints
+ * so the Clever / ClassLink login buttons can be shown without a real API.
+ * Usage: node scripts/k12-login-demo-server.mjs [port]
+ */
+import http from 'node:http'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const root = path.join(__dirname, '..', 'clients', 'web', 'dist')
+const port = Number(process.argv[2] || 9777)
+
+const mime = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+  '.json': 'application/json; charset=utf-8',
+  '.woff2': 'font/woff2',
+}
+
+function sendFile(res, filePath) {
+  const ext = path.extname(filePath)
+  res.setHeader('Content-Type', mime[ext] || 'application/octet-stream')
+  fs.createReadStream(filePath).pipe(res)
+}
+
+const server = http.createServer((req, res) => {
+  const u = new URL(req.url || '/', `http://127.0.0.1`)
+  if (u.pathname === '/api/v1/auth/oidc/status') {
+    res.setHeader('Content-Type', 'application/json; charset=utf-8')
+    res.end(
+      JSON.stringify({
+        enabled: true,
+        apiBase: `http://127.0.0.1:${port}`,
+        clever: true,
+        classlink: true,
+        google: false,
+        microsoft: false,
+        apple: false,
+        custom: [],
+      }),
+    )
+    return
+  }
+  if (u.pathname === '/api/v1/auth/saml/status') {
+    res.setHeader('Content-Type', 'application/json; charset=utf-8')
+    res.end(JSON.stringify({ enabled: false }))
+    return
+  }
+
+  let rel = u.pathname === '/' ? '/index.html' : u.pathname
+  if (rel.includes('..')) {
+    res.writeHead(400)
+    res.end()
+    return
+  }
+  let filePath = path.join(root, rel)
+  if (!fs.existsSync(filePath) || fs.statSync(filePath).isDirectory()) {
+    filePath = path.join(root, 'index.html')
+  }
+  if (!fs.existsSync(filePath)) {
+    res.writeHead(404)
+    res.end('dist not found — run: cd clients/web && VITE_API_URL=/api npm run build')
+    return
+  }
+  sendFile(res, filePath)
+})
+
+server.listen(port, '127.0.0.1', () => {
+  // eslint-disable-next-line no-console
+  console.log(`k12 demo http://127.0.0.1:${port}/login`)
+})

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -72,6 +72,13 @@ type Config struct {
 	OIDCAppleKeyID            string
 	OIDCApplePrivateKeyPEM    string
 
+	CleverSSOEnabled         bool
+	CleverOIDCClientID       string
+	CleverOIDCClientSecret   string
+	ClassLinkSSOEnabled      bool
+	ClassLinkOIDCClientID    string
+	ClassLinkOIDCClientSecret string
+
 	OneRosterEnabled             bool
 	OneRosterBearerFallbackToken string
 	OneRosterBearerFallbackInst  string // UUID string; used with fallback token when DB has no match
@@ -157,6 +164,13 @@ func Load() Config {
 		OIDCAppleKeyID:            firstNonEmptyTrimmed("OIDC_APPLE_KEY_ID"),
 		OIDCApplePrivateKeyPEM:    firstNonEmptyTrimmedOrFile("OIDC_APPLE_PRIVATE_KEY_PEM", "OIDC_APPLE_PRIVATE_KEY_PATH"),
 
+		CleverSSOEnabled:          boolEnv("CLEVER_SSO_ENABLED"),
+		CleverOIDCClientID:      firstNonEmptyTrimmed("CLEVER_OIDC_CLIENT_ID"),
+		CleverOIDCClientSecret:  firstNonEmptyTrimmed("CLEVER_OIDC_CLIENT_SECRET"),
+		ClassLinkSSOEnabled:     boolEnv("CLASSLINK_SSO_ENABLED"),
+		ClassLinkOIDCClientID:   firstNonEmptyTrimmed("CLASSLINK_OIDC_CLIENT_ID"),
+		ClassLinkOIDCClientSecret: firstNonEmptyTrimmed("CLASSLINK_OIDC_CLIENT_SECRET"),
+
 		OneRosterEnabled:             boolEnv("ONEROSTER_ENABLED"),
 		OneRosterBearerFallbackToken: firstNonEmptyTrimmed("ONEROSTER_BEARER_FALLBACK_TOKEN"),
 		OneRosterBearerFallbackInst:  strings.TrimSpace(os.Getenv("ONEROSTER_BEARER_FALLBACK_INSTITUTION_ID")),
@@ -179,6 +193,16 @@ func (c Config) OIDCAppleConfigured() bool {
 		strings.TrimSpace(c.OIDCAppleTeamID) != "" &&
 		strings.TrimSpace(c.OIDCAppleKeyID) != "" &&
 		strings.TrimSpace(c.OIDCApplePrivateKeyPEM) != ""
+}
+
+// CleverOIDCConfigured is true when Clever Instant Login client credentials are present.
+func (c Config) CleverOIDCConfigured() bool {
+	return strings.TrimSpace(c.CleverOIDCClientID) != "" && strings.TrimSpace(c.CleverOIDCClientSecret) != ""
+}
+
+// ClassLinkOIDCConfigured is true when ClassLink OIDC client credentials are present.
+func (c Config) ClassLinkOIDCConfigured() bool {
+	return strings.TrimSpace(c.ClassLinkOIDCClientID) != "" && strings.TrimSpace(c.ClassLinkOIDCClientSecret) != ""
 }
 
 // Validate returns an error if required values are missing for a full server start.

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -39,6 +39,12 @@ var configEnvKeys = []string{
 	"OIDC_MICROSOFT_TENANT",
 	"OIDC_PUBLIC_BASE_URL",
 	"OIDC_SSO_ENABLED",
+	"CLEVER_SSO_ENABLED",
+	"CLEVER_OIDC_CLIENT_ID",
+	"CLEVER_OIDC_CLIENT_SECRET",
+	"CLASSLINK_SSO_ENABLED",
+	"CLASSLINK_OIDC_CLIENT_ID",
+	"CLASSLINK_OIDC_CLIENT_SECRET",
 	"OPEN_ROUTER_API_KEY",
 	"OPENROUTER_API_KEY",
 	"ORIGINALITY_DETECTION_ENABLED",
@@ -317,5 +323,11 @@ func TestOIDCProviderConfiguredHelpers(t *testing.T) {
 	}
 	if (Config{OIDCAppleClientID: "a"}).OIDCAppleConfigured() != false {
 		t.Fatal("expected apple false")
+	}
+	if (Config{CleverOIDCClientID: "a", CleverOIDCClientSecret: "b"}).CleverOIDCConfigured() != true {
+		t.Fatal("expected clever true")
+	}
+	if (Config{ClassLinkOIDCClientID: "a", ClassLinkOIDCClientSecret: "b"}).ClassLinkOIDCConfigured() != true {
+		t.Fatal("expected classlink true")
 	}
 }

--- a/server/internal/httpserver/auth.go
+++ b/server/internal/httpserver/auth.go
@@ -265,8 +265,8 @@ func (d Deps) handleOIDCLink() http.HandlerFunc {
 			return
 		}
 		if !d.effectiveConfig().OIDCSSOEnabled &&
-			!(d.effectiveConfig().CleverSSOEnabled && d.effectiveConfig().CleverOIDCConfigured()) &&
-			!(d.effectiveConfig().ClassLinkSSOEnabled && d.effectiveConfig().ClassLinkOIDCConfigured()) {
+			(!d.effectiveConfig().CleverSSOEnabled || !d.effectiveConfig().CleverOIDCConfigured()) &&
+			(!d.effectiveConfig().ClassLinkSSOEnabled || !d.effectiveConfig().ClassLinkOIDCConfigured()) {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "OpenID Connect is not enabled on this server.")
 			return
 		}

--- a/server/internal/httpserver/auth.go
+++ b/server/internal/httpserver/auth.go
@@ -186,7 +186,10 @@ func (d Deps) handleOIDCStatus() http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		if !d.effectiveConfig().OIDCSSOEnabled {
+		oidcOn := d.effectiveConfig().OIDCSSOEnabled
+		cleverOn := d.effectiveConfig().CleverSSOEnabled && d.effectiveConfig().CleverOIDCConfigured()
+		classOn := d.effectiveConfig().ClassLinkSSOEnabled && d.effectiveConfig().ClassLinkOIDCConfigured()
+		if !oidcOn && !cleverOn && !classOn {
 			_, _ = w.Write([]byte(`{"enabled":false,"providers":[],"custom":[]}`))
 			return
 		}
@@ -209,18 +212,22 @@ func (d Deps) handleOIDCStatus() http.HandlerFunc {
 		}
 		base := strings.TrimRight(d.effectiveConfig().OIDCPublicBaseURL, "/")
 		_ = json.NewEncoder(w).Encode(struct {
-			Enabled   bool         `json:"enabled"`
-			APIBase   string       `json:"apiBase"`
-			Google    bool         `json:"google"`
-			Microsoft bool         `json:"microsoft"`
-			Apple     bool         `json:"apple"`
-			Custom    []customInfo `json:"custom"`
+			Enabled    bool         `json:"enabled"`
+			APIBase    string       `json:"apiBase"`
+			Google     bool         `json:"google"`
+			Microsoft  bool         `json:"microsoft"`
+			Apple      bool         `json:"apple"`
+			Clever     bool         `json:"clever"`
+			ClassLink  bool         `json:"classlink"`
+			Custom     []customInfo `json:"custom"`
 		}{
 			Enabled:   true,
 			APIBase:   base,
-			Google:    d.effectiveConfig().OIDCGoogleConfigured(),
-			Microsoft: d.effectiveConfig().OIDCMicrosoftConfigured(),
-			Apple:     d.effectiveConfig().OIDCAppleConfigured(),
+			Google:    oidcOn && d.effectiveConfig().OIDCGoogleConfigured(),
+			Microsoft: oidcOn && d.effectiveConfig().OIDCMicrosoftConfigured(),
+			Apple:     oidcOn && d.effectiveConfig().OIDCAppleConfigured(),
+			Clever:    cleverOn,
+			ClassLink: classOn,
 			Custom:    custom,
 		})
 	}
@@ -257,7 +264,9 @@ func (d Deps) handleOIDCLink() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
 			return
 		}
-		if !d.effectiveConfig().OIDCSSOEnabled {
+		if !d.effectiveConfig().OIDCSSOEnabled &&
+			!(d.effectiveConfig().CleverSSOEnabled && d.effectiveConfig().CleverOIDCConfigured()) &&
+			!(d.effectiveConfig().ClassLinkSSOEnabled && d.effectiveConfig().ClassLinkOIDCConfigured()) {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "OpenID Connect is not enabled on this server.")
 			return
 		}
@@ -266,8 +275,22 @@ func (d Deps) handleOIDCLink() http.HandlerFunc {
 			return
 		}
 		p := strings.TrimSpace(strings.ToLower(b.Provider))
-		if p != "google" && p != "microsoft" && p != "apple" && p != "custom" {
+		if p != "google" && p != "microsoft" && p != "apple" && p != "custom" && p != "clever" && p != "classlink" {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Unknown OIDC provider.")
+			return
+		}
+		if p == "google" || p == "microsoft" || p == "apple" || p == "custom" {
+			if !d.effectiveConfig().OIDCSSOEnabled {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "OpenID Connect is not enabled on this server.")
+				return
+			}
+		}
+		if p == "clever" && (!d.effectiveConfig().CleverSSOEnabled || !d.effectiveConfig().CleverOIDCConfigured()) {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Clever sign-in is not configured on this server.")
+			return
+		}
+		if p == "classlink" && (!d.effectiveConfig().ClassLinkSSOEnabled || !d.effectiveConfig().ClassLinkOIDCConfigured()) {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "ClassLink sign-in is not configured on this server.")
 			return
 		}
 		var customID *uuid.UUID

--- a/server/internal/repos/user/k12_profile.go
+++ b/server/internal/repos/user/k12_profile.go
@@ -1,0 +1,85 @@
+package user
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// FindByCleverID returns a user with the given Clever user id, or nil.
+func FindByCleverID(ctx context.Context, pool *pgxpool.Pool, cleverID string) (*Row, error) {
+	cleverID = strings.TrimSpace(cleverID)
+	if cleverID == "" {
+		return nil, nil
+	}
+	const q = `SELECT id::text, email, password_hash, display_name, first_name, last_name, avatar_url, ui_theme, sid,
+       login_blocked, deactivated_at
+FROM "user".users WHERE clever_id = $1`
+	return scanUserRow(ctx, pool, q, cleverID)
+}
+
+// FindByClassLinkID returns a user with the given ClassLink sourced id, or nil.
+func FindByClassLinkID(ctx context.Context, pool *pgxpool.Pool, classlinkID string) (*Row, error) {
+	classlinkID = strings.TrimSpace(classlinkID)
+	if classlinkID == "" {
+		return nil, nil
+	}
+	const q = `SELECT id::text, email, password_hash, display_name, first_name, last_name, avatar_url, ui_theme, sid,
+       login_blocked, deactivated_at
+FROM "user".users WHERE classlink_id = $1`
+	return scanUserRow(ctx, pool, q, classlinkID)
+}
+
+// UpdateK12ProfileAfterOIDC sets Clever/ClassLink identifiers, COPPA minor flag, and optional names after SSO.
+func UpdateK12ProfileAfterOIDC(
+	ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID,
+	cleverID, classLinkID *string, isMinor bool, givenName, familyName *string, connectedVia string,
+) error {
+	cv := (*string)(nil)
+	if cleverID != nil {
+		s := strings.TrimSpace(*cleverID)
+		if s != "" {
+			cv = &s
+		}
+	}
+	cl := (*string)(nil)
+	if classLinkID != nil {
+		s := strings.TrimSpace(*classLinkID)
+		if s != "" {
+			cl = &s
+		}
+	}
+	fn := (*string)(nil)
+	if givenName != nil {
+		s := strings.TrimSpace(*givenName)
+		if s != "" {
+			fn = &s
+		}
+	}
+	ln := (*string)(nil)
+	if familyName != nil {
+		s := strings.TrimSpace(*familyName)
+		if s != "" {
+			ln = &s
+		}
+	}
+	cvVia := strings.TrimSpace(connectedVia)
+	cvViaArg := any(nil)
+	if cvVia != "" {
+		cvViaArg = cvVia
+	}
+	_, err := pool.Exec(ctx, `
+UPDATE "user".users SET
+  clever_id = COALESCE($2, clever_id),
+  classlink_id = COALESCE($3, classlink_id),
+  is_minor = is_minor OR $4,
+  connected_via = COALESCE(connected_via, $5::text),
+  first_name = COALESCE($6, first_name),
+  last_name = COALESCE($7, last_name)
+WHERE id = $1`,
+		userID, cv, cl, isMinor, cvViaArg, fn, ln,
+	)
+	return err
+}

--- a/server/internal/repos/user/user.go
+++ b/server/internal/repos/user/user.go
@@ -41,10 +41,14 @@ func FindByEmail(ctx context.Context, pool *pgxpool.Pool, email string) (*Row, e
 	const q = `SELECT id::text, email, password_hash, display_name, first_name, last_name, avatar_url, ui_theme, sid,
        login_blocked, deactivated_at
 FROM "user".users WHERE email = $1`
+	return scanUserRow(ctx, pool, q, email)
+}
+
+func scanUserRow(ctx context.Context, pool *pgxpool.Pool, query string, arg any) (*Row, error) {
 	var r Row
 	var displayName, firstName, lastName, avatar, sid sql.NullString
 	var deactivatedAt sql.NullTime
-	err := pool.QueryRow(ctx, q, email).Scan(
+	err := pool.QueryRow(ctx, query, arg).Scan(
 		&r.ID, &r.Email, &r.PasswordHash, &displayName, &firstName, &lastName, &avatar, &r.UITheme, &sid,
 		&r.LoginBlocked, &deactivatedAt,
 	)
@@ -71,29 +75,7 @@ func FindByID(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID) (*Row, erro
 	const q = `SELECT id::text, email, password_hash, display_name, first_name, last_name, avatar_url, ui_theme, sid,
        login_blocked, deactivated_at
 FROM "user".users WHERE id = $1`
-	var r Row
-	var displayName, firstName, lastName, avatar, sid sql.NullString
-	var deactivatedAt sql.NullTime
-	err := pool.QueryRow(ctx, q, id).Scan(
-		&r.ID, &r.Email, &r.PasswordHash, &displayName, &firstName, &lastName, &avatar, &r.UITheme, &sid,
-		&r.LoginBlocked, &deactivatedAt,
-	)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	r.DisplayName = strPtr(displayName)
-	r.FirstName = strPtr(firstName)
-	r.LastName = strPtr(lastName)
-	r.AvatarURL = strPtr(avatar)
-	r.Sid = strPtr(sid)
-	if deactivatedAt.Valid {
-		t := deactivatedAt.Time
-		r.DeactivatedAt = &t
-	}
-	return &r, nil
+	return scanUserRow(ctx, pool, q, id)
 }
 
 // InsertUser creates a new user; email must be normalized. Returns the full row.
@@ -151,27 +133,5 @@ func FindByEmailCI(ctx context.Context, pool *pgxpool.Pool, email string) (*Row,
 	const q = `SELECT id::text, email, password_hash, display_name, first_name, last_name, avatar_url, ui_theme, sid,
        login_blocked, deactivated_at
 FROM "user".users WHERE lower(email) = lower($1)`
-	var r Row
-	var displayName, firstName, lastName, avatar, sid sql.NullString
-	var deactivatedAt sql.NullTime
-	err := pool.QueryRow(ctx, q, em).Scan(
-		&r.ID, &r.Email, &r.PasswordHash, &displayName, &firstName, &lastName, &avatar, &r.UITheme, &sid,
-		&r.LoginBlocked, &deactivatedAt,
-	)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	r.DisplayName = strPtr(displayName)
-	r.FirstName = strPtr(firstName)
-	r.LastName = strPtr(lastName)
-	r.AvatarURL = strPtr(avatar)
-	r.Sid = strPtr(sid)
-	if deactivatedAt.Valid {
-		t := deactivatedAt.Time
-		r.DeactivatedAt = &t
-	}
-	return &r, nil
+	return scanUserRow(ctx, pool, q, em)
 }

--- a/server/internal/service/oidcauth/k12_login.go
+++ b/server/internal/service/oidcauth/k12_login.go
@@ -1,0 +1,284 @@
+package oidcauth
+
+import (
+	"context"
+	"strings"
+
+	oidc "github.com/coreos/go-oidc/v3/oidc"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/oauth2"
+
+	pauth "github.com/lextures/lextures/server/internal/auth"
+	oidcrepo "github.com/lextures/lextures/server/internal/repos/oidc"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+	"github.com/lextures/lextures/server/internal/repos/user"
+	"github.com/lextures/lextures/server/internal/service/authservice"
+)
+
+func (s *Service) oidcFlowAllowed(pathProvider string) bool {
+	pv := strings.ToLower(strings.TrimSpace(pathProvider))
+	if s.Cfg.OIDCSSOEnabled {
+		return true
+	}
+	if pv == "clever" && s.Cfg.CleverSSOEnabled {
+		return true
+	}
+	if pv == "classlink" && s.Cfg.ClassLinkSSOEnabled {
+		return true
+	}
+	return false
+}
+
+// completeK12OIDCLogin finishes Clever or ClassLink after the OAuth code exchange (no ID token required).
+func (s *Service) completeK12OIDCLogin(
+	ctx context.Context, pool *pgxpool.Pool, jwt *pauth.JWTSigner,
+	pv string, flow *oidcrepo.FlowStateRow,
+	prov *oidc.Provider, o2 oauth2.Config, tok *oauth2.Token,
+) (authservice.AuthResponse, *string, error) {
+	if tok == nil || strings.TrimSpace(tok.AccessToken) == "" {
+		return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "The identity provider did not return an access token."}
+	}
+	var emailIn, subj string
+	var roleName string
+	var cleverID, classlinkID *string
+	var isMinor bool
+	var givenName, familyName *string
+	connectedVia := pv
+
+	switch pv {
+	case "clever":
+		me, err := FetchCleverMe(ctx, s.HTTP, tok.AccessToken)
+		if err != nil {
+			return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "Could not load your Clever profile. Please try again."}
+		}
+		if strings.TrimSpace(me.UserID) == "" {
+			return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "Clever did not return a user id."}
+		}
+		em := user.NormalizeEmail(me.Email)
+		if em == "" || !strings.Contains(em, "@") {
+			return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "Clever did not return a usable email address."}
+		}
+		emailIn = em
+		subj = me.UserID
+		roleName = me.RoleName
+		isMinor = me.IsMinor
+		if me.GivenName != "" {
+			g := me.GivenName
+			givenName = &g
+		}
+		if me.FamilyName != "" {
+			f := me.FamilyName
+			familyName = &f
+		}
+		cid := me.UserID
+		cleverID = &cid
+	case "classlink":
+		ctxU := oidc.ClientContext(ctx, s.HTTP)
+		ui, err := prov.UserInfo(ctxU, oauth2.StaticTokenSource(tok))
+		if err != nil {
+			return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "Could not load your ClassLink profile. Please try again."}
+		}
+		var raw map[string]any
+		if err := ui.Claims(&raw); err != nil {
+			return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "Could not read ClassLink profile claims."}
+		}
+		cl := ParseClassLinkUserInfoClaims(raw)
+		em := user.NormalizeEmail(cl.Email)
+		if em == "" || !strings.Contains(em, "@") {
+			return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "ClassLink did not return a usable email address."}
+		}
+		emailIn = em
+		if strings.TrimSpace(cl.SourcedID) != "" {
+			subj = strings.TrimSpace(cl.SourcedID)
+		} else {
+			subj = "email:" + em
+		}
+		roleName = cl.RoleName
+		if cl.GivenName != "" {
+			g := cl.GivenName
+			givenName = &g
+		}
+		if cl.FamilyName != "" {
+			f := cl.FamilyName
+			familyName = &f
+		}
+		sid := strings.TrimSpace(cl.SourcedID)
+		if sid != "" {
+			classlinkID = &sid
+		}
+	default:
+		return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "Unknown K-12 provider."}
+	}
+	if roleName == "" {
+		roleName = "Student"
+	}
+
+	ident, err := oidcrepo.FindIdentityByProviderAndSub(ctx, pool, pv, subj)
+	if err != nil {
+		return authservice.AuthResponse{}, nil, err
+	}
+	if ident != nil {
+		u, err := user.FindByID(ctx, pool, ident.UserID)
+		if err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		if u == nil {
+			return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "User not found."}
+		}
+		uid, err := uuid.Parse(u.ID)
+		if err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		if err := user.UpdateK12ProfileAfterOIDC(ctx, pool, uid, cleverID, classlinkID, isMinor, givenName, familyName, connectedVia); err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		u2, err := user.FindByID(ctx, pool, uid)
+		if err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		if u2 == nil {
+			return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "User not found."}
+		}
+		res, err := authservice.AuthResponseForUser(jwt, u2)
+		if err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		return res, flow.NextPath, nil
+	}
+
+	if pv == "clever" && cleverID != nil {
+		if u, err := user.FindByCleverID(ctx, pool, *cleverID); err != nil {
+			return authservice.AuthResponse{}, nil, err
+		} else if u != nil {
+			return s.finishK12ExistingUser(ctx, pool, jwt, u, pv, subj, emailIn, cleverID, classlinkID, isMinor, givenName, familyName, connectedVia, flow.NextPath)
+		}
+	}
+	if pv == "classlink" && classlinkID != nil {
+		if u, err := user.FindByClassLinkID(ctx, pool, *classlinkID); err != nil {
+			return authservice.AuthResponse{}, nil, err
+		} else if u != nil {
+			return s.finishK12ExistingUser(ctx, pool, jwt, u, pv, subj, emailIn, cleverID, classlinkID, isMinor, givenName, familyName, connectedVia, flow.NextPath)
+		}
+	}
+
+	if flow.ForUserID != nil {
+		u, err := user.FindByID(ctx, pool, *flow.ForUserID)
+		if err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		if u == nil {
+			return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "User not found."}
+		}
+		if user.NormalizeEmail(u.Email) != emailIn {
+			return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "The signed-in account email does not match the account you are connecting."}
+		}
+		uid, err := uuid.Parse(u.ID)
+		if err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		if _, err := oidcrepo.TryInsertIdentity(ctx, pool, uid, pv, subj, &emailIn); err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		if err := user.UpdateK12ProfileAfterOIDC(ctx, pool, uid, cleverID, classlinkID, isMinor, givenName, familyName, connectedVia); err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		u2, err := user.FindByID(ctx, pool, uid)
+		if err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		res, err := authservice.AuthResponseForUser(jwt, u2)
+		if err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		return res, flow.NextPath, nil
+	}
+
+	if u, err := user.FindByEmail(ctx, pool, emailIn); err != nil {
+		return authservice.AuthResponse{}, nil, err
+	} else if u != nil {
+		uid, err := uuid.Parse(u.ID)
+		if err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		if _, err := oidcrepo.TryInsertIdentity(ctx, pool, uid, pv, subj, &emailIn); err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		if err := user.UpdateK12ProfileAfterOIDC(ctx, pool, uid, cleverID, classlinkID, isMinor, givenName, familyName, connectedVia); err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		u2, err := user.FindByID(ctx, pool, uid)
+		if err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		res, err := authservice.AuthResponseForUser(jwt, u2)
+		if err != nil {
+			return authservice.AuthResponse{}, nil, err
+		}
+		return res, flow.NextPath, nil
+	}
+
+	ph, err := authservice.PlaceholderPasswordHash()
+	if err != nil {
+		return authservice.AuthResponse{}, nil, err
+	}
+	nu, err := user.InsertUser(ctx, pool, emailIn, ph, nil)
+	if err != nil {
+		return authservice.AuthResponse{}, nil, err
+	}
+	uid, err := uuid.Parse(nu.ID)
+	if err != nil {
+		return authservice.AuthResponse{}, nil, err
+	}
+	if err := rbac.AssignUserRoleByName(ctx, pool, uid, roleName); err != nil {
+		return authservice.AuthResponse{}, nil, err
+	}
+	if _, err := oidcrepo.TryInsertIdentity(ctx, pool, uid, pv, subj, &emailIn); err != nil {
+		return authservice.AuthResponse{}, nil, err
+	}
+	if err := user.UpdateK12ProfileAfterOIDC(ctx, pool, uid, cleverID, classlinkID, isMinor, givenName, familyName, connectedVia); err != nil {
+		return authservice.AuthResponse{}, nil, err
+	}
+	u3, err := user.FindByID(ctx, pool, uid)
+	if err != nil {
+		return authservice.AuthResponse{}, nil, err
+	}
+	if u3 == nil {
+		return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "User not found."}
+	}
+	res, err := authservice.AuthResponseForUser(jwt, u3)
+	if err != nil {
+		return authservice.AuthResponse{}, nil, err
+	}
+	return res, flow.NextPath, nil
+}
+
+func (s *Service) finishK12ExistingUser(
+	ctx context.Context, pool *pgxpool.Pool, jwt *pauth.JWTSigner,
+	u *user.Row, pv, subj, emailIn string,
+	cleverID, classlinkID *string, isMinor bool, givenName, familyName *string, connectedVia string,
+	nextPath *string,
+) (authservice.AuthResponse, *string, error) {
+	uid, err := uuid.Parse(u.ID)
+	if err != nil {
+		return authservice.AuthResponse{}, nil, err
+	}
+	if _, err := oidcrepo.TryInsertIdentity(ctx, pool, uid, pv, subj, &emailIn); err != nil {
+		return authservice.AuthResponse{}, nil, err
+	}
+	if err := user.UpdateK12ProfileAfterOIDC(ctx, pool, uid, cleverID, classlinkID, isMinor, givenName, familyName, connectedVia); err != nil {
+		return authservice.AuthResponse{}, nil, err
+	}
+	u2, err := user.FindByID(ctx, pool, uid)
+	if err != nil {
+		return authservice.AuthResponse{}, nil, err
+	}
+	if u2 == nil {
+		return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "User not found."}
+	}
+	res, err := authservice.AuthResponseForUser(jwt, u2)
+	if err != nil {
+		return authservice.AuthResponse{}, nil, err
+	}
+	return res, nextPath, nil
+}

--- a/server/internal/service/oidcauth/k12_profiles.go
+++ b/server/internal/service/oidcauth/k12_profiles.go
@@ -60,7 +60,7 @@ func FetchCleverMe(ctx context.Context, hc *http.Client, accessToken string) (*C
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	body, err := io.ReadAll(io.LimitReader(res.Body, 1<<20))
 	if err != nil {
 		return nil, err

--- a/server/internal/service/oidcauth/k12_profiles.go
+++ b/server/internal/service/oidcauth/k12_profiles.go
@@ -1,0 +1,178 @@
+package oidcauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const cleverAPIBase = "https://api.clever.com"
+
+// CleverMeProfile holds fields from Clever API GET /v3.0/me used for JIT and COPPA.
+type CleverMeProfile struct {
+	UserID     string
+	Email      string
+	GivenName  string
+	FamilyName string
+	IsMinor    bool
+	RoleName   string // Student, Teacher, or TA for rbac.AssignUserRoleByName
+}
+
+type cleverMeEnvelope struct {
+	Data *struct {
+		ID   string          `json:"id"`
+		Data json.RawMessage `json:"data"`
+	} `json:"data"`
+}
+
+type cleverUserData struct {
+	Email      string `json:"email"`
+	Name       *struct {
+		First string `json:"first"`
+		Last  string `json:"last"`
+	} `json:"name"`
+	Roles *struct {
+		Student       json.RawMessage `json:"student"`
+		Teacher       json.RawMessage `json:"teacher"`
+		Staff         json.RawMessage `json:"staff"`
+		DistrictAdmin json.RawMessage `json:"district_admin"`
+	} `json:"roles"`
+}
+
+// FetchCleverMe calls Clever's /v3.0/me with a bearer access token (Instant Login).
+func FetchCleverMe(ctx context.Context, hc *http.Client, accessToken string) (*CleverMeProfile, error) {
+	tok := strings.TrimSpace(accessToken)
+	if tok == "" {
+		return nil, fmt.Errorf("clever: missing access token")
+	}
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cleverAPIBase+"/v3.0/me", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+	res, err := hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("clever /me: status %d", res.StatusCode)
+	}
+	var env cleverMeEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, err
+	}
+	if env.Data == nil || strings.TrimSpace(env.Data.ID) == "" {
+		return nil, fmt.Errorf("clever /me: missing user id")
+	}
+	var ud cleverUserData
+	if len(env.Data.Data) > 0 {
+		_ = json.Unmarshal(env.Data.Data, &ud)
+	}
+	role := cleverRoleToAppRole(ud.Roles)
+	em := strings.TrimSpace(strings.ToLower(ud.Email))
+	gn, fn := "", ""
+	if ud.Name != nil {
+		gn = strings.TrimSpace(ud.Name.First)
+		fn = strings.TrimSpace(ud.Name.Last)
+	}
+	return &CleverMeProfile{
+		UserID:     strings.TrimSpace(env.Data.ID),
+		Email:      em,
+		GivenName:  gn,
+		FamilyName: fn,
+		IsMinor:    cleverDetectMinor(env.Data.Data),
+		RoleName:   role,
+	}, nil
+}
+
+func cleverDetectMinor(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return false
+	}
+	for _, k := range []string{"is_under_13", "isUnder13", "under_13"} {
+		if v, ok := m[k]; ok {
+			switch t := v.(type) {
+			case bool:
+				return t
+			case string:
+				return strings.EqualFold(t, "true") || t == "1"
+			case float64:
+				return t != 0
+			}
+		}
+	}
+	return false
+}
+
+func cleverRoleToAppRole(r *struct {
+	Student       json.RawMessage `json:"student"`
+	Teacher       json.RawMessage `json:"teacher"`
+	Staff         json.RawMessage `json:"staff"`
+	DistrictAdmin json.RawMessage `json:"district_admin"`
+}) string {
+	if r == nil {
+		return "Student"
+	}
+	if len(r.DistrictAdmin) > 0 && string(r.DistrictAdmin) != "null" {
+		return "Teacher"
+	}
+	if len(r.Teacher) > 0 && string(r.Teacher) != "null" {
+		return "Teacher"
+	}
+	if len(r.Staff) > 0 && string(r.Staff) != "null" {
+		return "Teacher"
+	}
+	return "Student"
+}
+
+// ClassLinkProfile holds identity fields from ClassLink userinfo claims.
+type ClassLinkProfile struct {
+	SourcedID  string
+	Email      string
+	GivenName  string
+	FamilyName string
+	RoleName   string
+}
+
+// ParseClassLinkUserInfoClaims maps ClassLink userinfo JSON claims to a profile.
+func ParseClassLinkUserInfoClaims(raw map[string]any) ClassLinkProfile {
+	var p ClassLinkProfile
+	if v, ok := raw["email"].(string); ok {
+		p.Email = strings.TrimSpace(strings.ToLower(v))
+	}
+	if v, ok := raw["given_name"].(string); ok {
+		p.GivenName = strings.TrimSpace(v)
+	}
+	if v, ok := raw["family_name"].(string); ok {
+		p.FamilyName = strings.TrimSpace(v)
+	}
+	for _, k := range []string{"classLink_sourcedId", "classlink_sourcedid", "sourcedId"} {
+		if v, ok := raw[k].(string); ok && strings.TrimSpace(v) != "" {
+			p.SourcedID = strings.TrimSpace(v)
+			break
+		}
+	}
+	p.RoleName = "Student"
+	if v, ok := raw["classLink_role"].(string); ok {
+		rl := strings.ToLower(strings.TrimSpace(v))
+		if strings.Contains(rl, "admin") || strings.Contains(rl, "teacher") || strings.Contains(rl, "staff") {
+			p.RoleName = "Teacher"
+		}
+	}
+	return p
+}

--- a/server/internal/service/oidcauth/k12_profiles_test.go
+++ b/server/internal/service/oidcauth/k12_profiles_test.go
@@ -1,0 +1,45 @@
+package oidcauth
+
+import (
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/config"
+)
+
+func TestOIDCFlowAllowed_K12WithoutGlobalOIDC(t *testing.T) {
+	s := NewService(config.Config{
+		OIDCSSOEnabled:            false,
+		CleverSSOEnabled:          true,
+		CleverOIDCClientID:        "id",
+		CleverOIDCClientSecret:    "sec",
+		ClassLinkSSOEnabled:       true,
+		ClassLinkOIDCClientID:     "id2",
+		ClassLinkOIDCClientSecret: "sec2",
+	})
+	if !s.oidcFlowAllowed("clever") {
+		t.Fatal("clever should be allowed")
+	}
+	if !s.oidcFlowAllowed("classlink") {
+		t.Fatal("classlink should be allowed")
+	}
+	if s.oidcFlowAllowed("google") {
+		t.Fatal("google should not be allowed without OIDC_SSO_ENABLED")
+	}
+}
+
+func TestParseClassLinkUserInfoClaims(t *testing.T) {
+	p := ParseClassLinkUserInfoClaims(map[string]any{
+		"email":               "T@School.EDU",
+		"given_name":          "Pat",
+		"family_name":         "Lee",
+		"classLink_sourcedId": "src-1",
+		"classLink_role":    "Teacher",
+	})
+	if p.Email != "t@school.edu" || p.GivenName != "Pat" || p.FamilyName != "Lee" || p.SourcedID != "src-1" || p.RoleName != "Teacher" {
+		t.Fatalf("unexpected profile: %+v", p)
+	}
+	p2 := ParseClassLinkUserInfoClaims(map[string]any{"email": "s@x.com"})
+	if p2.RoleName != "Student" {
+		t.Fatalf("want Student, got %q", p2.RoleName)
+	}
+}

--- a/server/internal/service/oidcauth/oidcauth.go
+++ b/server/internal/service/oidcauth/oidcauth.go
@@ -99,7 +99,7 @@ func (s *Service) BuildAuthorizeRedirectURL(
 	configID, linkID *uuid.UUID,
 	next *string,
 ) (string, error) {
-	if !s.Cfg.OIDCSSOEnabled {
+	if !s.oidcFlowAllowed(pathProvider) {
 		return "", authservice.FieldError{Message: "OpenID Connect is not enabled on this server."}
 	}
 	pv := strings.ToLower(strings.TrimSpace(pathProvider))
@@ -218,6 +218,16 @@ func (s *Service) resolveClient(pathProvider string, custom *oidcrepo.CustomProv
 			hdVal = *custom.HDRestriction
 		}
 		return iss, custom.ClientID, custom.ClientSecret, hdVal, nil
+	case "clever":
+		if !s.Cfg.CleverSSOEnabled || s.Cfg.CleverOIDCClientID == "" || s.Cfg.CleverOIDCClientSecret == "" {
+			return "", "", "", "", authservice.FieldError{Message: "Clever sign-in is not configured."}
+		}
+		return "https://clever.com", s.Cfg.CleverOIDCClientID, s.Cfg.CleverOIDCClientSecret, "", nil
+	case "classlink":
+		if !s.Cfg.ClassLinkSSOEnabled || s.Cfg.ClassLinkOIDCClientID == "" || s.Cfg.ClassLinkOIDCClientSecret == "" {
+			return "", "", "", "", authservice.FieldError{Message: "ClassLink sign-in is not configured."}
+		}
+		return "https://launchpad.classlink.com", s.Cfg.ClassLinkOIDCClientID, s.Cfg.ClassLinkOIDCClientSecret, "", nil
 	default:
 		return "", "", "", "", authservice.FieldError{Message: "Unknown OIDC provider."}
 	}
@@ -228,7 +238,7 @@ func (s *Service) CompleteLogin(
 	ctx context.Context, pool *pgxpool.Pool, jwt *pauth.JWTSigner,
 	pathProvider, code, state string,
 ) (authservice.AuthResponse, *string, error) {
-	if !s.Cfg.OIDCSSOEnabled {
+	if !s.oidcFlowAllowed(pathProvider) {
 		return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "OpenID Connect is not enabled on this server."}
 	}
 	_ = oidcrepo.DeleteStaleFlowState(ctx, pool)
@@ -281,6 +291,9 @@ func (s *Service) CompleteLogin(
 	tok, err := o2.Exchange(ctx2, code, oauth2.VerifierOption(flow.CodeVerifier))
 	if err != nil {
 		return authservice.AuthResponse{}, nil, authservice.FieldError{Message: "Could not complete sign-in with the identity provider."}
+	}
+	if pv == "clever" || pv == "classlink" {
+		return s.completeK12OIDCLogin(ctx, pool, jwt, pv, flow, prov, o2, tok)
 	}
 	raw, ok := tok.Extra("id_token").(string)
 	if !ok || raw == "" {

--- a/server/internal/service/oidcauth/oidcauth_test.go
+++ b/server/internal/service/oidcauth/oidcauth_test.go
@@ -9,6 +9,9 @@ func TestRedirectURIFor(t *testing.T) {
 	if got := redirectURIFor("http://api:8080/", "custom"); got != "http://api:8080/auth/oidc/custom/callback" {
 		t.Fatalf("custom: %q", got)
 	}
+	if got := redirectURIFor("http://api:8080", "clever"); got != "http://api:8080/auth/oidc/clever/callback" {
+		t.Fatalf("clever: %q", got)
+	}
 }
 
 func TestIssuerForCustomDiscovery(t *testing.T) {

--- a/server/migrations/120_clever_classlink_sso.sql
+++ b/server/migrations/120_clever_classlink_sso.sql
@@ -1,0 +1,38 @@
+-- Plan 4.4 — Clever / ClassLink K-12 SSO (OIDC Instant Login, JIT provisioning fields).
+
+ALTER TABLE "user".users
+    ADD COLUMN IF NOT EXISTS clever_id TEXT,
+    ADD COLUMN IF NOT EXISTS classlink_id TEXT,
+    ADD COLUMN IF NOT EXISTS is_minor BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS connected_via TEXT;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'users_clever_id_unique'
+    ) THEN
+        ALTER TABLE "user".users ADD CONSTRAINT users_clever_id_unique UNIQUE (clever_id);
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'users_classlink_id_unique'
+    ) THEN
+        ALTER TABLE "user".users ADD CONSTRAINT users_classlink_id_unique UNIQUE (classlink_id);
+    END IF;
+END $$;
+
+ALTER TABLE "user".users
+    ADD CONSTRAINT users_connected_via_check CHECK (
+        connected_via IS NULL OR connected_via IN ('clever', 'classlink')
+    ) NOT VALID;
+
+ALTER TABLE "user".users VALIDATE CONSTRAINT users_connected_via_check;
+
+COMMENT ON COLUMN "user".users.clever_id IS 'Clever user id from OIDC / profile; unique when set (plan 4.4).';
+COMMENT ON COLUMN "user".users.classlink_id IS 'ClassLink sourced id or stable id from claims when set (plan 4.4).';
+COMMENT ON COLUMN "user".users.connected_via IS 'K-12 middleware used for first provisioning: clever or classlink.';
+
+ALTER TABLE settings.user_oidc_identities DROP CONSTRAINT IF EXISTS user_oidc_identities_provider_check;
+
+ALTER TABLE settings.user_oidc_identities ADD CONSTRAINT user_oidc_identities_provider_check CHECK (
+    provider IN ('google', 'microsoft', 'apple', 'custom', 'clever', 'classlink')
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements plan **4.4 — Clever / ClassLink** (Instant Login phase): dedicated OIDC flows for Clever and ClassLink with PKCE, JIT user provisioning from Clever `/v3.0/me` or ClassLink userinfo, database columns for `clever_id`, `classlink_id`, `is_minor`, and `connected_via`, and login buttons when the respective feature flags and client credentials are set.

Clever Secure Sync and ClassLink roster consumption remain out of scope for this change; the completed plan document notes that explicitly.

## Configuration

- `CLEVER_SSO_ENABLED=1`, `CLEVER_OIDC_CLIENT_ID`, `CLEVER_OIDC_CLIENT_SECRET`
- `CLASSLINK_SSO_ENABLED=1`, `CLASSLINK_OIDC_CLIENT_ID`, `CLASSLINK_OIDC_CLIENT_SECRET`
- `OIDC_PUBLIC_BASE_URL` (or `LTI_API_BASE_URL`) must match the API origin used for redirect URIs (`/auth/oidc/clever/callback`, `/auth/oidc/classlink/callback`).

Clever and ClassLink can be enabled **without** `OIDC_SSO_ENABLED` for Google/Microsoft/Apple.

## Evidence

Screenshot and short screen recording of the login page with Clever and ClassLink buttons (demo build against a small static mock server; see `scripts/k12-login-demo-server.mjs` and `scripts/capture-k12-login-demo.sh`).

[Login page with Clever and ClassLink buttons](https://cursor.com/agents/bc-c1178205-0b35-5a99-b83c-eb2ce63708bc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fk12-login-clever-classlink.png)

[k12-login-clever-classlink-demo.mp4](https://cursor.com/agents/bc-c1178205-0b35-5a99-b83c-eb2ce63708bc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frecordings%2Fk12-login-clever-classlink-demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://lextures.slack.com/archives/D0B0KS3A9LM/p1777647610171919?thread_ts=1777647610.171919&cid=D0B0KS3A9LM)

<div><a href="https://cursor.com/agents/bc-c1178205-0b35-5a99-b83c-eb2ce63708bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1178205-0b35-5a99-b83c-eb2ce63708bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

