### PR TITLE
feat: collapsible sidebar, link edit popover, AI syllabus generation

### DIFF
--- a/clients/web/src/components/editor/block-editor/block-frame.tsx
+++ b/clients/web/src/components/editor/block-editor/block-frame.tsx
@@ -32,18 +32,6 @@ export function BlockFrame({ blockId, toolbar, children, className }: BlockFrame
       role="group"
       aria-label="Content block"
     >
-      {toolbar && (
-        <div
-          className={[
-            'absolute bottom-full left-0 z-20 mb-1 flex w-full justify-start transition-opacity duration-150',
-            selected
-              ? 'visible opacity-100'
-              : 'invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100',
-          ].join(' ')}
-        >
-          {toolbar}
-        </div>
-      )}
       <div
         className={[
           'border-l-2 border-transparent pl-3 transition-colors',
@@ -51,6 +39,20 @@ export function BlockFrame({ blockId, toolbar, children, className }: BlockFrame
           disabled ? 'opacity-60' : '',
         ].join(' ')}
       >
+        {toolbar && (
+          <div
+            className={[
+              'sticky top-0 z-20 w-full overflow-hidden transition-all duration-150',
+              selected
+                ? 'mb-2 h-9 opacity-100'
+                : 'h-0 opacity-0 group-hover:mb-2 group-hover:h-9 group-hover:opacity-100 group-focus-within:mb-2 group-focus-within:h-9 group-focus-within:opacity-100',
+            ].join(' ')}
+          >
+            <div className="flex justify-start">
+              {toolbar}
+            </div>
+          </div>
+        )}
         {children}
       </div>
     </div>

--- a/clients/web/src/components/editor/block-editor/markdown-body-editor.tsx
+++ b/clients/web/src/components/editor/block-editor/markdown-body-editor.tsx
@@ -1,9 +1,10 @@
+import { getMarkRange } from '@tiptap/core'
 import { Markdown } from '@tiptap/markdown'
 import Link from '@tiptap/extension-link'
 import Placeholder from '@tiptap/extension-placeholder'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { Image as ImageIcon } from 'lucide-react'
+import { ExternalLink, Image as ImageIcon, Trash2, X } from 'lucide-react'
 import { createPortal } from 'react-dom'
 import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { Editor } from '@tiptap/core'
@@ -79,6 +80,17 @@ type MentionUi = {
   top: number
 }
 
+type LinkPopoverState = {
+  href: string
+  text: string
+  editHref: string
+  editText: string
+  from: number
+  to: number
+  left: number
+  top: number
+}
+
 /**
  * WYSIWYG Markdown body: stores Markdown on the wire, renders formatted content while editing.
  */
@@ -112,6 +124,7 @@ export function MarkdownBodyEditor({
   const [structureError, setStructureError] = useState(false)
   const [mentionUi, setMentionUi] = useState<MentionUi | null>(null)
   const [activeIndex, setActiveIndex] = useState(0)
+  const [linkPopover, setLinkPopover] = useState<LinkPopoverState | null>(null)
 
   const mentionCtxRef = useRef({
     mentionUi: null as MentionUi | null,
@@ -228,7 +241,35 @@ export function MarkdownBodyEditor({
         })()
         return true
       },
+      handleClick(view: EditorView, pos: number, event: MouseEvent) {
+        if (disabledRef.current) return false
+        const { state } = view
+        const linkMarkType = state.schema.marks.link
+        if (!linkMarkType) return false
+        const $pos = state.doc.resolve(pos)
+        const linkMark = $pos.marks().find((m) => m.type === linkMarkType)
+        if (!linkMark) return false
+        event.preventDefault()
+        const range = getMarkRange($pos, linkMarkType)
+        if (!range) return false
+        const text = state.doc.textBetween(range.from, range.to)
+        const domCoords = view.coordsAtPos(pos)
+        const initialHref = (linkMark.attrs.href as string) ?? ''
+        setLinkPopover({
+          href: initialHref,
+          text,
+          editHref: initialHref,
+          editText: text,
+          from: range.from,
+          to: range.to,
+          left: domCoords.left,
+          top: domCoords.bottom + 6,
+        })
+        return true
+      },
     }),
+    // setLinkPopover is stable; disabledRef is a ref — no deps needed
+     
     [],
   )
 
@@ -403,6 +444,47 @@ export function MarkdownBodyEditor({
     editor.chain().focus().deleteRange({ from: mu.from, to: mu.to }).run()
     setMentionUi(null)
   }, [editor])
+
+  const applyLinkEdit = useCallback(() => {
+    if (!editor || !linkPopover) return
+    const href = linkPopover.editHref.trim()
+    const text = linkPopover.editText.trim() || linkPopover.href
+    editor
+      .chain()
+      .focus()
+      .insertContentAt(
+        { from: linkPopover.from, to: linkPopover.to },
+        href
+          ? { type: 'text', text, marks: [{ type: 'link', attrs: { href } }] }
+          : { type: 'text', text },
+      )
+      .run()
+    setLinkPopover(null)
+  }, [editor, linkPopover])
+
+  const removeLinkFromPopover = useCallback(() => {
+    if (!editor || !linkPopover) return
+    editor
+      .chain()
+      .focus()
+      .setTextSelection({ from: linkPopover.from, to: linkPopover.to })
+      .unsetMark('link')
+      .run()
+    setLinkPopover(null)
+  }, [editor, linkPopover])
+
+  useEffect(() => {
+    if (!editor || !linkPopover) return
+    const close = () => {
+      const { state } = editor
+      const $pos = state.doc.resolve(state.selection.from)
+      if (!$pos.marks().some((m) => m.type.name === 'link')) {
+        setLinkPopover(null)
+      }
+    }
+    editor.on('selectionUpdate', close)
+    return () => { editor.off('selectionUpdate', close) }
+  }, [editor, linkPopover])
 
   useEffect(() => {
     if (!editor) return
@@ -628,6 +710,100 @@ export function MarkdownBodyEditor({
                   </button>
                 ))
               )}
+            </div>,
+            document.body,
+          )
+        : null}
+      {linkPopover
+        ? createPortal(
+            <div
+              role="dialog"
+              aria-label="Edit link"
+              style={{
+                position: 'fixed',
+                left: Math.min(linkPopover.left, window.innerWidth - 320),
+                top: linkPopover.top,
+                zIndex: 60,
+                width: 'min(20rem, calc(100vw - 2rem))',
+              }}
+              className="rounded-xl border border-slate-200 bg-white p-3 shadow-lg shadow-slate-900/15 dark:border-neutral-600 dark:bg-neutral-900"
+              onMouseDown={(e) => e.stopPropagation()}
+            >
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+                  Edit link
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setLinkPopover(null)}
+                  className="rounded p-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-neutral-700 dark:hover:text-neutral-200"
+                  aria-label="Close link editor"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </div>
+              <div className="flex flex-col gap-2">
+                <div>
+                  <label className="mb-1 block text-xs text-slate-600 dark:text-neutral-300">URL</label>
+                  <input
+                    type="url"
+                    value={linkPopover.editHref}
+                    onChange={(e) => setLinkPopover((p) => p && { ...p, editHref: e.target.value })}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') { e.preventDefault(); applyLinkEdit() }
+                      if (e.key === 'Escape') { e.preventDefault(); setLinkPopover(null) }
+                    }}
+                    placeholder="https://"
+                    className="w-full rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-sm text-slate-900 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500"
+                    autoFocus
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs text-slate-600 dark:text-neutral-300">Display text</label>
+                  <input
+                    type="text"
+                    value={linkPopover.editText}
+                    onChange={(e) => setLinkPopover((p) => p && { ...p, editText: e.target.value })}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') { e.preventDefault(); applyLinkEdit() }
+                      if (e.key === 'Escape') { e.preventDefault(); setLinkPopover(null) }
+                    }}
+                    placeholder="Link text"
+                    className="w-full rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-sm text-slate-900 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500"
+                  />
+                </div>
+                <div className="flex items-center justify-between gap-2">
+                  <button
+                    type="button"
+                    onClick={removeLinkFromPopover}
+                    className="flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-rose-600 hover:bg-rose-50 dark:text-rose-400 dark:hover:bg-rose-950/40"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                    Remove link
+                  </button>
+                  <div className="flex items-center gap-1.5">
+                    {linkPopover.editHref.trim() ? (
+                      <a
+                        href={linkPopover.editHref.trim()}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-1 rounded-md px-2 py-1.5 text-xs text-slate-600 hover:bg-slate-100 dark:text-neutral-300 dark:hover:bg-neutral-700"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <ExternalLink className="h-3.5 w-3.5" />
+                        Visit
+                      </a>
+                    ) : null}
+                    <button
+                      type="button"
+                      onClick={applyLinkEdit}
+                      className="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+                    >
+                      Save
+                    </button>
+                  </div>
+                </div>
+              </div>
             </div>,
             document.body,
           )

