### PR TITLE
Security: bootstrap admin gate (C2) and doc updates (C3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Lextures is an LMS (Learning Management System) with two main services:
 Required env vars for the Go API (copy from `server/.env.example` to `server/.env`):
 - `DATABASE_URL=postgres://studydrift:studydrift@localhost:5432/studydrift?sslmode=disable`
 - `JWT_SECRET=change-me-use-at-least-32-characters-for-production`
+- `BOOTSTRAP_ADMIN_EMAIL` — optional; if set to your email, the **first** password signup on an empty human user table gets Global Admin. If unset, use `cd server && go run ./cmd/bootstrap-admin -email=you@example.com` after creating an account.
 - `RUN_MIGRATIONS=true`
 - `PORT=8080`
 - `PUBLIC_WEB_ORIGIN=http://localhost:5173`
@@ -32,6 +33,7 @@ Frontend env: `VITE_API_URL=http://localhost:8080` (set when running `npm run de
 | Task | Command | Working Directory |
 |------|---------|-------------------|
 | Go build | `go build -o bin/server ./cmd/server` | `server/` |
+| Grant Global Admin (CLI) | `go run ./cmd/bootstrap-admin -email=user@example.com` | `server/` (needs `DATABASE_URL`) |
 | Go test (short, no DB) | `go test ./... -count=1 -short -timeout=1m` | `server/` |
 | Go test (full, needs DB) | `make test` (needs `DATABASE_URL`) | `server/` |
 | Go lint | `golangci-lint run ./...` | `server/` |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,8 @@ services:
       # sslmode=disable avoids TLS negotiation issues with the local Postgres container.
       DATABASE_URL: postgres://studydrift:studydrift@postgres:5432/studydrift?sslmode=disable
       JWT_SECRET: change-me-in-production-use-a-long-random-string
+      # First password Global Admin only when signup email matches (see docs/SECURITY_ISSUES.md C2).
+      BOOTSTRAP_ADMIN_EMAIL: ${BOOTSTRAP_ADMIN_EMAIL:-}
       RUN_MIGRATIONS: "true"
       OPEN_ROUTER_API_KEY: ${OPEN_ROUTER_API_KEY:-}
       COURSE_FILES_ROOT: /var/course-files

--- a/docs/SECURITY_ISSUES.md
+++ b/docs/SECURITY_ISSUES.md
@@ -19,20 +19,17 @@ The themes that matter for a "ShinyHunters-style" intrusion are: **token theft s
   2. In `config.Load()` reject any `JWT_SECRET` that matches a known-default list (`change-me*`, `dev-secret-do-not-use*`, etc.) unless `ALLOW_INSECURE_JWT=1`.
   3. Rotate the secret on any environment that has ever booted with the default — invalidate all sessions.
 
-### C2. First signup self-promotes to Global Admin
-- **File:** [server/internal/service/authservice/credentials.go:165-197](../server/internal/service/authservice/credentials.go#L165) (`Signup`)
-- **Detail:** `Signup` takes a transactional advisory lock, counts non-system users, and if the count is zero assigns `Global Admin` to the new account. There is no environment gate, no invite check, no IP/host check.
-- **Risk:** If a fresh deployment is exposed to the internet for even a second before the operator signs up, a stranger can create the first account and become the platform's superuser. This is exactly the kind of misconfig that ShinyHunters-class attackers spray for.
-- **Fix:** Require an explicit bootstrap mechanism — environment variable (`BOOTSTRAP_ADMIN_EMAIL`), CLI subcommand (`server bootstrap-admin`), or signed invite token. Never derive admin status from "I happened to be first."
+### C2. First signup self-promotes to Global Admin — **fixed (2026-05-11)**
+- **File:** [server/internal/service/authservice/credentials.go](../server/internal/service/authservice/credentials.go) (`Signup`), [server/internal/config/config.go](../server/internal/config/config.go) (`BOOTSTRAP_ADMIN_EMAIL`), [server/cmd/bootstrap-admin/main.go](../server/cmd/bootstrap-admin/main.go)
+- **Detail (historical):** `Signup` used to assign `Global Admin` whenever the human user count was zero, with no environment gate.
+- **Risk (historical):** A stranger hitting a fresh internet-exposed deploy before the operator could seize superuser.
+- **Resolution:** Global Admin on first password signup only when `BOOTSTRAP_ADMIN_EMAIL` is set and equals the normalized signup email. Otherwise the first account is a normal Teacher. Operators can run `go run ./cmd/bootstrap-admin -email=…` from `server/` with `DATABASE_URL` to grant Global Admin after the fact.
 
-### C3. Live API keys present in repo-root `.env`
+### C3. Live API keys present in repo-root `.env` — **fixed (2026-05-11)**
 - **File:** [.env](../.env) (gitignored, but on developer machines and any tarball/backup that ignores `.gitignore`)
-- **Detail:** Contains what look like real `OPEN_ROUTER_API_KEY` and `GITHUB_TOKEN` (`github_pat_…`) values. `.env` is untracked but is not encrypted, not vaulted, and will end up in `tar`/`rsync`/IDE backups. Anyone who clones a developer's home directory or steals a laptop has them.
-- **Risk:** OpenRouter spend abuse, GitHub PAT pivoting (depending on scopes — `github_pat_` fine-grained tokens still grant per-repo write at minimum).
-- **Fix:**
-  1. Rotate **both** secrets now; assume compromise.
-  2. Move local secrets to a vault (1Password CLI, `op`, `direnv` + age-encrypted file, AWS SSM, Doppler).
-  3. Add a pre-commit hook (`gitleaks`/`trufflehog`) so a future `.env` slip is caught before push.
+- **Detail (historical):** The reported incident involved real-looking `OPEN_ROUTER_API_KEY` and `GITHUB_TOKEN` values in a local `.env`.
+- **Risk (historical):** OpenRouter spend abuse and GitHub PAT pivoting if those materials were copied or exfiltrated.
+- **Resolution:** Credentials were rotated/revoked. Keep `.env` out of version control; prefer a vault or secret manager for long-lived local keys. Automated secret scanning in CI/pre-commit remains tracked under **I2** if not already enabled.
 
 ---
 
@@ -225,7 +222,7 @@ At minimum:
 - 11 failed logins / 60 s → throttled (after H3 fix).
 - Upload a malicious SVG → either rejected (H4 fix) or stripped of script.
 - Upload an HTML course file → rendered as `text/html` only with `Content-Disposition: attachment` (H5 fix).
-- Sign up twice on a fresh DB → second signup must NOT receive Global Admin (C2 fix).
+- Fresh DB: first password signup must NOT become Global Admin unless `BOOTSTRAP_ADMIN_EMAIL` matches that user; a second signup never receives that bootstrap path (C2 fix).
 
 ### I5. Document a token-revocation runbook
 On suspected token leak (C1, H1, M3), what is the operator command? Today: rotate `JWT_SECRET` and bounce the server (kicks every active session). After M3 lands: bump `kid`. Codify this so it isn't invented mid-incident.
@@ -236,8 +233,8 @@ On suspected token leak (C1, H1, M3), what is the operator command? Today: rotat
 
 ### Block production launch
 1. **C1** Default JWT secret — remove and rotate.
-2. **C2** First-signup self-promotion — gate behind explicit bootstrap.
-3. **C3** Rotate the leaked-looking keys in repo `.env`.
+2. ~~**C2** First-signup self-promotion~~ — done (`BOOTSTRAP_ADMIN_EMAIL` + `bootstrap-admin` CLI).
+3. ~~**C3** Rotate the leaked-looking keys in repo `.env`~~ — done (rotated/revoked; hygiene ongoing).
 4. **H1** Move tokens to `HttpOnly` cookies (or at least the refresh token).
 5. **H2** Tighten CORS, add the security-headers middleware.
 6. **H3** Auth-endpoint rate limiting.

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,6 +4,10 @@
 DATABASE_URL=postgres://studydrift:studydrift@localhost:5432/studydrift?sslmode=disable
 JWT_SECRET=change-me-use-at-least-32-characters-for-production
 
+# First human password signup receives Global Admin only when this matches the signup email (trimmed, lowercased).
+# Leave unset so random first signups are never superusers; use `go run ./cmd/bootstrap-admin -email=…` from server/ to promote later.
+# BOOTSTRAP_ADMIN_EMAIL=you@yourdomain.com
+
 # Optional
 PORT=8080
 RUN_MIGRATIONS=true

--- a/server/cmd/bootstrap-admin/main.go
+++ b/server/cmd/bootstrap-admin/main.go
@@ -1,0 +1,53 @@
+// Command bootstrap-admin grants Global Admin to an existing user by email (operator tool).
+// Use when BOOTSTRAP_ADMIN_EMAIL was unset at first signup or to promote an account after deploy.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/lextures/lextures/server/internal/db"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+	"github.com/lextures/lextures/server/internal/repos/user"
+)
+
+func main() {
+	emailArg := flag.String("email", "", "user email to grant Global Admin (required)")
+	flag.Parse()
+	dsn := strings.TrimSpace(os.Getenv("DATABASE_URL"))
+	if dsn == "" {
+		log.Fatal("DATABASE_URL is required")
+	}
+	em := user.NormalizeEmail(*emailArg)
+	if em == "" {
+		log.Fatal("-email is required and must be a valid address")
+	}
+
+	ctx := context.Background()
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		log.Fatalf("db: %v", err)
+	}
+	defer pool.Close()
+
+	row, err := user.FindByEmail(ctx, pool, em)
+	if err != nil {
+		log.Fatalf("lookup: %v", err)
+	}
+	if row == nil {
+		log.Fatalf("no user with email %q", em)
+	}
+	uid, err := uuid.Parse(row.ID)
+	if err != nil {
+		log.Fatalf("user id: %v", err)
+	}
+	if err := rbac.AssignUserRoleByName(ctx, pool, uid, "Global Admin"); err != nil {
+		log.Fatalf("rbac: %v", err)
+	}
+	fmt.Printf("Global Admin granted to %s (%s)\n", em, row.ID)
+}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -27,6 +27,10 @@ type Config struct {
 	AllowInsecureJWT bool
 	RunMigrations    bool
 
+	// BootstrapAdminEmail, when non-empty, is the only email that may receive Global Admin
+	// on the first human password signup (empty DB besides system users). Loaded from BOOTSTRAP_ADMIN_EMAIL.
+	BootstrapAdminEmail string
+
 	OpenRouterAPIKey string
 	CourseFilesRoot  string
 
@@ -144,6 +148,8 @@ func Load() Config {
 		JWTSecret:        jwtSecret,
 		AllowInsecureJWT: allowInsecureJWT,
 		RunMigrations:    runMigrations(),
+
+		BootstrapAdminEmail: strings.ToLower(strings.TrimSpace(os.Getenv("BOOTSTRAP_ADMIN_EMAIL"))),
 
 		OpenRouterAPIKey: firstNonEmptyTrimmed("OPENROUTER_API_KEY", "OPEN_ROUTER_API_KEY"),
 		CourseFilesRoot:  stringDefault(firstNonEmptyTrimmed("COURSE_FILES_ROOT"), "data/course-files"),

--- a/server/internal/httpserver/auth.go
+++ b/server/internal/httpserver/auth.go
@@ -75,7 +75,7 @@ func (d Deps) handleSignup() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
 			return
 		}
-		res, err := authservice.Signup(r.Context(), d.Pool, d.JWTSigner, d.passwordChecker(), authservice.SignupRequest{
+		res, err := authservice.Signup(r.Context(), d.Pool, d.JWTSigner, d.effectiveConfig(), d.passwordChecker(), authservice.SignupRequest{
 			Email:       b.Email,
 			Password:    b.Password,
 			DisplayName: b.DisplayName,

--- a/server/internal/service/authservice/credentials.go
+++ b/server/internal/service/authservice/credentials.go
@@ -140,8 +140,9 @@ func Login(ctx context.Context, pool *pgxpool.Pool, jwt *pauth.JWTSigner, cfg co
 	return issueAuthAfterCredentialSuccess(ctx, pool, jwt, cfg, row, MergeClientMeta(req.Client, "password"))
 }
 
-// Signup .
-func Signup(ctx context.Context, pool *pgxpool.Pool, jwt *pauth.JWTSigner, checker hibp.Checker, req SignupRequest) (AuthResponse, error) {
+// Signup creates a password account. The first human user receives Global Admin only when
+// cfg.BootstrapAdminEmail is set and matches the signup email (see docs/SECURITY_ISSUES.md C2).
+func Signup(ctx context.Context, pool *pgxpool.Pool, jwt *pauth.JWTSigner, cfg config.Config, checker hibp.Checker, req SignupRequest) (AuthResponse, error) {
 	if err := validateSignup(&req); err != nil {
 		return AuthResponse{}, err
 	}
@@ -187,7 +188,7 @@ WHERE id <> $1::uuid`, communication.PlatformInboxSenderID.String()).Scan(&human
 	if err != nil {
 		return AuthResponse{}, err
 	}
-	if firstHuman {
+	if firstHuman && cfg.BootstrapAdminEmail != "" && email == cfg.BootstrapAdminEmail {
 		if err := rbac.AssignUserRoleByNameTx(ctx, tx, uid, "Global Admin"); err != nil {
 			return AuthResponse{}, err
 		}

--- a/server/internal/service/authservice/flow_db_test.go
+++ b/server/internal/service/authservice/flow_db_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lextures/lextures/server/internal/db"
 	"github.com/lextures/lextures/server/internal/migrate"
 	"github.com/lextures/lextures/server/internal/repos/rbac"
+	"github.com/lextures/lextures/server/internal/repos/user"
 )
 
 // Exercise signup/login/email-taken and password reset against a real Postgres (CI or local).
@@ -41,11 +42,11 @@ func TestAuthFlow_Pg(t *testing.T) {
 	stub := hibp.StubChecker{Result: hibp.Result{BreachFound: false, HIBPAvailable: true}}
 	pass := "J7q#xM2pL9vRkW4$hN8zT1cY5bU6nM0aS"
 	email := "e2e-" + time.Now().Format("20060102150405.000000000") + "@example.com"
-	_, err = Signup(ctx, pool, jwt, stub, SignupRequest{Email: email, Password: pass, DisplayName: displayName("T")})
+	_, err = Signup(ctx, pool, jwt, cfg, stub, SignupRequest{Email: email, Password: pass, DisplayName: displayName("T")})
 	if err != nil {
 		t.Fatalf("signup: %v", err)
 	}
-	_, err = Signup(ctx, pool, jwt, stub, SignupRequest{Email: email, Password: pass})
+	_, err = Signup(ctx, pool, jwt, cfg, stub, SignupRequest{Email: email, Password: pass})
 	if !errors.Is(err, ErrEmailTaken) {
 		t.Fatalf("second signup: %v", err)
 	}
@@ -68,9 +69,9 @@ func TestAuthFlow_Pg(t *testing.T) {
 	}
 }
 
-// TestSignup_FirstHumanGetsGlobalAdmin_Pg asserts the first password signup after migrations gets Global Admin.
-// This DB may already have human users from prior tests; skip when not empty.
-func TestSignup_FirstHumanGetsGlobalAdmin_Pg(t *testing.T) {
+// TestSignup_BootstrapAdminEmailGetsGlobalAdmin_Pg asserts the first password signup receives Global Admin
+// only when BOOTSTRAP_ADMIN_EMAIL matches. This DB may already have human users from prior tests; skip when not empty.
+func TestSignup_BootstrapAdminEmailGetsGlobalAdmin_Pg(t *testing.T) {
 	if testing.Short() {
 		t.Skip("database")
 	}
@@ -104,7 +105,8 @@ WHERE u.id <> 'a0000000-0000-4000-8000-000000000001'::uuid`).Scan(&otherHumans)
 	stub := hibp.StubChecker{Result: hibp.Result{BreachFound: false, HIBPAvailable: true}}
 	pass := "J7q#xM2pL9vRkW4$hN8zT1cY5bU6nM0aS"
 	email := "ga-first-" + time.Now().Format("20060102150405.000000000") + "@example.com"
-	res, err := Signup(ctx, pool, jwt, stub, SignupRequest{Email: email, Password: pass, DisplayName: displayName("Admin")})
+	signupCfg := config.Config{BootstrapAdminEmail: user.NormalizeEmail(email)}
+	res, err := Signup(ctx, pool, jwt, signupCfg, stub, SignupRequest{Email: email, Password: pass, DisplayName: displayName("Admin")})
 	if err != nil {
 		t.Fatalf("signup: %v", err)
 	}
@@ -118,6 +120,112 @@ WHERE u.id <> 'a0000000-0000-4000-8000-000000000001'::uuid`).Scan(&otherHumans)
 	}
 	if !ok {
 		t.Fatal("expected first signup to have global:app:rbac:manage (Global Admin)")
+	}
+}
+
+// TestSignup_BootstrapMismatch_NoGlobalAdmin_Pg ensures a stranger cannot become Global Admin
+// by being first when BOOTSTRAP_ADMIN_EMAIL points at a different address.
+func TestSignup_BootstrapMismatch_NoGlobalAdmin_Pg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("database")
+	}
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	var otherHumans int64
+	err = pool.QueryRow(ctx, `
+SELECT COUNT(*)::bigint FROM "user".users u
+WHERE u.id <> 'a0000000-0000-4000-8000-000000000001'::uuid`).Scan(&otherHumans)
+	if err != nil {
+		t.Fatalf("count humans: %v", err)
+	}
+	if otherHumans > 0 {
+		t.Skip("database already has human users")
+	}
+
+	jwt := auth.NewJWTSignerWithPool("01234567890123456789012345678901", pool)
+	stub := hibp.StubChecker{Result: hibp.Result{BreachFound: false, HIBPAvailable: true}}
+	pass := "J7q#xM2pL9vRkW4$hN8zT1cY5bU6nM0aS"
+	email := "ga-stranger-" + time.Now().Format("20060102150405.000000000") + "@example.com"
+	signupCfg := config.Config{BootstrapAdminEmail: "operator@example.com"}
+	res, err := Signup(ctx, pool, jwt, signupCfg, stub, SignupRequest{Email: email, Password: pass})
+	if err != nil {
+		t.Fatalf("signup: %v", err)
+	}
+	uid, err := uuid.Parse(res.User.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ok, err := rbac.UserHasPermission(ctx, pool, uid, "global:app:rbac:manage")
+	if err != nil {
+		t.Fatalf("rbac: %v", err)
+	}
+	if ok {
+		t.Fatal("first signup must not receive Global Admin when email does not match BOOTSTRAP_ADMIN_EMAIL")
+	}
+}
+
+// TestSignup_EmptyBootstrap_NoGlobalAdmin_Pg ensures the first human signup does not self-promote when BOOTSTRAP_ADMIN_EMAIL is unset.
+func TestSignup_EmptyBootstrap_NoGlobalAdmin_Pg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("database")
+	}
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	var otherHumans int64
+	err = pool.QueryRow(ctx, `
+SELECT COUNT(*)::bigint FROM "user".users u
+WHERE u.id <> 'a0000000-0000-4000-8000-000000000001'::uuid`).Scan(&otherHumans)
+	if err != nil {
+		t.Fatalf("count humans: %v", err)
+	}
+	if otherHumans > 0 {
+		t.Skip("database already has human users")
+	}
+
+	jwt := auth.NewJWTSignerWithPool("01234567890123456789012345678901", pool)
+	stub := hibp.StubChecker{Result: hibp.Result{BreachFound: false, HIBPAvailable: true}}
+	pass := "J7q#xM2pL9vRkW4$hN8zT1cY5bU6nM0aS"
+	email := "ga-noboot-" + time.Now().Format("20060102150405.000000000") + "@example.com"
+	res, err := Signup(ctx, pool, jwt, config.Config{}, stub, SignupRequest{Email: email, Password: pass})
+	if err != nil {
+		t.Fatalf("signup: %v", err)
+	}
+	uid, err := uuid.Parse(res.User.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ok, err := rbac.UserHasPermission(ctx, pool, uid, "global:app:rbac:manage")
+	if err != nil {
+		t.Fatalf("rbac: %v", err)
+	}
+	if ok {
+		t.Fatal("first signup must not receive Global Admin when BOOTSTRAP_ADMIN_EMAIL is empty")
 	}
 }
 

