### PR TITLE
fix: restore Canvas enrollment import broken by migration 041

### DIFF
--- a/server/internal/httpserver/canvas_import_ws.go
+++ b/server/internal/httpserver/canvas_import_ws.go
@@ -180,6 +180,7 @@ func (d Deps) runCanvasImport(
 		}
 	}
 	enrollmentRows := []map[string]any{}
+	rosterEmailByCanvasUID := make(map[int64]string)
 	if include.Enrollments {
 		if !progress("Loading Canvas enrollments...") {
 			return context.Canceled
@@ -187,6 +188,20 @@ func (d Deps) runCanvasImport(
 		enrollmentRows, err = canvasGetArrayPaginated(ctx, client, canvasBase, accessToken, fmt.Sprintf("courses/%d/enrollments", canvasCourseID), url.Values{"state[]": []string{"active", "invited", "creation_pending"}})
 		if err != nil {
 			return err
+		}
+		// Load the full user roster so we can resolve emails; Canvas enrollment
+		// mini-user objects often omit the email field entirely.
+		if rosterUsers, re := canvasGetArrayPaginated(ctx, client, canvasBase, accessToken,
+			fmt.Sprintf("courses/%d/users", canvasCourseID),
+			url.Values{"include[]": []string{"email"}}); re == nil {
+			for _, ru := range rosterUsers {
+				uid := int64At(ru, "id")
+				if uid > 0 {
+					if eg := normalizedLexturesEmailGuessFromCanvasUserMap(ru); eg != "" {
+						rosterEmailByCanvasUID[uid] = eg
+					}
+				}
+			}
 		}
 	}
 
@@ -375,9 +390,11 @@ func (d Deps) runCanvasImport(
 		}
 		for _, e := range enrollmentRows {
 			u := objAt(e, "user")
-			email := strings.ToLower(strings.TrimSpace(strAt(u, "email", "")))
+			canvasUID := int64At(u, "id")
+			// Prefer full-roster email; enrollment mini-user objects often omit it.
+			email := rosterEmailByCanvasUID[canvasUID]
 			if email == "" {
-				email = strings.ToLower(strings.TrimSpace(strAt(u, "login_id", "")))
+				email = normalizedLexturesEmailGuessFromCanvasUserMap(u)
 			}
 			if !strings.Contains(email, "@") {
 				continue
@@ -390,16 +407,22 @@ func (d Deps) runCanvasImport(
 			if pe != nil {
 				continue
 			}
-			role := "student"
-			if strings.Contains(strings.ToLower(strAt(e, "type", "")), "teacher") || strings.Contains(strings.ToLower(strAt(e, "type", "")), "ta") {
-				role = "instructor"
-			}
-			_, _ = tx.Exec(ctx, `
+			role := canvasEnrollmentTypeToRole(strAt(e, "type", ""))
+			// Use the three-column unique constraint (course_id, user_id, role) that
+			// replaced the old two-column one in migration 041. Skip owner rows so we
+			// never overwrite the course creator's ownership grant.
+			tag, ie := tx.Exec(ctx, `
 				INSERT INTO course.course_enrollments (course_id, user_id, role)
-				VALUES ($1, $2, $3)
-				ON CONFLICT (course_id, user_id) DO UPDATE SET role = EXCLUDED.role
-				WHERE course.course_enrollments.role <> 'owner'
+				SELECT $1, $2, $3
+				WHERE NOT EXISTS (
+					SELECT 1 FROM course.course_enrollments
+					WHERE course_id = $1 AND user_id = $2 AND role = 'owner'
+				)
+				ON CONFLICT (course_id, user_id, role) DO NOTHING
 			`, courseID, userID, role)
+			if ie == nil && tag.RowsAffected() > 0 {
+				_ = courseroles.RefreshManagedGrantsForCourseUser(ctx, tx, userID, courseID, courseCode)
+			}
 		}
 	}
 
@@ -661,6 +684,16 @@ func htmlToPlainText(html string) string {
 		b.WriteString("\n")
 	}
 	return strings.TrimSpace(b.String())
+}
+
+// canvasEnrollmentTypeToRole converts a Canvas enrollment type string (e.g.
+// "TeacherEnrollment", "TaEnrollment") to the Lextures course role it maps to.
+func canvasEnrollmentTypeToRole(canvasType string) string {
+	t := strings.ToLower(canvasType)
+	if strings.Contains(t, "teacher") || strings.Contains(t, "ta") {
+		return "instructor"
+	}
+	return "student"
 }
 
 func mapCanvasTypeToKind(t string) (kind string, bodyTable string) {

--- a/server/internal/httpserver/canvas_import_ws_test.go
+++ b/server/internal/httpserver/canvas_import_ws_test.go
@@ -5,6 +5,37 @@ import (
 	"testing"
 )
 
+func TestCanvasEnrollmentTypeToRole_TeacherAndTA(t *testing.T) {
+	for _, typ := range []string{"TeacherEnrollment", "TaEnrollment", "teacher", "ta", "head_ta"} {
+		if got := canvasEnrollmentTypeToRole(typ); got != "instructor" {
+			t.Errorf("canvasEnrollmentTypeToRole(%q) = %q, want instructor", typ, got)
+		}
+	}
+}
+
+func TestCanvasEnrollmentTypeToRole_OtherMapsToStudent(t *testing.T) {
+	for _, typ := range []string{"StudentEnrollment", "DesignerEnrollment", "ObserverEnrollment", "", "unknown"} {
+		if got := canvasEnrollmentTypeToRole(typ); got != "student" {
+			t.Errorf("canvasEnrollmentTypeToRole(%q) = %q, want student", typ, got)
+		}
+	}
+}
+
+func TestCanvasImportInclude_WithDefaults_AllFalseGivesAll(t *testing.T) {
+	got := (canvasImportInclude{}).withDefaults()
+	want := canvasImportInclude{Modules: true, Assignments: true, Quizzes: true, Enrollments: true, Grades: true, Settings: true}
+	if got != want {
+		t.Fatalf("withDefaults on zero include = %+v, want %+v", got, want)
+	}
+}
+
+func TestCanvasImportInclude_WithDefaults_PartialUnchanged(t *testing.T) {
+	partial := canvasImportInclude{Modules: true, Enrollments: true}
+	if got := partial.withDefaults(); got != partial {
+		t.Fatalf("withDefaults on partial should return as-is, got %+v", got)
+	}
+}
+
 func TestMarkdownFromHTML_ConvertsBasicFormatting(t *testing.T) {
 	md := markdownFromHTML("<h2>Title</h2><p>Hello <strong>world</strong> and <a href=\"https://example.com\">link</a>.</p>")
 	if !strings.Contains(md, "## Title") {


### PR DESCRIPTION
## Summary

- **Root cause 1 (critical):** Migration 041 changed the `course_enrollments` unique constraint from `(course_id, user_id)` to `(course_id, user_id, role)` to support multi-role enrollments. The Canvas import `ON CONFLICT` clause still referenced the old two-column constraint, causing every enrollment `INSERT` to fail with a PostgreSQL "no matching constraint" error. Because the call used `_, _` to ignore errors, the transaction silently aborted and the commit failed — so when enrollments were enabled, **nothing in the import was saved**.
- **Root cause 2:** Canvas enrollment API responses include "mini user" objects that commonly omit the `email` field. Without falling back to the full course roster (`courses/:id/users`), virtually every enrollment row was skipped silently even before reaching the SQL.

## Changes

- Load `courses/:id/users` roster before the import transaction; build a Canvas UID → email map used as the primary email source (mini-user object as fallback).
- Replace `ON CONFLICT (course_id, user_id) DO UPDATE` with `SELECT … WHERE NOT EXISTS (owner check) … ON CONFLICT (course_id, user_id, role) DO NOTHING` to match the post-migration schema and preserve owner rows.
- Call `courseroles.RefreshManagedGrantsForCourseUser` after each new enrollment so RBAC grants are synced in the same transaction.
- Extract `canvasEnrollmentTypeToRole` helper and add unit tests for role mapping and `withDefaults` behaviour.

## Test plan

- [x] `go build ./...` — clean compile
- [x] `go test ./internal/httpserver/... -run TestCanvas` — all 7 canvas tests pass (4 new)
- [x] `go test ./...` — full suite green
- [x] `golangci-lint run` — 0 issues