### PR TITLE
www: OpenSwarm-style dark marketing landing

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -6,20 +6,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Lextures is the open-source adaptive LMS: structured courses, gradebook, calendar, and AI-powered creation—self-host with Docker."
+      content="OpenSwarm is a multi-agent orchestrator: visual canvas dashboard, workflows, and your AI workforce—free and open source under the MIT license."
     />
-    <meta property="og:title" content="Lextures — Adaptive open-source learning" />
+    <meta property="og:title" content="OpenSwarm — Multi-agent orchestrator" />
     <meta
       property="og:description"
-      content="The first truly adaptive learning environment. Course management, AI assistance, full data ownership."
+      content="Orchestrate agents on a 2D canvas. Research, content, analysis, and automation workflows—MIT licensed."
     />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
-    <title>Lextures — Adaptive open-source learning environment</title>
+    <title>OpenSwarm — Multi-agent orchestrator</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&family=JetBrains+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -1,20 +1,12 @@
 import {
+  ArrowDown,
   ArrowRight,
-  BookOpen,
-  Bot,
-  Boxes,
-  CalendarDays,
   Github,
-  GraduationCap,
-  Inbox,
-  Layers,
-  LockOpen,
-  MessageSquareQuote,
-  MousePointer2,
-  Palette,
+  Menu,
+  Network,
   Sparkles,
-  Terminal,
-  Zap,
+  Workflow,
+  X,
 } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { useEffect, useState } from 'react'
@@ -22,57 +14,29 @@ import { HeroCanvas } from './components/HeroCanvas'
 import { FadeUp, MotionSection } from './components/Motion'
 
 const LINKS = {
-  github: 'https://github.com/StudyDrift/lextures',
-  demo: 'https://demo.lextures.com/',
-  docs: 'https://github.com/StudyDrift/lextures#readme',
+  github: 'https://github.com/openswarm/openswarm',
+  downloadMac: 'https://github.com/openswarm/openswarm/releases/latest',
 } as const
 
 const NAV = [
   { label: 'Features', href: '#features' },
-  { label: 'Demo', href: '#demo' },
-  { label: 'Docs', href: LINKS.docs },
+  { label: 'Workflows', href: '#workflows' },
+  { label: 'Get running', href: '#get-running' },
   { label: 'GitHub', href: LINKS.github },
-]
+] as const
 
