### PR TITLE
fix(e2e): archive course assertion and e2e-local script robustness

### DIFF
--- a/e2e/scripts/e2e-local.sh
+++ b/e2e/scripts/e2e-local.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Run the e2e suite without Docker using an ephemeral local Postgres cluster.
 #
+# Usage:
+#   ./e2e/scripts/e2e-local.sh              # full suite (cwd: repo root)
+#   ./e2e/scripts/e2e-local.sh tests/inbox.spec.ts
+#   ./e2e/scripts/e2e-local.sh e2e/tests/inbox.spec.ts   # same; e2e/ prefix is stripped
+# Any extra arguments are passed through to `playwright test` (e.g. --headed, --grep).
+#
 # Steps:
 #   1. Locate system PostgreSQL binaries (Homebrew, Linux packages, pg_config).
 #   2. initdb a fresh data directory in /tmp.
@@ -24,10 +30,39 @@
 
 set -euo pipefail
 
+# Declared up-front so `set -u` never trips on `"${PLAYWRIGHT_TEST_ARGS[@]}"` when the
+# suite is invoked with no extra args (e.g. `make e2e`) on Bash 3.2 / strict nounset.
+declare -a PLAYWRIGHT_TEST_ARGS=()
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PIDS=()
 PGDATA_DIR=""
 E2E_PG_PORT="${E2E_PG_PORT:-5454}"
+
+# `go run` and `npm run dev` are parents of the real long-lived processes. A plain
+# `kill $pid` often stops only the wrapper, leaving the API or Vite child alive.
+# Those orphans keep hitting DATABASE_URL (ephemeral Postgres) after teardown.
+kill_tree() {
+  local pid="$1"
+  local children
+  children="$(pgrep -P "${pid}" 2>/dev/null || true)"
+  for c in ${children}; do
+    kill_tree "${c}"
+  done
+  if kill -0 "${pid}" 2>/dev/null; then
+    kill -TERM "${pid}" 2>/dev/null || true
+  fi
+}
+
+force_kill_tree() {
+  local pid="$1"
+  local children
+  children="$(pgrep -P "${pid}" 2>/dev/null || true)"
+  for c in ${children}; do
+    force_kill_tree "${c}"
+  done
+  kill -KILL "${pid}" 2>/dev/null || true
+}
 E2E_PG_DB="lextures_e2e"
 E2E_PG_USER="e2e"
 # These are intentionally weak secrets used only for the throwaway test cluster.
