### PR TITLE
fix(demo): repair migration checksums for 120 and 135 on demo deploy

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -28,7 +28,7 @@ services:
       DATABASE_URL: postgres://studydrift:${POSTGRES_PASSWORD}@postgres:5432/studydrift?sslmode=disable
       JWT_SECRET: ${JWT_SECRET}
       RUN_MIGRATIONS: "true"
-      # Demo DB may retain checksum from migration 120 after an abbreviated deploy; align before migrate.
+      # Demo DB may retain checksums from migrations 120/135 after follow-up PR edits; align before migrate.
       MIGRATE_REPAIR_CHECKSUMS: "1"
       PORT: "8080"
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}

--- a/server/internal/migrate/repair.go
+++ b/server/internal/migrate/repair.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"strings"
@@ -20,37 +21,62 @@ func migrateRepairChecksumsEnabled() bool {
 	}
 }
 
-// repairMigration120DemoChecksum updates _sqlx_migrations when version 120's stored checksum
-// does not match the embedded file (abbreviated deploys, whitespace-only edits, etc.).
-// Only runs when MIGRATE_REPAIR_CHECKSUMS is enabled (demo docker-compose.deploy.yml).
-func repairMigration120DemoChecksum(ctx context.Context, c *pgx.Conn, fsys fs.FS, dir string) error {
+// demoChecksumRepairMigrations lists versions whose SQL files may legitimately drift
+// from what the demo droplet recorded (abbreviated deploys, follow-up PR edits) while
+// remaining idempotent (IF NOT EXISTS / ON CONFLICT DO NOTHING). When
+// MIGRATE_REPAIR_CHECKSUMS is enabled (docker-compose.deploy.yml), stored checksums
+// are updated to match the embedded files so migrate can proceed.
+var demoChecksumRepairMigrations = []struct {
+	version int64
+	file    string
+}{
+	{120, "120_clever_classlink.sql"},
+	{135, "135_org_role_grants.sql"},
+}
+
+// repairDemoMigrationChecksums updates _sqlx_migrations when a listed version's stored
+// checksum does not match the embedded file. Only runs when MIGRATE_REPAIR_CHECKSUMS
+// is enabled.
+func repairDemoMigrationChecksums(ctx context.Context, c *pgx.Conn, fsys fs.FS, dir string) error {
 	if !migrateRepairChecksumsEnabled() {
 		return nil
 	}
-	rel := dir + "/120_clever_classlink.sql"
+	for _, m := range demoChecksumRepairMigrations {
+		if err := repairOneMigrationChecksum(ctx, c, fsys, dir, m.version, m.file); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func repairOneMigrationChecksum(ctx context.Context, c *pgx.Conn, fsys fs.FS, dir string, version int64, file string) error {
+	rel := dir + "/" + file
 	body, err := fs.ReadFile(fsys, rel)
 	if err != nil {
-		return err
+		return fmt.Errorf("migrate repair v%d: read %q: %w", version, rel, err)
 	}
 	currentSum := sqlxChecksum(body)
 
 	var rowChecksum []byte
 	err = c.QueryRow(ctx,
 		`SELECT checksum FROM `+sqlxMigrationsTable+` WHERE version = $1`,
-		int64(120),
+		version,
 	).Scan(&rowChecksum)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
 		}
-		return err
+		return fmt.Errorf("migrate repair v%d: %w", version, err)
 	}
 	if bytes.Equal(rowChecksum, currentSum[:]) {
 		return nil
 	}
 	_, err = c.Exec(ctx,
 		`UPDATE `+sqlxMigrationsTable+` SET checksum = $1 WHERE version = $2`,
-		currentSum[:], int64(120),
+		currentSum[:], version,
 	)
-	return err
+	if err != nil {
+		return fmt.Errorf("migrate repair v%d: %w", version, err)
+	}
+	return nil
 }

--- a/server/internal/migrate/run.go
+++ b/server/internal/migrate/run.go
@@ -54,7 +54,7 @@ func runLocked(ctx context.Context, conn *pgx.Conn, fsys fs.FS, dir string) erro
 	if err := checkNotDirty(ctx, conn); err != nil {
 		return err
 	}
-	if err := repairMigration120DemoChecksum(ctx, conn, fsys, dir); err != nil {
+	if err := repairDemoMigrationChecksums(ctx, conn, fsys, dir); err != nil {
 		return err
 	}
 	entries, err := fs.ReadDir(fsys, dir)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The [Deploy Demo](https://github.com/StudyDrift/lextures/actions/runs/25608179335) job failed because the API container exited during startup with:

`migrate: migrations/135_org_role_grants.sql was modified after apply (version 135 checksum mismatch)`

The demo droplet keeps a persistent Postgres volume, so `_sqlx_migrations` still holds the checksum from when migration 135 was first applied. A later edit to `135_org_role_grants.sql` (e.g. follow-up PR) changes the embedded file checksum and the migrator correctly refuses to continue.

## Fix

`docker-compose.deploy.yml` already sets `MIGRATE_REPAIR_CHECKSUMS=1` for the same class of problem on migration 120. This change generalizes that repair path: when the flag is enabled, stored checksums for migrations **120** and **135** are updated to match the embedded SQL files if they differ (idempotent migrations only).

## Testing

- `go test ./internal/migrate/... -short`
- `go build ./cmd/server`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15186730-5c8b-4511-bc89-93641f321276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15186730-5c8b-4511-bc89-93641f321276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