-function ThemeToggle() {
-  const [mode, setMode] = useState<'dark' | 'light'>('dark')
+const PARTNERS = [
+  'Gmail',
+  'Slack',
+  'Notion',
+  'GitHub',
+  'Figma',
+  'Zapier',
+  'Google Sheets',
+  'Linear',
+] as const
 
-  useEffect(() => {
-    const stored = localStorage.getItem('lextures-theme') as 'dark' | 'light' | null
-    const initial = stored === 'light' ? 'light' : 'dark'
-    setMode(initial)
-    document.documentElement.classList.toggle('light', initial === 'light')
-  }, [])
-
-  const toggle = () => {
-    const next = mode === 'dark' ? 'light' : 'dark'
-    setMode(next)
-    localStorage.setItem('lextures-theme', next)
-    document.documentElement.classList.toggle('light', next === 'light')
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={toggle}
-      className="glass-panel relative inline-flex h-10 w-10 items-center justify-center rounded-xl text-sm font-medium text-slate-300 transition hover:border-cyan-400/40 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 light:text-slate-600 light:hover:text-slate-900"
-      aria-label={mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
-    >
-      <span className="sr-only">Toggle theme</span>
-      {mode === 'dark' ? (
-        <span className="text-lg" aria-hidden>
-          ☀️
-        </span>
-      ) : (
-        <span className="text-lg" aria-hidden>
-          🌙
-        </span>
-      )}
-    </button>
-  )
-}
-
-function LogoMark({ className = '' }: { className?: string }) {
+function SwarmLogoMark({ className = '' }: { className?: string }) {
   return (
     <svg
       viewBox="0 0 32 32"
@@ -81,265 +45,372 @@ function LogoMark({ className = '' }: { className?: string }) {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <rect width="32" height="32" rx="8" className="fill-slate-950 light:fill-white" />
+      <circle cx="10" cy="12" r="3" className="fill-cyan-400" />
+      <circle cx="22" cy="10" r="2.5" className="fill-cyan-300/80" />
+      <circle cx="18" cy="20" r="2.5" className="fill-violet-400/90" />
+      <circle cx="8" cy="22" r="2" className="fill-cyan-500/70" />
       <path
-        d="M8 22V10l6 8 6-8v12"
-        className="stroke-cyan-400 light:stroke-cyan-600"
-        strokeWidth="2"
+        d="M12.5 12.5L19.5 11M14 18l3.5-5M10 20l6-1"
+        className="stroke-cyan-400/50"
+        strokeWidth="1"
         strokeLinecap="round"
-        strokeLinejoin="round"
       />
     </svg>
   )
 }
 
-export default function App() {
+function CanvasPreview() {
   return (
-    <div className="relative min-h-screen overflow-x-hidden">
+    <div
+      className="relative overflow-hidden rounded-xl border border-cyan-400/20 bg-gradient-to-br from-neutral-950 via-[#0d1117] to-violet-950/40 p-4 ring-1 ring-inset ring-white/[0.04]"
+      aria-label="Preview of the 2D agent canvas"
+    >
+      <div className="mb-3 flex items-center justify-between text-[10px] font-medium uppercase tracking-wider text-neutral-500">
+        <span>Canvas</span>
+        <span className="rounded-full bg-cyan-400/15 px-2 py-0.5 text-cyan-300/90">Live</span>
+      </div>
+      <div className="relative aspect-[16/10] rounded-lg border border-white/5 bg-black/40">
+        <svg className="absolute inset-0 h-full w-full" aria-hidden>
+          <line x1="18%" y1="28%" x2="48%" y2="42%" stroke="rgba(34,211,238,0.35)" strokeWidth="1" />
+          <line x1="48%" y1="42%" x2="72%" y2="32%" stroke="rgba(34,211,238,0.35)" strokeWidth="1" />
+          <line x1="48%" y1="42%" x2="44%" y2="68%" stroke="rgba(167,139,250,0.35)" strokeWidth="1" />
+        </svg>
+        {[
+          { l: '16%', t: '24%', c: 'bg-cyan-400 shadow-[0_0_12px_rgba(34,211,238,0.45)]' },
+          { l: '44%', t: '38%', c: 'bg-cyan-300/90' },
+          { l: '68%', t: '28%', c: 'bg-cyan-400/80' },
+          { l: '40%', t: '62%', c: 'bg-violet-400/90 shadow-[0_0_10px_rgba(167,139,250,0.35)]' },
+        ].map((n, i) => (
+          <span
+            key={i}
+            className={`absolute h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full ring-1 ring-white/20 ${n.c}`}
+            style={{ left: n.l, top: n.t }}
+          />
+        ))}
+        <div className="absolute bottom-2 right-2 flex gap-1 rounded-md border border-white/10 bg-black/50 px-1.5 py-1 text-[9px] text-neutral-500">
+          <span className="px-1">−</span>
+          <span className="text-neutral-400">100%</span>
+          <span className="px-1">+</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function App() {
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  useEffect(() => {
+    document.documentElement.classList.remove('light')
+  }, [])
+
+  useEffect(() => {
+    if (menuOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = ''
+    }
+    return () => {
+      document.body.style.overflow = ''
+    }
+  }, [menuOpen])
+
+  const closeMenu = () => setMenuOpen(false)
+
+  const btnPrimary =
+    'inline-flex items-center justify-center gap-2 rounded-full bg-cyan-400 px-6 py-3 text-sm font-bold text-neutral-950 shadow-[0_0_24px_-4px_rgba(34,211,238,0.55)] transition duration-200 hover:scale-[1.03] hover:bg-cyan-300 hover:shadow-[0_0_32px_-2px_rgba(34,211,238,0.65)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400'
+
+  const btnOutline =
+    'inline-flex items-center justify-center gap-2 rounded-full border border-cyan-400/50 bg-transparent px-6 py-3 text-sm font-bold text-cyan-200 transition duration-200 hover:scale-[1.03] hover:border-cyan-300 hover:bg-cyan-400/10 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400'
+
+  return (
+    <div className="relative min-h-screen overflow-x-hidden bg-bg-deep text-neutral-200">
       <a
         href="#main"
-        className="focus:bg-cyan-400/20 sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-lg focus:px-4 focus:py-2 focus:text-sm focus:text-white"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-lg focus:bg-cyan-400/20 focus:px-4 focus:py-2 focus:text-sm focus:text-white"
       >
         Skip to content
       </a>
 
-      <header className="sticky top-0 z-50 border-b border-white/5 bg-bg-deep/75 backdrop-blur-xl light:border-slate-200/80 light:bg-white/80">
-        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3 sm:px-6 lg:px-8">
-          <a href="#" className="flex items-center gap-2.5 font-semibold tracking-tight text-white light:text-slate-900">
-            <LogoMark className="h-9 w-9 shrink-0 shadow-lg shadow-cyan-500/10 ring-1 ring-white/10 light:shadow-slate-900/5 light:ring-slate-200" />
-            <span className="text-lg">Lextures</span>
+      <header className="sticky top-0 z-50 h-[4.25rem] border-b border-white/[0.06] bg-[#0a0a0a]/85 backdrop-blur-xl">
+        <div className="mx-auto flex h-full max-w-[90rem] items-center justify-between gap-4 px-4 sm:px-6 lg:px-10">
+          <a href="#" className="flex items-center gap-2.5 font-semibold tracking-tight text-white">
+            <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-white/[0.04] ring-1 ring-white/10">
+              <SwarmLogoMark className="h-7 w-7" />
+            </span>
+            <span className="text-lg">OpenSwarm</span>
           </a>
-          <nav
-            className="-mx-1 flex max-w-[min(100vw-12rem,28rem)] items-center gap-0.5 overflow-x-auto px-1 pb-1 [-ms-overflow-style:none] [scrollbar-width:none] md:max-w-none md:gap-1 md:overflow-visible md:pb-0 [&::-webkit-scrollbar]:hidden"
-            aria-label="Primary"
-          >
+
+          <nav className="hidden items-center gap-1 md:flex" aria-label="Primary">
             {NAV.map((item) => (
               <a
                 key={item.href}
                 href={item.href}
-                className="shrink-0 rounded-lg px-2.5 py-2 text-sm font-medium text-slate-400 transition hover:bg-white/5 hover:text-white md:px-3 light:text-slate-600 light:hover:bg-slate-100 light:hover:text-slate-900"
+                className="rounded-lg px-3 py-2 text-sm font-medium text-neutral-400 no-underline transition hover:bg-white/[0.04] hover:text-white"
               >
                 {item.label}
               </a>
             ))}
           </nav>
-          <div className="flex items-center gap-2">
-            <ThemeToggle />
-            <a
-              href={LINKS.demo}
-              className="inline-flex shrink-0 items-center gap-1 rounded-xl bg-gradient-to-r from-cyan-400 to-sky-500 px-3 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-500/25 transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 sm:px-4"
-            >
-              <span className="hidden sm:inline">Get Started</span>
-              <span className="sm:hidden">Start</span>
-              <ArrowRight className="h-4 w-4" aria-hidden />
+
+          <div className="hidden items-center gap-3 md:flex">
+            <a href={LINKS.github} className={btnOutline + ' !px-5 !py-2.5 text-xs sm:text-sm'}>
+              <Github className="h-4 w-4" aria-hidden />
+              Clone repo
             </a>
+            <a href={LINKS.downloadMac} className={btnPrimary + ' !px-5 !py-2.5 text-xs sm:text-sm'}>
+              Download for Mac
+            </a>
+          </div>
+
+          <div className="flex items-center gap-2 md:hidden">
+            <button
+              type="button"
+              onClick={() => setMenuOpen(true)}
+              className="inline-flex h-11 w-11 items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-white transition hover:border-cyan-400/30 hover:bg-white/[0.06]"
+              aria-expanded={menuOpen}
+              aria-controls="mobile-nav"
+              aria-label="Open menu"
+            >
+              <Menu className="h-5 w-5" />
+            </button>
           </div>
         </div>
       </header>
 
+      {menuOpen ? (
+        <div
+          className="fixed inset-0 z-[60] flex flex-col bg-[#0a0a0a] md:hidden"
+          id="mobile-nav"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Navigation"
+        >
+          <div className="flex h-[4.25rem] items-center justify-between border-b border-white/[0.06] px-4">
+            <span className="text-sm font-semibold text-white">Menu</span>
+            <button
+              type="button"
+              onClick={closeMenu}
+              className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 text-white hover:bg-white/[0.06]"
+              aria-label="Close menu"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+          <nav className="flex flex-1 flex-col gap-1 p-4" aria-label="Mobile primary">
+            {NAV.map((item) => (
+              <a
+                key={item.href}
+                href={item.href}
+                onClick={closeMenu}
+                className="rounded-xl px-4 py-4 text-lg font-medium text-neutral-200 no-underline transition hover:bg-white/[0.04]"
+              >
+                {item.label}
+              </a>
+            ))}
+          </nav>
+          <div className="border-t border-white/[0.06] p-4 pb-8">
+            <a href={LINKS.downloadMac} onClick={closeMenu} className={btnPrimary + ' w-full'}>
+              Download for Mac
+            </a>
+            <a
+              href={LINKS.github}
+              onClick={closeMenu}
+              className={'mt-3 ' + btnOutline + ' w-full'}
+            >
+              <Github className="h-4 w-4" aria-hidden />
+              Clone repo
+            </a>
+          </div>
+        </div>
+      ) : null}
+
       <main id="main">
         {/* Hero */}
-        <section className="relative overflow-hidden pb-24 pt-16 sm:pb-32 sm:pt-24 lg:pt-28">
+        <section className="relative overflow-hidden pb-20 pt-14 sm:pb-28 sm:pt-20 lg:pt-24">
           <HeroCanvas />
-          <div className="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+          <div className="relative mx-auto max-w-[90rem] px-4 sm:px-6 lg:px-10">
             <motion.div
-              initial={{ opacity: 0, y: 16 }}
+              initial={{ opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+              transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
               className="flex flex-wrap items-center gap-3"
             >
-              <span className="glass-panel inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium text-cyan-200 light:text-cyan-800">
-                <Sparkles className="h-3.5 w-3.5 text-cyan-400 light:text-cyan-600" aria-hidden />
-                Open source · AGPL-3.0
+              <span className="inline-flex items-center gap-2 rounded-full border border-cyan-400/25 bg-cyan-400/10 px-3 py-1 text-xs font-medium tracking-wide text-cyan-200/95">
+                <Sparkles className="h-3.5 w-3.5 text-cyan-400" aria-hidden />
+                Free and open source · MIT
               </span>
-              <a
-                href={LINKS.github}
-                className="glass-panel inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium text-slate-300 transition hover:border-cyan-400/30 hover:text-white light:text-slate-600 light:hover:text-slate-900"
-              >
-                <Github className="h-3.5 w-3.5" aria-hidden />
-                Star on GitHub
-              </a>
             </motion.div>
 
             <motion.h1
-              className="mt-8 max-w-4xl text-4xl font-semibold tracking-tight text-white sm:text-5xl lg:text-6xl lg:leading-[1.05] light:text-slate-900"
-              initial={{ opacity: 0, y: 20 }}
+              className="mt-8 max-w-4xl text-4xl font-bold tracking-tight text-white sm:text-5xl lg:text-[3.25rem] lg:leading-[1.08]"
+              initial={{ opacity: 0, y: 18 }}
               animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.65, delay: 0.08, ease: [0.22, 1, 0.36, 1] }}
+              transition={{ duration: 0.55, delay: 0.06, ease: [0.22, 1, 0.36, 1] }}
             >
-              The first truly{' '}
-              <span className="text-gradient">adaptive learning</span> environment.
+              <span className="text-neutral-500"># </span>
+              OpenSwarm —{' '}
+              <span className="text-gradient">Multi-agent orchestrator</span>
             </motion.h1>
 
             <motion.p
-              className="mt-6 max-w-2xl text-lg leading-relaxed text-slate-400 sm:text-xl light:text-slate-600"
-              initial={{ opacity: 0, y: 16 }}
+              className="mt-6 max-w-2xl text-lg leading-[1.7] text-neutral-400 sm:text-xl"
+              initial={{ opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.18 }}
+              transition={{ duration: 0.5, delay: 0.14 }}
             >
-              Get to the content, faster. Lextures pairs structured course operations—modules,
-              calendar, gradebook, enrollments—with AI that drafts, adapts, and personalizes so you
-              spend less time on tooling and more time teaching.
+              Your AI workforce on a 2D canvas: coordinate agents, watch status, and ship parallel
+              workflows without losing the plot—built for developers who want clarity, not chaos.
             </motion.p>
 
             <motion.div
               className="mt-10 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center"
-              initial={{ opacity: 0, y: 12 }}
+              initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.55, delay: 0.28 }}
+              transition={{ duration: 0.5, delay: 0.22 }}
             >
-              <a
-                href={LINKS.demo}
-                className="inline-flex items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-cyan-400 to-sky-500 px-6 py-3.5 text-base font-semibold text-slate-950 shadow-xl shadow-cyan-500/20 transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400"
-              >
-                Try the Demo
-                <ArrowRight className="h-5 w-5" aria-hidden />
-              </a>
-              <a
-                href={LINKS.github}
-                className="glass-panel inline-flex items-center justify-center gap-2 rounded-xl px-6 py-3.5 text-base font-semibold text-white transition hover:border-cyan-400/35 hover:bg-white/[0.06] light:text-slate-900 light:hover:bg-white"
-              >
+              <a href={LINKS.github} className={btnPrimary}>
                 <Github className="h-5 w-5" aria-hidden />
-                Star on GitHub
+                Clone the repo
               </a>
-              <a
-                href="#self-host"
-                className="inline-flex items-center justify-center gap-2 rounded-xl border border-cyan-400/40 bg-cyan-400/10 px-6 py-3.5 text-base font-semibold text-cyan-100 transition hover:bg-cyan-400/15 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400 light:border-cyan-600/40 light:bg-cyan-500/10 light:text-cyan-900 light:hover:bg-cyan-500/15"
-              >
-                Self-Host Now
+              <a href={LINKS.downloadMac} className={btnOutline}>
+                Download for macOS
               </a>
             </motion.div>
 
-            <motion.dl
-              className="mt-14 grid gap-6 sm:grid-cols-3"
+            <motion.a
+              href="#features"
+              className="mt-16 inline-flex items-center gap-2 text-sm text-neutral-500 no-underline transition hover:text-cyan-300"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
-              transition={{ delay: 0.4, duration: 0.6 }}
+              transition={{ delay: 0.45, duration: 0.5 }}
             >
-              {[
-                { k: 'Deploy', v: 'Docker · PostgreSQL + MongoDB wired' },
-                { k: 'Frontend', v: 'React 19 + Tailwind — fast & polished' },
-                { k: 'Freedom', v: 'Full data ownership, no vendor lock-in' },
-              ].map((row) => (
-                <div key={row.k} className="glass-panel rounded-2xl p-5">
-                  <dt className="text-xs font-semibold uppercase tracking-wider text-cyan-300/90 light:text-cyan-700">
-                    {row.k}
-                  </dt>
-                  <dd className="mt-2 text-sm text-slate-300 light:text-slate-600">{row.v}</dd>
-                </div>
-              ))}
-            </motion.dl>
+              <ArrowDown className="h-4 w-4 text-cyan-500/80" aria-hidden />
+              Scroll to explore
+            </motion.a>
           </div>
         </section>
 
-        {/* Problem → Solution */}
-        <MotionSection className="border-y border-white/5 bg-bg-elevated/40 py-20 light:border-slate-200/80 light:bg-white/40">
-          <div className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-2 lg:items-center lg:px-8">
+        <div className="mx-auto max-w-[90rem] border-t border-white/[0.06] px-4 sm:px-6 lg:px-10" />
+
+        {/* Orchestrator intro */}
+        <MotionSection className="py-20 sm:py-24">
+          <div className="mx-auto grid max-w-[90rem] gap-12 px-4 sm:px-6 lg:grid-cols-2 lg:items-center lg:gap-16 lg:px-10">
             <FadeUp>
-              <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl light:text-slate-900">
-                Traditional LMS workflows weren&apos;t built for modern velocity.
+              <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+                Orchestration that feels like mission control
               </h2>
-              <p className="mt-4 text-slate-400 light:text-slate-600">
-                Fragmented tools, brittle content pipelines, and rigid paths slow educators down.
-                Learners bounce between tabs instead of staying in flow.
+              <p className="mt-5 text-lg leading-[1.75] text-neutral-400">
+                OpenSwarm maps agents to a spatial canvas so you can reason about dependencies,
+                parallelism, and health at a glance. No fireworks—just a calm, high-contrast
+                surface that mirrors how teams actually run multi-step AI work in 2026.
               </p>
+              <ul className="mt-8 space-y-3 text-neutral-300">
+                {[
+                  'Compose graphs of agents with explicit handoffs and guardrails.',
+                  'Run batches in parallel while keeping observability front and center.',
+                  'Drop in skills and tools where they belong—see the graph, not a black box.',
+                ].map((line) => (
+                  <li key={line} className="flex gap-3">
+                    <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-400" />
+                    <span>{line}</span>
+                  </li>
+                ))}
+              </ul>
             </FadeUp>
-            <FadeUp delay={0.1}>
-              <div className="glass-panel relative overflow-hidden rounded-3xl p-8">
-                <div className="absolute -right-16 -top-16 h-48 w-48 rounded-full bg-cyan-500/20 blur-3xl" />
-                <div className="relative">
-                  <div className="flex items-center gap-2 text-cyan-300 light:text-cyan-700">
-                    <Zap className="h-5 w-5" aria-hidden />
-                    <span className="text-sm font-semibold uppercase tracking-wide">
-                      The Lextures flow
-                    </span>
-                  </div>
-                  <p className="mt-4 text-lg font-medium text-white light:text-slate-900">
-                    One adaptive workspace: structure when you need it, AI when it helps, speed
-                    everywhere else.
-                  </p>
-                  <ul className="mt-6 space-y-3 text-slate-300 light:text-slate-600">
-                    <li className="flex gap-2">
-                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-400" />
-                      Ship courses with modular authoring and rich editing—without the busywork.
-                    </li>
-                    <li className="flex gap-2">
-                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-sky-400" />
-                      Generate quizzes and iterate content with guardrails you control.
-                    </li>
-                    <li className="flex gap-2">
-                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-400" />
-                      Personalize paths while keeping institutional-grade operations intact.
-                    </li>
-                  </ul>
+            <FadeUp delay={0.08}>
+              <div className="glass-panel relative overflow-hidden rounded-2xl p-8">
+                <div className="absolute -right-20 -top-20 h-56 w-56 rounded-full bg-violet-500/15 blur-3xl" />
+                <div className="absolute -bottom-16 -left-16 h-48 w-48 rounded-full bg-cyan-500/10 blur-3xl" />
+                <div className="relative flex items-center gap-2 text-cyan-300/95">
+                  <Network className="h-5 w-5" aria-hidden />
+                  <span className="text-sm font-semibold uppercase tracking-wider">Agent mesh</span>
                 </div>
+                <p className="relative mt-4 text-lg font-medium leading-relaxed text-white">
+                  The canvas is the contract: nodes are agents, edges are intent, and the layout is
+                  yours to evolve as workflows mature.
+                </p>
+                <p className="relative mt-4 font-mono text-sm text-neutral-500">
+                  <span className="code-inline text-neutral-400">~/.claude/skills/</span> and repo-local
+                  skills sit alongside first-class integrations—documented, diffable, and boring in the
+                  best way.
+                </p>
               </div>
             </FadeUp>
           </div>
         </MotionSection>
 
-        {/* Features */}
-        <MotionSection id="features" className="py-24 sm:py-28">
-          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        {/* Core features */}
+        <MotionSection id="features" className="border-y border-white/[0.06] bg-bg-elevated/50 py-20 sm:py-28">
+          <div className="mx-auto max-w-[90rem] px-4 sm:px-6 lg:px-10">
             <FadeUp className="max-w-2xl">
-              <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl light:text-slate-900">
-                Everything you expect from an LMS—elevated by adaptive AI.
-              </h2>
-              <p className="mt-4 text-lg text-slate-400 light:text-slate-600">
-                Purpose-built for educators and builders who refuse to compromise between polish and
-                ownership.
+              <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Core features</h2>
+              <p className="mt-4 text-lg leading-relaxed text-neutral-400">
+                Everything is tuned for scannability: bold titles, short copy, and cards that lift
+                slightly on hover—premium without the noise.
               </p>
             </FadeUp>
 
-            <div className="mt-14 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="mt-14 grid gap-5 lg:grid-cols-12">
+              <FadeUp className="lg:col-span-7">
+                <article className="glass-panel group flex h-full flex-col rounded-2xl p-6 transition duration-200 hover:-translate-y-0.5 hover:border-cyan-400/25 hover:shadow-[0_20px_50px_-24px_rgba(34,211,238,0.25)] sm:p-8">
+                  <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-cyan-400/10 text-cyan-300 ring-1 ring-cyan-400/25">
+                        <LayoutDashboardIcon />
+                      </div>
+                      <h3 className="mt-5 text-xl font-bold text-white">Visual canvas dashboard</h3>
+                      <p className="mt-3 text-sm leading-relaxed text-neutral-400 sm:text-base">
+                        Pan, zoom, and rearrange agents as living infrastructure. Status chips and
+                        edges stay readable under load—this is the hero surface of OpenSwarm.
+                      </p>
+                    </div>
+                    <div className="w-full shrink-0 lg:max-w-[340px]">
+                      <CanvasPreview />
+                    </div>
+                  </div>
+                </article>
+              </FadeUp>
+              <div className="grid gap-5 lg:col-span-5">
+                {[
+                  {
+                    title: 'Parallel runs with guardrails',
+                    body: 'Fan out work, merge results, and keep policy checks attached to the graph—not buried in logs.',
+                  },
+                  {
+                    title: 'Workflow templates',
+                    body: 'Start from research, content, analysis, or automation presets—then fork into your own layout.',
+                  },
+                  {
+                    title: 'Developer-native ergonomics',
+                    body: 'Keyboard-friendly navigation, monospace hints for paths and commands, and Git-first workflows.',
+                  },
+                ].map((f) => (
+                  <FadeUp key={f.title}>
+                    <article className="glass-panel group h-full rounded-2xl p-6 transition duration-200 hover:-translate-y-0.5 hover:border-cyan-400/20 hover:shadow-[0_16px_40px_-28px_rgba(34,211,238,0.2)]">
+                      <h3 className="text-lg font-bold text-white">{f.title}</h3>
+                      <p className="mt-2 text-sm leading-relaxed text-neutral-400">{f.body}</p>
+                    </article>
+                  </FadeUp>
+                ))}
+              </div>
+            </div>
+
+            <div className="mt-5 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
               {[
                 {
-                  icon: Bot,
-                  title: 'AI course & quiz generation',
-                  body: 'Draft outlines, lessons, and assessments faster—then refine with full editorial control.',
+                  title: 'Integrations hub',
+                  body: 'Connect the tools your team already lives in—email, docs, issue trackers, and design files.',
                 },
                 {
-                  icon: MousePointer2,
-                  title: 'Adaptive learning paths',
-                  body: 'Tune journeys to readiness and goals so learners progress with momentum, not friction.',
-                },
-                {
-                  icon: Layers,
-                  title: 'Rich course workspace',
-                  body: 'Drag-and-drop modules and a TipTap-powered editor for structured, beautiful content.',
-                },
-                {
-                  icon: CalendarDays,
-                  title: 'Calendar & gradebook',
-                  body: 'Operational clarity for cohorts: schedules, submissions, and outcomes in one place.',
-                },
-                {
-                  icon: Inbox,
-                  title: 'Inbox & communication',
-                  body: 'Keep learners and instructors aligned without bolting on yet another chat stack.',
-                },
-                {
-                  icon: Sparkles,
-                  title: 'OpenRouter integration',
-                  body: 'Optional model routing so teams can standardize providers without rewriting workflows.',
-                },
-                {
-                  icon: LockOpen,
-                  title: 'Self-hosted & sovereign',
-                  body: 'Docker-ready deploys with PostgreSQL—and MongoDB wired for future platform depth.',
+                  title: 'Observable execution',
+                  body: 'Lightweight traces per node so you can answer “what ran, where, and why” without leaving the canvas.',
                 },
               ].map((f) => (
                 <FadeUp key={f.title}>
-                  <article className="glass-panel group relative h-full rounded-2xl p-6 transition hover:border-cyan-400/25 hover:shadow-[0_0_0_1px_rgba(34,211,238,0.08)]">
-                    <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-cyan-400/10 text-cyan-300 ring-1 ring-cyan-400/20 light:bg-cyan-500/15 light:text-cyan-700">
-                      <f.icon className="h-5 w-5" aria-hidden />
-                    </div>
-                    <h3 className="mt-5 text-lg font-semibold text-white light:text-slate-900">
-                      {f.title}
-                    </h3>
-                    <p className="mt-2 text-sm leading-relaxed text-slate-400 light:text-slate-600">
-                      {f.body}
-                    </p>
+                  <article className="glass-panel group h-full rounded-2xl p-6 transition duration-200 hover:-translate-y-0.5 hover:border-cyan-400/20">
+                    <h3 className="text-lg font-bold text-white">{f.title}</h3>
+                    <p className="mt-2 text-sm leading-relaxed text-neutral-400">{f.body}</p>
                   </article>
                 </FadeUp>
               ))}
@@ -347,283 +418,65 @@ export default function App() {
           </div>
         </MotionSection>
 
-        {/* Demo teaser */}
-        <MotionSection id="demo" className="pb-24">
-          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <FadeUp className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-              <div>
-                <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl light:text-slate-900">
-                  Mission control for courses—built for speed.
-                </h2>
-                <p className="mt-3 max-w-xl text-slate-400 light:text-slate-600">
-                  The interface stays calm under complexity: enrollments, adaptive signals, and
-                  authoring surface where they belong.
-                </p>
-              </div>
-              <a
-                href={LINKS.demo}
-                className="inline-flex shrink-0 items-center gap-2 self-start rounded-xl border border-white/10 bg-white/5 px-5 py-2.5 text-sm font-semibold text-white transition hover:border-cyan-400/35 hover:bg-white/10 light:border-slate-200 light:bg-white light:text-slate-900 light:hover:border-cyan-500/40"
-              >
-                Open live demo
-                <ArrowRight className="h-4 w-4" aria-hidden />
-              </a>
-            </FadeUp>
-
-            <FadeUp delay={0.08} className="mt-10">
-              <div className="glass-panel relative overflow-hidden rounded-3xl border-cyan-400/15 p-2 shadow-2xl shadow-cyan-500/5 ring-1 ring-white/10 light:shadow-slate-900/10">
-                <div className="flex items-center gap-2 border-b border-white/5 px-4 py-3 light:border-slate-200/80">
-                  <span className="h-2.5 w-2.5 rounded-full bg-red-400/80" />
-                  <span className="h-2.5 w-2.5 rounded-full bg-amber-400/80" />
-                  <span className="h-2.5 w-2.5 rounded-full bg-emerald-400/80" />
-                  <span className="ml-3 font-mono text-xs text-slate-500 light:text-slate-400">
-                    demo.lextures.com
-                  </span>
-                </div>
-                <div className="grid gap-0 lg:grid-cols-[240px_1fr]">
-                  <div className="hidden border-r border-white/5 bg-slate-950/40 p-4 lg:block light:border-slate-200/80 light:bg-slate-50/80">
-                    <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
-                      Workspace
-                    </p>
-                    <ul className="mt-4 space-y-2 text-sm text-slate-300 light:text-slate-600">
-                      <li className="rounded-lg bg-cyan-400/10 px-3 py-2 text-cyan-100 light:bg-cyan-500/15 light:text-cyan-900">
-                        Adaptive overview
-                      </li>
-                      <li className="rounded-lg px-3 py-2 hover:bg-white/5 light:hover:bg-slate-100">
-                        Modules
-                      </li>
-                      <li className="rounded-lg px-3 py-2 hover:bg-white/5 light:hover:bg-slate-100">
-                        Gradebook
-                      </li>
-                      <li className="rounded-lg px-3 py-2 hover:bg-white/5 light:hover:bg-slate-100">
-                        Calendar
-                      </li>
-                    </ul>
-                  </div>
-                  <div className="relative min-h-[320px] bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-6 sm:min-h-[380px] light:from-slate-100 light:via-white light:to-slate-50">
-                    <div className="flex flex-wrap items-start justify-between gap-4">
-                      <div>
-                        <p className="text-xs font-medium uppercase tracking-wider text-cyan-300/90 light:text-cyan-700">
-                          Course dashboard
-                        </p>
-                        <p className="mt-1 text-xl font-semibold text-white light:text-slate-900">
-                          Quantum Foundations
-                        </p>
-                      </div>
-                      <span className="rounded-full bg-emerald-400/15 px-3 py-1 text-xs font-semibold text-emerald-300 ring-1 ring-emerald-400/25 light:text-emerald-800">
-                        Live cohort
-                      </span>
-                    </div>
-                    <div className="mt-8 grid gap-4 sm:grid-cols-3">
-                      {[
-                        { label: 'Engagement', value: '94%', tone: 'from-cyan-400 to-sky-500' },
-                        { label: 'At-risk', value: '3 learners', tone: 'from-amber-400 to-orange-500' },
-                        { label: 'AI assists', value: '128', tone: 'from-indigo-400 to-violet-500' },
-                      ].map((card) => (
-                        <div
-                          key={card.label}
-                          className="rounded-2xl border border-white/10 bg-white/[0.04] p-4 light:border-slate-200 light:bg-white light:shadow-sm"
-                        >
-                          <p className="text-xs text-slate-400 light:text-slate-500">{card.label}</p>
-                          <p
-                            className={`mt-2 bg-gradient-to-r ${card.tone} bg-clip-text text-2xl font-semibold text-transparent`}
-                          >
-                            {card.value}
-                          </p>
-                        </div>
-                      ))}
-                    </div>
-                    <div className="mt-6 rounded-2xl border border-dashed border-cyan-400/25 bg-cyan-400/[0.06] p-4 light:border-cyan-600/30 light:bg-cyan-500/10">
-                      <p className="text-sm font-medium text-cyan-100 light:text-cyan-900">
-                        Adaptive suggestion
-                      </p>
-                      <p className="mt-1 text-sm text-slate-300 light:text-slate-600">
-                        Shorten the mid-module quiz for learners trending ahead—keep rigor, reduce
-                        stall points.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </FadeUp>
-          </div>
-        </MotionSection>
-
-        {/* Audiences */}
-        <MotionSection className="border-y border-white/5 bg-bg-elevated/35 py-24 light:border-slate-200/80 light:bg-slate-50/80">
-          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <FadeUp className="max-w-2xl">
-              <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl light:text-slate-900">
-                Built for the people who actually run learning programs.
-              </h2>
-            </FadeUp>
-            <div className="mt-12 grid gap-6 lg:grid-cols-3">
-              {[
-                {
-                  icon: GraduationCap,
-                  title: 'For educators',
-                  body: 'Spend energy on pedagogy—not patchwork integrations. Ship iterations weekly, not per semester.',
-                },
-                {
-                  icon: BookOpen,
-                  title: 'For institutions',
-                  body: 'Operational backbone you can trust: enrollments, grading, calendars—and an AI layer teams can govern.',
-                },
-                {
-                  icon: Terminal,
-                  title: 'For developers',
-                  body: 'Own the stack. Extend the Go API and React SPA, self-host with Docker, and keep data where it belongs.',
-                },
-              ].map((block) => (
-                <FadeUp key={block.title}>
-                  <div className="glass-panel h-full rounded-2xl p-7">
-                    <block.icon className="h-8 w-8 text-cyan-300 light:text-cyan-700" aria-hidden />
-                    <h3 className="mt-5 text-xl font-semibold text-white light:text-slate-900">
-                      {block.title}
-                    </h3>
-                    <p className="mt-3 text-slate-400 light:text-slate-600">{block.body}</p>
-                  </div>
-                </FadeUp>
-              ))}
-            </div>
-          </div>
-        </MotionSection>
-
-        {/* Tech stack */}
-        <MotionSection className="py-24">
-          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <FadeUp className="max-w-2xl">
-              <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl light:text-slate-900">
-                Modern foundations. Battle-tested patterns.
-              </h2>
-              <p className="mt-4 text-slate-400 light:text-slate-600">
-                A cohesive codebase designed for clarity—fast UX up front, dependable services
-                behind the scenes.
-              </p>
-            </FadeUp>
-            <FadeUp delay={0.06} className="mt-10 flex flex-wrap gap-3">
-              {[
-                'React 19',
-                'Vite 8',
-                'Tailwind CSS v4',
-                'TypeScript',
-                'Go API',
-                'Chi',
-                'PostgreSQL',
-                'MongoDB',
-                'Docker',
-                'JWT auth',
-              ].map((tag) => (
-                <span
-                  key={tag}
-                  className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-medium text-slate-200 light:border-slate-200 light:bg-white light:text-slate-800"
-                >
-                  {tag}
-                </span>
-              ))}
-            </FadeUp>
-          </div>
-        </MotionSection>
-
-        {/* Testimonials */}
-        <MotionSection className="pb-24">
-          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <FadeUp className="flex items-center gap-3">
-              <MessageSquareQuote className="h-8 w-8 text-cyan-400 light:text-cyan-600" aria-hidden />
-              <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl light:text-slate-900">
-                Community voices
-              </h2>
-            </FadeUp>
-            <div className="mt-12 grid gap-6 lg:grid-cols-3">
-              {[
-                {
-                  quote:
-                    'We finally have an LMS that feels like product engineering—not a procurement compromise.',
-                  name: 'Dr. Amara Chen',
-                  role: 'Program Director, placeholder quote',
-                },
-                {
-                  quote:
-                    'The adaptive layer is the unlock: learners stay in flow while we keep institutional rigor.',
-                  name: 'Jordan Ellis',
-                  role: 'Instructional Designer, placeholder quote',
-                },
-                {
-                  quote:
-                    'Self-hosting with Docker gave us ownership without sacrificing a polished learner UX.',
-                  name: 'Sam Rivera',
-                  role: 'Platform Engineer, placeholder quote',
-                },
-              ].map((t) => (
-                <FadeUp key={t.name}>
-                  <blockquote className="glass-panel flex h-full flex-col rounded-2xl p-7">
-                    <p className="text-lg leading-relaxed text-slate-200 light:text-slate-700">
-                      “{t.quote}”
-                    </p>
-                    <footer className="mt-6 text-sm text-slate-400 light:text-slate-500">
-                      <span className="font-semibold text-white light:text-slate-900">{t.name}</span>
-                      <span className="block">{t.role}</span>
-                    </footer>
-                  </blockquote>
-                </FadeUp>
-              ))}
-            </div>
-            <FadeUp delay={0.1} className="mt-10 flex flex-wrap items-center gap-4">
-              <div className="glass-panel inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm text-slate-300 light:text-slate-600">
-                <Github className="h-4 w-4" aria-hidden />
-                Watch releases & discussions on GitHub
-              </div>
-              <a
-                href={LINKS.github}
-                className="text-sm font-semibold text-cyan-300 underline-offset-4 hover:underline light:text-cyan-700"
-              >
-                Explore the repository →
-              </a>
-            </FadeUp>
-          </div>
-        </MotionSection>
-
-        {/* Open source */}
-        <MotionSection id="self-host" className="border-t border-white/5 bg-bg-elevated/45 py-24 light:border-slate-200/80 light:bg-white/60">
-          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <div className="grid gap-12 lg:grid-cols-2 lg:items-center">
+        {/* Get running */}
+        <MotionSection id="get-running" className="py-20 sm:py-28">
+          <div className="mx-auto max-w-[90rem] px-4 sm:px-6 lg:px-10">
+            <div className="grid gap-12 lg:grid-cols-2 lg:items-start">
               <FadeUp>
-                <div className="inline-flex items-center gap-2 rounded-full border border-cyan-400/25 bg-cyan-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-cyan-200 light:border-cyan-600/30 light:bg-cyan-500/10 light:text-cyan-800">
-                  <Boxes className="h-3.5 w-3.5" aria-hidden />
-                  Open Source & Self-Host
-                </div>
-                <h2 className="mt-6 text-3xl font-semibold tracking-tight text-white sm:text-4xl light:text-slate-900">
-                  AGPL-3.0 licensed. Your cloud, your rules.
-                </h2>
-                <p className="mt-4 text-lg text-slate-400 light:text-slate-600">
-                  No surprise egress fees on your pedagogy. Deploy with Docker, bring your own AI
-                  keys, and scale with confidence—without surrendering core workflows to a closed
-                  roadmap.
+                <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Get running</h2>
+                <p className="mt-4 text-lg text-neutral-400">
+                  Three steps from zero to a local orchestrator—copy, configure, run.
                 </p>
-                <ul className="mt-8 space-y-4 text-slate-300 light:text-slate-600">
-                  <li className="flex gap-3">
-                    <Palette className="mt-0.5 h-5 w-5 shrink-0 text-cyan-400 light:text-cyan-600" />
-                    Transparent codebase you can audit, fork, and extend.
-                  </li>
-                  <li className="flex gap-3">
-                    <LockOpen className="mt-0.5 h-5 w-5 shrink-0 text-cyan-400 light:text-cyan-600" />
-                    PostgreSQL today—MongoDB wired for platform evolution on your timeline.
-                  </li>
-                </ul>
+                <ol className="mt-10 space-y-6">
+                  {[
+                    {
+                      step: '01',
+                      title: 'Clone the repository',
+                      body: 'Pull the latest main branch and open it in your editor of choice.',
+                    },
+                    {
+                      step: '02',
+                      title: 'Install dependencies',
+                      body: 'Follow the README for runtime versions—keep it boring and reproducible.',
+                    },
+                    {
+                      step: '03',
+                      title: 'Launch the canvas',
+                      body: 'Start the dev server, open the UI, and pin your first agent graph.',
+                    },
+                  ].map((row) => (
+                    <li key={row.step} className="flex gap-4">
+                      <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-cyan-400/30 bg-cyan-400/10 font-mono text-xs font-bold text-cyan-200">
+                        {row.step}
+                      </span>
+                      <div>
+                        <p className="font-semibold text-white">{row.title}</p>
+                        <p className="mt-1 text-sm text-neutral-400">{row.body}</p>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+                <a href={LINKS.downloadMac} className={'mt-10 ' + btnPrimary}>
+                  Download for Mac
+                </a>
               </FadeUp>
-              <FadeUp delay={0.08}>
-                <div className="glass-panel rounded-3xl p-6 font-mono text-sm leading-relaxed text-slate-200 light:text-slate-700">
-                  <div className="flex items-center justify-between text-xs text-slate-500">
-                    <span>docker-compose.yml</span>
-                    <span className="rounded bg-white/5 px-2 py-0.5 light:bg-slate-100">example</span>
+              <FadeUp delay={0.06}>
+                <div className="glass-panel rounded-2xl p-6 font-mono text-sm leading-relaxed">
+                  <div className="flex items-center justify-between text-xs text-neutral-500">
+                    <span>terminal</span>
+                    <span className="rounded-md bg-white/[0.06] px-2 py-0.5 text-[10px] uppercase tracking-wider">
+                      bash
+                    </span>
                   </div>
-                  <pre className="mt-4 overflow-x-auto text-[13px] text-cyan-100 light:text-cyan-900">
-                    {`git clone https://github.com/StudyDrift/lextures.git
-cd lextures
-docker compose up -d postgres mongo
-# configure server/.env → run API & web`}
+                  <pre className="mt-5 overflow-x-auto text-[13px] leading-relaxed text-cyan-100/95">
+                    {`git clone https://github.com/openswarm/openswarm.git
+cd openswarm
+# see README for env + first run
+npm install && npm run dev`}
                   </pre>
-                  <p className="mt-4 text-xs text-slate-500">
-                    See repository README for environment variables and production hardening notes.
+                  <p className="mt-5 text-xs text-neutral-500">
+                    Commands are illustrative; replace with the canonical steps from the repository
+                    README when you wire your release.
                   </p>
                 </div>
               </FadeUp>
@@ -631,65 +484,150 @@ docker compose up -d postgres mongo
           </div>
         </MotionSection>
 
-        {/* Final CTA */}
-        <MotionSection className="pb-28 pt-10">
-          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        {/* Workflows */}
+        <MotionSection id="workflows" className="border-y border-white/[0.06] bg-bg-elevated/35 py-20 sm:py-28">
+          <div className="mx-auto max-w-[90rem] px-4 sm:px-6 lg:px-10">
+            <FadeUp className="max-w-2xl">
+              <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Workflows</h2>
+              <p className="mt-4 text-lg text-neutral-400">
+                Four patterns teams reach for first—each maps cleanly to parallel lanes on the
+                canvas.
+              </p>
+            </FadeUp>
+            <div className="mt-14 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+              {[
+                {
+                  title: 'Research',
+                  body: 'Fan out source gathering, dedupe findings, and merge into a single brief—agents run side by side.',
+                  icon: '↔',
+                },
+                {
+                  title: 'Content',
+                  body: 'Draft, critique, and format in passes you can see: every hop is a node, every merge is explicit.',
+                  icon: '◇',
+                },
+                {
+                  title: 'Analysis',
+                  body: 'Split metrics exploration from narrative synthesis so numbers stay honest and prose stays sharp.',
+                  icon: '⊕',
+                },
+                {
+                  title: 'Automation',
+                  body: 'Trigger integrations on a schedule or webhook—keep human checkpoints as hard stops on the graph.',
+                  icon: '⟡',
+                },
+              ].map((w) => (
+                <FadeUp key={w.title}>
+                  <article className="glass-panel group flex h-full flex-col rounded-2xl p-6 transition duration-200 hover:-translate-y-0.5 hover:border-violet-400/20">
+                    <span
+                      className="text-2xl text-cyan-400/90"
+                      aria-hidden
+                    >
+                      {w.icon}
+                    </span>
+                    <h3 className="mt-4 text-lg font-bold text-white">{w.title}</h3>
+                    <p className="mt-2 flex-1 text-sm leading-relaxed text-neutral-400">{w.body}</p>
+                    <div className="mt-5 flex items-center gap-1 text-xs font-medium uppercase tracking-wider text-cyan-500/80">
+                      <Workflow className="h-3.5 w-3.5" aria-hidden />
+                      Parallel lanes
+                    </div>
+                  </article>
+                </FadeUp>
+              ))}
+            </div>
+          </div>
+        </MotionSection>
+
+        {/* Works with */}
+        <MotionSection className="py-20 sm:py-24">
+          <div className="mx-auto max-w-[90rem] px-4 sm:px-6 lg:px-10">
+            <FadeUp className="max-w-2xl">
+              <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Works with</h2>
+              <p className="mt-4 text-neutral-400">
+                Grayscale tiles brighten on hover—swap in SVG marks when you have brand assets.
+              </p>
+            </FadeUp>
+            <FadeUp delay={0.06} className="mt-10">
+              <div className="flex flex-wrap gap-3 sm:gap-4">
+                {[...PARTNERS, ...PARTNERS].map((name, i) => (
+                  <div
+                    key={`${name}-${i}`}
+                    className="group flex min-w-[7.5rem] flex-1 items-center justify-center rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-4 text-center text-sm font-semibold text-neutral-500 transition duration-200 hover:scale-[1.02] hover:border-cyan-400/25 hover:text-cyan-200 sm:min-w-[8.5rem] sm:flex-none sm:px-5"
+                  >
+                    <span className="transition group-hover:text-cyan-200">{name}</span>
+                  </div>
+                ))}
+              </div>
+            </FadeUp>
+          </div>
+        </MotionSection>
+
+        {/* CTA banner */}
+        <MotionSection className="pb-24 pt-4">
+          <div className="mx-auto max-w-[90rem] px-4 sm:px-6 lg:px-10">
             <FadeUp>
-              <div className="relative overflow-hidden rounded-[2rem] border border-cyan-400/20 bg-gradient-to-br from-cyan-500/15 via-sky-500/10 to-indigo-500/10 p-10 text-center shadow-[0_0_80px_-20px_rgba(34,211,238,0.35)] light:border-cyan-600/25 light:from-cyan-500/10 light:shadow-slate-900/10 sm:p-14">
-                <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(255,255,255,0.08),transparent)]" />
-                <h2 className="relative text-3xl font-semibold tracking-tight text-white sm:text-4xl light:text-slate-900">
-                  Start building better learning experiences today.
+              <div className="relative overflow-hidden rounded-[1.75rem] border border-cyan-400/20 bg-gradient-to-br from-cyan-500/10 via-transparent to-violet-600/15 px-8 py-12 text-center sm:px-14 sm:py-16">
+                <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,rgba(34,211,238,0.12),transparent_55%)]" />
+                <h2 className="relative text-3xl font-bold tracking-tight text-white sm:text-4xl">
+                  Start orchestrating
                 </h2>
-                <p className="relative mx-auto mt-4 max-w-2xl text-lg text-slate-200 light:text-slate-600">
-                  Try the hosted demo, star the project, or self-host in minutes. The adaptive era of
-                  learning infrastructure is open source.
+                <p className="relative mx-auto mt-4 max-w-xl text-lg text-neutral-300">
+                  MIT licensed, community-driven, and designed to stay fast. Grab the source or ship
+                  the Mac build—your canvas is waiting.
                 </p>
-                <div className="relative mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row sm:flex-wrap">
-                  <a
-                    href={LINKS.demo}
-                    className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-white px-8 py-3.5 text-base font-semibold text-slate-950 shadow-lg transition hover:bg-slate-100 sm:w-auto"
-                  >
-                    Launch Demo
-                  </a>
-                  <a
-                    href={LINKS.github}
-                    className="glass-panel inline-flex w-full items-center justify-center gap-2 rounded-xl px-8 py-3.5 text-base font-semibold text-white light:text-slate-900 sm:w-auto"
-                  >
+                <div className="relative mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                  <a href={LINKS.github} className={btnPrimary}>
                     <Github className="h-5 w-5" aria-hidden />
-                    GitHub
+                    Open GitHub
+                    <ArrowRight className="h-4 w-4 opacity-80" aria-hidden />
                   </a>
-                  <a
-                    href={LINKS.docs}
-                    className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-white/25 bg-transparent px-8 py-3.5 text-base font-semibold text-white transition hover:bg-white/10 light:border-slate-300 light:text-slate-900 light:hover:bg-slate-100 sm:w-auto"
-                  >
-                    Read the Docs
+                  <a href={LINKS.downloadMac} className={btnOutline}>
+                    Latest release
                   </a>
                 </div>
+                <p className="relative mt-8 text-sm text-neutral-500">
+                  <span className="rounded-full border border-white/10 bg-black/30 px-3 py-1 font-medium text-neutral-400">
+                    MIT License
+                  </span>
+                  <span className="mx-2 text-neutral-600">·</span>
+                  Free and open source
+                </p>
               </div>
             </FadeUp>
           </div>
         </MotionSection>
       </main>
 
-      <footer className="border-t border-white/5 py-10 light:border-slate-200/80">
-        <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
-          <div className="flex items-center gap-2 text-sm text-slate-500 light:text-slate-500">
-            <LogoMark className="h-8 w-8 opacity-90" />
-            <span>© {new Date().getFullYear()} Lextures · AGPL-3.0</span>
+      <footer className="border-t border-white/[0.06] bg-[#080808] py-8">
+        <div className="mx-auto flex max-w-[90rem] flex-col gap-6 px-4 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-10">
+          <div className="flex items-center gap-2 text-sm text-neutral-500">
+            <SwarmLogoMark className="h-8 w-8 opacity-90" />
+            <span>© {new Date().getFullYear()} OpenSwarm · MIT</span>
           </div>
-          <div className="flex flex-wrap gap-4 text-sm font-medium text-slate-400 light:text-slate-600">
-            <a className="hover:text-white light:hover:text-slate-900" href={LINKS.demo}>
-              Demo
-            </a>
-            <a className="hover:text-white light:hover:text-slate-900" href={LINKS.github}>
+          <div className="flex flex-wrap gap-6 text-sm font-medium text-neutral-400">
+            <a href={LINKS.github} className="no-underline hover:text-white">
               GitHub
             </a>
-            <a className="hover:text-white light:hover:text-slate-900" href={LINKS.docs}>
-              Docs
+            <a href="#features" className="no-underline hover:text-white">
+              Features
+            </a>
+            <a href="#get-running" className="no-underline hover:text-white">
+              Get running
             </a>
           </div>
         </div>
       </footer>
     </div>
+  )
+}
+
+function LayoutDashboardIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden fill="none" stroke="currentColor">
+      <rect x="3" y="3" width="7" height="9" rx="1.5" strokeWidth="2" />
+      <rect x="14" y="3" width="7" height="5" rx="1.5" strokeWidth="2" />
+      <rect x="14" y="12" width="7" height="9" rx="1.5" strokeWidth="2" />
+      <rect x="3" y="16" width="7" height="5" rx="1.5" strokeWidth="2" />
+    </svg>
   )
 }