--- a/clients/web/src/components/layout/__tests__/side-nav-main-links.test.tsx
+++ b/clients/web/src/components/layout/__tests__/side-nav-main-links.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 import { PERM_REPORTS_VIEW } from '../../../lib/rbac-api'
+import { ShellNavProvider } from '../shell-nav-context'
 import { SideNavMainLinks } from '../side-nav-main-links'
 
 vi.mock('../../../context/use-inbox-unread', () => ({
@@ -19,7 +20,9 @@ describe('SideNavMainLinks', () => {
   it('renders core navigation and unread badge when inbox has items', () => {
     render(
       <MemoryRouter>
-        <SideNavMainLinks />
+        <ShellNavProvider>
+          <SideNavMainLinks />
+        </ShellNavProvider>
       </MemoryRouter>,
     )
     expect(screen.getByRole('link', { name: /^dashboard$/i })).toHaveAttribute('href', '/')

--- a/clients/web/src/components/layout/shell-nav-context-core.ts
+++ b/clients/web/src/components/layout/shell-nav-context-core.ts
@@ -4,6 +4,8 @@ export type ShellNavContextValue = {
   mobileNavOpen: boolean
   setMobileNavOpen: Dispatch<SetStateAction<boolean>>
   closeMobileNav: () => void
+  sideNavCollapsed: boolean
+  toggleSideNav: () => void
 }
 
 export const ShellNavContext = createContext<ShellNavContextValue | null>(null)

--- a/clients/web/src/components/layout/shell-nav-context.tsx
+++ b/clients/web/src/components/layout/shell-nav-context.tsx
@@ -5,7 +5,11 @@ export function ShellNavProvider({ children }: { children: ReactNode }) {
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
   const [sideNavCollapsed, setSideNavCollapsed] = useState(() => {
     if (typeof window === 'undefined') return false
-    return localStorage.getItem('lextures-sidenav-collapsed') === 'true'
+    try {
+      return localStorage.getItem('lextures-sidenav-collapsed') === 'true'
+    } catch {
+      return false
+    }
   })
 
   const closeMobileNav = useCallback(() => setMobileNavOpen(false), [])
@@ -13,7 +17,11 @@ export function ShellNavProvider({ children }: { children: ReactNode }) {
   const toggleSideNav = useCallback(() => {
     setSideNavCollapsed((prev) => {
       const next = !prev
-      localStorage.setItem('lextures-sidenav-collapsed', String(next))
+      try {
+        localStorage.setItem('lextures-sidenav-collapsed', String(next))
+      } catch {
+        // Ignore storage errors (e.g. private mode)
+      }
       return next
     })
   }, [])

--- a/clients/web/src/components/layout/shell-nav-context.tsx
+++ b/clients/web/src/components/layout/shell-nav-context.tsx
@@ -3,10 +3,30 @@ import { ShellNavContext } from './shell-nav-context-core'
 
 export function ShellNavProvider({ children }: { children: ReactNode }) {
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
+  const [sideNavCollapsed, setSideNavCollapsed] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return localStorage.getItem('lextures-sidenav-collapsed') === 'true'
+  })
+
   const closeMobileNav = useCallback(() => setMobileNavOpen(false), [])
+
+  const toggleSideNav = useCallback(() => {
+    setSideNavCollapsed((prev) => {
+      const next = !prev
+      localStorage.setItem('lextures-sidenav-collapsed', String(next))
+      return next
+    })
+  }, [])
+
   const value = useMemo(
-    () => ({ mobileNavOpen, setMobileNavOpen, closeMobileNav }),
-    [mobileNavOpen, closeMobileNav],
+    () => ({
+      mobileNavOpen,
+      setMobileNavOpen,
+      closeMobileNav,
+      sideNavCollapsed,
+      toggleSideNav,
+    }),
+    [mobileNavOpen, closeMobileNav, sideNavCollapsed, toggleSideNav],
   )
   return <ShellNavContext.Provider value={value}>{children}</ShellNavContext.Provider>
 }

--- a/clients/web/src/components/layout/side-nav-command-palette.tsx
+++ b/clients/web/src/components/layout/side-nav-command-palette.tsx
@@ -1,32 +1,44 @@
 import { Search } from 'lucide-react'
 import { useCommandPalette } from '../command-palette/use-command-palette'
 import { shortcutHint } from './top-bar-utils'
+import { useShellNav } from './use-shell-nav'
 
 /** Full-width capsule trigger below the sidebar header (desktop + mobile drawer). */
 export function SideNavCommandPaletteTrigger() {
   const { open } = useCommandPalette()
+  const { sideNavCollapsed } = useShellNav()
+
   return (
-    <div className="shrink-0 px-3 pb-3 pt-0.5">
+    <div className={`shrink-0 pb-3 pt-0.5 ${sideNavCollapsed ? 'px-3' : 'px-3'}`}>
       <button
         type="button"
-        role='searchbox'
+        role="searchbox"
         aria-label="Search courses, people, pages, and actions"
         data-command-palette-anchor="sidebar"
         data-onboarding="command-palette"
         onClick={() => open()}
-        className="flex w-full items-center gap-2.5 rounded-full bg-[#E8E9EB] py-2 pl-3 pr-2 text-left text-sm text-slate-500 outline-none transition hover:bg-[#E0E2E5] focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:bg-neutral-800 dark:text-neutral-400 dark:hover:bg-neutral-700 dark:focus-visible:ring-neutral-500/40"
+        className={`flex items-center rounded-full bg-[#E8E9EB] text-left text-sm text-slate-500 outline-none transition hover:bg-[#E0E2E5] focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:bg-neutral-800 dark:text-neutral-400 dark:hover:bg-neutral-700 dark:focus-visible:ring-neutral-500/40 ${
+          sideNavCollapsed ? 'h-10 w-10 justify-center p-0 mx-auto' : 'w-full gap-2.5 py-2 pl-3 pr-2'
+        }`}
+        title={sideNavCollapsed ? 'Search' : undefined}
       >
         <Search
-          className="h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500"
+          className={`h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500 ${
+            sideNavCollapsed ? 'h-5 w-5' : ''
+          }`}
           strokeWidth={1.75}
           aria-hidden
         />
-        <span className="min-w-0 flex-1 truncate font-medium text-slate-500 dark:text-neutral-400">
-          Search
-        </span>
-        <kbd className="pointer-events-none flex h-7 min-w-[1.75rem] shrink-0 items-center justify-center rounded-lg border border-black/[0.06] bg-white px-2 font-mono text-[11px] font-medium text-slate-500 shadow-sm dark:border-white/10 dark:bg-neutral-900 dark:text-neutral-400">
-          {shortcutHint()}
-        </kbd>
+        {!sideNavCollapsed && (
+          <>
+            <span className="min-w-0 flex-1 truncate font-medium text-slate-500 dark:text-neutral-400">
+              Search
+            </span>
+            <kbd className="pointer-events-none flex h-7 min-w-[1.75rem] shrink-0 items-center justify-center rounded-lg border border-black/[0.06] bg-white px-2 font-mono text-[11px] font-medium text-slate-500 shadow-sm dark:border-white/10 dark:bg-neutral-900 dark:text-neutral-400">
+              {shortcutHint()}
+            </kbd>
+          </>
+        )}
       </button>
     </div>
   )

--- a/clients/web/src/components/layout/side-nav-course-links.tsx
+++ b/clients/web/src/components/layout/side-nav-course-links.tsx
@@ -1,4 +1,4 @@
-import { NavLink, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import {
   ArrowLeft,
   Award,
@@ -29,7 +29,9 @@ import {
 } from '../../lib/courses-api'
 import { useCourseViewAs } from '../../lib/course-view-as'
 import { useViewerEnrollmentRoles } from '../../lib/use-viewer-enrollment-roles'
-import { sideNavActiveClass, sideNavLinkClass } from './side-nav-styles'
+import { sideNavActiveClass } from './side-nav-styles'
+import { SideNavLink } from './side-nav-link'
+import { useShellNav } from './use-shell-nav'
 
 type SideNavCourseLinksProps = {
   courseCode: string
@@ -37,6 +39,7 @@ type SideNavCourseLinksProps = {
 
 export function SideNavCourseLinks({ courseCode }: SideNavCourseLinksProps) {
   const location = useLocation()
+  const { sideNavCollapsed } = useShellNav()
   const {
     notebookEnabled,
     feedEnabled,
@@ -51,8 +54,7 @@ export function SideNavCourseLinks({ courseCode }: SideNavCourseLinksProps) {
   const viewerEnrollmentRoles = useViewerEnrollmentRoles(courseCode)
 
   const base = `/courses/${encodeURIComponent(courseCode)}`
-  const canViewGradebook =
-    !permLoading && allows(courseGradebookViewPermission(courseCode))
+  const canViewGradebook = !permLoading && allows(courseGradebookViewPermission(courseCode))
   const canViewEnrollments =
     viewerEnrollmentRoles !== null &&
     viewerIsCourseStaffEnrollment(viewerEnrollmentRoles) &&
@@ -60,158 +62,97 @@ export function SideNavCourseLinks({ courseCode }: SideNavCourseLinksProps) {
     !permLoading &&
     allows(courseEnrollmentsReadPermission(courseCode))
   const canViewMyGrades = viewerShouldShowMyGradesNav(viewerEnrollmentRoles, courseViewPreview)
-  const canManageCourse =
-    !permLoading && allows(courseItemCreatePermission(courseCode))
-  const canManageQuestionBank =
-    !permLoading && allows(courseItemsCreatePermission(courseCode))
+  const canManageCourse = !permLoading && allows(courseItemCreatePermission(courseCode))
+  const canManageQuestionBank = !permLoading && allows(courseItemsCreatePermission(courseCode))
 
   return (
     <>
-      <NavLink
-        to="/courses"
-        className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-      >
-        <ArrowLeft className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+      <SideNavLink to="/courses" icon={<ArrowLeft className="h-5 w-5" />}>
         Back
-      </NavLink>
-      <p className="px-3 pb-1 pt-3 text-sm font-bold tracking-tight text-slate-900 dark:text-neutral-100">
-        Course Menu
-      </p>
-      <NavLink
-        to={base}
-        end
-        className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-      >
-        <LayoutDashboard className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+      </SideNavLink>
+      {!sideNavCollapsed && (
+        <p className="px-3 pb-1 pt-3 text-sm font-bold tracking-tight text-slate-900 dark:text-neutral-100">
+          Course Menu
+        </p>
+      )}
+      <SideNavLink to={base} end icon={<LayoutDashboard className="h-5 w-5" />}>
         Dashboard
-      </NavLink>
+      </SideNavLink>
       {feedEnabled && (
-        <NavLink
-          to={`${base}/feed`}
-          className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-        >
-          <MessageSquare className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        <SideNavLink to={`${base}/feed`} icon={<MessageSquare className="h-5 w-5" />}>
           Feed
-        </NavLink>
+        </SideNavLink>
       )}
       {discussionsEnabled && (
-        <NavLink
-          to={`${base}/discussions`}
-          className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-        >
-          <MessagesSquare className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        <SideNavLink to={`${base}/discussions`} icon={<MessagesSquare className="h-5 w-5" />}>
           Discussions
-        </NavLink>
+        </SideNavLink>
       )}
-      <NavLink
-        to={`${base}/syllabus`}
-        className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-      >
-        <FileText className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+      <SideNavLink to={`${base}/syllabus`} icon={<FileText className="h-5 w-5" />}>
         Syllabus
-      </NavLink>
-      <NavLink
-        to={`${base}/modules`}
-        className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-      >
-        <Layers className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+      </SideNavLink>
+      <SideNavLink to={`${base}/modules`} icon={<Layers className="h-5 w-5" />}>
         Modules
-      </NavLink>
+      </SideNavLink>
       {canManageQuestionBank && questionBankEnabled && (
-        <NavLink
-          to={`${base}/questions`}
-          className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-        >
-          <ListChecks className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        <SideNavLink to={`${base}/questions`} icon={<ListChecks className="h-5 w-5" />}>
           Question bank
-        </NavLink>
+        </SideNavLink>
       )}
       {canManageQuestionBank && questionBankEnabled && (
-        <NavLink
-          to={`${base}/misconception-report`}
-          className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-        >
-          <Lightbulb className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        <SideNavLink to={`${base}/misconception-report`} icon={<Lightbulb className="h-5 w-5" />}>
           Misconceptions
-        </NavLink>
+        </SideNavLink>
       )}
       {notebookEnabled && (
-        <NavLink
-          to={`${base}/notebook`}
-          className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-        >
-          <NotebookPen className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        <SideNavLink to={`${base}/notebook`} icon={<NotebookPen className="h-5 w-5" />}>
           Notebook
-        </NavLink>
+        </SideNavLink>
       )}
       {calendarEnabled && (
-        <NavLink
-          to={`${base}/calendar`}
-          className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-        >
-          <Calendar className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        <SideNavLink to={`${base}/calendar`} icon={<Calendar className="h-5 w-5" />}>
           Calendar
-        </NavLink>
+        </SideNavLink>
       )}
       {canViewMyGrades && (
-        <NavLink
-          to={`${base}/my-grades`}
-          className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-        >
-          <Award className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        <SideNavLink to={`${base}/my-grades`} icon={<Award className="h-5 w-5" />}>
           My grades
-        </NavLink>
+        </SideNavLink>
       )}
       {canViewGradebook && (
-        <NavLink
-          to={`${base}/gradebook`}
-          className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-        >
-          <ClipboardList className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        <SideNavLink to={`${base}/gradebook`} icon={<ClipboardList className="h-5 w-5" />}>
           Gradebook
-        </NavLink>
+        </SideNavLink>
       )}
       {sbgEnabled && canViewGradebook && (
-        <NavLink
-          to={`${base}/standards-gradebook`}
-          className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-        >
-          <BookMarked className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        <SideNavLink to={`${base}/standards-gradebook`} icon={<BookMarked className="h-5 w-5" />}>
           Standards gradebook
-        </NavLink>
+        </SideNavLink>
       )}
       {standardsAlignmentEnabled && (canViewGradebook || canManageCourse) && (
-        <NavLink
-          to={`${base}/standards-coverage`}
-          className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-        >
-          <BookMarked className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        <SideNavLink to={`${base}/standards-coverage`} icon={<BookMarked className="h-5 w-5" />}>
           Standards coverage
-        </NavLink>
+        </SideNavLink>
       )}
       {canViewEnrollments && (
-        <NavLink
-          to={`${base}/enrollments`}
-          className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-        >
-          <Users className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        <SideNavLink to={`${base}/enrollments`} icon={<Users className="h-5 w-5" />}>
           Enrollments
-        </NavLink>
+        </SideNavLink>
       )}
       {canManageCourse && (
-        <NavLink
+        <SideNavLink
           to={`${base}/settings/general`}
           className={() => {
             const settingsPrefix = `${base}/settings`
             const onSettings =
               location.pathname === settingsPrefix ||
               location.pathname.startsWith(`${settingsPrefix}/`)
-            return `${sideNavLinkClass} ${onSettings ? sideNavActiveClass : ''}`
+            return onSettings ? sideNavActiveClass : ''
           }}
+          icon={<Settings className="h-5 w-5" />}
         >
-          <Settings className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
           Settings
-        </NavLink>
+        </SideNavLink>
       )}
     </>
   )

--- a/clients/web/src/components/layout/side-nav-course-settings-links.tsx
+++ b/clients/web/src/components/layout/side-nav-course-settings-links.tsx
@@ -1,4 +1,4 @@
-import { NavLink, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import {
   Archive,
   ArrowLeft,
@@ -11,7 +11,9 @@ import {
   Target,
 } from 'lucide-react'
 import { courseSettingsSectionFromPathname } from './side-nav-path-utils'
-import { sideNavActiveClass, sideNavLinkClass } from './side-nav-styles'
+import { sideNavActiveClass } from './side-nav-styles'
+import { SideNavLink } from './side-nav-link'
+import { useShellNav } from './use-shell-nav'
 
 type SideNavCourseSettingsLinksProps = {
   courseCode: string
@@ -19,85 +21,79 @@ type SideNavCourseSettingsLinksProps = {
 
 export function SideNavCourseSettingsLinks({ courseCode }: SideNavCourseSettingsLinksProps) {
   const location = useLocation()
+  const { sideNavCollapsed } = useShellNav()
   const section = courseSettingsSectionFromPathname(location.pathname)
   const base = `/courses/${encodeURIComponent(courseCode)}/settings`
 
   return (
     <>
-      <NavLink
+      <SideNavLink
         to={`/courses/${encodeURIComponent(courseCode)}`}
-        className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
+        icon={<ArrowLeft className="h-5 w-5" />}
       >
-        <ArrowLeft className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
         Back
-      </NavLink>
-      <p className="px-3 pb-1 pt-3 text-sm font-bold tracking-tight text-slate-900 dark:text-neutral-100">
-        Course Settings
-      </p>
-      <NavLink
+      </SideNavLink>
+      {!sideNavCollapsed && (
+        <p className="px-3 pb-1 pt-3 text-sm font-bold tracking-tight text-slate-900 dark:text-neutral-100">
+          Course Settings
+        </p>
+      )}
+      <SideNavLink
         to={`${base}/general`}
-        className={() => `${sideNavLinkClass} ${section === 'general' ? sideNavActiveClass : ''}`}
+        className={() => (section === 'general' ? sideNavActiveClass : '')}
+        icon={<Info className="h-5 w-5" />}
       >
-        <Info className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
         General
-      </NavLink>
-      <NavLink
+      </SideNavLink>
+      <SideNavLink
         to={`${base}/grading`}
-        className={() => `${sideNavLinkClass} ${section === 'grading' ? sideNavActiveClass : ''}`}
+        className={() => (section === 'grading' ? sideNavActiveClass : '')}
+        icon={<Scale className="h-5 w-5" />}
       >
-        <Scale className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
         Grading
-      </NavLink>
-      <NavLink
+      </SideNavLink>
+      <SideNavLink
         to={`${base}/outcomes`}
-        className={() => `${sideNavLinkClass} ${section === 'outcomes' ? sideNavActiveClass : ''}`}
+        className={() => (section === 'outcomes' ? sideNavActiveClass : '')}
+        icon={<Target className="h-5 w-5" />}
       >
-        <Target className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
         Outcomes
-      </NavLink>
-      <NavLink
+      </SideNavLink>
+      <SideNavLink
         to={`${base}/features`}
-        className={() =>
-          `${sideNavLinkClass} ${section === 'features' ? sideNavActiveClass : ''}`
-        }
+        className={() => (section === 'features' ? sideNavActiveClass : '')}
+        icon={<SlidersHorizontal className="h-5 w-5" />}
       >
-        <SlidersHorizontal className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
         Features
-      </NavLink>
-      <NavLink
+      </SideNavLink>
+      <SideNavLink
         to={`${base}/sections`}
-        className={() =>
-          `${sideNavLinkClass} ${section === 'sections' ? sideNavActiveClass : ''}`
-        }
+        className={() => (section === 'sections' ? sideNavActiveClass : '')}
+        icon={<LayoutGrid className="h-5 w-5" />}
       >
-        <LayoutGrid className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
         Sections
-      </NavLink>
-      <NavLink
+      </SideNavLink>
+      <SideNavLink
         to={`${base}/import-export`}
-        className={() =>
-          `${sideNavLinkClass} ${section === 'import-export' ? sideNavActiveClass : ''}`
-        }
+        className={() => (section === 'import-export' ? sideNavActiveClass : '')}
+        icon={<FolderInput className="h-5 w-5" />}
       >
-        <FolderInput className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
         Import / export
-      </NavLink>
-      <NavLink
+      </SideNavLink>
+      <SideNavLink
         to={`${base}/blueprint`}
-        className={() =>
-          `${sideNavLinkClass} ${section === 'blueprint' ? sideNavActiveClass : ''}`
-        }
+        className={() => (section === 'blueprint' ? sideNavActiveClass : '')}
+        icon={<BookCopy className="h-5 w-5" />}
       >
-        <BookCopy className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
         Blueprint
-      </NavLink>
-      <NavLink
+      </SideNavLink>
+      <SideNavLink
         to={`${base}/archive`}
-        className={() => `${sideNavLinkClass} ${section === 'archive' ? sideNavActiveClass : ''}`}
+        className={() => (section === 'archive' ? sideNavActiveClass : '')}
+        icon={<Archive className="h-5 w-5" />}
       >
-        <Archive className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
         Archived
-      </NavLink>
+      </SideNavLink>
     </>
   )
 }

--- a/clients/web/src/components/layout/side-nav-footer.tsx
+++ b/clients/web/src/components/layout/side-nav-footer.tsx
@@ -1,5 +1,7 @@
 import { NavLink } from 'react-router-dom'
+import { PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import { RELEASE_VERSION } from '../../lib/release-version'
+import { useShellNav } from './use-shell-nav'
 
 const linkClass =
   'text-slate-600 underline decoration-slate-300 underline-offset-2 transition hover:text-slate-900 hover:decoration-slate-500 dark:text-neutral-400 dark:decoration-neutral-600 dark:hover:text-neutral-100 dark:hover:decoration-neutral-400'
@@ -11,27 +13,57 @@ function versionLabel(version: string) {
 }
 
 export function SideNavFooter() {
+  const { sideNavCollapsed, toggleSideNav } = useShellNav()
   const year = new Date().getFullYear()
 
   return (
-    <footer className="shrink-0 border-t border-slate-200/80 px-3 py-2.5 text-[11px] leading-snug text-slate-500 dark:border-neutral-800 dark:text-neutral-500">
-      <p className="flex min-w-0 items-baseline justify-between gap-2 text-slate-600 dark:text-neutral-400">
-        <span className="min-w-0 shrink">© {year} Lextures</span>
-        <span className="shrink-0 text-slate-500 tabular-nums dark:text-neutral-500" title="App version">
-          {versionLabel(RELEASE_VERSION)}
-        </span>
-      </p>
-      <p className="mt-1">
-        <NavLink to="/terms" className={linkClass}>
-          Terms of use
-        </NavLink>
-        <span className="mx-1 text-slate-400 dark:text-neutral-600" aria-hidden="true">
-          ·
-        </span>
-        <NavLink to="/privacy" className={linkClass}>
-          Privacy policy
-        </NavLink>
-      </p>
+    <footer
+      className={`shrink-0 border-t border-slate-200/80 px-3 py-2.5 text-[11px] leading-snug text-slate-500 dark:border-neutral-800 dark:text-neutral-500 ${
+        sideNavCollapsed ? 'flex justify-center' : ''
+      }`}
+    >
+      <button
+        type="button"
+        onClick={toggleSideNav}
+        className={`mb-2 flex w-full items-center gap-3 rounded-lg px-2 py-1.5 text-sm font-medium text-slate-500 transition-colors hover:bg-white/80 hover:text-slate-900 dark:text-neutral-400 dark:hover:bg-neutral-800/90 dark:hover:text-neutral-50 ${
+          sideNavCollapsed ? 'justify-center' : ''
+        }`}
+        title={sideNavCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+      >
+        {sideNavCollapsed ? (
+          <PanelLeftOpen className="h-5 w-5 shrink-0" />
+        ) : (
+          <>
+            <PanelLeftClose className="h-5 w-5 shrink-0" />
+            <span>Collapse</span>
+          </>
+        )}
+      </button>
+
+      {!sideNavCollapsed && (
+        <>
+          <p className="flex min-w-0 items-baseline justify-between gap-2 text-slate-600 dark:text-neutral-400">
+            <span className="min-w-0 shrink">© {year} Lextures</span>
+            <span
+              className="shrink-0 text-slate-500 tabular-nums dark:text-neutral-500"
+              title="App version"
+            >
+              {versionLabel(RELEASE_VERSION)}
+            </span>
+          </p>
+          <p className="mt-1">
+            <NavLink to="/terms" className={linkClass}>
+              Terms of use
+            </NavLink>
+            <span className="mx-1 text-slate-400 dark:text-neutral-600" aria-hidden="true">
+              ·
+            </span>
+            <NavLink to="/privacy" className={linkClass}>
+              Privacy policy
+            </NavLink>
+          </p>
+        </>
+      )}
     </footer>
   )
 }

--- a/clients/web/src/components/layout/side-nav-link.tsx
+++ b/clients/web/src/components/layout/side-nav-link.tsx
@@ -1,0 +1,41 @@
+import { type ReactNode } from 'react'
+import { NavLink, type NavLinkProps } from 'react-router-dom'
+import { sideNavActiveClass, sideNavLinkClass } from './side-nav-styles'
+import { useShellNav } from './use-shell-nav'
+
+interface SideNavLinkProps extends NavLinkProps {
+  icon: ReactNode
+  children: ReactNode
+  badge?: ReactNode
+}
+
+export function SideNavLink({ icon, children, badge, className, ...props }: SideNavLinkProps) {
+  const { sideNavCollapsed } = useShellNav()
+
+  return (
+    <NavLink
+      {...props}
+      className={(navProps) => {
+        const baseClass = typeof className === 'function' ? className(navProps) : className
+        const activeClass = navProps.isActive ? sideNavActiveClass : ''
+        const collapseClass = sideNavCollapsed ? 'justify-center' : ''
+        return `${sideNavLinkClass} ${activeClass} ${collapseClass} ${baseClass || ''}`
+      }}
+    >
+      <span className="flex h-5 w-5 shrink-0 items-center justify-center text-current opacity-90">
+        {icon}
+      </span>
+      {!sideNavCollapsed && (
+        <span className="flex min-w-0 flex-1 items-center justify-between gap-2">
+          <span className="truncate">{children}</span>
+          {badge}
+        </span>
+      )}
+      {sideNavCollapsed && badge && (
+        <span className="absolute right-2 top-2">
+          {badge}
+        </span>
+      )}
+    </NavLink>
+  )
+}

--- a/clients/web/src/components/layout/side-nav-main-links.tsx
+++ b/clients/web/src/components/layout/side-nav-main-links.tsx
@@ -1,4 +1,3 @@
-import { NavLink } from 'react-router-dom'
 import {
   Accessibility,
   BarChart3,
@@ -17,7 +16,7 @@ import {
   PERM_PARENT_DASHBOARD,
   PERM_REPORTS_VIEW,
 } from '../../lib/rbac-api'
-import { sideNavActiveClass, sideNavLinkClass } from './side-nav-styles'
+import { SideNavLink } from './side-nav-link'
 
 export function SideNavMainLinks() {
   const unreadInboxCount = useInboxUnreadCount()
@@ -27,92 +26,55 @@ export function SideNavMainLinks() {
   const canManageAccommodations = !permLoading && allows(PERM_ACCOMMODATIONS_MANAGE)
   const isParent = !permLoading && allows(PERM_PARENT_DASHBOARD)
 
+  const unreadBadge = unreadInboxCount > 0 && (
+    <span
+      className="inline-flex min-h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-red-600 px-1.5 text-[11px] font-semibold tabular-nums leading-none text-white"
+      aria-label={`${unreadInboxCount} unread`}
+    >
+      {unreadInboxCount > 99 ? '99+' : unreadInboxCount}
+    </span>
+  )
+
   return (
     <>
-      <NavLink
-        to="/"
-        end
-        className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-      >
-        <LayoutDashboard className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+      <SideNavLink to="/" end icon={<LayoutDashboard className="h-5 w-5" />}>
         Dashboard
-      </NavLink>
+      </SideNavLink>
       {isParent && (
-        <NavLink
-          to="/parent"
-          className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-        >
-          <UsersRound className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        <SideNavLink to="/parent" icon={<UsersRound className="h-5 w-5" />}>
           Family
-        </NavLink>
+        </SideNavLink>
       )}
-      <NavLink
-        to="/courses"
-        className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-      >
-        <BookOpen className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+      <SideNavLink to="/courses" icon={<BookOpen className="h-5 w-5" />}>
         Courses
-      </NavLink>
-      <NavLink
-        to="/notebooks"
-        className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-      >
-        <BookMarked className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+      </SideNavLink>
+      <SideNavLink to="/notebooks" icon={<BookMarked className="h-5 w-5" />}>
         My Notebooks
-      </NavLink>
-      <NavLink
-        to="/calendar"
-        className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-      >
-        <Calendar className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+      </SideNavLink>
+      <SideNavLink to="/calendar" icon={<Calendar className="h-5 w-5" />}>
         Calendar
-      </NavLink>
+      </SideNavLink>
       {canViewReports && (
-        <NavLink
-          to="/reports"
-          className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-        >
-          <BarChart3 className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        <SideNavLink to="/reports" icon={<BarChart3 className="h-5 w-5" />}>
           Reports
-        </NavLink>
+        </SideNavLink>
       )}
       {canManageAccommodations && (
-        <NavLink
-          to="/admin/accommodations"
-          className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-        >
-          <Accessibility className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        <SideNavLink to="/admin/accommodations" icon={<Accessibility className="h-5 w-5" />}>
           Accommodations
-        </NavLink>
+        </SideNavLink>
       )}
-      <NavLink
+      <SideNavLink
         to="/inbox"
         data-onboarding="nav-inbox"
-        className={({ isActive }) =>
-          `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''} justify-between gap-2`
-        }
+        icon={<Inbox className="h-5 w-5" />}
+        badge={unreadBadge}
       >
-        <span className="flex min-w-0 flex-1 items-center gap-3">
-          <Inbox className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
-          <span className="truncate">Inbox</span>
-        </span>
-        {unreadInboxCount > 0 && (
-          <span
-            className="inline-flex min-h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-red-600 px-1.5 text-[11px] font-semibold tabular-nums leading-none text-white"
-            aria-label={`${unreadInboxCount} unread`}
-          >
-            {unreadInboxCount > 99 ? '99+' : unreadInboxCount}
-          </span>
-        )}
-      </NavLink>
-      <NavLink
-        to="/settings"
-        data-onboarding="nav-settings"
-        className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-      >
-        <Settings className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+        Inbox
+      </SideNavLink>
+      <SideNavLink to="/settings" data-onboarding="nav-settings" icon={<Settings className="h-5 w-5" />}>
         Settings
-      </NavLink>
+      </SideNavLink>
     </>
   )
 }

--- a/clients/web/src/components/layout/side-nav-settings-links.tsx
+++ b/clients/web/src/components/layout/side-nav-settings-links.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { NavLink, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import { useOrgRoleCapabilities } from '../../hooks/use-org-role-capabilities'
 import {
   ArrowLeft,
@@ -26,15 +26,19 @@ import {
 } from '../../lib/rbac-api'
 import { settingsViewFromPathname } from './side-nav-path-utils'
 import { sideNavActiveClass, sideNavLinkClass } from './side-nav-styles'
+import { SideNavLink } from './side-nav-link'
+import { useShellNav } from './use-shell-nav'
 
 export function SideNavSettingsLinks() {
   const { allows, loading: permLoading } = usePermissions()
+  const { sideNavCollapsed } = useShellNav()
   const canManageRbac = !permLoading && allows(PERM_RBAC_MANAGE)
   const orgRoleCaps = useOrgRoleCapabilities()
   const canOrgRolesNav =
     canManageRbac || (!orgRoleCaps.loading && orgRoleCaps.canManageOrgRoleGrants)
   const canOrgUnits = !permLoading && (canManageRbac || allows(PERM_TENANT_ORG_UNITS_ADMIN))
-  const canOrgRoles = !permLoading && (allows(PERM_TENANT_ORG_ROLES_MANAGE) || allows(PERM_TENANT_ORG_ROLES_VIEW))
+  const canOrgRoles =
+    !permLoading && (allows(PERM_TENANT_ORG_ROLES_MANAGE) || allows(PERM_TENANT_ORG_ROLES_VIEW))
   const { scimEnabled: platformScimEnabled } = usePlatformScimEnabled(canManageRbac)
   const location = useLocation()
   const view = settingsViewFromPathname(location.pathname)
@@ -49,163 +53,163 @@ export function SideNavSettingsLinks() {
 
   return (
     <>
-      <NavLink
-        to="/"
-        end
-        className={({ isActive }) => `${sideNavLinkClass} ${isActive ? sideNavActiveClass : ''}`}
-      >
-        <ArrowLeft className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
+      <SideNavLink to="/" icon={<ArrowLeft className="h-5 w-5" />} end>
         Back
-      </NavLink>
-      <p className="px-3 pb-1 pt-3 text-sm font-bold tracking-tight text-slate-900 dark:text-neutral-100">
-        User Settings
-      </p>
-      <NavLink
+      </SideNavLink>
+      {!sideNavCollapsed && (
+        <p className="px-3 pb-1 pt-3 text-sm font-bold tracking-tight text-slate-900 dark:text-neutral-100">
+          User Settings
+        </p>
+      )}
+      <SideNavLink
         to="/settings/account"
-        className={() => `${sideNavLinkClass} ${view === 'account' ? sideNavActiveClass : ''}`}
+        className={() => (view === 'account' ? sideNavActiveClass : '')}
+        icon={<User className="h-5 w-5" />}
       >
-        <User className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
         Account
-      </NavLink>
-      <NavLink
+      </SideNavLink>
+      <SideNavLink
         to="/settings/notifications"
-        className={() => `${sideNavLinkClass} ${view === 'notifications' ? sideNavActiveClass : ''}`}
+        className={() => (view === 'notifications' ? sideNavActiveClass : '')}
+        icon={<Bell className="h-5 w-5" />}
       >
-        <Bell className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
         Notifications
-      </NavLink>
+      </SideNavLink>
       {(canOrgUnits || canOrgRoles || canManageRbac || canOrgRolesNav) && (
         <>
-          <p className="px-3 pb-1 pt-4 text-sm font-bold tracking-tight text-slate-900 dark:text-neutral-100">
-            System Settings
-          </p>
+          {!sideNavCollapsed && (
+            <p className="px-3 pb-1 pt-4 text-sm font-bold tracking-tight text-slate-900 dark:text-neutral-100">
+              System Settings
+            </p>
+          )}
           {(canOrgUnits || canOrgRoles || canOrgRolesNav) && (
             <>
               {canOrgUnits && (
-                <NavLink
+                <SideNavLink
                   to="/settings/org-units"
-                  className={() => `${sideNavLinkClass} ${view === 'org-units' ? sideNavActiveClass : ''}`}
+                  className={() => (view === 'org-units' ? sideNavActiveClass : '')}
+                  icon={<FolderTree className="h-5 w-5" />}
                 >
-                  <FolderTree className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
                   Org structure
-                </NavLink>
+                </SideNavLink>
               )}
               {(canOrgRoles || canOrgRolesNav) && (
-                <NavLink
+                <SideNavLink
                   to="/settings/org-roles"
-                  className={() => `${sideNavLinkClass} ${view === 'org-roles' ? sideNavActiveClass : ''}`}
+                  className={() => (view === 'org-roles' ? sideNavActiveClass : '')}
+                  icon={<Shield className="h-5 w-5" />}
                 >
-                  <Shield className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
                   Roles &amp; permissions
-                </NavLink>
+                </SideNavLink>
               )}
               {(canOrgUnits || canOrgRoles) && (
                 <>
-                  <NavLink
+                  <SideNavLink
                     to="/settings/terms"
-                    className={() => `${sideNavLinkClass} ${view === 'terms' ? sideNavActiveClass : ''}`}
+                    className={() => (view === 'terms' ? sideNavActiveClass : '')}
+                    icon={<CalendarRange className="h-5 w-5" />}
                   >
-                    <CalendarRange className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
                     Academic terms
-                  </NavLink>
-                  <NavLink
+                  </SideNavLink>
+                  <SideNavLink
                     to="/settings/org-branding"
-                    className={() =>
-                      `${sideNavLinkClass} ${view === 'org-branding' ? sideNavActiveClass : ''}`
-                    }
+                    className={() => (view === 'org-branding' ? sideNavActiveClass : '')}
+                    icon={<Palette className="h-5 w-5" />}
                   >
-                    <Palette className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
                     Branding
-                  </NavLink>
+                  </SideNavLink>
                 </>
               )}
             </>
           )}
           {canManageRbac && (
             <>
-              <NavLink
+              <SideNavLink
                 to="/settings/roles"
-                className={() => `${sideNavLinkClass} ${view === 'roles' ? sideNavActiveClass : ''}`}
+                className={() => (view === 'roles' ? sideNavActiveClass : '')}
+                icon={<Shield className="h-5 w-5" />}
               >
-                <Shield className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
                 Roles and Permissions
-              </NavLink>
-              <NavLink
+              </SideNavLink>
+              <SideNavLink
                 to="/settings/lti-tools"
-                className={() => `${sideNavLinkClass} ${view === 'lti-tools' ? sideNavActiveClass : ''}`}
+                className={() => (view === 'lti-tools' ? sideNavActiveClass : '')}
+                icon={<Plug className="h-5 w-5" />}
               >
-                <Plug className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
                 LTI tools
-              </NavLink>
-              <NavLink
+              </SideNavLink>
+              <SideNavLink
                 to="/settings/platform"
-                className={() => `${sideNavLinkClass} ${view === 'platform' ? sideNavActiveClass : ''}`}
+                className={() => (view === 'platform' ? sideNavActiveClass : '')}
+                icon={<Settings2 className="h-5 w-5" />}
               >
-                <Settings2 className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
                 Global platform
-              </NavLink>
-              <NavLink
+              </SideNavLink>
+              <SideNavLink
                 to="/settings/organizations"
-                className={() => `${sideNavLinkClass} ${view === 'organizations' ? sideNavActiveClass : ''}`}
+                className={() => (view === 'organizations' ? sideNavActiveClass : '')}
+                icon={<Building2 className="h-5 w-5" />}
               >
-                <Building2 className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
                 Organizations
-              </NavLink>
+              </SideNavLink>
               {platformScimEnabled && (
-                <NavLink
+                <SideNavLink
                   to="/settings/scim-provisioning"
-                  className={() =>
-                    `${sideNavLinkClass} ${view === 'scim-provisioning' ? sideNavActiveClass : ''}`
-                  }
+                  className={() => (view === 'scim-provisioning' ? sideNavActiveClass : '')}
+                  icon={<Link2 className="h-5 w-5" />}
                 >
-                  <Link2 className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
                   SCIM provisioning
-                </NavLink>
+                </SideNavLink>
               )}
               <div className="flex flex-col gap-0.5">
                 <button
                   type="button"
                   onClick={() => setAiOpen((o) => !o)}
-                  className={`flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm font-medium transition-colors hover:bg-white/80 hover:text-slate-900 dark:text-neutral-400 dark:hover:bg-neutral-800/90 dark:hover:text-neutral-50 ${
-                    aiSectionActive ? sideNavActiveClass : 'text-slate-500'
-                  }`}
+                  className={`${sideNavLinkClass} ${
+                    sideNavCollapsed ? 'justify-center' : ''
+                  } ${aiSectionActive ? sideNavActiveClass : 'text-slate-500'}`}
                   aria-expanded={aiOpen}
+                  title={sideNavCollapsed ? 'Intelligence' : undefined}
                 >
                   <Bot className="h-5 w-5 shrink-0 text-current opacity-90" aria-hidden />
-                  <span className="min-w-0 flex-1">Intelligence</span>
-                  <ChevronDown
-                    className={`h-4 w-4 shrink-0 text-current opacity-70 transition-transform duration-200 ease-out ${
-                      aiOpen ? 'rotate-180' : 'rotate-0'
-                    }`}
-                    aria-hidden
-                  />
+                  {!sideNavCollapsed && (
+                    <>
+                      <span className="min-w-0 flex-1">Intelligence</span>
+                      <ChevronDown
+                        className={`h-4 w-4 shrink-0 text-current opacity-70 transition-transform duration-200 ease-out ${
+                          aiOpen ? 'rotate-180' : 'rotate-0'
+                        }`}
+                        aria-hidden
+                      />
+                    </>
+                  )}
                 </button>
-                <div
-                  className={`grid transition-[grid-template-rows] duration-200 ease-out ${
-                    aiOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
-                  }`}
-                >
-                  <div className="min-h-0 overflow-hidden">
-                    <div className="flex flex-col gap-0.5 border-l border-slate-200/80 pl-2 dark:border-neutral-600/80">
-                      <NavLink
-                        to="/settings/ai/models"
-                        className={() =>
-                          `${sideNavLinkClass} ${view === 'ai-models' ? sideNavActiveClass : ''}`
-                        }
-                      >
-                        Models
-                      </NavLink>
-                      <NavLink
-                        to="/settings/ai/system-prompts"
-                        className={() =>
-                          `${sideNavLinkClass} ${view === 'ai-prompts' ? sideNavActiveClass : ''}`
-                        }
-                      >
-                        System Prompts
-                      </NavLink>
+                {!sideNavCollapsed && (
+                  <div
+                    className={`grid transition-[grid-template-rows] duration-200 ease-out ${
+                      aiOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+                    }`}
+                  >
+                    <div className="min-h-0 overflow-hidden">
+                      <div className="flex flex-col gap-0.5 border-l border-slate-200/80 pl-2 dark:border-neutral-600/80">
+                        <SideNavLink
+                          to="/settings/ai/models"
+                          className={() => (view === 'ai-models' ? sideNavActiveClass : '')}
+                          icon={null}
+                        >
+                          Models
+                        </SideNavLink>
+                        <SideNavLink
+                          to="/settings/ai/system-prompts"
+                          className={() => (view === 'ai-prompts' ? sideNavActiveClass : '')}
+                          icon={null}
+                        >
+                          System Prompts
+                        </SideNavLink>
+                      </div>
                     </div>
                   </div>
-                </div>
+                )}
               </div>
             </>
           )}

--- a/clients/web/src/components/layout/side-nav-styles.ts
+++ b/clients/web/src/components/layout/side-nav-styles.ts
@@ -1,5 +1,5 @@
 export const sideNavLinkClass =
-  'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium text-slate-500 transition-colors hover:bg-white/80 hover:text-slate-900 dark:text-neutral-400 dark:hover:bg-neutral-800/90 dark:hover:text-neutral-50'
+  'relative flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium text-slate-500 transition-colors hover:bg-white/80 hover:text-slate-900 dark:text-neutral-400 dark:hover:bg-neutral-800/90 dark:hover:text-neutral-50'
 
 export const sideNavActiveClass =
   'bg-white text-slate-900 shadow-sm ring-1 ring-black/[0.05] dark:bg-neutral-800 dark:text-neutral-50 dark:shadow-none dark:ring-1 dark:ring-inset dark:ring-white/10'

--- a/clients/web/src/components/layout/side-nav.tsx
+++ b/clients/web/src/components/layout/side-nav.tsx
@@ -10,7 +10,7 @@ import { SideNavSettingsLinks } from './side-nav-settings-links'
 import { SideNavCommandPaletteTrigger } from './side-nav-command-palette'
 
 export function SideNav() {
-  const { mobileNavOpen, closeMobileNav } = useShellNav()
+  const { mobileNavOpen, closeMobileNav, sideNavCollapsed } = useShellNav()
   const location = useLocation()
 
   useEffect(() => {
@@ -75,22 +75,28 @@ export function SideNav() {
       <aside
         id="shell-nav"
         data-onboarding="side-nav"
-        className={`lms-chrome flex h-dvh min-h-0 w-[min(17.5rem,88vw)] max-w-[280px] flex-col border-r border-slate-200/70 bg-[#F2F2F2] text-slate-900 print:hidden dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100 md:h-screen md:w-60 md:max-w-none md:shrink-0 md:translate-x-0 ${
+        className={`lms-chrome flex h-dvh min-h-0 w-[min(17.5rem,88vw)] max-w-[280px] flex-col border-r border-slate-200/70 bg-[#F2F2F2] text-slate-900 transition-[width] duration-300 ease-in-out print:hidden dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100 md:h-screen ${
+          sideNavCollapsed ? 'md:w-[72px]' : 'md:w-60'
+        } md:max-w-none md:shrink-0 md:translate-x-0 ${
           mobileNavOpen ? 'max-md:translate-x-0' : 'max-md:-translate-x-full'
         } max-md:fixed max-md:left-0 max-md:top-0 max-md:z-40 max-md:shadow-2xl max-md:transition-transform max-md:duration-200 max-md:ease-out max-md:pt-[env(safe-area-inset-top)] max-md:pb-[env(safe-area-inset-bottom)]`}
       >
         <div className="flex shrink-0 items-center px-3 pb-1 pt-3 md:px-3 md:pb-2 md:pt-4">
           <NavLink
             to="/"
-            className="flex min-h-0 min-w-0 flex-1 items-center gap-3 rounded-2xl p-1 pr-2 outline-none ring-slate-400/30 transition hover:bg-white/50 focus-visible:ring-2 dark:ring-neutral-500/40 dark:hover:bg-white/5"
+            className={`flex min-h-0 min-w-0 flex-1 items-center gap-3 rounded-2xl p-1 outline-none ring-slate-400/30 transition hover:bg-white/50 focus-visible:ring-2 dark:ring-neutral-500/40 dark:hover:bg-white/5 ${
+              sideNavCollapsed ? 'justify-center pr-1' : 'pr-2'
+            }`}
             end
           >
             <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white shadow-sm ring-1 ring-slate-900/[0.06] dark:bg-neutral-800 dark:ring-white/10">
               <BrandLogo className="mx-0 h-7 w-auto shrink-0 object-contain object-left" />
             </span>
-            <span className="truncate text-[1.05rem] font-semibold tracking-tight text-slate-950 dark:text-neutral-100">
-              Lextures
-            </span>
+            {!sideNavCollapsed && (
+              <span className="truncate text-[1.05rem] font-semibold tracking-tight text-slate-950 dark:text-neutral-100">
+                Lextures
+              </span>
+            )}
           </NavLink>
         </div>
         <SideNavCommandPaletteTrigger />

--- a/clients/web/src/pages/lms/dashboard.tsx
+++ b/clients/web/src/pages/lms/dashboard.tsx
@@ -253,7 +253,11 @@ export default function Dashboard() {
   })
 
   useEffect(() => {
-    localStorage.setItem('dashboard_collapsed_sections', JSON.stringify(collapsedSections))
+    try {
+      localStorage.setItem('dashboard_collapsed_sections', JSON.stringify(collapsedSections))
+    } catch {
+      // Ignore storage errors
+    }
   }, [collapsedSections])
 
   const toggleSection = (id: string) => {

--- a/server/internal/httpserver/course_syllabus.go
+++ b/server/internal/httpserver/course_syllabus.go
@@ -2,6 +2,7 @@ package httpserver
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -10,6 +11,8 @@ import (
 	"github.com/lextures/lextures/server/internal/apierr"
 	"github.com/lextures/lextures/server/internal/repos/course"
 	"github.com/lextures/lextures/server/internal/repos/enrollment"
+	userai "github.com/lextures/lextures/server/internal/repos/user"
+	"github.com/lextures/lextures/server/internal/service/openrouter"
 )
 
 type syllabusResponse struct {
@@ -199,21 +202,41 @@ func (d Deps) handleGenerateSyllabusSection() http.HandlerFunc {
 		}
 		heading := strings.TrimSpace(body.SectionHeading)
 		existing := strings.TrimSpace(body.ExistingMarkdown)
-		var b strings.Builder
+
+		or := d.openRouterClient()
+		if or == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "AI generation is not configured. Set an OpenRouter API key in Platform Settings.")
+			return
+		}
+
+		model, err := userai.GetCourseSetupModelID(r.Context(), d.Pool, viewer)
+		if err != nil {
+			model = userai.DefaultCourseSetupModelID
+		}
+
+		const sysPrompt = `You are an expert academic writer helping instructors author course syllabi. When given a section heading and instructions, write clear, concise syllabus content in Markdown. Use the heading level provided (## or ###) if one is given. Write in a professional but accessible tone suitable for university students. Output only the Markdown content — no preamble, no code fences, no commentary.`
+
+		var userMsg strings.Builder
 		if heading != "" {
-			b.WriteString("## ")
-			b.WriteString(heading)
-			b.WriteString("\n\n")
+			fmt.Fprintf(&userMsg, "Section heading: %s\n\n", heading)
 		}
-		// Temporary non-AI fallback to keep syllabus authoring flow functional while the
-		// Rust syllabussectionai behavior is still being ported.
-		b.WriteString(instructions)
+		fmt.Fprintf(&userMsg, "Instructions: %s", instructions)
 		if existing != "" {
-			b.WriteString("\n\n")
-			b.WriteString(existing)
+			fmt.Fprintf(&userMsg, "\n\nExisting content to revise or extend:\n%s", existing)
 		}
+
+		generated, err := or.ChatCompletion(model, []openrouter.Message{
+			{Role: "system", Content: sysPrompt},
+			{Role: "user", Content: userMsg.String()},
+		})
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadGateway, apierr.CodeInternal, "AI generation failed: "+err.Error())
+			return
+		}
+
+		markdown := strings.TrimSpace(generated)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		_ = json.NewEncoder(w).Encode(resp{Markdown: b.String()})
+		_ = json.NewEncoder(w).Encode(resp{Markdown: markdown})
 	}
 }
 


### PR DESCRIPTION
- Sidebar collapses to 72px icon-only rail; state persisted to localStorage. New SideNavLink component handles collapsed/expanded rendering uniformly. Section headings hidden when collapsed; footer gains expand/collapse toggle.
- Clicking any link in the markdown body editor opens an inline popover to edit URL and display text, remove the link, or open it in a new tab.
- Syllabus section AI generation replaced with a real OpenRouter ChatCompletion call; falls back to 503 if no API key is configured rather than echoing input.