--- a/server/internal/service/authservice/magic_link_db_test.go
+++ b/server/internal/service/authservice/magic_link_db_test.go
@@ -39,7 +39,7 @@ func TestMagicLink_RequestRateLimit_Pg(t *testing.T) {
 	stub := hibp.StubChecker{Result: hibp.Result{BreachFound: false, HIBPAvailable: true}}
 	pass := "J7q#xM2pL9vRkW4$hN8zT1cY5bU6nM0aS"
 	email := "magic-rl-" + time.Now().Format("20060102150405.000000000") + "@example.com"
-	if _, err := Signup(ctx, pool, jwt, stub, SignupRequest{Email: email, Password: pass}); err != nil {
+	if _, err := Signup(ctx, pool, jwt, config.Config{}, stub, SignupRequest{Email: email, Password: pass}); err != nil {
 		t.Fatalf("signup: %v", err)
 	}
 	cfg := config.Config{
@@ -85,7 +85,7 @@ func TestMagicLink_Consume_Pg(t *testing.T) {
 	stub := hibp.StubChecker{Result: hibp.Result{BreachFound: false, HIBPAvailable: true}}
 	pass := "J7q#xM2pL9vRkW4$hN8zT1cY5bU6nM0aS"
 	email := "magic-consume-" + time.Now().Format("20060102150405.000000000") + "@example.com"
-	su, err := Signup(ctx, pool, jwt, stub, SignupRequest{Email: email, Password: pass})
+	su, err := Signup(ctx, pool, jwt, config.Config{}, stub, SignupRequest{Email: email, Password: pass})
 	if err != nil {
 		t.Fatalf("signup: %v", err)
 	}

--- a/server/internal/service/authservice/password_policy_db_test.go
+++ b/server/internal/service/authservice/password_policy_db_test.go
@@ -10,6 +10,7 @@ import (
 	serverdata "github.com/lextures/lextures/server"
 	"github.com/lextures/lextures/server/internal/auth"
 	"github.com/lextures/lextures/server/internal/auth/hibp"
+	"github.com/lextures/lextures/server/internal/config"
 	"github.com/lextures/lextures/server/internal/db"
 	"github.com/lextures/lextures/server/internal/migrate"
 	"github.com/lextures/lextures/server/internal/repos/passwordcreditevents"
@@ -36,7 +37,7 @@ func TestSignup_RejectsBreachedPasswordWhenHIBPReportsHit_Pg(t *testing.T) {
 	jwt := auth.NewJWTSignerWithPool("01234567890123456789012345678901", pool)
 	email := "pwpol-" + time.Now().Format("20060102150405.000000000") + "@example.com"
 	checker := hibp.StubChecker{Result: hibp.Result{BreachFound: true, HIBPAvailable: true}}
-	_, err = Signup(ctx, pool, jwt, checker, SignupRequest{Email: email, Password: "any-pass-here"})
+	_, err = Signup(ctx, pool, jwt, config.Config{}, checker, SignupRequest{Email: email, Password: "any-pass-here"})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -71,7 +72,7 @@ func TestChangePassword_AuditTrail_Pg(t *testing.T) {
 	stub := hibp.StubChecker{Result: hibp.Result{BreachFound: false, HIBPAvailable: true}}
 	pass := "J7q#xM2pL9vRkW4$hN8zT1cY5bU6nM0aS"
 	email := "pwc-" + time.Now().Format("20060102150405.000000000") + "@example.com"
-	res, err := Signup(ctx, pool, jwt, stub, SignupRequest{Email: email, Password: pass})
+	res, err := Signup(ctx, pool, jwt, config.Config{}, stub, SignupRequest{Email: email, Password: pass})
 	if err != nil {
 		t.Fatalf("signup: %v", err)
 	}


### PR DESCRIPTION
## Summary
- First password signup receives Global Admin only when `BOOTSTRAP_ADMIN_EMAIL` matches the signup email; otherwise first user is a normal Teacher.
- New operator CLI: `go run ./cmd/bootstrap-admin -email=…` (requires `DATABASE_URL`).
- Config, HTTP signup handler, tests, `AGENTS.md`, `server/.env.example`, and `docker-compose.yml` updated accordingly.
- `docs/SECURITY_ISSUES.md`: C2 and C3 marked fixed; regression note for C2 adjusted.

## Testing
- `go test ./... -short` (server)