### PR TITLE
design(www): refresh marketing site visuals and UX

### DIFF
--- a/www/design.md
+++ b/www/design.md
@@ -1,0 +1,105 @@
+# Lextures Marketing Site — Design System
+
+Inspired by the OpenSwarm aesthetic: clean, minimal, purposeful. No dark mode. Built for institutional credibility, not visual novelty.
+
+---
+
+## Core Principles
+
+- **Light over dark.** White and near-white backgrounds. Sections differentiate through subtle surface tones, not color drama.
+- **Typography-first.** Hierarchy is earned by font weight and size, not gradient text or glow effects.
+- **Borders over shadows.** Prefer a 1px border to deep drop shadows. Shadows are `shadow-sm` at most.
+- **Generous whitespace.** Sections breathe. Content is not crowded.
+- **One accent color.** Indigo (`#4f46e5`) is used sparingly — buttons, icons, highlights only.
+
+---
+
+## Color Palette
+
+| Token           | Value       | Use                                     |
+|-----------------|-------------|-----------------------------------------|
+| `bg-white`      | `#ffffff`   | Page background, card backgrounds       |
+| `bg-surface`    | `#f8fafc`   | Alternate section backgrounds           |
+| `bg-surface-2`  | `#f1f5f9`   | Subtle insets, quote blocks             |
+| `border-default`| `#e2e8f0`   | Card borders, section dividers          |
+| `text-primary`  | `#0f172a`   | Headings, high-importance text          |
+| `text-body`     | `#334155`   | Body copy                               |
+| `text-muted`    | `#64748b`   | Captions, secondary labels              |
+| `text-faint`    | `#94a3b8`   | Timestamps, footnotes                   |
+| `accent`        | `#4f46e5`   | Primary buttons, icon backgrounds, links|
+| `accent-hover`  | `#4338ca`   | Button hover state                      |
+| `accent-light`  | `#eef2ff`   | Icon container backgrounds, tinted cards|
+| `accent-border` | `#c7d2fe`   | Accent-adjacent borders                 |
+
+---
+
+## Typography
+
+**Fonts loaded:** DM Sans (body, UI), Instrument Serif (display/hero emphasis)
+
+| Role          | Family            | Weight | Size (desktop)  |
+|---------------|-------------------|--------|-----------------|
+| Hero H1       | Instrument Serif  | 400    | 52–60px, italic |
+| H2 (section)  | DM Sans           | 700    | 36–40px         |
+| H3 (card)     | DM Sans           | 600    | 18px            |
+| Body (large)  | DM Sans           | 400    | 18–20px         |
+| Body (default)| DM Sans           | 400    | 15–16px         |
+| Eyebrow       | DM Sans           | 500    | 13px, uppercase, letter-spacing |
+
+---
+
+## Spacing
+
+- Section vertical padding: `py-24 sm:py-32`
+- Container: `max-w-6xl mx-auto px-4 sm:px-6 lg:px-8`
+- Card padding: `p-6 sm:p-7`
+- Grid gap: `gap-5` (cards), `gap-8` (major layout splits)
+
+---
+
+## Components
+
+### Buttons
+
+**Primary:**
+- `bg-indigo-600 text-white rounded-md px-6 py-3 text-sm font-semibold`
+- Hover: `bg-indigo-700`
+- No glow, no scale animation — just a clean color shift
+
+**Secondary:**
+- `border border-slate-300 bg-white text-slate-700 rounded-md px-6 py-3 text-sm font-semibold`
+- Hover: `border-slate-400 bg-slate-50`
+
+### Cards
+
+- `bg-white border border-slate-200 rounded-xl p-6 shadow-sm`
+- Hover: `hover:border-indigo-200 hover:shadow-md` (subtle lift)
+- No glassmorphism. No backdrop blur.
+
+### Feature Icon
+
+- Container: `h-10 w-10 rounded-lg bg-indigo-50 flex items-center justify-center`
+- Icon: `text-indigo-600 h-5 w-5`
+
+### Nav
+
+- Sticky, `bg-white/95 backdrop-blur-sm border-b border-slate-200`
+- Links: `text-slate-600 hover:text-slate-900 text-sm font-medium`
+
+### Section Dividers
+
+- Alternate sections use `bg-surface` (`#f8fafc`) — no border required
+- When borders needed: `border-t border-slate-200`
+
+---
+
+## What Was Removed
+
+- Dark backgrounds (`bg-slate-950`, `bg-bg-deep`)
+- Glass panels (`backdrop-blur`, `bg-white/[0.03]`)
+- Noise texture overlay
+- Radial gradient glows
+- `rounded-full` pill buttons (replaced with `rounded-md`)
+- `text-gradient` shimmer on hero text
+- Sky-blue glow shadows (`shadow-[0_0_24px...]`)
+- `ring-1 ring-white/10` treatment

--- a/www/index.html
+++ b/www/index.html
@@ -11,7 +11,7 @@
     <meta property="og:title" content="Lextures — Learning management for serious institutions" />
     <meta
       property="og:description"
-      content="Run courses, grade with confidence, and connect your SIS and classroom tools in one calm, accessible platform."
+      content="Open-source LMS with adaptive delivery, institutional workflows, and LTI-friendly integrations—self-host on Postgres."
     />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -65,10 +65,10 @@ function LogoMark({ className = '' }: { className?: string }) {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <rect width="32" height="32" rx="8" fill="currentColor" className="text-slate-900" />
+      <rect width="32" height="32" rx="8" fill="#4f46e5" />
       <path
         d="M9 23V9h5.2c2.9 0 5.1 1.6 5.1 4.2 0 2.5-2.2 4.1-5.1 4.1H12.5V23H9Zm3.5-8.2h1.4c1.4 0 2.3-.7 2.3-1.8 0-1.2-.9-1.9-2.3-1.9h-1.4v3.7Z"
-        fill="#38bdf8"
+        fill="white"
       />
     </svg>
   )
