### PR TITLE
feat: add /api/v1/users endpoints and fix CLI paths

### DIFF
--- a/clients/cli/cmd/assignments.go
+++ b/clients/cli/cmd/assignments.go
@@ -388,7 +388,7 @@ func runAssignmentsSubmit(cmd *cobra.Command, _ []string) error {
 	info, err := os.Stat(cleanPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("File not found: %s", filePath)
+			return fmt.Errorf("file not found: %s", filePath)
 		}
 		return fmt.Errorf("accessing file %s: %w", filePath, err)
 	}

--- a/clients/cli/cmd/assignments_test.go
+++ b/clients/cli/cmd/assignments_test.go
@@ -677,8 +677,8 @@ func TestAssignmentsSubmit_FileNotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing file, got nil")
 	}
-	if !strings.Contains(err.Error(), "File not found") {
-		t.Errorf("err = %q; want 'File not found'", err.Error())
+	if !strings.Contains(err.Error(), "file not found") {
+		t.Errorf("err = %q; want 'file not found'", err.Error())
 	}
 	if !strings.Contains(err.Error(), "/nonexistent/path/submission.zip") {
 		t.Errorf("err = %q; want the file path in error message", err.Error())

--- a/clients/cli/cmd/users.go
+++ b/clients/cli/cmd/users.go
@@ -70,7 +70,7 @@ func runUsersList(cmd *cobra.Command, args []string) error {
 		params.Set("page", fmt.Sprintf("%d", usersListFlags.page))
 	}
 
-	path := "/api/users"
+	path := "/api/v1/users"
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
@@ -120,7 +120,7 @@ var usersGetCmd = &cobra.Command{
 func runUsersGet(cmd *cobra.Command, args []string) error {
 	c := client.New(Cfg.Server, Cfg.APIKey)
 
-	req, err := c.NewRequest(http.MethodGet, "/api/users/"+url.PathEscape(args[0]), nil)
+	req, err := c.NewRequest(http.MethodGet, "/api/v1/users/"+url.PathEscape(args[0]), nil)
 	if err != nil {
 		return fmt.Errorf("building request: %w", err)
 	}
@@ -198,7 +198,7 @@ func runUsersCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("encoding request: %w", err)
 	}
 
-	req, err := c.NewRequest(http.MethodPost, "/api/users", bytes.NewReader(raw))
+	req, err := c.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(raw))
 	if err != nil {
 		return fmt.Errorf("building request: %w", err)
 	}
@@ -283,7 +283,7 @@ func runUsersEnroll(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("encoding request: %w", err)
 	}
 
-	path := "/api/courses/" + url.PathEscape(usersEnrollFlags.course) + "/enrollments"
+	path := "/api/v1/courses/" + url.PathEscape(usersEnrollFlags.course) + "/enrollments"
 	req, err := c.NewRequest(http.MethodPost, path, bytes.NewReader(raw))
 	if err != nil {
 		return fmt.Errorf("building request: %w", err)
@@ -328,7 +328,7 @@ func resolveUserID(c *client.Client, idOrEmail string) (id, name string, err err
 		return idOrEmail, "", nil
 	}
 
-	req, err := c.NewRequest(http.MethodGet, "/api/users/"+url.PathEscape(idOrEmail), nil)
+	req, err := c.NewRequest(http.MethodGet, "/api/v1/users/"+url.PathEscape(idOrEmail), nil)
 	if err != nil {
 		return "", "", err
 	}

--- a/clients/cli/cmd/users_test.go
+++ b/clients/cli/cmd/users_test.go
@@ -23,19 +23,19 @@ func newUsersServer(t *testing.T, cfg usersServerConfig) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/users":
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/users":
 			if cfg.listHandler != nil {
 				cfg.listHandler(w, r)
 			} else {
 				http.NotFound(w, r)
 			}
-		case r.Method == http.MethodPost && r.URL.Path == "/api/users":
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/users":
 			if cfg.createHandler != nil {
 				cfg.createHandler(w, r)
 			} else {
 				http.NotFound(w, r)
 			}
-		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/users/"):
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v1/users/"):
 			if cfg.getHandler != nil {
 				cfg.getHandler(w, r)
 			} else {

--- a/server/internal/httpserver/server.go
+++ b/server/internal/httpserver/server.go
@@ -137,6 +137,9 @@ func NewHandler(d Deps) http.Handler {
 	r.Post("/api/v1/orgs/{orgId}/branding/logo", d.handleOrgBrandingUpload("logo"))
 	r.Post("/api/v1/orgs/{orgId}/branding/favicon", d.handleOrgBrandingUpload("favicon"))
 	r.Get("/api/v1/orgs/{orgId}/users", d.handleOrgUsersSearch())
+	r.Get("/api/v1/users", d.handleUsersList())
+	r.Get("/api/v1/users/{user_id}", d.handleUsersGet())
+	r.Post("/api/v1/users", d.handleUsersCreate())
 	// Course calendar feed (iCalendar) — must register before /api/v1/courses/{course_code} static routes that might shadow.
 	r.Get("/api/v1/courses/{course_code}/calendar.ics", d.handleCourseICS())
 	// One Route for /api/v1/courses/{course_code} so GET and PATCH /markdown-theme share the same chi subtree

--- a/server/internal/httpserver/users_http.go
+++ b/server/internal/httpserver/users_http.go
@@ -1,0 +1,274 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+	userrepo "github.com/lextures/lextures/server/internal/repos/user"
+	"github.com/lextures/lextures/server/internal/service/authservice"
+)
+
+type cliUser struct {
+	ID        string    `json:"id"`
+	Email     string    `json:"email"`
+	Name      string    `json:"name"`
+	Role      string    `json:"role"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+// appRoleToCliRole maps app_roles.name → CLI role string.
+func appRoleToCliRole(name string) string {
+	switch name {
+	case "Teacher":
+		return "instructor"
+	case "Student":
+		return "student"
+	case "TA":
+		return "ta"
+	default:
+		return strings.ToLower(name)
+	}
+}
+
+// cliRoleToAppRole maps CLI role string → app_roles.name.
+func cliRoleToAppRole(role string) string {
+	switch strings.ToLower(role) {
+	case "instructor":
+		return "Teacher"
+	case "student":
+		return "Student"
+	case "ta":
+		return "TA"
+	default:
+		return role
+	}
+}
+
+const platformInboxUUID = "a0000000-0000-4000-8000-000000000001"
+
+// GET /api/v1/users
+func (d Deps) handleUsersList() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+
+		limit := 50
+		page := 1
+		if v := r.URL.Query().Get("limit"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				limit = n
+			}
+		}
+		if v := r.URL.Query().Get("page"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				page = n
+			}
+		}
+		roleFilter := strings.TrimSpace(r.URL.Query().Get("role"))
+		orgFilter := strings.TrimSpace(r.URL.Query().Get("org"))
+		offset := (page - 1) * limit
+
+		args := []any{}
+		argIdx := 1
+
+		roleJoin := ""
+		roleWhere := ""
+		if roleFilter != "" {
+			dbRole := cliRoleToAppRole(roleFilter)
+			roleJoin = `JOIN "user".user_app_roles uar_f ON uar_f.user_id = u.id
+JOIN "user".app_roles ar_f ON ar_f.id = uar_f.role_id`
+			roleWhere = fmt.Sprintf("AND ar_f.name = $%d", argIdx)
+			args = append(args, dbRole)
+			argIdx++
+		}
+
+		orgWhere := ""
+		if orgFilter != "" {
+			oid, err := uuid.Parse(orgFilter)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid org UUID.")
+				return
+			}
+			orgWhere = fmt.Sprintf("AND u.org_id = $%d", argIdx)
+			args = append(args, oid)
+			argIdx++
+		}
+
+		args = append(args, limit, offset)
+		limitIdx := argIdx
+		offsetIdx := argIdx + 1
+
+		q := fmt.Sprintf(`
+SELECT u.id::text, u.email, u.display_name,
+       (SELECT ar.name FROM "user".user_app_roles uar
+        JOIN "user".app_roles ar ON ar.id = uar.role_id
+        WHERE uar.user_id = u.id ORDER BY ar.name LIMIT 1) AS role,
+       u.created_at
+FROM "user".users u
+%s
+WHERE u.id <> '%s'::uuid
+%s %s
+ORDER BY u.email ASC
+LIMIT $%d OFFSET $%d
+`, roleJoin, platformInboxUUID, roleWhere, orgWhere, limitIdx, offsetIdx)
+
+		rows, err := d.Pool.Query(r.Context(), q, args...)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to list users.")
+			return
+		}
+		defer rows.Close()
+
+		out := []cliUser{}
+		for rows.Next() {
+			var u cliUser
+			var dn, roleName *string
+			if err := rows.Scan(&u.ID, &u.Email, &dn, &roleName, &u.CreatedAt); err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to list users.")
+				return
+			}
+			if dn != nil {
+				u.Name = *dn
+			}
+			if roleName != nil {
+				u.Role = appRoleToCliRole(*roleName)
+			}
+			out = append(out, u)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"users": out})
+	}
+}
+
+// GET /api/v1/users/{user_id}
+func (d Deps) handleUsersGet() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+
+		rawID := chi.URLParam(r, "user_id")
+		decoded, err := url.PathUnescape(rawID)
+		if err != nil {
+			decoded = rawID
+		}
+
+		const baseSelect = `
+SELECT u.id::text, u.email, u.display_name,
+       (SELECT ar.name FROM "user".user_app_roles uar
+        JOIN "user".app_roles ar ON ar.id = uar.role_id
+        WHERE uar.user_id = u.id ORDER BY ar.name LIMIT 1) AS role,
+       u.created_at
+FROM "user".users u WHERE `
+
+		var q string
+		var arg any
+		if _, err := uuid.Parse(decoded); err == nil {
+			q = baseSelect + "u.id = $1::uuid"
+			parsed, _ := uuid.Parse(decoded)
+			arg = parsed
+		} else {
+			q = baseSelect + "LOWER(u.email) = LOWER($1)"
+			arg = decoded
+		}
+
+		var out cliUser
+		var dn, roleName *string
+		err = d.Pool.QueryRow(r.Context(), q, arg).Scan(&out.ID, &out.Email, &dn, &roleName, &out.CreatedAt)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "User not found.")
+			return
+		}
+		if dn != nil {
+			out.Name = *dn
+		}
+		if roleName != nil {
+			out.Role = appRoleToCliRole(*roleName)
+		}
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+// POST /api/v1/users
+func (d Deps) handleUsersCreate() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+
+		var body struct {
+			Email string `json:"email"`
+			Name  string `json:"name"`
+			Role  string `json:"role"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+
+		email := userrepo.NormalizeEmail(body.Email)
+		if email == "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "email is required.")
+			return
+		}
+		name := strings.TrimSpace(body.Name)
+		if name == "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "name is required.")
+			return
+		}
+
+		role := strings.TrimSpace(strings.ToLower(body.Role))
+		if role == "" {
+			role = "student"
+		}
+		appRole := cliRoleToAppRole(role)
+
+		ph, err := authservice.PlaceholderPasswordHash()
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to provision user.")
+			return
+		}
+
+		var id string
+		var createdAt time.Time
+		err = d.Pool.QueryRow(r.Context(), `
+INSERT INTO "user".users (email, password_hash, display_name, org_id)
+VALUES ($1, $2, $3, (SELECT id FROM tenant.organizations WHERE slug = 'default' LIMIT 1))
+RETURNING id::text, created_at
+`, email, ph, name).Scan(&id, &createdAt)
+		if err != nil {
+			var pe *pgconn.PgError
+			if errors.As(err, &pe) && pe.Code == "23505" {
+				apierr.WriteJSON(w, http.StatusConflict, apierr.CodeConflict, "A user with that email already exists.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to create user.")
+			return
+		}
+
+		uid, _ := uuid.Parse(id)
+		if err := rbac.AssignUserRoleByName(r.Context(), d.Pool, uid, appRole); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to assign role.")
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, cliUser{
+			ID:        id,
+			Email:     email,
+			Name:      name,
+			Role:      role,
+			CreatedAt: createdAt,
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- The CLI `users` subcommands (`list`, `get`, `create`, `enroll`) were calling `/api/users` (missing the `/v1/` prefix), causing 404s — no matching server routes existed for those paths
- Added `GET /api/v1/users`, `GET /api/v1/users/{user_id}`, and `POST /api/v1/users` handlers to the server with admin auth (`global:app:rbac:manage`)
- Fixed all four wrong paths in the CLI (`/api/users*` → `/api/v1/users*`, `/api/courses*` → `/api/v1/courses*`)
- New `POST /api/v1/users` provisions users with a placeholder password hash and assigns the requested app role (`student`→Student, `instructor`→Teacher, `ta`→TA)

## Test plan

- [ ] `lextures users list` returns a paginated list of users
- [ ] `lextures users get <uuid>` and `lextures users get <email>` resolve correctly
- [ ] `lextures users create --email x --name y --role student` creates a user and returns 201
- [ ] `lextures users enroll --course X --user Y --role student` no longer 404s
- [ ] Unauthenticated or non-admin requests to `/api/v1/users` return 401/403

🤖 Generated with [Claude Code](https://claude.com/claude-code)