### PR TITLE
Global calendar with per-course toggles

### DIFF
--- a/clients/web/src/pages/lms/calendar.tsx
+++ b/clients/web/src/pages/lms/calendar.tsx
@@ -1,10 +1,78 @@
-import { useEffect, useMemo, useState } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { authorizedFetch } from '../../lib/api'
-import { readApiErrorMessage } from '../../lib/errors'
 import { parseCalendarDateFromQuery } from '../../lib/command-palette-go-to'
-import type { CoursePublic } from '../../lib/courses-api'
+import { readApiErrorMessage } from '../../lib/errors'
+import {
+  fetchCourseStructure,
+  type CoursePublic,
+  type CourseStructureItem,
+} from '../../lib/courses-api'
+import { CourseCalendar, type CourseCalendarAssignment } from './course-calendar'
 import { LmsPage } from './lms-page'
+
+const LS_DISABLED_KEY = 'lextures.globalCalendar.disabledCourseIds'
+
+function readDisabledCourseIdsFromStorage(): string[] | null {
+  try {
+    const raw = window.localStorage.getItem(LS_DISABLED_KEY)
+    if (raw == null) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return null
+    return parsed.filter((x): x is string => typeof x === 'string')
+  } catch {
+    return null
+  }
+}
+
+function writeDisabledCourseIdsToStorage(ids: string[]) {
+  try {
+    window.localStorage.setItem(LS_DISABLED_KEY, JSON.stringify(ids))
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+function mergeDisabledIds(eligible: CoursePublic[], stored: string[] | null): Set<string> {
+  const eligibleIds = new Set(eligible.map((c) => c.id))
+  if (stored === null) {
+    return new Set()
+  }
+  const out = new Set<string>()
+  for (const id of stored) {
+    if (eligibleIds.has(id)) out.add(id)
+  }
+  return out
+}
+
+function structureToAssignments(
+  course: CoursePublic,
+  items: CourseStructureItem[],
+  paletteIndex: number,
+): CourseCalendarAssignment[] {
+  const isDueCalendarItem = (
+    i: CourseStructureItem,
+  ): i is CourseStructureItem & {
+    kind: 'content_page' | 'assignment' | 'quiz'
+    dueAt: string
+  } =>
+    (i.kind === 'content_page' || i.kind === 'assignment' || i.kind === 'quiz') && Boolean(i.dueAt)
+
+  const title = course.title.trim() || course.courseCode
+  return items.filter(isDueCalendarItem).map((i) => ({
+    id: i.id,
+    title: i.title,
+    dueAt: i.dueAt,
+    kind: i.kind,
+    pointsWorth: i.pointsWorth,
+    pointsPossible: i.pointsPossible,
+    isAdaptive: i.isAdaptive,
+    linkCourseCode: course.courseCode,
+    courseTitle: title,
+    courseLabel: course.courseCode,
+    paletteIndex,
+  }))
+}
 
 export default function Calendar() {
   const [searchParams] = useSearchParams()
@@ -12,28 +80,42 @@ export default function Calendar() {
   const dateKey = useMemo(() => parseCalendarDateFromQuery(rawDate), [rawDate])
 
   const [courses, setCourses] = useState<CoursePublic[] | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  const [coursesError, setCoursesError] = useState<string | null>(null)
+  const [disabledCourseIds, setDisabledCourseIds] = useState<Set<string>>(() => new Set())
+
+  const [structureByCourseId, setStructureByCourseId] = useState<
+    Record<string, CourseStructureItem[] | null>
+  >({})
+  const [structureErrors, setStructureErrors] = useState<Record<string, string>>({})
+  const [structuresLoading, setStructuresLoading] = useState(false)
 
   useEffect(() => {
     let cancelled = false
     ;(async () => {
-      setError(null)
+      setCoursesError(null)
       try {
         const res = await authorizedFetch('/api/v1/courses')
         const raw: unknown = await res.json().catch(() => ({}))
         if (!res.ok) {
           if (!cancelled) {
             setCourses([])
-            setError(readApiErrorMessage(raw))
+            setCoursesError(readApiErrorMessage(raw))
+            setDisabledCourseIds(new Set())
           }
           return
         }
         const data = raw as { courses?: CoursePublic[] }
-        if (!cancelled) setCourses(data.courses ?? [])
+        const list = data.courses ?? []
+        if (!cancelled) {
+          setCourses(list)
+          const eligible = list.filter((c) => !c.archived && c.calendarEnabled !== false)
+          setDisabledCourseIds(mergeDisabledIds(eligible, readDisabledCourseIdsFromStorage()))
+        }
       } catch {
         if (!cancelled) {
           setCourses([])
-          setError('Could not load courses.')
+          setCoursesError('Could not load courses.')
+          setDisabledCourseIds(new Set())
         }
       }
     })()
@@ -42,69 +124,209 @@ export default function Calendar() {
     }
   }, [])
 
-  const heading = dateKey
-    ? new Date(dateKey + 'T12:00:00').toLocaleDateString(undefined, {
-        weekday: 'long',
-        month: 'long',
-        day: 'numeric',
-        year: 'numeric',
-      })
-    : 'Calendar'
-
-  const withCalendar = useMemo(
+  const eligibleCourses = useMemo(
     () => (courses ?? []).filter((c) => !c.archived && c.calendarEnabled !== false),
     [courses],
   )
 
+  const enabledCourses = useMemo(
+    () => eligibleCourses.filter((c) => !disabledCourseIds.has(c.id)),
+    [eligibleCourses, disabledCourseIds],
+  )
+
+  const paletteIndexByCourseId = useMemo(() => {
+    const m = new Map<string, number>()
+    eligibleCourses.forEach((c, i) => m.set(c.id, i))
+    return m
+  }, [eligibleCourses])
+
+  useEffect(() => {
+    let cancelled = false
+    const targets = enabledCourses
+
+    if (targets.length === 0) {
+      setStructuresLoading(false)
+      setStructureByCourseId({})
+      setStructureErrors({})
+      return
+    }
+
+    setStructuresLoading(true)
+    setStructureErrors({})
+
+    ;(async () => {
+      const next: Record<string, CourseStructureItem[] | null> = {}
+      const errs: Record<string, string> = {}
+
+      await Promise.all(
+        targets.map(async (c) => {
+          try {
+            const items = await fetchCourseStructure(c.courseCode)
+            if (!cancelled) next[c.id] = items
+          } catch (e) {
+            if (!cancelled) {
+              next[c.id] = null
+              errs[c.id] = e instanceof Error ? e.message : 'Could not load calendar.'
+            }
+          }
+        }),
+      )
+
+      if (cancelled) return
+      setStructureByCourseId(next)
+      setStructureErrors(errs)
+      setStructuresLoading(false)
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [enabledCourses])
+
+  const mergedAssignments: CourseCalendarAssignment[] = useMemo(() => {
+    const out: CourseCalendarAssignment[] = []
+    for (const c of enabledCourses) {
+      const items = structureByCourseId[c.id]
+      if (!items) continue
+      const pi = paletteIndexByCourseId.get(c.id) ?? 0
+      out.push(...structureToAssignments(c, items, pi))
+    }
+    return out
+  }, [enabledCourses, structureByCourseId, paletteIndexByCourseId])
+
+  const hasAnyLoadedStructure = useMemo(
+    () => enabledCourses.some((c) => Array.isArray(structureByCourseId[c.id])),
+    [enabledCourses, structureByCourseId],
+  )
+
+  const setCourseEnabled = useCallback((courseId: string, enabled: boolean) => {
+    setDisabledCourseIds((prev) => {
+      const next = new Set(prev)
+      if (enabled) next.delete(courseId)
+      else next.add(courseId)
+      writeDisabledCourseIdsToStorage([...next])
+      return next
+    })
+  }, [])
+
+  const showAllCourses = useCallback(() => {
+    setDisabledCourseIds(() => {
+      writeDisabledCourseIdsToStorage([])
+      return new Set()
+    })
+  }, [])
+
+  const hideAllCourses = useCallback(() => {
+    setDisabledCourseIds(() => {
+      const all = eligibleCourses.map((c) => c.id)
+      writeDisabledCourseIdsToStorage(all)
+      return new Set(all)
+    })
+  }, [eligibleCourses])
+
+  const representativeCourseCode = enabledCourses[0]?.courseCode ?? ''
+
   return (
     <LmsPage
-      title={heading}
-      description={
-        dateKey
-          ? 'Jump into a course calendar for this day. Times and due chips always use your local time zone once you are inside the course.'
-          : 'Pick a day from search (try Cmd/Ctrl + K with a date like 2026-04-21) or open a course calendar from the course sidebar.'
-      }
+      title="Calendar"
+      description="Month, week, and to-do views across your courses. Toggle courses on the left to show or hide their due dates."
+      fillHeight
     >
-      {error && (
+      {coursesError && (
         <p className="mt-6 rounded-lg border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800 dark:border-rose-900/60 dark:bg-rose-950/50 dark:text-rose-200">
-          {error}
+          {coursesError}
         </p>
       )}
-      {courses === null && !error && <p className="mt-8 text-sm text-slate-500 dark:text-neutral-400">Loading…</p>}
-      {courses && courses.length === 0 && !error && (
+      {courses === null && !coursesError && (
+        <p className="mt-8 text-sm text-slate-500 dark:text-neutral-400">Loading…</p>
+      )}
+      {courses && courses.length === 0 && !coursesError && (
         <p className="mt-8 text-sm text-slate-600 dark:text-neutral-300">No courses on your account yet.</p>
       )}
-      {courses && courses.length > 0 && withCalendar.length === 0 && !error && (
+      {courses && courses.length > 0 && eligibleCourses.length === 0 && !coursesError && (
         <p className="mt-8 text-sm text-slate-600 dark:text-neutral-300">
           No enrolled courses have the calendar tool enabled.
         </p>
       )}
-      {dateKey && withCalendar.length > 0 ? (
-        <ul className="mt-8 space-y-2">
-          {withCalendar.map((c) => (
-            <li key={c.id}>
-              <Link
-                to={`/courses/${encodeURIComponent(c.courseCode)}/calendar?date=${encodeURIComponent(dateKey)}`}
-                className="block rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50/40 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-indigo-500/40 dark:hover:bg-neutral-800"
-              >
-                {c.title.trim() || c.courseCode}
-                <span className="mt-0.5 block text-xs font-normal text-slate-500 dark:text-neutral-400">
-                  Open course calendar
-                </span>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      ) : null}
-      {!dateKey && withCalendar.length > 0 ? (
-        <p className="mt-8 text-sm text-slate-600 dark:text-neutral-300">
-          Use the{' '}
-          <kbd className="rounded border border-slate-200 bg-slate-100 px-1.5 py-0.5 font-mono text-xs dark:border-neutral-600 dark:bg-neutral-800">
-            ⌘K
-          </kbd>{' '}
-          palette with a date, or choose a course under <span className="font-medium">Courses</span> and open its Calendar
-          page.
-        </p>
+      {eligibleCourses.length > 0 ? (
+        <div className="mt-4 flex min-h-0 flex-1 flex-col gap-5 lg:mt-6 lg:flex-row lg:gap-6">
+          <aside className="shrink-0 lg:sticky lg:top-4 lg:max-h-[min(28rem,calc(100vh-8rem))] lg:w-72 lg:self-start">
+            <div className="rounded-2xl border border-slate-200/90 bg-white p-4 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/90">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-sm font-semibold tracking-tight text-slate-900 dark:text-neutral-100">
+                    Courses
+                  </h2>
+                  <p className="mt-1 text-xs text-slate-500 dark:text-neutral-400">
+                    Show due dates from selected courses on the calendar.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={showAllCourses}
+                  className="rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-semibold text-slate-700 transition hover:bg-white dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+                >
+                  Show all
+                </button>
+                <button
+                  type="button"
+                  onClick={hideAllCourses}
+                  className="rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-semibold text-slate-700 transition hover:bg-white dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+                >
+                  Hide all
+                </button>
+              </div>
+              <ul className="mt-4 max-h-64 space-y-2 overflow-y-auto overscroll-contain pr-0.5 lg:max-h-[min(22rem,calc(100vh-12rem))]">
+                {eligibleCourses.map((c) => {
+                  const enabled = !disabledCourseIds.has(c.id)
+                  const label = c.title.trim() || c.courseCode
+                  const err = structureErrors[c.id]
+                  return (
+                    <li key={c.id}>
+                      <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-transparent px-2 py-2 transition hover:border-slate-200 hover:bg-slate-50/80 dark:hover:border-neutral-600 dark:hover:bg-neutral-800/60">
+                        <input
+                          type="checkbox"
+                          className="mt-1 h-4 w-4 shrink-0 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-neutral-600 dark:bg-neutral-900 dark:text-indigo-500 dark:focus:ring-indigo-400"
+                          checked={enabled}
+                          onChange={(e) => setCourseEnabled(c.id, e.target.checked)}
+                        />
+                        <span className="min-w-0 flex-1">
+                          <span className="block text-sm font-medium text-slate-900 dark:text-neutral-100">
+                            {label}
+                          </span>
+                          <span className="mt-0.5 block text-xs text-slate-500 dark:text-neutral-400">
+                            {c.courseCode}
+                          </span>
+                          {enabled && err ? (
+                            <span className="mt-1 block text-xs text-rose-600 dark:text-rose-400">{err}</span>
+                          ) : null}
+                        </span>
+                      </label>
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
+          </aside>
+          <div className="flex min-h-[28rem] min-w-0 flex-1 flex-col lg:min-h-0">
+            {enabledCourses.length === 0 ? (
+              <p className="rounded-xl border border-dashed border-slate-200 bg-slate-50/80 px-4 py-8 text-center text-sm text-slate-600 dark:border-neutral-700 dark:bg-neutral-950/40 dark:text-neutral-300">
+                Turn on at least one course to load its schedule.
+              </p>
+            ) : structuresLoading && !hasAnyLoadedStructure ? (
+              <p className="text-sm text-slate-500 dark:text-neutral-400">Loading calendars…</p>
+            ) : (
+              <CourseCalendar
+                courseCode={representativeCourseCode}
+                assignments={mergedAssignments}
+                canRescheduleDueByDrag={false}
+                initialDateKey={dateKey}
+              />
+            )}
+          </div>
+        </div>
       ) : null}
     </LmsPage>
   )

--- a/clients/web/src/pages/lms/calendar.tsx
+++ b/clients/web/src/pages/lms/calendar.tsx
@@ -144,17 +144,19 @@ export default function Calendar() {
     let cancelled = false
     const targets = enabledCourses
 
-    if (targets.length === 0) {
-      setStructuresLoading(false)
-      setStructureByCourseId({})
+    void (async () => {
+      if (targets.length === 0) {
+        await Promise.resolve()
+        if (cancelled) return
+        setStructuresLoading(false)
+        setStructureByCourseId({})
+        setStructureErrors({})
+        return
+      }
+
+      setStructuresLoading(true)
       setStructureErrors({})
-      return
-    }
 
-    setStructuresLoading(true)
-    setStructureErrors({})
-
-    ;(async () => {
       const next: Record<string, CourseStructureItem[] | null> = {}
       const errs: Record<string, string> = {}
 

--- a/clients/web/src/pages/lms/course-calendar.tsx
+++ b/clients/web/src/pages/lms/course-calendar.tsx
@@ -47,6 +47,17 @@ export type CourseCalendarAssignment = {
   /** Quizzes: summed question points when not adaptive. */
   pointsPossible?: number | null
   isAdaptive?: boolean
+  /**
+   * When set (e.g. global `/calendar`), item links use this course instead of the
+   * parent `CourseCalendar` `courseCode` prop.
+   */
+  linkCourseCode?: string
+  /** Optional line in the hover card (e.g. course title or code). */
+  courseTitle?: string
+  /** Short prefix in month chips / week rows (e.g. course code). */
+  courseLabel?: string
+  /** Tint index for aggregated views (`0`–`6`, wraps). */
+  paletteIndex?: number
 }
 
 type ViewId = 'month' | 'week' | 'todo'
@@ -81,6 +92,41 @@ function calendarItemPointsSummary(a: CourseCalendarAssignment): string | null {
 type CalendarAssignmentHoverOpen = {
   assignment: CourseCalendarAssignment
   anchor: HTMLElement
+}
+
+const MONTH_CHIP_PALETTE = [
+  'block w-full truncate rounded-md bg-indigo-50/90 px-1 py-0.5 text-left text-[11px] font-semibold leading-tight text-indigo-900 transition hover:bg-indigo-100 hover:ring-1 hover:ring-indigo-200/80 dark:bg-indigo-950/50 dark:text-indigo-100 dark:hover:bg-indigo-900/60 dark:hover:ring-indigo-500/40',
+  'block w-full truncate rounded-md bg-violet-50/90 px-1 py-0.5 text-left text-[11px] font-semibold leading-tight text-violet-900 transition hover:bg-violet-100 hover:ring-1 hover:ring-violet-200/80 dark:bg-violet-950/50 dark:text-violet-100 dark:hover:bg-violet-900/60 dark:hover:ring-violet-500/40',
+  'block w-full truncate rounded-md bg-emerald-50/90 px-1 py-0.5 text-left text-[11px] font-semibold leading-tight text-emerald-900 transition hover:bg-emerald-100 hover:ring-1 hover:ring-emerald-200/80 dark:bg-emerald-950/50 dark:text-emerald-100 dark:hover:bg-emerald-900/60 dark:hover:ring-emerald-500/40',
+  'block w-full truncate rounded-md bg-amber-50/90 px-1 py-0.5 text-left text-[11px] font-semibold leading-tight text-amber-950 transition hover:bg-amber-100 hover:ring-1 hover:ring-amber-200/80 dark:bg-amber-950/50 dark:text-amber-100 dark:hover:bg-amber-900/60 dark:hover:ring-amber-500/40',
+  'block w-full truncate rounded-md bg-rose-50/90 px-1 py-0.5 text-left text-[11px] font-semibold leading-tight text-rose-900 transition hover:bg-rose-100 hover:ring-1 hover:ring-rose-200/80 dark:bg-rose-950/50 dark:text-rose-100 dark:hover:bg-rose-900/60 dark:hover:ring-rose-500/40',
+  'block w-full truncate rounded-md bg-sky-50/90 px-1 py-0.5 text-left text-[11px] font-semibold leading-tight text-sky-900 transition hover:bg-sky-100 hover:ring-1 hover:ring-sky-200/80 dark:bg-sky-950/50 dark:text-sky-100 dark:hover:bg-sky-900/60 dark:hover:ring-sky-500/40',
+  'block w-full truncate rounded-md bg-fuchsia-50/90 px-1 py-0.5 text-left text-[11px] font-semibold leading-tight text-fuchsia-900 transition hover:bg-fuchsia-100 hover:ring-1 hover:ring-fuchsia-200/80 dark:bg-fuchsia-950/50 dark:text-fuchsia-100 dark:hover:bg-fuchsia-900/60 dark:hover:ring-fuchsia-500/40',
+] as const
+
+const WEEK_CARD_PALETTE = [
+  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-indigo-500/50 dark:hover:bg-indigo-950/40',
+  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-violet-200 hover:bg-violet-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-violet-500/50 dark:hover:bg-violet-950/40',
+  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-emerald-200 hover:bg-emerald-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-emerald-500/50 dark:hover:bg-emerald-950/40',
+  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-amber-200 hover:bg-amber-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-amber-500/50 dark:hover:bg-amber-950/40',
+  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-rose-200 hover:bg-rose-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-rose-500/50 dark:hover:bg-rose-950/40',
+  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-sky-200 hover:bg-sky-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-sky-500/50 dark:hover:bg-sky-950/40',
+  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-fuchsia-200 hover:bg-fuchsia-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-fuchsia-500/50 dark:hover:bg-fuchsia-950/40',
+] as const
+
+function monthChipClassForAssignment(a: CourseCalendarAssignment, canDrag: boolean): string {
+  const base =
+    MONTH_CHIP_PALETTE[Math.abs(a.paletteIndex ?? 0) % MONTH_CHIP_PALETTE.length] ??
+    MONTH_CHIP_PALETTE[0]
+  const drag = canDrag ? 'cursor-grab touch-manipulation active:cursor-grabbing' : ''
+  return `${base} ${drag}`.trim()
+}
+
+function weekCardClassForAssignment(a: CourseCalendarAssignment): string {
+  return (
+    WEEK_CARD_PALETTE[Math.abs(a.paletteIndex ?? 0) % WEEK_CARD_PALETTE.length] ??
+    WEEK_CARD_PALETTE[0]
+  )
 }
 
 function AssignmentHoverPortal({ open }: { open: CalendarAssignmentHoverOpen | null }) {
@@ -136,6 +182,9 @@ function AssignmentHoverPortal({ open }: { open: CalendarAssignmentHoverOpen | n
       <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">
         {calendarItemKindLabel(a.kind)}
       </p>
+      {a.courseTitle ? (
+        <p className="mt-1 text-xs font-medium text-slate-600 dark:text-neutral-300">{a.courseTitle}</p>
+      ) : null}
       <p className="mt-1 font-semibold tracking-tight text-slate-950 dark:text-neutral-100">
         {a.title || 'Untitled'}
       </p>
@@ -156,6 +205,7 @@ type CalendarMonthDraggableDueLinkProps = {
   a: CourseCalendarAssignment
   to: string
   canDrag: boolean
+  chipClassName: string
   onShowAssignmentHover: (a: CourseCalendarAssignment, el: HTMLElement) => void
   onHideAssignmentHover: () => void
 }
@@ -164,6 +214,7 @@ function CalendarMonthDraggableDueLink({
   a,
   to,
   canDrag,
+  chipClassName,
   onShowAssignmentHover,
   onHideAssignmentHover,
 }: CalendarMonthDraggableDueLinkProps) {
@@ -172,6 +223,8 @@ function CalendarMonthDraggableDueLink({
     disabled: !canDrag,
   })
   const style = transform ? { transform: CSS.Translate.toString(transform) } : undefined
+  const label = a.courseLabel?.trim()
+  const chipText = label ? `${label} · ${a.title || 'Untitled'}` : a.title || 'Untitled'
   return (
     <li className="min-w-0">
       <Link
@@ -179,16 +232,14 @@ function CalendarMonthDraggableDueLink({
         style={style}
         {...(canDrag ? { ...listeners, ...attributes } : {})}
         to={to}
-        aria-label={`${calendarItemKindLabel(a.kind)}: ${a.title || 'Untitled'}. Due ${formatDueShort(a.dueAt)}.`}
+        aria-label={`${calendarItemKindLabel(a.kind)}: ${chipText}. Due ${formatDueShort(a.dueAt)}.`}
         onMouseEnter={(e) => onShowAssignmentHover(a, e.currentTarget)}
         onMouseLeave={onHideAssignmentHover}
         onFocus={(e) => onShowAssignmentHover(a, e.currentTarget)}
         onBlur={onHideAssignmentHover}
-        className={`block w-full truncate rounded-md bg-indigo-50/90 px-1 py-0.5 text-left text-[11px] font-semibold leading-tight text-indigo-900 transition hover:bg-indigo-100 hover:ring-1 hover:ring-indigo-200/80 dark:bg-indigo-950/50 dark:text-indigo-100 dark:hover:bg-indigo-900/60 dark:hover:ring-indigo-500/40 ${
-          canDrag ? 'cursor-grab touch-manipulation active:cursor-grabbing' : ''
-        } ${isDragging ? 'opacity-40' : ''}`}
+        className={`${chipClassName} ${isDragging ? 'opacity-40' : ''}`}
       >
-        {a.title || 'Untitled'}
+        {chipText}
       </Link>
     </li>
   )
@@ -253,10 +304,11 @@ function CalendarMonthDayCell({
         <ul className="mt-1 min-h-0 flex-1 space-y-0.5 overflow-y-auto overscroll-contain">
           {dayItems.map((a) => (
             <CalendarMonthDraggableDueLink
-              key={a.id}
+              key={`${a.linkCourseCode ?? ''}:${a.id}`}
               a={a}
               to={itemPath(a)}
               canDrag={canDragReschedule}
+              chipClassName={monthChipClassForAssignment(a, canDragReschedule)}
               onShowAssignmentHover={onShowAssignmentHover}
               onHideAssignmentHover={onHideAssignmentHover}
             />
@@ -370,6 +422,8 @@ export function CourseCalendar({
       const dayKey = overId.slice(CAL_DAY_ID.length)
       const assignment = assignments.find((x) => x.id === itemId)
       if (!assignment) return
+      const patchCourse = assignment.linkCourseCode ?? courseCode
+      if (!patchCourse) return
       if (dateKeyLocal(new Date(assignment.dueAt)) === dayKey) return
 
       const cells = monthGridCells(monthAnchor)
@@ -380,7 +434,7 @@ export function CourseCalendar({
       setRescheduleBusy(true)
       setRescheduleError(null)
       try {
-        await patchCourseStructureItemDueAt(courseCode, itemId, { dueAt: nextIso })
+        await patchCourseStructureItemDueAt(patchCourse, itemId, { dueAt: nextIso })
         await onDueDatesChanged?.()
       } catch (e) {
         setRescheduleError(e instanceof Error ? e.message : 'Could not update due date.')
@@ -417,27 +471,27 @@ export function CourseCalendar({
     return sorted.filter((a) => isInTodoWindow(new Date(a.dueAt), t))
   }, [sorted])
 
-  const modulesBase = useMemo(
-    () => `/courses/${encodeURIComponent(courseCode)}/modules`,
+  const itemPath = useCallback(
+    (a: CourseCalendarAssignment) => {
+      const code = a.linkCourseCode ?? courseCode
+      const base = `/courses/${encodeURIComponent(code)}/modules`
+      if (a.kind === 'assignment') return `${base}/assignment/${encodeURIComponent(a.id)}`
+      if (a.kind === 'quiz') return `${base}/quiz/${encodeURIComponent(a.id)}`
+      return `${base}/content/${encodeURIComponent(a.id)}`
+    },
     [courseCode],
   )
 
-  const itemPath = useCallback(
-    (a: CourseCalendarAssignment) => {
-      if (a.kind === 'assignment') return `${modulesBase}/assignment/${encodeURIComponent(a.id)}`
-      if (a.kind === 'quiz') return `${modulesBase}/quiz/${encodeURIComponent(a.id)}`
-      return `${modulesBase}/content/${encodeURIComponent(a.id)}`
-    },
-    [modulesBase],
-  )
-
   function assignmentRow(a: CourseCalendarAssignment) {
+    const label = a.courseLabel?.trim()
     return (
-      <li key={a.id}>
-        <Link
-          to={itemPath(a)}
-          className="group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-indigo-500/50 dark:hover:bg-indigo-950/40"
-        >
+      <li key={`${a.linkCourseCode ?? courseCode}:${a.id}`}>
+        <Link to={itemPath(a)} className={weekCardClassForAssignment(a)}>
+          {label ? (
+            <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+              {label}
+            </span>
+          ) : null}
           <span className="text-sm font-semibold tracking-tight text-slate-950 group-hover:text-indigo-800 dark:text-neutral-100 dark:group-hover:text-indigo-300">
             {a.title || 'Untitled'}
           </span>


### PR DESCRIPTION
## Summary
- Replaces the global `/calendar` placeholder with the same month/week/to-do experience as the course calendar.
- Adds a course list with checkboxes (Show all / Hide all); only enabled courses load structure and contribute due items.
- Persists disabled course IDs in `localStorage` (`lextures.globalCalendar.disabledCourseIds`).
- Extends `CourseCalendarAssignment` for aggregated views: `linkCourseCode`, `courseTitle`, `courseLabel`, `paletteIndex`; item links and drag PATCH resolve the owning course.

## Notes
- Drag reschedule remains disabled on the global view (`canRescheduleDueByDrag={false}`).
- `?date=` continues to focus the requested day.