--- a/www/src/components/HeroCanvas.tsx
+++ b/www/src/components/HeroCanvas.tsx
@@ -24,15 +24,10 @@ export function HeroCanvas() {
   ] as const
 
   return (
-    <div
-      className="pointer-events-none absolute inset-0 overflow-hidden"
-      aria-hidden
-    >
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_80%_60%_at_50%_-10%,rgba(34,211,238,0.22),transparent),radial-gradient(ellipse_60%_50%_at_100%_40%,rgba(56,189,248,0.12),transparent),radial-gradient(ellipse_50%_40%_at_0%_80%,rgba(99,102,241,0.08),transparent)]" />
-      <svg
-        className="absolute inset-0 h-full w-full opacity-[0.35] light:opacity-20"
-        preserveAspectRatio="none"
-      >
+    <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden>
+      <div className="bg-noise absolute inset-0 opacity-90" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_85%_55%_at_50%_-5%,rgba(34,211,238,0.14),transparent),radial-gradient(ellipse_55%_45%_at_100%_35%,rgba(139,92,246,0.08),transparent),radial-gradient(ellipse_50%_40%_at_0%_85%,rgba(34,211,238,0.06),transparent)]" />
+      <svg className="absolute inset-0 h-full w-full opacity-[0.32]" preserveAspectRatio="none">
         {edges.map(([a, b], i) => {
           const na = nodes[a]
           const nb = nodes[b]
@@ -43,26 +38,26 @@ export function HeroCanvas() {
               y1={`${na.y}`}
               x2={`${nb.x}`}
               y2={`${nb.y}`}
-              stroke="url(#lxGrad)"
+              stroke="url(#swarmGrad)"
               strokeWidth="1"
               initial={{ opacity: 0 }}
-              animate={{ opacity: 0.9 }}
-              transition={{ duration: 0.85, delay: 0.12 * i, ease: 'easeOut' }}
+              animate={{ opacity: 0.85 }}
+              transition={{ duration: 0.85, delay: 0.1 * i, ease: 'easeOut' }}
             />
           )
         })}
         <defs>
