### PR TITLE
fix(server): satisfy golangci-lint unused on org role grants

### DIFF
--- a/server/internal/httpserver/org_role_grants.go
+++ b/server/internal/httpserver/org_role_grants.go
@@ -17,11 +17,6 @@ import (
 	"github.com/lextures/lextures/server/internal/repos/rbac"
 )
 
-const (
-	permOrgRolesManage = "tenant:org:roles:manage"
-	permOrgRolesView   = "tenant:org:roles:view"
-)
-
 type orgRoleGrantJSON struct {
 	ID         string  `json:"id"`
 	OrgID      string  `json:"orgId"`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI for [PR #79](https://github.com/StudyDrift/lextures/pull/79) failed in **Server (Go)** with `unused` linter errors for `permOrgRolesManage` and `permOrgRolesView` in `org_role_grants.go`. Those strings were never referenced; `orgRoleAccess` already enforces access via `permGlobalRBACManage` and org-scoped roles.

## Change

- Remove the unused `const` block.

## Verification

- `golangci-lint run ./...` in `server/` (0 issues)
- `go test ./... -short` in `server/`

**Base:** `feat/org-role-hierarchy` — merge this into the feature branch (or cherry-pick the commit) so PR #79’s CI goes green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f0af771-2efe-4b37-ae35-55f3fb92cd10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f0af771-2efe-4b37-ae35-55f3fb92cd10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