@@ -39,7 +74,14 @@ cleanup() {
   echo ""
   echo "==> Tearing down local e2e stack..."
   for pid in "${PIDS[@]-}"; do
-    kill "$pid" 2>/dev/null || true
+    kill_tree "${pid}"
+  done
+  # Let child processes (compiled server, Vite) exit after the wrapper receives SIGTERM.
+  sleep 1
+  for pid in "${PIDS[@]-}"; do
+    if kill -0 "${pid}" 2>/dev/null; then
+      force_kill_tree "${pid}"
+    fi
   done
   if [[ -n "${PGDATA_DIR}" && -d "${PGDATA_DIR}" ]]; then
     "${PG_CTL:-pg_ctl}" -D "${PGDATA_DIR}" stop -m fast 2>/dev/null || true
@@ -160,11 +202,26 @@ for i in $(seq 1 30); do
 done
 echo "    Web client healthy."
 
-# Run Playwright.
+# Run Playwright. Optional args are forwarded to `playwright test` (paths relative to
+# e2e/ after cd). Paths given as e2e/tests/... from repo root are normalized.
 echo "==> Running Playwright tests..."
 cd "${REPO_ROOT}/e2e"
 npm ci --prefer-offline --quiet
 npx playwright install --with-deps chromium
-E2E_BASE_URL="http://localhost:5173" \
-  E2E_API_URL="http://localhost:${E2E_API_PORT}" \
-  npx playwright test
+PLAYWRIGHT_TEST_ARGS=()
+for arg in "$@"; do
+  if [[ "${arg}" == e2e/* ]]; then
+    PLAYWRIGHT_TEST_ARGS+=("${arg#e2e/}")
+  else
+    PLAYWRIGHT_TEST_ARGS+=("${arg}")
+  fi
+done
+if [[ "${#PLAYWRIGHT_TEST_ARGS[@]}" -gt 0 ]]; then
+  E2E_BASE_URL="http://localhost:5173" \
+    E2E_API_URL="http://localhost:${E2E_API_PORT}" \
+    npx playwright test "${PLAYWRIGHT_TEST_ARGS[@]}"
+else
+  E2E_BASE_URL="http://localhost:5173" \
+    E2E_API_URL="http://localhost:${E2E_API_PORT}" \
+    npx playwright test
+fi

--- a/e2e/tests/courses.spec.ts
+++ b/e2e/tests/courses.spec.ts
@@ -135,7 +135,7 @@ test.describe('Course settings', () => {
     seededCourse,
   }) => {
     await page.goto(`/courses/${seededCourse.courseCode}/settings/general`)
-    
+
     const titleInput = page.getByRole('textbox', { name: /^title$/i })
     await titleInput.clear()
     await titleInput.fill('Updated E2E Title')
@@ -146,10 +146,10 @@ test.describe('Course settings', () => {
 
     // The save button is at the bottom of the general form.
     await page.getByRole('button', { name: /save/i }).first().click()
-    
+
     // After saving the updated title should appear in the breadcrumb or heading.
     await expect(page.getByText('Updated E2E Title')).toBeVisible({ timeout: 8000 })
-    
+
     // Navigate back to course detail to verify description update.
     await page.goto(`/courses/${seededCourse.courseCode}`)
     await expect(page.getByText('Updated E2E Description')).toBeVisible()
@@ -157,17 +157,17 @@ test.describe('Course settings', () => {
 
   test('toggling published status', async ({ coursePage: page, seededCourse }) => {
     await page.goto(`/courses/${seededCourse.courseCode}/settings/general`)
-    
+
     const publishSwitch = page.getByRole('switch', { name: /published/i })
     const isInitiallyPublished = await publishSwitch.getAttribute('aria-checked') === 'true'
-    
+
     // Toggle it.
     await publishSwitch.click()
     await expect(page.getByText(/saved|published|draft/i).first()).toBeVisible()
-    
+
     const isNowPublished = await publishSwitch.getAttribute('aria-checked') === 'true'
     expect(isNowPublished).not.toBe(isInitiallyPublished)
-    
+
     // Catalog visibility lives in the collapsible "Course details" block (not in the page chrome).
     await page.goto(`/courses/${seededCourse.courseCode}`)
     const courseDetails = page.locator('details').filter({ hasText: 'Course details' })
@@ -181,25 +181,25 @@ test.describe('Course settings', () => {
 
   test('change reading theme preset', async ({ coursePage: page, seededCourse }) => {
     await page.goto(`/courses/${seededCourse.courseCode}/settings/general`)
-    
+
     // Look for a theme preset button, e.g., "Night" or "Reader".
     const nightTheme = page.getByRole('button', { name: /night/i })
     await expect(nightTheme).toBeVisible()
     await nightTheme.click()
-    
+
     // Theme selection usually saves immediately as per UI note.
     await expect(page.getByText(/reading theme saved/i)).toBeVisible()
   })
 
   test('toggle schedule mode between fixed and relative', async ({ coursePage: page, seededCourse }) => {
     await page.goto(`/courses/${seededCourse.courseCode}/settings/general`)
-    
+
     const scheduleSwitch = page.getByRole('switch', { name: /relative/i })
     const isInitiallyRelative = await scheduleSwitch.getAttribute('aria-checked') === 'true'
-    
+
     // Toggle it.
     await scheduleSwitch.click()
-    
+
     // Verify fields change.
     if (isInitiallyRelative) {
       // Should now be fixed.
@@ -208,7 +208,7 @@ test.describe('Course settings', () => {
       // Should now be relative.
       await expect(page.getByLabel(/^end after$/i)).toBeVisible()
     }
-    
+
     // Save changes.
     await page.getByRole('button', { name: /save/i }).first().click()
     await expect(page.getByText(/saved/i).first()).toBeVisible()
@@ -216,21 +216,24 @@ test.describe('Course settings', () => {
 
   test('archive (delete) course', async ({ coursePage: page, seededCourse }) => {
     await page.goto(`/courses/${seededCourse.courseCode}/settings/archive`)
-    
+
     await page.getByRole('button', { name: /delete course/i }).click()
-    
+
     // Confirm modal appears.
     const modal = page.getByRole('dialog')
     await expect(modal).toBeVisible()
     await expect(modal.getByText(/archives the entire course/i)).toBeVisible()
-    
+
     // Click confirm.
     await modal.getByRole('button', { name: /archive course/i }).click()
-    
+
     // Should be redirected to /courses.
     await expect(page).toHaveURL(/\/courses$/)
-    
-    // Verify it's no longer in the list.
-    await expect(page.getByText(seededCourse.title)).not.toBeVisible()
+
+    // Verify it's no longer in the list. Use an exact link match so we do not
+    // collide with headings like "E2E Test Course — archive" (substring match).
+    await expect(
+      page.getByRole('link', { name: seededCourse.title, exact: true }),
+    ).not.toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary

- **Archive course test:** `getByText(seededCourse.title)` matched both the courses list link and the archive settings heading (`E2E Test Course — archive`) because Playwright text matching is substring-based, which triggered a strict-mode violation. The assertion now targets the course card link with `exact: true`.
- **e2e-local.sh:** Declare `PLAYWRIGHT_TEST_ARGS` up front so `make e2e` with no extra args does not hit an unbound array under `set -u`. Teardown now kills `go run` / Vite child processes so orphaned servers do not keep running after the suite. Optional Playwright paths can be passed through with `e2e/` prefix normalization.

## Verification

- `make e2e` — 60 passed, 6 skipped (full Chromium suite).