-          <linearGradient id="lxGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-            <stop offset="0%" stopColor="#22d3ee" stopOpacity="0.2" />
-            <stop offset="50%" stopColor="#38bdf8" stopOpacity="0.9" />
-            <stop offset="100%" stopColor="#6366f1" stopOpacity="0.35" />
+          <linearGradient id="swarmGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stopColor="#22d3ee" stopOpacity="0.15" />
+            <stop offset="50%" stopColor="#22d3ee" stopOpacity="0.75" />
+            <stop offset="100%" stopColor="#a78bfa" stopOpacity="0.35" />
           </linearGradient>
         </defs>
       </svg>
       {nodes.map((n, i) => (
         <motion.span
           key={i}
-          className="absolute rounded-full bg-cyan-400/80 shadow-[0_0_24px_rgba(34,211,238,0.45)] ring-1 ring-cyan-200/30 light:bg-cyan-500 light:shadow-[0_0_18px_rgba(6,182,212,0.35)]"
+          className="absolute rounded-full bg-cyan-400/75 shadow-[0_0_20px_rgba(34,211,238,0.35)] ring-1 ring-cyan-200/25"
           style={{
             left: n.x,
             top: n.y,
@@ -73,10 +68,10 @@ export function HeroCanvas() {
           }}
           initial={{ scale: 0.6, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
-          transition={{ duration: 0.6, delay: 0.05 * i, type: 'spring', stiffness: 120 }}
+          transition={{ duration: 0.55, delay: 0.04 * i, type: 'spring', stiffness: 140 }}
         />
       ))}
-      <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_0%,#020617_88%)] light:bg-[linear-gradient(to_bottom,transparent_0%,#f8fafc_90%)]" />
+      <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_0%,#0a0a0a_90%)]" />
     </div>
   )
 }

--- a/www/src/index.css
+++ b/www/src/index.css
@@ -1,14 +1,13 @@
 @import "tailwindcss";
 
-@custom-variant light (&:where(.light, .light *));
-
 @theme {
-  --font-sans: "Instrument Sans", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, monospace;
 
-  --color-bg-deep: #020617;
-  --color-bg-elevated: #0b1220;
+  --color-bg-deep: #0a0a0a;
+  --color-bg-elevated: #111111;
   --color-accent: #22d3ee;
+  --color-accent-bright: #00f0ff;
   --color-accent-soft: #67e8f9;
   --color-accent-dim: rgba(34, 211, 238, 0.12);
 }
@@ -19,35 +18,32 @@
   }
 
   body {
-    @apply bg-bg-deep text-slate-100 antialiased font-sans;
-    font-feature-settings: "ss01" on, "cv02" on;
+    @apply bg-bg-deep text-neutral-200 antialiased font-sans;
+    font-feature-settings: "cv02" on, "ss01" on;
   }
 
   ::selection {
-    @apply bg-cyan-500/30 text-white;
+    @apply bg-cyan-500/35 text-white;
   }
 
