### PR TITLE
Grant Global Admin to first password signup on fresh install

### DIFF
--- a/server/internal/repos/rbac/rbac.go
+++ b/server/internal/repos/rbac/rbac.go
@@ -27,3 +27,21 @@ ON CONFLICT (user_id, role_id) DO NOTHING
 `, userID.String(), roleID)
 	return err
 }
+
+// AssignUserRoleByNameTx links the user to a named app role inside a transaction.
+func AssignUserRoleByNameTx(ctx context.Context, tx pgx.Tx, userID uuid.UUID, roleName string) error {
+	var roleID string
+	err := tx.QueryRow(ctx, `SELECT id::text FROM "user".app_roles WHERE name = $1`, roleName).Scan(&roleID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `
+INSERT INTO "user".user_app_roles (user_id, role_id)
+VALUES ($1::uuid, $2::uuid)
+ON CONFLICT (user_id, role_id) DO NOTHING
+`, userID.String(), roleID)
+	return err
+}

--- a/server/internal/repos/user/user.go
+++ b/server/internal/repos/user/user.go
@@ -15,16 +15,16 @@ import (
 
 // Row is a users table row for authentication and profile in API responses.
 type Row struct {
-	ID           string
-	Email        string
-	PasswordHash string
-	DisplayName  *string
-	FirstName    *string
-	LastName     *string
-	AvatarURL    *string
-	UITheme      string
-	Sid          *string
-	LoginBlocked bool
+	ID            string
+	Email         string
+	PasswordHash  string
+	DisplayName   *string
+	FirstName     *string
+	LastName      *string
+	AvatarURL     *string
+	UITheme       string
+	Sid           *string
+	LoginBlocked  bool
 	DeactivatedAt *time.Time
 }
 
@@ -88,6 +88,34 @@ RETURNING id::text, email, password_hash, display_name, first_name, last_name, a
 	var dn, fn, ln, av, sid sql.NullString
 	var deactivatedAt sql.NullTime
 	err := pool.QueryRow(ctx, q, email, passwordHash, displayName).Scan(
+		&r.ID, &r.Email, &r.PasswordHash, &dn, &fn, &ln, &av, &r.UITheme, &sid,
+		&r.LoginBlocked, &deactivatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	r.DisplayName = strPtr(dn)
+	r.FirstName = strPtr(fn)
+	r.LastName = strPtr(ln)
+	r.AvatarURL = strPtr(av)
+	r.Sid = strPtr(sid)
+	if deactivatedAt.Valid {
+		t := deactivatedAt.Time
+		r.DeactivatedAt = &t
+	}
+	return &r, nil
+}
+
+// InsertUserTx is InsertUser within an existing transaction.
+func InsertUserTx(ctx context.Context, tx pgx.Tx, email, passwordHash string, displayName *string) (*Row, error) {
+	const q = `INSERT INTO "user".users (email, password_hash, display_name)
+VALUES ($1, $2, $3)
+RETURNING id::text, email, password_hash, display_name, first_name, last_name, avatar_url, ui_theme, sid,
+  login_blocked, deactivated_at`
+	var r Row
+	var dn, fn, ln, av, sid sql.NullString
+	var deactivatedAt sql.NullTime
+	err := tx.QueryRow(ctx, q, email, passwordHash, displayName).Scan(
 		&r.ID, &r.Email, &r.PasswordHash, &dn, &fn, &ln, &av, &r.UITheme, &sid,
 		&r.LoginBlocked, &deactivatedAt,
 	)

--- a/server/internal/service/authservice/credentials.go
+++ b/server/internal/service/authservice/credentials.go
@@ -137,7 +137,26 @@ func Signup(ctx context.Context, pool *pgxpool.Pool, jwt *pauth.JWTSigner, check
 	}
 	dn := trimStringPtr(req.DisplayName)
 
-	row, err := user.InsertUser(ctx, pool, email, ph, dn)
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return AuthResponse{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext('signup_first_human'))`); err != nil {
+		return AuthResponse{}, err
+	}
+
+	var humanCount int64
+	err = tx.QueryRow(ctx, `
+SELECT COUNT(*)::bigint FROM "user".users
+WHERE id <> $1::uuid`, communication.PlatformInboxSenderID.String()).Scan(&humanCount)
+	if err != nil {
+		return AuthResponse{}, err
+	}
+	firstHuman := humanCount == 0
+
+	row, err := user.InsertUserTx(ctx, tx, email, ph, dn)
 	if err != nil {
 		var pe *pgconn.PgError
 		if errors.As(err, &pe) && pe.Code == "23505" {
@@ -149,9 +168,18 @@ func Signup(ctx context.Context, pool *pgxpool.Pool, jwt *pauth.JWTSigner, check
 	if err != nil {
 		return AuthResponse{}, err
 	}
-	if err := rbac.AssignUserRoleByName(ctx, pool, uid, "Teacher"); err != nil {
+	if firstHuman {
+		if err := rbac.AssignUserRoleByNameTx(ctx, tx, uid, "Global Admin"); err != nil {
+			return AuthResponse{}, err
+		}
+	}
+	if err := rbac.AssignUserRoleByNameTx(ctx, tx, uid, "Teacher"); err != nil {
 		return AuthResponse{}, err
 	}
+	if err := tx.Commit(ctx); err != nil {
+		return AuthResponse{}, err
+	}
+
 	_ = passwordcreditevents.Insert(ctx, pool, uid, passwordcreditevents.KindSignup, hibpRes.BreachFound, hibpRes.HIBPAvailable)
 	communication.SendWelcomeMessage(ctx, pool, email)
 	return responseFromRow(jwt, row)

--- a/server/internal/service/authservice/flow_db_test.go
+++ b/server/internal/service/authservice/flow_db_test.go
@@ -7,12 +7,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	serverdata "github.com/lextures/lextures/server"
 	"github.com/lextures/lextures/server/internal/auth"
 	"github.com/lextures/lextures/server/internal/auth/hibp"
 	"github.com/lextures/lextures/server/internal/config"
 	"github.com/lextures/lextures/server/internal/db"
 	"github.com/lextures/lextures/server/internal/migrate"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
 )
 
 // Exercise signup/login/email-taken and password reset against a real Postgres (CI or local).
@@ -63,6 +65,59 @@ func TestAuthFlow_Pg(t *testing.T) {
 	// full reset would need the raw token; wrong token path is covered
 	if _, err := ResetPassword(ctx, pool, stub, ResetPasswordRequest{Token: "nope", Password: pass}); !errors.Is(err, ErrInvalidResetToken) {
 		t.Fatalf("reset bad token: %v", err)
+	}
+}
+
+// TestSignup_FirstHumanGetsGlobalAdmin_Pg asserts the first password signup after migrations gets Global Admin.
+// This DB may already have human users from prior tests; skip when not empty.
+func TestSignup_FirstHumanGetsGlobalAdmin_Pg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("database")
+	}
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	var otherHumans int64
+	err = pool.QueryRow(ctx, `
+SELECT COUNT(*)::bigint FROM "user".users u
+WHERE u.id <> 'a0000000-0000-4000-8000-000000000001'::uuid`).Scan(&otherHumans)
+	if err != nil {
+		t.Fatalf("count humans: %v", err)
+	}
+	if otherHumans > 0 {
+		t.Skip("database already has human users")
+	}
+
+	jwt := auth.NewJWTSigner("01234567890123456789012345678901")
+	stub := hibp.StubChecker{Result: hibp.Result{BreachFound: false, HIBPAvailable: true}}
+	pass := "J7q#xM2pL9vRkW4$hN8zT1cY5bU6nM0aS"
+	email := "ga-first-" + time.Now().Format("20060102150405.000000000") + "@example.com"
+	res, err := Signup(ctx, pool, jwt, stub, SignupRequest{Email: email, Password: pass, DisplayName: displayName("Admin")})
+	if err != nil {
+		t.Fatalf("signup: %v", err)
+	}
+	uid, err := uuid.Parse(res.User.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ok, err := rbac.UserHasPermission(ctx, pool, uid, "global:app:rbac:manage")
+	if err != nil {
+		t.Fatalf("rbac: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected first signup to have global:app:rbac:manage (Global Admin)")
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When someone registers via password signup (`POST /api/v1/auth/signup`) on an empty database (only the seeded platform inbox user exists), they now receive the **Global Admin** app role in addition to **Teacher**, so the first human account can administer RBAC and platform settings without manual DB fixes.

## Implementation notes

- Signup runs in a single transaction with `pg_advisory_xact_lock` so concurrent first signups cannot both become Global Admin.
- “Fresh install” is defined as **no rows in `user.users` other than** `PlatformInboxSenderID` (`a0000000-0000-4000-8000-000000000001`), matching migration `031_platform_inbox_sender.sql`.
- Added `user.InsertUserTx` and `rbac.AssignUserRoleByNameTx` for transactional inserts and role assignment.

## Testing

- `go test ./... -count=1 -short -timeout=2m` (server)
- Optional Postgres test `TestSignup_FirstHumanGetsGlobalAdmin_Pg` skips when the DB already has human users (shared CI DB).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://lextures.slack.com/archives/D0B0KS3A9LM/p1777772597349469?thread_ts=1777772597.349469&cid=D0B0KS3A9LM)

<div><a href="https://cursor.com/agents/bc-4230488d-d0c9-5b3b-842e-760c2ebc9471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4230488d-d0c9-5b3b-842e-760c2ebc9471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

