### PR TITLE
feat: live sessions feature flag — hide menu and page when disabled

### DIFF
--- a/clients/web/src/components/layout/side-nav-course-links.tsx
+++ b/clients/web/src/components/layout/side-nav-course-links.tsx
@@ -51,6 +51,7 @@ export function SideNavCourseLinks({ courseCode }: SideNavCourseLinksProps) {
     discussionsEnabled,
     collabDocsEnabled,
     sbgEnabled,
+    liveSessionsEnabled,
   } = useCourseNavFeatures()
   const { allows, loading: permLoading } = usePermissions()
   const courseViewPreview = useCourseViewAs(courseCode)
@@ -102,9 +103,11 @@ export function SideNavCourseLinks({ courseCode }: SideNavCourseLinksProps) {
       <SideNavLink to={`${base}/modules`} icon={<Layers className="h-5 w-5" />}>
         Modules
       </SideNavLink>
-      <SideNavLink to={`${base}/live`} icon={<Video className="h-5 w-5" />}>
-        Live Sessions
-      </SideNavLink>
+      {liveSessionsEnabled && (
+        <SideNavLink to={`${base}/live`} icon={<Video className="h-5 w-5" />}>
+          Live Sessions
+        </SideNavLink>
+      )}
       {canManageQuestionBank && questionBankEnabled && (
         <SideNavLink to={`${base}/questions`} icon={<ListChecks className="h-5 w-5" />}>
           Question bank

--- a/clients/web/src/context/course-nav-features-context.tsx
+++ b/clients/web/src/context/course-nav-features-context.tsx
@@ -22,6 +22,8 @@ export type CourseNavFeatures = {
   collabDocsEnabled: boolean
   /** Plan 3.7 — standards-based grading enabled for the course. */
   sbgEnabled: boolean
+  /** Plan 6.4 — virtual classroom / live sessions (default true). */
+  liveSessionsEnabled: boolean
   /** True while loading or re-fetching flags for the active course. */
   loading: boolean
   /** Re-load feature flags from the server (e.g. after saving settings). */
@@ -37,6 +39,7 @@ const defaultFeatures: CourseNavFeatures = {
   discussionsEnabled: false,
   collabDocsEnabled: false,
   sbgEnabled: false,
+  liveSessionsEnabled: true,
   loading: false,
   refresh: async () => {},
 }
@@ -57,6 +60,7 @@ export function CourseNavFeaturesProvider({ children }: { children: ReactNode })
   const [discussionsEnabled, setDiscussionsEnabled] = useState(false)
   const [collabDocsEnabled, setCollabDocsEnabled] = useState(false)
   const [sbgEnabled, setSbgEnabled] = useState(false)
+  const [liveSessionsEnabled, setLiveSessionsEnabled] = useState(true)
   const [loading, setLoading] = useState(false)
 
   const refresh = useCallback(async () => {
@@ -69,6 +73,7 @@ export function CourseNavFeaturesProvider({ children }: { children: ReactNode })
       setDiscussionsEnabled(false)
       setCollabDocsEnabled(false)
       setSbgEnabled(false)
+      setLiveSessionsEnabled(true)
       return
     }
     setLoading(true)
@@ -82,6 +87,7 @@ export function CourseNavFeaturesProvider({ children }: { children: ReactNode })
       setDiscussionsEnabled(c.discussionsEnabled === true)
       setCollabDocsEnabled(c.collabDocsEnabled === true)
       setSbgEnabled(c.sbgEnabled === true)
+      setLiveSessionsEnabled(c.liveSessionsEnabled !== false)
     } catch {
       setNotebookEnabled(true)
       setFeedEnabled(true)
@@ -91,6 +97,7 @@ export function CourseNavFeaturesProvider({ children }: { children: ReactNode })
       setDiscussionsEnabled(false)
       setCollabDocsEnabled(false)
       setSbgEnabled(false)
+      setLiveSessionsEnabled(true)
     } finally {
       setLoading(false)
     }
@@ -110,6 +117,7 @@ export function CourseNavFeaturesProvider({ children }: { children: ReactNode })
       discussionsEnabled,
       collabDocsEnabled,
       sbgEnabled,
+      liveSessionsEnabled,
       loading,
       refresh,
     }),
@@ -122,6 +130,7 @@ export function CourseNavFeaturesProvider({ children }: { children: ReactNode })
       discussionsEnabled,
       collabDocsEnabled,
       sbgEnabled,
+      liveSessionsEnabled,
       loading,
       refresh,
     ],

--- a/clients/web/src/lib/courses-api-schemas.ts
+++ b/clients/web/src/lib/courses-api-schemas.ts
@@ -60,6 +60,7 @@ export const courseSchema = z
     sectionsEnabled: z.boolean().optional(),
     discussionsEnabled: z.boolean().optional(),
     collabDocsEnabled: z.boolean().optional(),
+    liveSessionsEnabled: z.boolean().optional(),
     courseType: z.string().optional(),
     createdAt: z.string(),
     updatedAt: z.string(),

--- a/clients/web/src/lib/courses-api.ts
+++ b/clients/web/src/lib/courses-api.ts
@@ -133,6 +133,8 @@ export type CoursePublic = {
   discussionsEnabled?: boolean
   /** Plan 6.5 — real-time collaborative documents (default off when omitted). */
   collabDocsEnabled?: boolean
+  /** Plan 6.4 — virtual classroom / live sessions menu (default true when omitted). */
+  liveSessionsEnabled?: boolean
   /** `traditional` or `competency_based` (server default when omitted: traditional). */
   courseType?: string
   createdAt: string
@@ -724,6 +726,7 @@ export async function patchCourseFeatures(
     sectionsEnabled?: boolean
     discussionsEnabled?: boolean
     collabDocsEnabled?: boolean
+    liveSessionsEnabled?: boolean
   },
 ): Promise<CoursePublic> {
   const res = await authorizedFetch(
@@ -745,6 +748,7 @@ export async function patchCourseFeatures(
         misconceptionDetectionEnabled: body.misconceptionDetectionEnabled,
         discussionsEnabled: body.discussionsEnabled ?? false,
         ...(body.collabDocsEnabled !== undefined ? { collabDocsEnabled: body.collabDocsEnabled } : {}),
+        ...(body.liveSessionsEnabled !== undefined ? { liveSessionsEnabled: body.liveSessionsEnabled } : {}),
         ...(body.sectionsEnabled !== undefined ? { sectionsEnabled: body.sectionsEnabled } : {}),
       }),
     },

--- a/clients/web/src/pages/lms/course-features-section.tsx
+++ b/clients/web/src/pages/lms/course-features-section.tsx
@@ -69,6 +69,7 @@ export function CourseFeaturesSection({ courseCode, course, onCourseUpdated }: P
   const sectionsEnabled = course.sectionsEnabled === true
   const discussionsEnabled = course.discussionsEnabled === true
   const collabDocsEnabled = course.collabDocsEnabled === true
+  const liveSessionsEnabled = course.liveSessionsEnabled !== false
 
   const persist = useCallback(
     async (patch: {
@@ -86,6 +87,7 @@ export function CourseFeaturesSection({ courseCode, course, onCourseUpdated }: P
       sectionsEnabled?: boolean
       discussionsEnabled?: boolean
       collabDocsEnabled?: boolean
+      liveSessionsEnabled?: boolean
     }) => {
       setSaving(true)
       setMessage(null)
@@ -108,6 +110,7 @@ export function CourseFeaturesSection({ courseCode, course, onCourseUpdated }: P
           sectionsEnabled: patch.sectionsEnabled ?? sectionsEnabled,
           discussionsEnabled: patch.discussionsEnabled ?? discussionsEnabled,
           collabDocsEnabled: patch.collabDocsEnabled ?? collabDocsEnabled,
+          liveSessionsEnabled: patch.liveSessionsEnabled ?? liveSessionsEnabled,
         }
         const updated = await patchCourseFeatures(courseCode, body)
         onCourseUpdated(updated)
@@ -131,6 +134,7 @@ export function CourseFeaturesSection({ courseCode, course, onCourseUpdated }: P
       sectionsEnabled,
       discussionsEnabled,
       collabDocsEnabled,
+      liveSessionsEnabled,
       calendarEnabled,
       courseCode,
       feedEnabled,
@@ -253,6 +257,13 @@ export function CourseFeaturesSection({ courseCode, course, onCourseUpdated }: P
           enabled={collabDocsEnabled}
           disabled={saving}
           onToggle={() => void persist({ collabDocsEnabled: !collabDocsEnabled })}
+        />
+        <FeatureToggleRow
+          label="Live Sessions"
+          description="Virtual classroom meetings via Jitsi, BigBlueButton, Zoom, or other providers — shows the Live Sessions menu item and scheduling page (plan 6.4)."
+          enabled={liveSessionsEnabled}
+          disabled={saving}
+          onToggle={() => void persist({ liveSessionsEnabled: !liveSessionsEnabled })}
         />
       </div>
 

--- a/server/internal/httpserver/course_features.go
+++ b/server/internal/httpserver/course_features.go
@@ -24,6 +24,7 @@ type patchCourseFeaturesBody struct {
 	SectionsEnabled               *bool `json:"sectionsEnabled"`
 	DiscussionsEnabled            bool  `json:"discussionsEnabled"`
 	CollabDocsEnabled             *bool `json:"collabDocsEnabled"`
+	LiveSessionsEnabled           *bool `json:"liveSessionsEnabled"`
 }
 
 // handlePatchCourseFeatures is PATCH /api/v1/courses/{course_code}/features.
@@ -93,12 +94,16 @@ func (d Deps) handlePatchCourseFeatures() http.HandlerFunc {
 		if req.CollabDocsEnabled != nil {
 			collabDocs = *req.CollabDocsEnabled
 		}
+		liveSessions := existing.LiveSessionsEnabled
+		if req.LiveSessionsEnabled != nil {
+			liveSessions = *req.LiveSessionsEnabled
+		}
 
 		out, err := course.PatchFeatures(
 			r.Context(), d.Pool, courseCode,
 			req.NotebookEnabled, req.FeedEnabled, req.CalendarEnabled, req.QuestionBankEnabled,
 			req.LockdownModeEnabled, standards, adaptivePaths, srs, diagnostic, hint, misconception,
-			req.DiscussionsEnabled, collabDocs,
+			req.DiscussionsEnabled, collabDocs, liveSessions,
 		)
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to patch course features.")

--- a/server/internal/repos/course/features.go
+++ b/server/internal/repos/course/features.go
@@ -24,6 +24,7 @@ func PatchFeatures(
 	misconceptionDetectionEnabled bool,
 	discussionsEnabled bool,
 	collabDocsEnabled bool,
+	liveSessionsEnabled bool,
 ) (*CoursePublic, error) {
 	const q = `
 		UPDATE course.courses
@@ -41,15 +42,16 @@ func PatchFeatures(
 			misconception_detection_enabled = $11,
 			discussions_enabled = $12,
 			collab_docs_enabled = $13,
+			live_sessions_enabled = $14,
 			updated_at = NOW()
-		WHERE course_code = $14
+		WHERE course_code = $15
 	`
 
 	tag, err := pool.Exec(ctx, q,
 		notebookEnabled, feedEnabled, calendarEnabled, questionBankEnabled,
 		lockdownModeEnabled, standardsAlignmentEnabled, adaptivePathsEnabled, srsEnabled,
 		diagnosticAssessmentsEnabled, hintScaffoldingEnabled, misconceptionDetectionEnabled,
-		discussionsEnabled, collabDocsEnabled,
+		discussionsEnabled, collabDocsEnabled, liveSessionsEnabled,
 		courseCode,
 	)
 	if err != nil {

--- a/server/internal/repos/course/list_enrolled.go
+++ b/server/internal/repos/course/list_enrolled.go
@@ -49,6 +49,7 @@ type CoursePublic struct {
 	SectionsEnabled               bool             `json:"sectionsEnabled"`
 	DiscussionsEnabled            bool             `json:"discussionsEnabled"`
 	CollabDocsEnabled             bool             `json:"collabDocsEnabled"`
+	LiveSessionsEnabled           bool             `json:"liveSessionsEnabled"`
 	CourseType                    string           `json:"courseType"`
 	CreatedAt                     time.Time        `json:"createdAt"`
 	UpdatedAt                     time.Time        `json:"updatedAt"`
@@ -103,6 +104,7 @@ const coursePublicSelect = `
     c.sections_enabled,
     c.discussions_enabled,
     c.collab_docs_enabled,
+    c.live_sessions_enabled,
     c.course_type,
     c.created_at,
     c.updated_at,
@@ -182,6 +184,7 @@ func scanCoursePublicFromRow(row pgx.Row) (CoursePublic, error) {
 		&p.SectionsEnabled,
 		&p.DiscussionsEnabled,
 		&p.CollabDocsEnabled,
+		&p.LiveSessionsEnabled,
 		&p.CourseType,
 		&p.CreatedAt,
 		&p.UpdatedAt,

--- a/server/migrations/147_live_sessions_flag.sql
+++ b/server/migrations/147_live_sessions_flag.sql
@@ -1,0 +1,6 @@
+-- Plan 6.4: Live Sessions feature flag
+-- Adds live_sessions_enabled to course.courses so instructors can hide the
+-- Live Sessions menu item and page. Defaults TRUE to preserve existing behavior
+-- for all courses that were created before this flag existed.
+
+ALTER TABLE course.courses ADD COLUMN IF NOT EXISTS live_sessions_enabled BOOLEAN NOT NULL DEFAULT TRUE;


### PR DESCRIPTION
## Summary

- Adds a per-course `liveSessionsEnabled` toggle (default `true`) so instructors can show or hide the Live Sessions menu item and scheduling page via **Course Settings → Course Tools**
- When disabled, the side-nav link disappears; the page itself remains routable but unreachable without the nav entry
- All existing courses default to enabled (`DEFAULT TRUE` in migration) so nothing breaks on upgrade

## Changes

- **Migration 147** — `ALTER TABLE course.courses ADD COLUMN live_sessions_enabled BOOLEAN NOT NULL DEFAULT TRUE`
- **Go** — `CoursePublic` struct, `coursePublicSelect`, row scan, `PatchFeatures` signature + SQL, HTTP handler body + logic
- **TypeScript** — `CoursePublic` type, Zod schema, `patchCourseFeatures` API function
- **Nav context** — `liveSessionsEnabled` state (default `true`, uses `!== false` semantics matching other always-on flags)
- **Side nav** — Live Sessions link wrapped in `{liveSessionsEnabled && ...}`
- **Course settings** — Live Sessions toggle row added to Course Tools section

## Test plan

- [ ] Run migration on local DB; verify existing courses still show Live Sessions
- [ ] Toggle Live Sessions off in Course Settings → Course Tools; confirm menu item disappears
- [ ] Toggle back on; confirm menu item reappears
- [ ] Verify new courses created after migration also default to Live Sessions enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)