-  .light body {
-    @apply bg-slate-50 text-slate-900;
+  a:not([class*="rounded"]):not([class*="no-underline"]) {
+    @apply text-cyan-300 underline-offset-4 transition-colors hover:text-cyan-200 hover:underline;
   }
+}
 
-  .light ::selection {
-    @apply bg-cyan-600/25 text-slate-900;
-  }
+/* Subtle film grain for hero / tech feel */
+@utility bg-noise {
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
 }
 
 @utility glass-panel {
-  @apply border border-white/10 bg-white/[0.03] shadow-[0_0_0_1px_rgba(255,255,255,0.04)_inset] backdrop-blur-xl;
-}
-
-.light .glass-panel {
-  @apply border-slate-200/80 bg-white/70 shadow-[0_1px_0_rgba(15,23,42,0.06)_inset] backdrop-blur-xl;
+  @apply border border-white/[0.08] bg-white/[0.03] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] backdrop-blur-xl;
 }
 
 @utility text-gradient {
-  @apply bg-gradient-to-r from-cyan-300 via-sky-400 to-blue-500 bg-clip-text text-transparent;
+  @apply bg-gradient-to-r from-cyan-300 via-cyan-400 to-violet-400 bg-clip-text text-transparent;
 }
 
-.light .text-gradient {
-  @apply from-cyan-600 via-sky-600 to-blue-600;
+@utility code-inline {
+  @apply rounded-md bg-white/[0.06] px-1.5 py-0.5 font-mono text-[0.9em] text-neutral-200 ring-1 ring-white/10;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Redesigns the `www` Vite marketing site to match the OpenSwarm landing spec: dark-only mission-control aesthetic, ~90rem max width, cyan/teal accents, subtle swarm/canvas motif, sticky nav with mobile overlay, pill CTAs, and section flow (orchestrator intro, core features with canvas preview, get running + code block, workflows grid, “works with” strip, CTA banner, minimal footer).

## Changes

- **`www/src/App.tsx`**: New single-page layout (OpenSwarm branding, hamburger menu on small screens, no theme toggle), placeholder GitHub/release URLs (`github.com/openswarm/openswarm`).
- **`www/src/index.css`**: Deep `#0a0a0a` tokens, Inter + JetBrains Mono, noise utility, glass cards, `code-inline` utility; removed light-mode variant.
- **`www/src/components/HeroCanvas.tsx`**: Dark-only gradients, swarm lines, bottom fade to page background.
- **`www/index.html`**: Meta/title copy for OpenSwarm.

## Notes

- GitHub and `git clone` URLs are illustrative placeholders until the real OpenSwarm repo/release links are provided.
- `www/package.json` name is still `lextures-marketing`; rename in a follow-up if desired.

## Testing

- `cd www && npm install && npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f1b9e23-3ce6-4539-83f7-32dc9524a233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f1b9e23-3ce6-4539-83f7-32dc9524a233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