@@ -78,49 +78,27 @@ export default function App() {
   const [menuOpen, setMenuOpen] = useState(false)
 
   useEffect(() => {
-    if (menuOpen) {
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = ''
-    }
-    return () => {
-      document.body.style.overflow = ''
-    }
+    document.body.style.overflow = menuOpen ? 'hidden' : ''
+    return () => { document.body.style.overflow = '' }
   }, [menuOpen])
 
   const closeMenu = () => setMenuOpen(false)
 
-  const btnPrimary =
-    'inline-flex items-center justify-center gap-2 rounded-full bg-sky-400 px-6 py-3 text-sm font-bold text-slate-950 shadow-[0_0_24px_-4px_rgba(56,189,248,0.5)] transition duration-200 hover:scale-[1.02] hover:bg-sky-300 hover:shadow-[0_0_32px_-2px_rgba(56,189,248,0.55)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400'
-
-  const btnOutline =
-    'inline-flex items-center justify-center gap-2 rounded-full border border-sky-400/45 bg-transparent px-6 py-3 text-sm font-bold text-sky-100 transition duration-200 hover:scale-[1.02] hover:border-sky-300 hover:bg-sky-400/10 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400'
-
   return (
-    <div className="relative min-h-screen overflow-x-hidden bg-bg-deep text-slate-300">
-      <div
-        className="pointer-events-none fixed inset-0 bg-noise opacity-90"
-        aria-hidden
-      />
-      <div
-        className="pointer-events-none fixed inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-20%,rgba(56,189,248,0.15),transparent)]"
-        aria-hidden
-      />
-
+    <div className="relative min-h-screen overflow-x-hidden bg-white text-slate-700">
       <a
         href="#main"
-        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-lg focus:bg-sky-400/20 focus:px-4 focus:py-2 focus:text-sm focus:text-white"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-indigo-600 focus:px-4 focus:py-2 focus:text-sm focus:text-white"
       >
         Skip to content
       </a>
 
-      <header className="sticky top-0 z-50 border-b border-white/[0.06] bg-slate-950/80 backdrop-blur-xl">
+      {/* Header */}
+      <header className="sticky top-0 z-50 border-b border-slate-200 bg-white/95 backdrop-blur-sm">
         <div className="mx-auto flex h-16 max-w-6xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
-          <a href="#" className="flex items-center gap-2.5 font-semibold tracking-tight text-white no-underline">
-            <span className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-lg ring-1 ring-white/10">
-              <LogoMark className="h-9 w-9" />
-            </span>
-            <span className="text-lg">Lextures</span>
+          <a href="#" className="flex items-center gap-2.5 no-underline">
+            <LogoMark className="h-8 w-8 shrink-0" />
+            <span className="text-base font-semibold text-slate-900 tracking-tight">Lextures</span>
           </a>
 
           <nav className="hidden items-center gap-1 md:flex" aria-label="Primary">
@@ -128,7 +106,7 @@ export default function App() {
               <a
                 key={item.href}
                 href={item.href}
-                className="rounded-lg px-3 py-2 text-sm font-medium text-slate-400 no-underline transition hover:bg-white/[0.04] hover:text-white"
+                className="rounded-md px-3 py-2 text-sm font-medium text-slate-600 no-underline transition-colors hover:bg-slate-100 hover:text-slate-900"
               >
                 {item.label}
               </a>
@@ -136,10 +114,10 @@ export default function App() {
           </nav>
 
           <div className="hidden items-center gap-3 md:flex">
-            <a href={LINKS.github} className={btnOutline + ' !px-5 !py-2.5 text-xs sm:text-sm'}>
+            <a href={LINKS.github} className="btn-secondary">
               Source
             </a>
-            <a href={LINKS.demo} className={btnPrimary + ' !px-5 !py-2.5 text-xs sm:text-sm'}>
+            <a href={LINKS.demo} className="btn-primary">
               Try the demo
             </a>
           </div>
@@ -147,33 +125,37 @@ export default function App() {
           <button
             type="button"
             onClick={() => setMenuOpen(true)}
-            className="inline-flex h-11 w-11 items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-white transition hover:border-sky-400/30 hover:bg-white/[0.06] md:hidden"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 text-slate-600 transition hover:bg-slate-100 md:hidden"
             aria-expanded={menuOpen}
             aria-controls="mobile-nav"
             aria-label="Open menu"
           >
-            <Menu className="h-5 w-5" />
+            <Menu className="h-4 w-4" />
           </button>
         </div>
       </header>
 
-      {menuOpen ? (
+      {/* Mobile nav */}
+      {menuOpen && (
         <div
-          className="fixed inset-0 z-[60] flex flex-col bg-slate-950 md:hidden"
+          className="fixed inset-0 z-[60] flex flex-col bg-white md:hidden"
           id="mobile-nav"
           role="dialog"
           aria-modal="true"
           aria-label="Navigation"
         >
-          <div className="flex h-16 items-center justify-between border-b border-white/[0.06] px-4">
-            <span className="text-sm font-semibold text-white">Menu</span>
+          <div className="flex h-16 items-center justify-between border-b border-slate-200 px-4">
+            <div className="flex items-center gap-2.5">
+              <LogoMark className="h-8 w-8" />
+              <span className="text-base font-semibold text-slate-900">Lextures</span>
+            </div>
             <button
               type="button"
               onClick={closeMenu}
-              className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 text-white hover:bg-white/[0.06]"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 text-slate-600 hover:bg-slate-100"
               aria-label="Close menu"
             >
-              <X className="h-5 w-5" />
+              <X className="h-4 w-4" />
             </button>
           </div>
           <nav className="flex flex-1 flex-col gap-1 p-4" aria-label="Mobile primary">
@@ -182,114 +164,114 @@ export default function App() {
                 key={item.href}
                 href={item.href}
                 onClick={closeMenu}
-                className="rounded-xl px-4 py-4 text-lg font-medium text-slate-200 no-underline transition hover:bg-white/[0.04]"
+                className="rounded-lg px-4 py-3.5 text-base font-medium text-slate-700 no-underline transition hover:bg-slate-100"
               >
                 {item.label}
               </a>
             ))}
           </nav>
-          <div className="border-t border-white/[0.06] p-4 pb-8">
-            <a href={LINKS.demo} onClick={closeMenu} className={btnPrimary + ' w-full'}>
+          <div className="border-t border-slate-200 p-4 pb-8 flex flex-col gap-3">
+            <a href={LINKS.demo} onClick={closeMenu} className="btn-primary w-full justify-center">
               Try the demo
             </a>
-            <a href={LINKS.github} onClick={closeMenu} className={'mt-3 ' + btnOutline + ' w-full'}>
+            <a href={LINKS.github} onClick={closeMenu} className="btn-secondary w-full justify-center">
               View on GitHub
             </a>
           </div>
         </div>
-      ) : null}
+      )}
 
-      <main id="main" className="relative">
-        <section className="relative overflow-hidden pb-20 pt-16 sm:pb-28 sm:pt-24">
+      <main id="main">
+        {/* Hero */}
+        <section className="border-b border-slate-200 py-20 sm:py-28 lg:py-32">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <p className="text-sm font-medium uppercase tracking-widest text-sky-400/90">
-              Learning management
+            <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600">
+              Open-source learning management
             </p>
-            <h1 className="mt-6 max-w-3xl font-display text-4xl font-normal italic leading-[1.12] tracking-tight text-white sm:text-5xl lg:text-[3.25rem]">
+            <h1 className="mt-5 max-w-3xl font-display text-4xl font-normal italic leading-[1.1] tracking-tight text-slate-900 sm:text-5xl lg:text-[3.25rem]">
               Calm software for{' '}
-              <span className="not-italic text-gradient">courses, cohorts, and credentials</span>
+              <span className="not-italic text-indigo-600">courses, cohorts, and credentials</span>
             </h1>
-            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-slate-400 sm:text-xl">
+            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-slate-600 sm:text-xl">
               Lextures is an LMS built for institutions that cannot afford toy-grade reliability—where
               roster truth, accessible content, and defensible grading matter as much as the syllabus.
             </p>
-            <div className="mt-10 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
-              <a href={LINKS.demo} className={btnPrimary}>
+            <div className="mt-9 flex flex-col gap-3 sm:flex-row sm:items-center">
+              <a href={LINKS.demo} className="btn-primary gap-2">
                 Open the live demo
-                <ArrowRight className="h-4 w-4 opacity-90" aria-hidden />
+                <ArrowRight className="h-4 w-4" aria-hidden />
               </a>
-              <a href={LINKS.github} className={btnOutline}>
+              <a href={LINKS.github} className="btn-secondary">
                 Browse the repository
               </a>
             </div>
-            <p className="mt-10 text-sm text-slate-500">
+            <p className="mt-8 text-sm text-slate-400">
               Prefer to self-host or extend? The application stack is MIT-licensed—bring your own Postgres
               and ship on your timeline.
             </p>
           </div>
         </section>
 
-        <section id="product" className="border-y border-white/[0.06] bg-bg-elevated/40 py-20 sm:py-28">
+        {/* Product pillars */}
+        <section id="product" className="bg-surface py-20 sm:py-28">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <div className="max-w-2xl">
-              <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Product pillars</h2>
-              <p className="mt-4 text-lg leading-relaxed text-slate-400">
+              <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+                Product pillars
+              </h2>
+              <p className="mt-4 text-lg leading-relaxed text-slate-600">
                 Everything here is aimed at the same outcome: fewer surprises for learners, instructors, and
                 the teams who support them.
               </p>
             </div>
-            <div className="mt-14 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
               {FEATURES.map(({ title, body, icon: Icon }) => (
-                <article
-                  key={title}
-                  className="glass-panel group rounded-2xl p-6 transition duration-200 hover:-translate-y-0.5 hover:border-sky-400/25 hover:shadow-[0_20px_50px_-28px_rgba(56,189,248,0.2)] sm:p-7"
-                >
-                  <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-sky-400/10 text-sky-300 ring-1 ring-sky-400/20">
+                <article key={title} className="feature-card">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600">
                     <Icon className="h-5 w-5" aria-hidden />
                   </div>
-                  <h3 className="mt-5 text-lg font-bold text-white">{title}</h3>
-                  <p className="mt-2 text-sm leading-relaxed text-slate-400 sm:text-[0.9375rem]">{body}</p>
+                  <h3 className="mt-5 text-base font-semibold text-slate-900">{title}</h3>
+                  <p className="mt-2 text-sm leading-relaxed text-slate-600">{body}</p>
                 </article>
               ))}
             </div>
           </div>
         </section>
 
-        <section id="institutions" className="py-20 sm:py-28">
-          <div className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-2 lg:items-center lg:gap-16 lg:px-8">
+        {/* Institutions */}
+        <section id="institutions" className="border-y border-slate-200 py-20 sm:py-28">
+          <div className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-2 lg:items-center lg:gap-20 lg:px-8">
             <div>
-              <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+              <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
                 For districts, campuses, and programs that outgrow spreadsheets
               </h2>
-              <p className="mt-5 text-lg leading-relaxed text-slate-400">
+              <p className="mt-5 text-lg leading-relaxed text-slate-600">
                 Whether you are launching a new online program or standardizing delivery across schools,
                 Lextures focuses on the workflows that break first at scale: enrollment drift, duplicate
                 content, inconsistent accommodations, and grading that cannot be audited.
               </p>
-              <ul className="mt-8 space-y-3 text-slate-300">
+              <ul className="mt-8 space-y-3">
                 {[
                   'Role-aware navigation so admins, instructors, and learners each get a sane default.',
                   'Content and media pipelines that respect accessibility expectations from day one.',
                   'Integration posture that plays nicely with SIS, SSO, and classroom toolchains.',
                 ].map((line) => (
-                  <li key={line} className="flex gap-3">
-                    <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-sky-400" />
+                  <li key={line} className="flex gap-3 text-slate-700">
+                    <span className="mt-2.5 h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-500" />
                     <span>{line}</span>
                   </li>
                 ))}
               </ul>
             </div>
-            <div className="glass-panel relative overflow-hidden rounded-2xl p-8">
-              <div className="absolute -right-16 -top-16 h-48 w-48 rounded-full bg-indigo-500/20 blur-3xl" />
-              <div className="absolute -bottom-12 -left-12 h-40 w-40 rounded-full bg-sky-500/15 blur-3xl" />
-              <p className="relative text-sm font-semibold uppercase tracking-wider text-sky-300/95">
+            <div className="rounded-xl border border-slate-200 bg-surface-2 p-8">
+              <p className="text-xs font-semibold uppercase tracking-wider text-indigo-600">
                 Design principle
               </p>
-              <p className="relative mt-4 text-xl font-medium leading-snug text-white">
+              <p className="mt-4 text-xl font-medium leading-snug text-slate-900">
                 If a registrar would wince at the data model, it does not ship—operational honesty beats
                 feature checklists.
               </p>
-              <p className="relative mt-5 text-sm leading-relaxed text-slate-500">
+              <p className="mt-5 text-sm leading-relaxed text-slate-500">
                 Lextures is under active development; the public demo is the fastest way to see current
                 capabilities and UX direction.
               </p>
@@ -297,50 +279,57 @@ export default function App() {
           </div>
         </section>
 
-        <section id="integrations" className="border-t border-white/[0.06] bg-bg-elevated/30 py-20 sm:py-28">
+        {/* Integrations */}
+        <section id="integrations" className="bg-surface py-20 sm:py-28">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <div className="max-w-2xl">
-              <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+              <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
                 Plays well with institutional identity
               </h2>
-              <p className="mt-4 text-lg text-slate-400">
+              <p className="mt-4 text-lg text-slate-600">
                 Standards and protocols matter when your next audit is always one calendar quarter away.
                 The roadmap emphasizes boring, testable interoperability over proprietary magic.
               </p>
             </div>
-            <dl className="mt-12 grid gap-6 sm:grid-cols-2">
+            <dl className="mt-12 grid gap-5 sm:grid-cols-2">
               {[
                 { term: 'LTI & launches', desc: 'Deep links into tools learners already know—without cloning accounts by hand.' },
                 { term: 'Roster realities', desc: 'Class sections, co-teachers, and enrollment churn modeled explicitly—not as an afterthought.' },
                 { term: 'Auth that fits', desc: 'Password, magic link, and enterprise SSO patterns so security teams can say yes.' },
                 { term: 'Exports you can defend', desc: 'Grades and evidence trails structured for review, accreditation, and appeals.' },
               ].map((row) => (
-                <div key={row.term} className="glass-panel rounded-xl p-5">
-                  <dt className="font-semibold text-white">{row.term}</dt>
-                  <dd className="mt-2 text-sm leading-relaxed text-slate-400">{row.desc}</dd>
+                <div key={row.term} className="feature-card">
+                  <dt className="text-sm font-semibold text-slate-900">{row.term}</dt>
+                  <dd className="mt-2 text-sm leading-relaxed text-slate-600">{row.desc}</dd>
                 </div>
               ))}
             </dl>
           </div>
         </section>
 
-        <section className="pb-24 pt-4">
+        {/* CTA */}
+        <section className="border-t border-slate-200 py-20 sm:py-28">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <div className="relative overflow-hidden rounded-3xl border border-sky-400/20 bg-gradient-to-br from-sky-500/10 via-transparent to-indigo-600/15 px-8 py-12 text-center sm:px-14 sm:py-16">
-              <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,rgba(56,189,248,0.12),transparent_55%)]" />
-              <h2 className="relative text-3xl font-bold tracking-tight text-white sm:text-4xl">
+            <div className="rounded-2xl bg-indigo-600 px-8 py-14 text-center sm:px-14">
+              <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
                 See Lextures in action
               </h2>
-              <p className="relative mx-auto mt-4 max-w-xl text-lg text-slate-300">
+              <p className="mx-auto mt-4 max-w-xl text-lg text-indigo-100">
                 Walk the learner and instructor paths on the hosted demo, then decide whether the stack
                 matches your institution&apos;s risk profile.
               </p>
-              <div className="relative mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
-                <a href={LINKS.demo} className={btnPrimary}>
+              <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                <a
+                  href={LINKS.demo}
+                  className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-semibold text-indigo-700 transition-colors hover:bg-indigo-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                >
                   Go to demo.lextures.com
-                  <ArrowRight className="h-4 w-4 opacity-90" aria-hidden />
+                  <ArrowRight className="h-4 w-4" aria-hidden />
                 </a>
-                <a href={LINKS.github} className={btnOutline}>
+                <a
+                  href={LINKS.github}
+                  className="inline-flex items-center justify-center gap-2 rounded-md border border-indigo-400 px-6 py-3 text-sm font-semibold text-white transition-colors hover:border-indigo-200 hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                >
                   Study the source
                 </a>
               </div>
@@ -349,30 +338,31 @@ export default function App() {
         </section>
       </main>
 
-      <footer className="border-t border-white/[0.06] bg-slate-950 py-10">
+      {/* Footer */}
+      <footer className="border-t border-slate-200 bg-white py-10">
         <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4 sm:flex-row sm:items-start sm:justify-between sm:px-6 lg:px-8">
           <div>
-            <div className="flex items-center gap-2 text-white">
+            <div className="flex items-center gap-2.5">
               <LogoMark className="h-8 w-8" />
-              <span className="text-base font-semibold">Lextures</span>
+              <span className="text-base font-semibold text-slate-900">Lextures</span>
             </div>
             <p className="mt-3 max-w-xs text-sm leading-relaxed text-slate-500">
               Marketing site for the Lextures learning platform. Product development happens in the open on
               GitHub.
             </p>
-            <p className="mt-4 text-sm text-slate-600">© {new Date().getFullYear()} Lextures contributors</p>
+            <p className="mt-4 text-sm text-slate-400">© {new Date().getFullYear()} Lextures contributors</p>
           </div>
-          <div className="flex flex-wrap gap-x-10 gap-y-3 text-sm font-medium text-slate-400">
-            <a href={LINKS.demo} className="no-underline hover:text-white">
+          <div className="flex flex-wrap gap-x-10 gap-y-3 text-sm font-medium text-slate-500">
+            <a href={LINKS.demo} className="no-underline hover:text-slate-900 transition-colors">
               Live demo
             </a>
-            <a href={LINKS.github} className="no-underline hover:text-white">
+            <a href={LINKS.github} className="no-underline hover:text-slate-900 transition-colors">
               GitHub
             </a>
-            <a href="#product" className="no-underline hover:text-white">
+            <a href="#product" className="no-underline hover:text-slate-900 transition-colors">
               Product
             </a>
-            <a href="#institutions" className="no-underline hover:text-white">
+            <a href="#institutions" className="no-underline hover:text-slate-900 transition-colors">
               Institutions
             </a>
           </div>

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -2,14 +2,18 @@ import {
   ArrowRight,
   BarChart3,
   BookOpen,
+  BrainCircuit,
+  Code2,
   GraduationCap,
   Menu,
-  Plug,
-  Shield,
-  Users,
+  RefreshCw,
+  ShieldCheck,
+  Unplug,
   X,
+  Zap,
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { HeroCanvas } from './HeroCanvas'
 
 const LINKS = {
   demo: 'https://demo.lextures.com/',
@@ -17,42 +21,79 @@ const LINKS = {
 } as const
 
 const NAV = [
-  { label: 'Product', href: '#product' },
+  { label: 'Features', href: '#features' },
+  { label: 'Adaptive AI', href: '#ai' },
   { label: 'Institutions', href: '#institutions' },
   { label: 'Integrations', href: '#integrations' },
-  { label: 'Demo', href: LINKS.demo },
 ] as const
 
 const FEATURES = [
   {
-    title: 'Courses that stay organized',
-    body: 'Structure units, lessons, and files so learners always know what is due next—without turning your catalog into a maze.',
+    title: 'Adaptive quiz delivery',
+    body: 'Quizzes adjust difficulty in real time using Item Response Theory. Every learner gets the right questions at the right moment—not a one-size-fits-all test.',
+    icon: BrainCircuit,
+  },
+  {
+    title: 'AI-generated content',
+    body: 'Generate quiz questions from learning objectives, build rubrics from assignment descriptions, and produce progressive hints that guide without giving answers.',
+    icon: Zap,
+  },
+  {
+    title: '14+ question types',
+    body: 'Multiple choice, essay, live code execution, image hotspots, matching, ordering, formula, and audio/video responses—built for every subject.',
     icon: BookOpen,
   },
   {
-    title: 'Assessment with guardrails',
-    body: 'Ship quizzes and assignments with clear rubrics, revision paths, and grading workflows instructors can trust at scale.',
-    icon: GraduationCap,
-  },
-  {
-    title: 'Built for real rosters',
-    body: 'Designed around sections, roles, and institutional boundaries so the right people see the right courses by default.',
-    icon: Users,
-  },
-  {
-    title: 'Operational visibility',
-    body: 'Surface progress and workload early—so teams can intervene with context instead of chasing spreadsheets after the fact.',
+    title: 'Standards-based gradebook',
+    body: 'Map assignments to NGSS, CCSS, or your own standards. Track mastery by objective—not just points. Every grading change is logged with who, what, and why.',
     icon: BarChart3,
   },
   {
-    title: 'Privacy-minded by design',
-    body: 'Treat student data as a liability to minimize, not a commodity to monetize. FERPA-shaped instincts are table stakes.',
-    icon: Shield,
+    title: 'Canvas, Moodle & Blackboard-ready',
+    body: 'LTI 1.3 provider: run Lextures inside any LMS your institution already uses. Import courses and question banks from Canvas with AI-assisted migration.',
+    icon: Unplug,
   },
   {
-    title: 'Interoperable stack',
-    body: 'Meet schools where their tools already live—LTI launches, roster signals, and the boring plumbing that keeps IT calm.',
-    icon: Plug,
+    title: 'Enterprise identity & provisioning',
+    body: 'SAML 2.0, OIDC, Clever, and ClassLink SSO. OneRoster 1.2 CSV and SCIM 2.0 HTTP for bulk roster sync. TOTP and WebAuthn MFA for every account.',
+    icon: ShieldCheck,
+  },
+] as const
+
+const AI_CAPABILITIES = [
+  {
+    title: 'Item Response Theory engine',
+    body: "Questions are calibrated using IRT 2PL/3PL models. The system estimates each learner's mastery level in real time and routes them to the content they actually need next—not what's next in the syllabus.",
+    icon: BrainCircuit,
+  },
+  {
+    title: 'Misconception detection',
+    body: 'AI analyzes incorrect responses across the class and surfaces the most common errors to instructors—so they can address patterns in the next session instead of marking them wrong and moving on.',
+    icon: GraduationCap,
+  },
+  {
+    title: 'Spaced repetition scheduler',
+    body: 'The SRS engine schedules review material at scientifically optimal intervals. Knowledge sticks between sessions instead of fading before the final exam.',
+    icon: RefreshCw,
+  },
+] as const
+
+const INTEGRATIONS = [
+  {
+    term: 'LTI 1.3 provider & consumer',
+    desc: 'Launch Lextures inside Canvas, Blackboard, or Moodle. Roster sync via NRPS, grade passback via AGS, and deep linking for publisher content—all spec-compliant.',
+  },
+  {
+    term: 'Canvas import',
+    desc: 'Move courses, question banks, and grades from Canvas using WebSocket-based import with AI-assisted migration. QTI 2.1/3.0 question bank imports from any major LMS.',
+  },
+  {
+    term: 'SSO & roster provisioning',
+    desc: 'SAML 2.0, OIDC, Clever, and ClassLink for identity. OneRoster 1.2 CSV and SCIM 2.0 HTTP for roster sync. Auto-provision users on first login.',
+  },
+  {
+    term: 'Defensible exports',
+    desc: 'Grade exports structured for accreditation reviews and appeals. iCalendar feeds for due dates. QTI exports for question bank portability.',
   },
 ] as const
 
@@ -183,18 +224,24 @@ export default function App() {
 
       <main id="main">
         {/* Hero */}
-        <section className="border-b border-slate-200 py-20 sm:py-28 lg:py-32">
-          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        <section className="relative overflow-hidden border-b border-slate-200 py-20 sm:py-28 lg:py-32">
+          <HeroCanvas />
+          {/* Gradient keeps text readable against the canvas */}
+          <div
+            className="pointer-events-none absolute inset-0 bg-gradient-to-r from-white via-white/90 to-white/20"
+            aria-hidden
+          />
+          <div className="relative z-10 mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600">
               Open-source learning management
             </p>
-            <h1 className="mt-5 max-w-3xl font-display text-4xl font-normal italic leading-[1.1] tracking-tight text-slate-900 sm:text-5xl lg:text-[3.25rem]">
-              Calm software for{' '}
-              <span className="not-italic text-indigo-600">courses, cohorts, and credentials</span>
+            <h1 className="mt-5 max-w-2xl font-display text-4xl font-normal italic leading-[1.1] tracking-tight text-slate-900 sm:text-5xl lg:text-[3.25rem]">
+              The LMS that{' '}
+              <span className="not-italic text-indigo-600">adapts to every learner</span>
             </h1>
-            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-slate-600 sm:text-xl">
-              Lextures is an LMS built for institutions that cannot afford toy-grade reliability—where
-              roster truth, accessible content, and defensible grading matter as much as the syllabus.
+            <p className="mt-6 max-w-xl text-lg leading-relaxed text-slate-600 sm:text-xl">
+              Lextures brings adaptive quizzes, AI-generated content, and standards-based grading
+              to institutions ready to move past static course delivery.
             </p>
             <div className="mt-9 flex flex-col gap-3 sm:flex-row sm:items-center">
               <a href={LINKS.demo} className="btn-primary gap-2">
@@ -206,22 +253,21 @@ export default function App() {
               </a>
             </div>
             <p className="mt-8 text-sm text-slate-400">
-              Prefer to self-host or extend? The application stack is MIT-licensed—bring your own Postgres
-              and ship on your timeline.
+              MIT-licensed · Self-host on your own Postgres · LTI 1.3 ready
             </p>
           </div>
         </section>
 
-        {/* Product pillars */}
-        <section id="product" className="bg-surface py-20 sm:py-28">
+        {/* Features */}
+        <section id="features" className="bg-surface py-20 sm:py-28">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <div className="max-w-2xl">
               <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
-                Product pillars
+                Everything instructors need. Nothing they don't.
               </h2>
               <p className="mt-4 text-lg leading-relaxed text-slate-600">
-                Everything here is aimed at the same outcome: fewer surprises for learners, instructors, and
-                the teams who support them.
+                Lextures is a full LMS—course management, assessments, gradebook, and integrations—
+                built from the ground up with adaptive intelligence at the core.
               </p>
             </div>
             <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
@@ -238,23 +284,52 @@ export default function App() {
           </div>
         </section>
 
+        {/* Adaptive AI */}
+        <section id="ai" className="border-y border-slate-200 py-20 sm:py-28">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+            <div className="max-w-2xl">
+              <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600">
+                Intelligence built in
+              </p>
+              <h2 className="mt-3 text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+                Not an AI add-on. An adaptive core.
+              </h2>
+              <p className="mt-4 text-lg leading-relaxed text-slate-600">
+                Adaptive delivery, misconception detection, and spaced repetition are core infrastructure—
+                not a chatbot widget bolted onto a legacy gradebook.
+              </p>
+            </div>
+            <div className="mt-12 grid gap-8 lg:grid-cols-3">
+              {AI_CAPABILITIES.map(({ title, body, icon: Icon }) => (
+                <div key={title} className="flex flex-col gap-4">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-indigo-600 text-white shadow-sm">
+                    <Icon className="h-5 w-5" aria-hidden />
+                  </div>
+                  <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+                  <p className="text-sm leading-relaxed text-slate-600">{body}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
         {/* Institutions */}
-        <section id="institutions" className="border-y border-slate-200 py-20 sm:py-28">
+        <section id="institutions" className="bg-surface py-20 sm:py-28">
           <div className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-2 lg:items-center lg:gap-20 lg:px-8">
             <div>
               <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
-                For districts, campuses, and programs that outgrow spreadsheets
+                Built around how institutions actually operate
               </h2>
               <p className="mt-5 text-lg leading-relaxed text-slate-600">
-                Whether you are launching a new online program or standardizing delivery across schools,
-                Lextures focuses on the workflows that break first at scale: enrollment drift, duplicate
-                content, inconsistent accommodations, and grading that cannot be audited.
+                From K-12 districts to university programs, Lextures is modeled on the workflows
+                that break first at scale: enrollment drift, inconsistent accommodations, grading
+                that can't be audited, and content no one can keep synchronized.
               </p>
               <ul className="mt-8 space-y-3">
                 {[
-                  'Role-aware navigation so admins, instructors, and learners each get a sane default.',
-                  'Content and media pipelines that respect accessibility expectations from day one.',
-                  'Integration posture that plays nicely with SIS, SSO, and classroom toolchains.',
+                  'Course blueprints let coordinators maintain master templates and push updates to every child section at once.',
+                  'Accommodations are managed at the platform level—extra time and reduced distraction mode apply automatically, without per-assignment workarounds.',
+                  'Every grading action is logged: who changed what, when, and why—so appeals and accreditation reviews have a real paper trail.',
                 ].map((line) => (
                   <li key={line} className="flex gap-3 text-slate-700">
                     <span className="mt-2.5 h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-500" />
@@ -268,62 +343,114 @@ export default function App() {
                 Design principle
               </p>
               <p className="mt-4 text-xl font-medium leading-snug text-slate-900">
-                If a registrar would wince at the data model, it does not ship—operational honesty beats
-                feature checklists.
+                If a registrar would wince at the data model, it doesn't ship—operational honesty
+                beats feature checklists.
               </p>
               <p className="mt-5 text-sm leading-relaxed text-slate-500">
-                Lextures is under active development; the public demo is the fastest way to see current
-                capabilities and UX direction.
+                Lextures is under active development. The public demo is the fastest way to see
+                current capabilities and the direction the product is heading.
               </p>
+              <a href={LINKS.demo} className="btn-primary mt-6 inline-flex gap-2">
+                See it live
+                <ArrowRight className="h-4 w-4" aria-hidden />
+              </a>
             </div>
           </div>
         </section>
 
         {/* Integrations */}
-        <section id="integrations" className="bg-surface py-20 sm:py-28">
+        <section id="integrations" className="border-t border-slate-200 py-20 sm:py-28">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <div className="max-w-2xl">
               <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
-                Plays well with institutional identity
+                Works inside the stack you already have
               </h2>
               <p className="mt-4 text-lg text-slate-600">
-                Standards and protocols matter when your next audit is always one calendar quarter away.
-                The roadmap emphasizes boring, testable interoperability over proprietary magic.
+                No rip-and-replace. Lextures is designed to integrate with Canvas, Blackboard,
+                Moodle, and your district SIS—or stand alone as your primary LMS.
               </p>
             </div>
             <dl className="mt-12 grid gap-5 sm:grid-cols-2">
-              {[
-                { term: 'LTI & launches', desc: 'Deep links into tools learners already know—without cloning accounts by hand.' },
-                { term: 'Roster realities', desc: 'Class sections, co-teachers, and enrollment churn modeled explicitly—not as an afterthought.' },
-                { term: 'Auth that fits', desc: 'Password, magic link, and enterprise SSO patterns so security teams can say yes.' },
-                { term: 'Exports you can defend', desc: 'Grades and evidence trails structured for review, accreditation, and appeals.' },
-              ].map((row) => (
+              {INTEGRATIONS.map((row) => (
                 <div key={row.term} className="feature-card">
                   <dt className="text-sm font-semibold text-slate-900">{row.term}</dt>
                   <dd className="mt-2 text-sm leading-relaxed text-slate-600">{row.desc}</dd>
                 </div>
               ))}
             </dl>
+            <div className="mt-10 flex flex-wrap items-center gap-x-8 gap-y-3 text-sm text-slate-400">
+              {['LTI 1.3', 'SAML 2.0', 'OIDC', 'OneRoster 1.2', 'SCIM 2.0', 'Clever', 'ClassLink', 'QTI 2.1/3.0', 'Canvas import', 'iCalendar'].map((tag) => (
+                <span key={tag} className="font-medium text-slate-500">{tag}</span>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Code section */}
+        <section className="bg-surface border-y border-slate-200 py-16 sm:py-20">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+            <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:gap-16">
+              <div className="lg:max-w-md">
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600">
+                  <Code2 className="h-5 w-5" aria-hidden />
+                </div>
+                <h2 className="mt-5 text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">
+                  Open source, MIT-licensed
+                </h2>
+                <p className="mt-4 leading-relaxed text-slate-600">
+                  The full application stack—Go backend, React frontend, database migrations—is
+                  public on GitHub. Deploy on your own infrastructure, fork it, or contribute.
+                  No vendor lock-in, no usage fees.
+                </p>
+                <div className="mt-6 flex gap-3">
+                  <a href={LINKS.github} className="btn-primary gap-2">
+                    View on GitHub
+                    <ArrowRight className="h-4 w-4" aria-hidden />
+                  </a>
+                </div>
+              </div>
+              <div className="flex-1 rounded-xl border border-slate-200 bg-slate-900 p-6 font-mono text-sm leading-relaxed shadow-sm">
+                <p className="text-slate-500"># Get started in minutes</p>
+                <p className="mt-3">
+                  <span className="text-indigo-400">git clone</span>{' '}
+                  <span className="text-slate-300">https://github.com/StudyDrift/lextures</span>
+                </p>
+                <p className="mt-1">
+                  <span className="text-indigo-400">cd</span>{' '}
+                  <span className="text-slate-300">lextures</span>
+                </p>
+                <p className="mt-3 text-slate-500"># Start with Docker Compose</p>
+                <p className="mt-1">
+                  <span className="text-indigo-400">docker compose up</span>{' '}
+                  <span className="text-slate-400">-d</span>
+                </p>
+                <p className="mt-3 text-slate-500"># Or run locally with your own Postgres</p>
+                <p className="mt-1">
+                  <span className="text-indigo-400">make</span>{' '}
+                  <span className="text-slate-300">dev</span>
+                </p>
+              </div>
+            </div>
           </div>
         </section>
 
         {/* CTA */}
-        <section className="border-t border-slate-200 py-20 sm:py-28">
+        <section className="py-20 sm:py-28">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <div className="rounded-2xl bg-indigo-600 px-8 py-14 text-center sm:px-14">
               <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
-                See Lextures in action
+                See what modern course delivery looks like
               </h2>
               <p className="mx-auto mt-4 max-w-xl text-lg text-indigo-100">
-                Walk the learner and instructor paths on the hosted demo, then decide whether the stack
-                matches your institution&apos;s risk profile.
+                Walk the learner and instructor paths on the hosted demo—adaptive quizzes, gradebook,
+                Canvas import, and all. Then evaluate whether the stack fits your institution.
               </p>
               <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
                 <a
                   href={LINKS.demo}
                   className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-semibold text-indigo-700 transition-colors hover:bg-indigo-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
                 >
-                  Go to demo.lextures.com
+                  Open demo.lextures.com
                   <ArrowRight className="h-4 w-4" aria-hidden />
                 </a>
                 <a
@@ -347,8 +474,8 @@ export default function App() {
               <span className="text-base font-semibold text-slate-900">Lextures</span>
             </div>
             <p className="mt-3 max-w-xs text-sm leading-relaxed text-slate-500">
-              Marketing site for the Lextures learning platform. Product development happens in the open on
-              GitHub.
+              Open-source learning management system for adaptive education. Built in public
+              on GitHub.
             </p>
             <p className="mt-4 text-sm text-slate-400">© {new Date().getFullYear()} Lextures contributors</p>
           </div>
@@ -359,11 +486,17 @@ export default function App() {
             <a href={LINKS.github} className="no-underline hover:text-slate-900 transition-colors">
               GitHub
             </a>
-            <a href="#product" className="no-underline hover:text-slate-900 transition-colors">
-              Product
+            <a href="#features" className="no-underline hover:text-slate-900 transition-colors">
+              Features
+            </a>
+            <a href="#ai" className="no-underline hover:text-slate-900 transition-colors">
+              Adaptive AI
             </a>
             <a href="#institutions" className="no-underline hover:text-slate-900 transition-colors">
               Institutions
+            </a>
+            <a href="#integrations" className="no-underline hover:text-slate-900 transition-colors">
+              Integrations
             </a>
           </div>
         </div>

--- a/www/src/App.tsx
+++ b/www/src/App.tsx
@@ -106,7 +106,7 @@ function LogoMark({ className = '' }: { className?: string }) {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <rect width="32" height="32" rx="8" fill="#4f46e5" />
+      <rect width="32" height="32" rx="8" fill="var(--color-accent)" />
       <path
         d="M9 23V9h5.2c2.9 0 5.1 1.6 5.1 4.2 0 2.5-2.2 4.1-5.1 4.1H12.5V23H9Zm3.5-8.2h1.4c1.4 0 2.3-.7 2.3-1.8 0-1.2-.9-1.9-2.3-1.9h-1.4v3.7Z"
         fill="white"
@@ -126,20 +126,20 @@ export default function App() {
   const closeMenu = () => setMenuOpen(false)
 
   return (
-    <div className="relative min-h-screen overflow-x-hidden bg-white text-slate-700">
+    <div className="relative min-h-screen overflow-x-hidden bg-stone-50 text-slate-700">
       <a
         href="#main"
-        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-indigo-600 focus:px-4 focus:py-2 focus:text-sm focus:text-white"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-lg focus:bg-accent focus:px-4 focus:py-2 focus:text-sm focus:text-white"
       >
         Skip to content
       </a>
 
       {/* Header */}
-      <header className="sticky top-0 z-50 border-b border-slate-200 bg-white/95 backdrop-blur-sm">
+      <header className="sticky top-0 z-50 border-b border-stone-200/80 bg-stone-50/90 backdrop-blur-md">
         <div className="mx-auto flex h-16 max-w-6xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
           <a href="#" className="flex items-center gap-2.5 no-underline">
             <LogoMark className="h-8 w-8 shrink-0" />
-            <span className="text-base font-semibold text-slate-900 tracking-tight">Lextures</span>
+            <span className="text-base font-semibold tracking-tight text-stone-900">Lextures</span>
           </a>
 
           <nav className="hidden items-center gap-1 md:flex" aria-label="Primary">
@@ -147,7 +147,7 @@ export default function App() {
               <a
                 key={item.href}
                 href={item.href}
-                className="rounded-md px-3 py-2 text-sm font-medium text-slate-600 no-underline transition-colors hover:bg-slate-100 hover:text-slate-900"
+                className="rounded-lg px-3 py-2 text-sm font-medium text-stone-600 no-underline transition-colors hover:bg-stone-200/60 hover:text-stone-900"
               >
                 {item.label}
               </a>
@@ -166,7 +166,7 @@ export default function App() {
           <button
             type="button"
             onClick={() => setMenuOpen(true)}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 text-slate-600 transition hover:bg-slate-100 md:hidden"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-stone-200 text-stone-600 transition hover:bg-stone-200/50 md:hidden"
             aria-expanded={menuOpen}
             aria-controls="mobile-nav"
             aria-label="Open menu"
@@ -179,21 +179,21 @@ export default function App() {
       {/* Mobile nav */}
       {menuOpen && (
         <div
-          className="fixed inset-0 z-[60] flex flex-col bg-white md:hidden"
+          className="fixed inset-0 z-[60] flex flex-col bg-stone-50 md:hidden"
           id="mobile-nav"
           role="dialog"
           aria-modal="true"
           aria-label="Navigation"
         >
-          <div className="flex h-16 items-center justify-between border-b border-slate-200 px-4">
+          <div className="flex h-16 items-center justify-between border-b border-stone-200 px-4">
             <div className="flex items-center gap-2.5">
               <LogoMark className="h-8 w-8" />
-              <span className="text-base font-semibold text-slate-900">Lextures</span>
+              <span className="text-base font-semibold text-stone-900">Lextures</span>
             </div>
             <button
               type="button"
               onClick={closeMenu}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 text-slate-600 hover:bg-slate-100"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-stone-200 text-stone-600 hover:bg-stone-200/50"
               aria-label="Close menu"
             >
               <X className="h-4 w-4" />
@@ -205,13 +205,13 @@ export default function App() {
                 key={item.href}
                 href={item.href}
                 onClick={closeMenu}
-                className="rounded-lg px-4 py-3.5 text-base font-medium text-slate-700 no-underline transition hover:bg-slate-100"
+                className="rounded-lg px-4 py-3.5 text-base font-medium text-stone-800 no-underline transition hover:bg-stone-200/50"
               >
                 {item.label}
               </a>
             ))}
           </nav>
-          <div className="border-t border-slate-200 p-4 pb-8 flex flex-col gap-3">
+          <div className="flex flex-col gap-3 border-t border-stone-200 p-4 pb-8">
             <a href={LINKS.demo} onClick={closeMenu} className="btn-primary w-full justify-center">
               Try the demo
             </a>
@@ -224,24 +224,24 @@ export default function App() {
 
       <main id="main">
         {/* Hero */}
-        <section className="relative overflow-hidden border-b border-slate-200 py-20 sm:py-28 lg:py-32">
+        <section className="relative overflow-hidden border-b border-stone-200/90 bg-white py-20 sm:py-28 lg:py-32">
           <HeroCanvas />
-          {/* Gradient keeps text readable against the canvas */}
+          {/* Fade keeps the canvas visible but never competes with copy */}
           <div
-            className="pointer-events-none absolute inset-0 bg-gradient-to-r from-white via-white/90 to-white/20"
+            className="pointer-events-none absolute inset-0 bg-gradient-to-r from-white via-white/95 to-transparent"
             aria-hidden
           />
           <div className="relative z-10 mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600">
+            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-stone-500">
               Open-source learning management
             </p>
-            <h1 className="mt-5 max-w-2xl font-display text-4xl font-normal italic leading-[1.1] tracking-tight text-slate-900 sm:text-5xl lg:text-[3.25rem]">
+            <h1 className="font-display mt-6 max-w-2xl text-[2.15rem] font-normal leading-[1.12] tracking-[-0.02em] text-stone-900 sm:text-5xl lg:text-[3.05rem]">
               The LMS that{' '}
-              <span className="not-italic text-indigo-600">adapts to every learner</span>
+              <span className="text-accent">adapts as learners move</span>
             </h1>
-            <p className="mt-6 max-w-xl text-lg leading-relaxed text-slate-600 sm:text-xl">
-              Lextures brings adaptive quizzes, AI-generated content, and standards-based grading
-              to institutions ready to move past static course delivery.
+            <p className="mt-6 max-w-xl text-lg leading-relaxed text-stone-600 sm:text-xl">
+              Adaptive quizzes, instructor workflows, and integrations that fit schools and programs
+              running at real scale—not a slide deck with a gradebook attached.
             </p>
             <div className="mt-9 flex flex-col gap-3 sm:flex-row sm:items-center">
               <a href={LINKS.demo} className="btn-primary gap-2">
@@ -252,8 +252,8 @@ export default function App() {
                 Browse the repository
               </a>
             </div>
-            <p className="mt-8 text-sm text-slate-400">
-              MIT-licensed · Self-host on your own Postgres · LTI 1.3 ready
+            <p className="mt-8 text-sm text-stone-400">
+              MIT license · Self-hosted Postgres · LTI 1.3
             </p>
           </div>
         </section>
@@ -262,22 +262,22 @@ export default function App() {
         <section id="features" className="bg-surface py-20 sm:py-28">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <div className="max-w-2xl">
-              <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
-                Everything instructors need. Nothing they don't.
+              <h2 className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
+                Built for courses, grading, and the messy middle
               </h2>
-              <p className="mt-4 text-lg leading-relaxed text-slate-600">
-                Lextures is a full LMS—course management, assessments, gradebook, and integrations—
-                built from the ground up with adaptive intelligence at the core.
+              <p className="mt-4 text-lg leading-relaxed text-stone-600">
+                Course management, assessments, gradebook, and integrations—without treating
+                adaptation like a marketing bolt-on.
               </p>
             </div>
             <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
               {FEATURES.map(({ title, body, icon: Icon }) => (
                 <article key={title} className="feature-card">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent-muted/70 text-accent">
                     <Icon className="h-5 w-5" aria-hidden />
                   </div>
-                  <h3 className="mt-5 text-base font-semibold text-slate-900">{title}</h3>
-                  <p className="mt-2 text-sm leading-relaxed text-slate-600">{body}</p>
+                  <h3 className="mt-5 text-base font-semibold text-stone-900">{title}</h3>
+                  <p className="mt-2 text-sm leading-relaxed text-stone-600">{body}</p>
                 </article>
               ))}
             </div>
@@ -285,28 +285,28 @@ export default function App() {
         </section>
 
         {/* Adaptive AI */}
-        <section id="ai" className="border-y border-slate-200 py-20 sm:py-28">
+        <section id="ai" className="border-y border-stone-200/90 bg-white py-20 sm:py-28">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <div className="max-w-2xl">
-              <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600">
-                Intelligence built in
+              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-stone-500">
+                Delivery & outcomes
               </p>
-              <h2 className="mt-3 text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
-                Not an AI add-on. An adaptive core.
+              <h2 className="mt-3 text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
+                Adaptive mechanics, not buzzwords
               </h2>
-              <p className="mt-4 text-lg leading-relaxed text-slate-600">
-                Adaptive delivery, misconception detection, and spaced repetition are core infrastructure—
-                not a chatbot widget bolted onto a legacy gradebook.
+              <p className="mt-4 text-lg leading-relaxed text-stone-600">
+                Routing, misconceptions, and review scheduling sit next to grading and content—because
+                that is where they actually affect outcomes.
               </p>
             </div>
             <div className="mt-12 grid gap-8 lg:grid-cols-3">
               {AI_CAPABILITIES.map(({ title, body, icon: Icon }) => (
-                <div key={title} className="flex flex-col gap-4">
-                  <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-indigo-600 text-white shadow-sm">
+                <div key={title} className="flex flex-col gap-4 rounded-xl border border-stone-200/90 bg-stone-50/50 p-6">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-stone-900 text-white shadow-sm">
                     <Icon className="h-5 w-5" aria-hidden />
                   </div>
-                  <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
-                  <p className="text-sm leading-relaxed text-slate-600">{body}</p>
+                  <h3 className="text-lg font-semibold text-stone-900">{title}</h3>
+                  <p className="text-sm leading-relaxed text-stone-600">{body}</p>
                 </div>
               ))}
             </div>
@@ -317,10 +317,10 @@ export default function App() {
         <section id="institutions" className="bg-surface py-20 sm:py-28">
           <div className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-2 lg:items-center lg:gap-20 lg:px-8">
             <div>
-              <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+              <h2 className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
                 Built around how institutions actually operate
               </h2>
-              <p className="mt-5 text-lg leading-relaxed text-slate-600">
+              <p className="mt-5 text-lg leading-relaxed text-stone-600">
                 From K-12 districts to university programs, Lextures is modeled on the workflows
                 that break first at scale: enrollment drift, inconsistent accommodations, grading
                 that can't be audited, and content no one can keep synchronized.
@@ -331,22 +331,22 @@ export default function App() {
                   'Accommodations are managed at the platform level—extra time and reduced distraction mode apply automatically, without per-assignment workarounds.',
                   'Every grading action is logged: who changed what, when, and why—so appeals and accreditation reviews have a real paper trail.',
                 ].map((line) => (
-                  <li key={line} className="flex gap-3 text-slate-700">
-                    <span className="mt-2.5 h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-500" />
+                  <li key={line} className="flex gap-3 text-stone-700">
+                    <span className="mt-2.5 h-1.5 w-1.5 shrink-0 rounded-full bg-accent" />
                     <span>{line}</span>
                   </li>
                 ))}
               </ul>
             </div>
-            <div className="rounded-xl border border-slate-200 bg-surface-2 p-8">
-              <p className="text-xs font-semibold uppercase tracking-wider text-indigo-600">
+            <div className="rounded-xl border border-stone-200/90 bg-surface-2 p-8 shadow-[inset_0_1px_0_rgba(255,255,255,0.6)]">
+              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-stone-500">
                 Design principle
               </p>
-              <p className="mt-4 text-xl font-medium leading-snug text-slate-900">
+              <p className="mt-4 text-xl font-medium leading-snug text-stone-900">
                 If a registrar would wince at the data model, it doesn't ship—operational honesty
                 beats feature checklists.
               </p>
-              <p className="mt-5 text-sm leading-relaxed text-slate-500">
+              <p className="mt-5 text-sm leading-relaxed text-stone-500">
                 Lextures is under active development. The public demo is the fastest way to see
                 current capabilities and the direction the product is heading.
               </p>
@@ -359,13 +359,13 @@ export default function App() {
         </section>
 
         {/* Integrations */}
-        <section id="integrations" className="border-t border-slate-200 py-20 sm:py-28">
+        <section id="integrations" className="border-t border-stone-200/90 bg-white py-20 sm:py-28">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <div className="max-w-2xl">
-              <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+              <h2 className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
                 Works inside the stack you already have
               </h2>
-              <p className="mt-4 text-lg text-slate-600">
+              <p className="mt-4 text-lg text-stone-600">
                 No rip-and-replace. Lextures is designed to integrate with Canvas, Blackboard,
                 Moodle, and your district SIS—or stand alone as your primary LMS.
               </p>
@@ -373,31 +373,31 @@ export default function App() {
             <dl className="mt-12 grid gap-5 sm:grid-cols-2">
               {INTEGRATIONS.map((row) => (
                 <div key={row.term} className="feature-card">
-                  <dt className="text-sm font-semibold text-slate-900">{row.term}</dt>
-                  <dd className="mt-2 text-sm leading-relaxed text-slate-600">{row.desc}</dd>
+                  <dt className="text-sm font-semibold text-stone-900">{row.term}</dt>
+                  <dd className="mt-2 text-sm leading-relaxed text-stone-600">{row.desc}</dd>
                 </div>
               ))}
             </dl>
-            <div className="mt-10 flex flex-wrap items-center gap-x-8 gap-y-3 text-sm text-slate-400">
+            <div className="mt-10 flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-stone-400">
               {['LTI 1.3', 'SAML 2.0', 'OIDC', 'OneRoster 1.2', 'SCIM 2.0', 'Clever', 'ClassLink', 'QTI 2.1/3.0', 'Canvas import', 'iCalendar'].map((tag) => (
-                <span key={tag} className="font-medium text-slate-500">{tag}</span>
+                <span key={tag} className="font-medium text-stone-500">{tag}</span>
               ))}
             </div>
           </div>
         </section>
 
         {/* Code section */}
-        <section className="bg-surface border-y border-slate-200 py-16 sm:py-20">
+        <section className="border-y border-stone-200/90 bg-surface py-16 sm:py-20">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:gap-16">
               <div className="lg:max-w-md">
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600">
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent-muted/70 text-accent">
                   <Code2 className="h-5 w-5" aria-hidden />
                 </div>
-                <h2 className="mt-5 text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">
+                <h2 className="mt-5 text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
                   Open source, MIT-licensed
                 </h2>
-                <p className="mt-4 leading-relaxed text-slate-600">
+                <p className="mt-4 leading-relaxed text-stone-600">
                   The full application stack—Go backend, React frontend, database migrations—is
                   public on GitHub. Deploy on your own infrastructure, fork it, or contribute.
                   No vendor lock-in, no usage fees.
@@ -409,25 +409,25 @@ export default function App() {
                   </a>
                 </div>
               </div>
-              <div className="flex-1 rounded-xl border border-slate-200 bg-slate-900 p-6 font-mono text-sm leading-relaxed shadow-sm">
-                <p className="text-slate-500"># Get started in minutes</p>
+              <div className="flex-1 rounded-xl border border-stone-800 bg-stone-950 p-6 font-mono text-sm leading-relaxed shadow-sm">
+                <p className="text-stone-500"># Get started in minutes</p>
                 <p className="mt-3">
-                  <span className="text-indigo-400">git clone</span>{' '}
-                  <span className="text-slate-300">https://github.com/StudyDrift/lextures</span>
+                  <span className="text-teal-400">git clone</span>{' '}
+                  <span className="text-stone-300">https://github.com/StudyDrift/lextures</span>
                 </p>
                 <p className="mt-1">
-                  <span className="text-indigo-400">cd</span>{' '}
-                  <span className="text-slate-300">lextures</span>
+                  <span className="text-teal-400">cd</span>{' '}
+                  <span className="text-stone-300">lextures</span>
                 </p>
-                <p className="mt-3 text-slate-500"># Start with Docker Compose</p>
+                <p className="mt-3 text-stone-500"># Start with Docker Compose</p>
                 <p className="mt-1">
-                  <span className="text-indigo-400">docker compose up</span>{' '}
-                  <span className="text-slate-400">-d</span>
+                  <span className="text-teal-400">docker compose up</span>{' '}
+                  <span className="text-stone-500">-d</span>
                 </p>
-                <p className="mt-3 text-slate-500"># Or run locally with your own Postgres</p>
+                <p className="mt-3 text-stone-500"># Or run locally with your own Postgres</p>
                 <p className="mt-1">
-                  <span className="text-indigo-400">make</span>{' '}
-                  <span className="text-slate-300">dev</span>
+                  <span className="text-teal-400">make</span>{' '}
+                  <span className="text-stone-300">dev</span>
                 </p>
               </div>
             </div>
@@ -437,26 +437,20 @@ export default function App() {
         {/* CTA */}
         <section className="py-20 sm:py-28">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <div className="rounded-2xl bg-indigo-600 px-8 py-14 text-center sm:px-14">
-              <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
-                See what modern course delivery looks like
+            <div className="rounded-2xl border border-stone-200/90 bg-white px-8 py-14 text-center shadow-[0_12px_40px_-24px_rgba(28,25,23,0.35)] sm:px-14">
+              <h2 className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
+                Try the product on the hosted demo
               </h2>
-              <p className="mx-auto mt-4 max-w-xl text-lg text-indigo-100">
-                Walk the learner and instructor paths on the hosted demo—adaptive quizzes, gradebook,
-                Canvas import, and all. Then evaluate whether the stack fits your institution.
+              <p className="mx-auto mt-4 max-w-xl text-lg leading-relaxed text-stone-600">
+                Walk learner and instructor flows—quizzes, gradebook, imports—then decide if the stack
+                matches your institution.
               </p>
               <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
-                <a
-                  href={LINKS.demo}
-                  className="inline-flex items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-semibold text-indigo-700 transition-colors hover:bg-indigo-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-                >
+                <a href={LINKS.demo} className="btn-primary gap-2 px-6 py-3">
                   Open demo.lextures.com
                   <ArrowRight className="h-4 w-4" aria-hidden />
                 </a>
-                <a
-                  href={LINKS.github}
-                  className="inline-flex items-center justify-center gap-2 rounded-md border border-indigo-400 px-6 py-3 text-sm font-semibold text-white transition-colors hover:border-indigo-200 hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-                >
+                <a href={LINKS.github} className="btn-secondary px-6 py-3">
                   Study the source
                 </a>
               </div>
@@ -466,36 +460,36 @@ export default function App() {
       </main>
 
       {/* Footer */}
-      <footer className="border-t border-slate-200 bg-white py-10">
-        <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4 sm:flex-row sm:items-start sm:justify-between sm:px-6 lg:px-8">
+      <footer className="border-t border-stone-200/90 bg-white py-12">
+        <div className="mx-auto flex max-w-6xl flex-col gap-10 px-4 sm:flex-row sm:items-start sm:justify-between sm:px-6 lg:px-8">
           <div>
             <div className="flex items-center gap-2.5">
               <LogoMark className="h-8 w-8" />
-              <span className="text-base font-semibold text-slate-900">Lextures</span>
+              <span className="text-base font-semibold text-stone-900">Lextures</span>
             </div>
-            <p className="mt-3 max-w-xs text-sm leading-relaxed text-slate-500">
-              Open-source learning management system for adaptive education. Built in public
+            <p className="mt-3 max-w-xs text-sm leading-relaxed text-stone-500">
+              Open-source LMS for courses, assessments, and institutional workflows. Developed in public
               on GitHub.
             </p>
-            <p className="mt-4 text-sm text-slate-400">© {new Date().getFullYear()} Lextures contributors</p>
+            <p className="mt-4 text-sm text-stone-400">© {new Date().getFullYear()} Lextures contributors</p>
           </div>
-          <div className="flex flex-wrap gap-x-10 gap-y-3 text-sm font-medium text-slate-500">
-            <a href={LINKS.demo} className="no-underline hover:text-slate-900 transition-colors">
+          <div className="flex flex-wrap gap-x-8 gap-y-2 text-sm font-medium text-stone-500">
+            <a href={LINKS.demo} className="no-underline transition-colors hover:text-stone-900">
               Live demo
             </a>
-            <a href={LINKS.github} className="no-underline hover:text-slate-900 transition-colors">
+            <a href={LINKS.github} className="no-underline transition-colors hover:text-stone-900">
               GitHub
             </a>
-            <a href="#features" className="no-underline hover:text-slate-900 transition-colors">
+            <a href="#features" className="no-underline transition-colors hover:text-stone-900">
               Features
             </a>
-            <a href="#ai" className="no-underline hover:text-slate-900 transition-colors">
+            <a href="#ai" className="no-underline transition-colors hover:text-stone-900">
               Adaptive AI
             </a>
-            <a href="#institutions" className="no-underline hover:text-slate-900 transition-colors">
+            <a href="#institutions" className="no-underline transition-colors hover:text-stone-900">
               Institutions
             </a>
-            <a href="#integrations" className="no-underline hover:text-slate-900 transition-colors">
+            <a href="#integrations" className="no-underline transition-colors hover:text-stone-900">
               Integrations
             </a>
           </div>

--- a/www/src/HeroCanvas.tsx
+++ b/www/src/HeroCanvas.tsx
@@ -8,44 +8,54 @@ interface Dot {
   r: number
 }
 
+const ACCENT_RGB = '13, 148, 136' /* teal-600 */
+const NODE_RGB = '120, 113, 108' /* stone-500 */
+
 export function HeroCanvas() {
   const ref = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
-    const canvas = ref.current
-    if (!canvas) return
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
+    const surface = ref.current
+    if (!surface) return
+    const graphics = surface.getContext('2d')
+    if (!graphics) return
 
-    const COUNT = 90
-    const LINK_DIST = 145
+    const canvas: HTMLCanvasElement = surface
+    const ctx: CanvasRenderingContext2D = graphics
+
+    const reduceMotion =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    const COUNT = reduceMotion ? 42 : 64
+    const LINK_DIST = 132
     let raf = 0
     const dots: Dot[] = []
 
     function resize() {
-      canvas!.width = canvas!.offsetWidth
-      canvas!.height = canvas!.offsetHeight
+      canvas.width = canvas.offsetWidth
+      canvas.height = canvas.offsetHeight
     }
 
     function init() {
-      const w = canvas!.width
-      const h = canvas!.height
+      const w = canvas.width
+      const h = canvas.height
       dots.length = 0
       for (let i = 0; i < COUNT; i++) {
         dots.push({
           x: Math.random() * w,
           y: Math.random() * h,
-          vx: (Math.random() - 0.5) * 0.45,
-          vy: (Math.random() - 0.5) * 0.45,
-          r: Math.random() * 1.4 + 0.6,
+          vx: reduceMotion ? 0 : (Math.random() - 0.5) * 0.35,
+          vy: reduceMotion ? 0 : (Math.random() - 0.5) * 0.35,
+          r: Math.random() * 1.2 + 0.45,
         })
       }
     }
 
-    function tick() {
-      const w = canvas!.width
-      const h = canvas!.height
-      ctx!.clearRect(0, 0, w, h)
+    function drawFrame() {
+      const w = canvas.width
+      const h = canvas.height
+      ctx.clearRect(0, 0, w, h)
 
       for (const d of dots) {
         d.x += d.vx
@@ -60,25 +70,30 @@ export function HeroCanvas() {
           const dy = dots[i].y - dots[j].y
           const dist = Math.sqrt(dx * dx + dy * dy)
           if (dist < LINK_DIST) {
-            const alpha = (1 - dist / LINK_DIST) * 0.16
-            ctx!.beginPath()
-            ctx!.strokeStyle = `rgba(99,102,241,${alpha})`
-            ctx!.lineWidth = 0.75
-            ctx!.moveTo(dots[i].x, dots[i].y)
-            ctx!.lineTo(dots[j].x, dots[j].y)
-            ctx!.stroke()
+            const alpha = (1 - dist / LINK_DIST) * 0.065
+            ctx.beginPath()
+            ctx.strokeStyle = `rgba(${ACCENT_RGB},${alpha})`
+            ctx.lineWidth = 0.65
+            ctx.moveTo(dots[i].x, dots[i].y)
+            ctx.lineTo(dots[j].x, dots[j].y)
+            ctx.stroke()
           }
         }
       }
 
       for (const d of dots) {
-        ctx!.beginPath()
-        ctx!.arc(d.x, d.y, d.r, 0, Math.PI * 2)
-        ctx!.fillStyle = 'rgba(99,102,241,0.38)'
-        ctx!.fill()
+        ctx.beginPath()
+        ctx.arc(d.x, d.y, d.r, 0, Math.PI * 2)
+        ctx.fillStyle = `rgba(${NODE_RGB},0.22)`
+        ctx.fill()
       }
+    }
 
-      raf = requestAnimationFrame(tick)
+    function tick() {
+      drawFrame()
+      if (!reduceMotion) {
+        raf = requestAnimationFrame(tick)
+      }
     }
 
     resize()
@@ -88,6 +103,9 @@ export function HeroCanvas() {
     const ro = new ResizeObserver(() => {
       resize()
       init()
+      if (reduceMotion) {
+        drawFrame()
+      }
     })
     ro.observe(canvas)
 

--- a/www/src/HeroCanvas.tsx
+++ b/www/src/HeroCanvas.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef } from 'react'
+
+interface Dot {
+  x: number
+  y: number
+  vx: number
+  vy: number
+  r: number
+}
+
+export function HeroCanvas() {
+  const ref = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = ref.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const COUNT = 90
+    const LINK_DIST = 145
+    let raf = 0
+    const dots: Dot[] = []
+
+    function resize() {
+      canvas!.width = canvas!.offsetWidth
+      canvas!.height = canvas!.offsetHeight
+    }
+
+    function init() {
+      const w = canvas!.width
+      const h = canvas!.height
+      dots.length = 0
+      for (let i = 0; i < COUNT; i++) {
+        dots.push({
+          x: Math.random() * w,
+          y: Math.random() * h,
+          vx: (Math.random() - 0.5) * 0.45,
+          vy: (Math.random() - 0.5) * 0.45,
+          r: Math.random() * 1.4 + 0.6,
+        })
+      }
+    }
+
+    function tick() {
+      const w = canvas!.width
+      const h = canvas!.height
+      ctx!.clearRect(0, 0, w, h)
+
+      for (const d of dots) {
+        d.x += d.vx
+        d.y += d.vy
+        if (d.x < 0 || d.x > w) d.vx *= -1
+        if (d.y < 0 || d.y > h) d.vy *= -1
+      }
+
+      for (let i = 0; i < dots.length; i++) {
+        for (let j = i + 1; j < dots.length; j++) {
+          const dx = dots[i].x - dots[j].x
+          const dy = dots[i].y - dots[j].y
+          const dist = Math.sqrt(dx * dx + dy * dy)
+          if (dist < LINK_DIST) {
+            const alpha = (1 - dist / LINK_DIST) * 0.16
+            ctx!.beginPath()
+            ctx!.strokeStyle = `rgba(99,102,241,${alpha})`
+            ctx!.lineWidth = 0.75
+            ctx!.moveTo(dots[i].x, dots[i].y)
+            ctx!.lineTo(dots[j].x, dots[j].y)
+            ctx!.stroke()
+          }
+        }
+      }
+
+      for (const d of dots) {
+        ctx!.beginPath()
+        ctx!.arc(d.x, d.y, d.r, 0, Math.PI * 2)
+        ctx!.fillStyle = 'rgba(99,102,241,0.38)'
+        ctx!.fill()
+      }
+
+      raf = requestAnimationFrame(tick)
+    }
+
+    resize()
+    init()
+    tick()
+
+    const ro = new ResizeObserver(() => {
+      resize()
+      init()
+    })
+    ro.observe(canvas)
+
+    return () => {
+      cancelAnimationFrame(raf)
+      ro.disconnect()
+    }
+  }, [])
+
+  return <canvas ref={ref} className="absolute inset-0 h-full w-full" aria-hidden />
+}

--- a/www/src/index.css
+++ b/www/src/index.css
@@ -4,17 +4,24 @@
   --font-sans: "DM Sans", ui-sans-serif, system-ui, sans-serif;
   --font-display: "Instrument Serif", ui-serif, Georgia, serif;
 
-  --color-surface: #f8fafc;
-  --color-surface-2: #f1f5f9;
-  --color-accent: #4f46e5;
-  --color-accent-hover: #4338ca;
-  --color-accent-light: #eef2ff;
-  --color-accent-border: #c7d2fe;
+  --color-surface: #fafaf9;
+  --color-surface-2: #f5f5f4;
+  /* Teal accent: distinct from default “SaaS indigo”, still serious for education */
+  --color-accent: #0f766e;
+  --color-accent-hover: #115e59;
+  --color-accent-muted: #ccfbf1;
+  --color-accent-border: #99f6e4;
 }
 
 @layer base {
   html {
     scroll-behavior: smooth;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
   }
 
   body {
@@ -23,22 +30,22 @@
   }
 
   ::selection {
-    @apply bg-indigo-100 text-indigo-900;
+    @apply bg-teal-100 text-teal-950;
   }
 
   a:not([class]) {
-    @apply text-indigo-600 underline-offset-4 transition-colors hover:text-indigo-700 hover:underline;
+    @apply text-accent underline-offset-4 transition-colors hover:text-accent-hover hover:underline;
   }
 }
 
 @utility btn-primary {
-  @apply inline-flex items-center justify-center gap-2 rounded-md bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors duration-150 hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600;
+  @apply inline-flex items-center justify-center gap-2 rounded-lg bg-accent px-5 py-2.5 text-sm font-semibold text-white shadow-[0_1px_2px_rgba(15,118,110,0.18)] transition-colors duration-150 hover:bg-accent-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent;
 }
 
 @utility btn-secondary {
-  @apply inline-flex items-center justify-center gap-2 rounded-md border border-slate-300 bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 transition-colors duration-150 hover:border-slate-400 hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600;
+  @apply inline-flex items-center justify-center gap-2 rounded-lg border border-stone-300 bg-white px-5 py-2.5 text-sm font-semibold text-stone-800 transition-colors duration-150 hover:border-stone-400 hover:bg-stone-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent;
 }
 
 @utility feature-card {
-  @apply bg-white border border-slate-200 rounded-xl p-6 shadow-sm transition-all duration-150 hover:border-indigo-200 hover:shadow-md;
+  @apply rounded-xl border border-stone-200/90 bg-white p-6 shadow-[0_1px_2px_rgba(28,25,23,0.04)] transition-[box-shadow,border-color] duration-150 hover:border-stone-300 hover:shadow-[0_4px_14px_rgba(28,25,23,0.07)];
 }

--- a/www/src/index.css
+++ b/www/src/index.css
@@ -4,12 +4,12 @@
   --font-sans: "DM Sans", ui-sans-serif, system-ui, sans-serif;
   --font-display: "Instrument Serif", ui-serif, Georgia, serif;
 
-  --color-bg-deep: #0b1120;
-  --color-bg-elevated: #111827;
-  --color-accent: #38bdf8;
-  --color-accent-soft: #7dd3fc;
-  --color-accent-dim: rgba(56, 189, 248, 0.12);
-  --color-accent-2: #a5b4fc;
+  --color-surface: #f8fafc;
+  --color-surface-2: #f1f5f9;
+  --color-accent: #4f46e5;
+  --color-accent-hover: #4338ca;
+  --color-accent-light: #eef2ff;
+  --color-accent-border: #c7d2fe;
 }
 
 @layer base {
@@ -18,27 +18,27 @@
   }
 
   body {
-    @apply bg-bg-deep text-slate-300 antialiased font-sans;
+    @apply bg-white text-slate-700 antialiased font-sans;
     font-optical-sizing: auto;
   }
 
   ::selection {
-    @apply bg-sky-500/35 text-white;
+    @apply bg-indigo-100 text-indigo-900;
   }
 
-  a:not([class*="rounded"]):not([class*="no-underline"]) {
-    @apply text-sky-300 underline-offset-4 transition-colors hover:text-sky-200 hover:underline;
+  a:not([class]) {
+    @apply text-indigo-600 underline-offset-4 transition-colors hover:text-indigo-700 hover:underline;
   }
 }
 
-@utility bg-noise {
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
+@utility btn-primary {
+  @apply inline-flex items-center justify-center gap-2 rounded-md bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors duration-150 hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600;
 }
 
-@utility glass-panel {
-  @apply border border-white/[0.08] bg-white/[0.03] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] backdrop-blur-xl;
+@utility btn-secondary {
+  @apply inline-flex items-center justify-center gap-2 rounded-md border border-slate-300 bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 transition-colors duration-150 hover:border-slate-400 hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600;
 }
 
-@utility text-gradient {
-  @apply bg-gradient-to-r from-sky-300 via-sky-200 to-indigo-300 bg-clip-text text-transparent;
+@utility feature-card {
+  @apply bg-white border border-slate-200 rounded-xl p-6 shadow-sm transition-all duration-150 hover:border-indigo-200 hover:shadow-md;
 }


### PR DESCRIPTION
## Summary

Updates the public marketing site (`www/`) toward a cleaner, less template-forward presentation: teal accent and warm stone surfaces instead of default indigo, subtler hero canvas animation with reduced-motion handling, clearer section hierarchy, and a CTA that reads as a product card rather than a full-bleed banner.

## Test plan

- [ ] `cd www && npm run build`
- [ ] Spot-check hero, feature grid, integrations, and footer in the browser.


Made with [Cursor](https://cursor.com)