### PR TITLE
fix: remove unused imports breaking marketing site build

### DIFF
--- a/www/src/pages/HigherEdPage.tsx
+++ b/www/src/pages/HigherEdPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, BarChart3, BookOpen, BrainCircuit, GraduationCap, RefreshCw, ShieldCheck, Unplug } from 'lucide-react'
+import { ArrowRight, BarChart3, BookOpen, BrainCircuit, GraduationCap, ShieldCheck, Unplug } from 'lucide-react'
 import { Header } from '../components/Header'
 
 const LINKS = {

--- a/www/src/pages/K12Page.tsx
+++ b/www/src/pages/K12Page.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, BarChart3, BrainCircuit, GraduationCap, RefreshCw, ShieldCheck, Users, Zap } from 'lucide-react'
+import { ArrowRight, BarChart3, GraduationCap, RefreshCw, ShieldCheck, Users, Zap } from 'lucide-react'
 import { Header } from '../components/Header'
 
 const LINKS = {

--- a/www/src/pages/SelfLearnerPage.tsx
+++ b/www/src/pages/SelfLearnerPage.tsx
@@ -1,11 +1,6 @@
 import { ArrowRight, BrainCircuit, RefreshCw, TrendingUp, Zap } from 'lucide-react'
 import { Header } from '../components/Header'
 
-const LINKS = {
-  demo: 'https://demo.lextures.com/',
-  github: 'https://github.com/StudyDrift/lextures',
-} as const
-
 const PROBLEMS = [
   {
     title: 'You don\'t know what you don\'t know',


### PR DESCRIPTION
## Summary
- Drop unused `RefreshCw` import from `www/src/pages/HigherEdPage.tsx`
- Drop unused `BrainCircuit` import from `www/src/pages/K12Page.tsx`
- Drop unused `LINKS` constant from `www/src/pages/SelfLearnerPage.tsx`

These were producing TS6133 errors and failing the marketing site `tsc -b && vite build` step in CI (run [26057607971](https://github.com/StudyDrift/lextures/actions/runs/26057607971/job/76609496855)).

## Test plan
- [x] `npm run build` in `www/` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)