### PR TITLE
feat(settings): unify single-save experience across all course settings tabs

### DIFF
--- a/clients/web/src/pages/lms/course-blueprint-settings.tsx
+++ b/clients/web/src/pages/lms/course-blueprint-settings.tsx
@@ -1,4 +1,5 @@
 import { type FormEvent, useCallback, useEffect, useState } from 'react'
+import { Loader2, Save } from 'lucide-react'
 import {
   deleteBlueprintChildLink,
   fetchBlueprintChildren,
@@ -39,6 +40,14 @@ export function CourseBlueprintSection({ courseCode, course, onCourseUpdated }: 
   const [childPick, setChildPick] = useState('')
   const [pushResult, setPushResult] = useState<BlueprintPushResult | null>(null)
 
+  const [isBlueprintDraft, setIsBlueprintDraft] = useState(course.isBlueprint ?? false)
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const [saveMessage, setSaveMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    setIsBlueprintDraft(course.isBlueprint ?? false)
+  }, [course.isBlueprint])
+
   const reload = useCallback(async () => {
     if (!canOrgBlueprint || !course.isBlueprint) {
       setChildren([])
@@ -64,22 +73,31 @@ export function CourseBlueprintSection({ courseCode, course, onCourseUpdated }: 
     void reload()
   }, [reload])
 
-  async function onToggleBlueprint(e: FormEvent) {
-    e.preventDefault()
+  const isDirty = isBlueprintDraft !== course.isBlueprint
+
+  const discardChanges = useCallback(() => {
+    setIsBlueprintDraft(course.isBlueprint ?? false)
+    setSaveStatus('idle')
+    setSaveMessage(null)
+  }, [course.isBlueprint])
+
+  const onSingleSaveChanges = useCallback(async () => {
     if (!course.orgId) return
-    setBusy(true)
+    setSaveStatus('saving')
+    setSaveMessage(null)
     try {
-      const next = !course.isBlueprint
-      const updated = await patchCourseBlueprint(courseCode, next)
+      const updated = await patchCourseBlueprint(courseCode, isBlueprintDraft)
       onCourseUpdated(updated)
-      toastSaveOk(next ? 'Course marked as blueprint' : 'Blueprint designation removed')
+      toastSaveOk(isBlueprintDraft ? 'Course marked as blueprint' : 'Blueprint designation removed')
+      setSaveStatus('saved')
       await reload()
     } catch (err) {
-      toastMutationError(err instanceof Error ? err.message : 'Could not update blueprint flag.')
-    } finally {
-      setBusy(false)
+      const msg = err instanceof Error ? err.message : 'Could not update blueprint flag.'
+      setSaveStatus('error')
+      setSaveMessage(msg)
+      toastMutationError(msg)
     }
-  }
+  }, [course.orgId, courseCode, isBlueprintDraft, onCourseUpdated, reload])
 
   async function onLinkChild(e: FormEvent) {
     e.preventDefault()
@@ -153,24 +171,34 @@ export function CourseBlueprintSection({ courseCode, course, onCourseUpdated }: 
             Last sync: {formatSyncAt(course.blueprintLastSyncAt ?? null)}.
           </p>
         ) : null}
-        <form className="mt-4 flex flex-wrap items-center gap-3" onSubmit={onToggleBlueprint}>
-          <button
-            type="submit"
-            disabled={busy || Boolean(course.blueprintParentCourseCode)}
-            className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {course.isBlueprint ? 'Remove blueprint designation' : 'Mark as blueprint course'}
-          </button>
-          {course.blueprintParentCourseCode ? (
+        <div className="mt-4 flex items-center justify-between rounded-xl border border-slate-100 bg-slate-50/60 p-4 dark:border-neutral-850 dark:bg-neutral-900/40">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+              Enable Blueprint Designation
+            </span>
             <span className="text-xs text-slate-500 dark:text-neutral-400">
-              Child courses cannot be toggled as blueprints until unlinked.
+              {course.blueprintParentCourseCode
+                ? 'Child courses cannot be toggled as blueprints until unlinked.'
+                : 'Turn this course into a master blueprint course.'}
             </span>
-          ) : (
-            <span className="text-xs text-slate-500 dark:text-neutral-400" aria-live="polite">
-              {course.isBlueprint ? 'Blueprint mode on — link empty child courses below.' : 'Off'}
-            </span>
-          )}
-        </form>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={isBlueprintDraft}
+            disabled={busy || Boolean(course.blueprintParentCourseCode)}
+            onClick={() => setIsBlueprintDraft(!isBlueprintDraft)}
+            className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-50 ${
+              isBlueprintDraft ? 'bg-indigo-600' : 'bg-slate-200 dark:bg-neutral-800'
+            }`}
+          >
+            <span
+              className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                isBlueprintDraft ? 'translate-x-5' : 'translate-x-0'
+              }`}
+            />
+          </button>
+        </div>
       </div>
 
       {course.isBlueprint ? (
@@ -280,6 +308,51 @@ export function CourseBlueprintSection({ courseCode, course, onCourseUpdated }: 
           </div>
         </>
       ) : null}
+
+      {isDirty && (
+        <div className="fixed bottom-6 left-1/2 z-50 w-full max-w-2xl -translate-x-1/2 px-4 animate-in fade-in slide-in-from-bottom-4 duration-300">
+          <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white/90 px-6 py-4 shadow-xl backdrop-blur-md dark:border-neutral-800 dark:bg-neutral-900/90">
+            <div className="flex flex-col">
+              <span className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Unsaved changes</span>
+              <span className="text-xs text-slate-500 dark:text-neutral-400">
+                {saveStatus === 'error' && saveMessage ? (
+                  <span className="text-rose-600 dark:text-rose-400 font-medium">{saveMessage}</span>
+                ) : (
+                  "You have changed this course's blueprint designation."
+                )}
+              </span>
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={discardChanges}
+                disabled={saveStatus === 'saving'}
+                className="rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100 hover:text-slate-900 disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-850 dark:hover:text-neutral-200 transition"
+              >
+                Discard
+              </button>
+              <button
+                type="button"
+                onClick={() => void onSingleSaveChanges()}
+                disabled={saveStatus === 'saving'}
+                className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-md hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-60 transition active:scale-95"
+              >
+                {saveStatus === 'saving' ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  <>
+                    <Save className="h-4 w-4" />
+                    Save changes
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </section>
   )
 }

--- a/clients/web/src/pages/lms/course-grading-settings.tsx
+++ b/clients/web/src/pages/lms/course-grading-settings.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Plus, Trash2 } from 'lucide-react'
+import { Loader2, Plus, Save, Trash2 } from 'lucide-react'
 import { useCourseNavFeatures } from '../../context/course-nav-features-context'
 import { usePermissions } from '../../context/use-permissions'
+import { toastSaveOk } from '../../lib/lms-toast'
 import {
   courseItemCreatePermission,
   DEFAULT_LETTER_GRADE_SCALE_JSON,
@@ -69,13 +70,26 @@ export function CourseGradingSettingsSection({ courseCode }: { courseCode: strin
   const [itemPatchingId, setItemPatchingId] = useState<string | null>(null)
   const [schemeType, setSchemeType] = useState('points')
   const [schemeJsonText, setSchemeJsonText] = useState('')
-  const [schemeStatus, setSchemeStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
-  const [schemeMessage, setSchemeMessage] = useState<string | null>(null)
   const [passMinPct, setPassMinPct] = useState('60')
   const [completeMinPct, setCompleteMinPct] = useState('50')
   const [sbgEnabled, setSbgEnabled] = useState(false)
   const [sbgRule, setSbgRule] = useState('most_recent')
   const [sbgScaleText, setSbgScaleText] = useState(() => JSON.stringify(DEFAULT_SBG_PROFICIENCY_JSON, null, 2))
+
+  const [initialSettings, setInitialSettings] = useState<{
+    gradingScale: string
+    assignmentGroups: EditableGroup[]
+    sbgEnabled: boolean
+    sbgRule: string
+    sbgScaleText: string
+  } | null>(null)
+
+  const [initialScheme, setInitialScheme] = useState<{
+    type: string
+    passMinPct: string
+    completeMinPct: string
+    scaleJsonText: string
+  } | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -86,61 +100,82 @@ export function CourseGradingSettingsSection({ courseCode }: { courseCode: strin
         fetchCourseStructure(courseCode),
         fetchCourseGradingScheme(courseCode),
       ])
-      setGradingScale(g.gradingScale)
-      setGroups(
-        g.assignmentGroups.length > 0
-          ? groupsToEditable(g.assignmentGroups)
-          : [
-              {
-                clientKey: newClientKey(),
-                name: 'Assignments',
-                sortOrder: 0,
-                weightPercent: '100',
-                dropLowest: '0',
-                dropHighest: '0',
-                replaceLowestWithFinal: false,
-              },
-            ],
-      )
+
+      const defaultGroups = [
+        {
+          clientKey: newClientKey(),
+          name: 'Assignments',
+          sortOrder: 0,
+          weightPercent: '100',
+          dropLowest: '0',
+          dropHighest: '0',
+          replaceLowestWithFinal: false,
+        },
+      ]
+      const loadedGroups = g.assignmentGroups.length > 0
+        ? groupsToEditable(g.assignmentGroups)
+        : defaultGroups
+
+      const loadedSbgScale = g.sbgProficiencyScaleJson != null
+        ? JSON.stringify(g.sbgProficiencyScaleJson, null, 2)
+        : JSON.stringify(DEFAULT_SBG_PROFICIENCY_JSON, null, 2)
+
+      const initialS = {
+        gradingScale: g.gradingScale,
+        assignmentGroups: loadedGroups,
+        sbgEnabled: g.sbgEnabled === true,
+        sbgRule: g.sbgAggregationRule?.trim() || 'most_recent',
+        sbgScaleText: loadedSbgScale,
+      }
+
+      setInitialSettings(initialS)
+      setGradingScale(initialS.gradingScale)
+      setGroups(JSON.parse(JSON.stringify(initialS.assignmentGroups)))
+      setSbgEnabled(initialS.sbgEnabled)
+      setSbgRule(initialS.sbgRule)
+      setSbgScaleText(initialS.sbgScaleText)
+
       setStructure(items)
+
+      let initialSch: typeof initialScheme
       const sch = schemeEnvelope.scheme
       if (sch) {
-        setSchemeType(sch.type)
+        let text = ''
         try {
-          setSchemeJsonText(JSON.stringify(sch.scaleJson ?? {}, null, 2))
+          text = JSON.stringify(sch.scaleJson ?? {}, null, 2)
         } catch {
-          setSchemeJsonText('{}')
+          text = '{}'
         }
+        let pass = '60'
+        let complete = '50'
         const sj = sch.scaleJson as Record<string, unknown> | null
         if (sch.type === 'pass_fail' && sj && typeof sj.pass_min_pct === 'number') {
-          setPassMinPct(String(sj.pass_min_pct))
-        } else {
-          setPassMinPct('60')
+          pass = String(sj.pass_min_pct)
         }
         if (sch.type === 'complete_incomplete' && sj && typeof sj.complete_min_pct === 'number') {
-          setCompleteMinPct(String(sj.complete_min_pct))
-        } else {
-          setCompleteMinPct('50')
+          complete = String(sj.complete_min_pct)
+        }
+
+        initialSch = {
+          type: sch.type,
+          passMinPct: pass,
+          completeMinPct: complete,
+          scaleJsonText: text,
         }
       } else {
-        setSchemeType('points')
-        setSchemeJsonText(JSON.stringify(DEFAULT_LETTER_GRADE_SCALE_JSON, null, 2))
-        setPassMinPct('60')
-        setCompleteMinPct('50')
+        initialSch = {
+          type: 'points',
+          passMinPct: '60',
+          completeMinPct: '50',
+          scaleJsonText: JSON.stringify(DEFAULT_LETTER_GRADE_SCALE_JSON, null, 2),
+        }
       }
-      setSchemeStatus('idle')
-      setSchemeMessage(null)
-      setSbgEnabled(g.sbgEnabled === true)
-      setSbgRule(g.sbgAggregationRule?.trim() || 'most_recent')
-      try {
-        setSbgScaleText(
-          g.sbgProficiencyScaleJson != null
-            ? JSON.stringify(g.sbgProficiencyScaleJson, null, 2)
-            : JSON.stringify(DEFAULT_SBG_PROFICIENCY_JSON, null, 2),
-        )
-      } catch {
-        setSbgScaleText(JSON.stringify(DEFAULT_SBG_PROFICIENCY_JSON, null, 2))
-      }
+
+      setInitialScheme(initialSch)
+      setSchemeType(initialSch.type)
+      setSchemeJsonText(initialSch.scaleJsonText)
+      setPassMinPct(initialSch.passMinPct)
+      setCompleteMinPct(initialSch.completeMinPct)
     } catch (e) {
       setLoadError(e instanceof Error ? e.message : 'Could not load grading settings.')
     } finally {
@@ -151,6 +186,180 @@ export function CourseGradingSettingsSection({ courseCode }: { courseCode: strin
   useEffect(() => {
     void load()
   }, [load])
+
+  const isSettingsDirty = useMemo(() => {
+    if (!initialSettings) return false
+    if (initialSettings.gradingScale !== gradingScale) return true
+    if (initialSettings.sbgEnabled !== sbgEnabled) return true
+    if (sbgEnabled) {
+      if (initialSettings.sbgRule !== sbgRule) return true
+      if (initialSettings.sbgScaleText !== sbgScaleText) return true
+    }
+    const cleanInitial = initialSettings.assignmentGroups.map((g) => ({
+      name: g.name.trim(),
+      weightPercent: String(Number(g.weightPercent) || 0),
+      dropLowest: String(Number(g.dropLowest) || 0),
+      dropHighest: String(Number(g.dropHighest) || 0),
+      replaceLowestWithFinal: g.replaceLowestWithFinal,
+    }))
+    const cleanCurrent = groups.map((g) => ({
+      name: g.name.trim(),
+      weightPercent: String(Number(g.weightPercent) || 0),
+      dropLowest: String(Number(g.dropLowest) || 0),
+      dropHighest: String(Number(g.dropHighest) || 0),
+      replaceLowestWithFinal: g.replaceLowestWithFinal,
+    }))
+    return JSON.stringify(cleanInitial) !== JSON.stringify(cleanCurrent)
+  }, [initialSettings, gradingScale, groups, sbgEnabled, sbgRule, sbgScaleText])
+
+  const isSchemeDirty = useMemo(() => {
+    if (!initialScheme) return false
+    if (initialScheme.type !== schemeType) return true
+    if (schemeType === 'letter' || schemeType === 'gpa') {
+      let normalInitial = initialScheme.scaleJsonText
+      let normalCurrent = schemeJsonText
+      try {
+        normalInitial = JSON.stringify(JSON.parse(initialScheme.scaleJsonText))
+      } catch {
+        // Fallback to original text if invalid JSON
+      }
+      try {
+        normalCurrent = JSON.stringify(JSON.parse(schemeJsonText))
+      } catch {
+        // Fallback to original text if invalid JSON
+      }
+      if (normalInitial !== normalCurrent) return true
+    } else if (schemeType === 'pass_fail') {
+      if (initialScheme.passMinPct !== passMinPct) return true
+    } else if (schemeType === 'complete_incomplete') {
+      if (initialScheme.completeMinPct !== completeMinPct) return true
+    }
+    return false
+  }, [initialScheme, schemeType, schemeJsonText, passMinPct, completeMinPct])
+
+  const isDirty = isSettingsDirty || isSchemeDirty
+
+  const discardChanges = useCallback(() => {
+    if (initialSettings) {
+      setGradingScale(initialSettings.gradingScale)
+      setGroups(JSON.parse(JSON.stringify(initialSettings.assignmentGroups)))
+      setSbgEnabled(initialSettings.sbgEnabled)
+      setSbgRule(initialSettings.sbgRule)
+      setSbgScaleText(initialSettings.sbgScaleText)
+    }
+    if (initialScheme) {
+      setSchemeType(initialScheme.type)
+      setSchemeJsonText(initialScheme.scaleJsonText)
+      setPassMinPct(initialScheme.passMinPct)
+      setCompleteMinPct(initialScheme.completeMinPct)
+    }
+    setSaveStatus('idle')
+    setSaveMessage(null)
+  }, [initialSettings, initialScheme])
+
+  async function onSingleSaveChanges() {
+    if (!canEdit) return
+    setSaveStatus('saving')
+    setSaveMessage(null)
+
+    try {
+      const promises: Promise<unknown>[] = []
+
+      let sbgProficiencyScaleJson: unknown = undefined
+      if (sbgEnabled && isSettingsDirty) {
+        try {
+          sbgProficiencyScaleJson = JSON.parse(sbgScaleText || '{}')
+        } catch {
+          setSaveStatus('error')
+          setSaveMessage('SBG proficiency scale must be valid JSON.')
+          return
+        }
+      }
+
+      if (isSettingsDirty) {
+        const named = groups.filter((g) => g.name.trim())
+        if (named.length === 0) {
+          setSaveStatus('error')
+          setSaveMessage('Add at least one assignment group with a name, or remove extra rows.')
+          return
+        }
+        if (named.length !== groups.length) {
+          setSaveStatus('error')
+          setSaveMessage('Each assignment group needs a name.')
+          return
+        }
+      }
+
+      let scaleJson: unknown = {}
+      if (isSchemeDirty) {
+        if (schemeType === 'letter' || schemeType === 'gpa') {
+          try {
+            scaleJson = JSON.parse(schemeJsonText || '[]')
+          } catch {
+            setSaveStatus('error')
+            setSaveMessage('Letter bands must be valid JSON.')
+            return
+          }
+        } else if (schemeType === 'pass_fail') {
+          const n = Number.parseFloat(passMinPct)
+          scaleJson = { pass_min_pct: Number.isFinite(n) ? n : 60 }
+        } else if (schemeType === 'complete_incomplete') {
+          const n = Number.parseFloat(completeMinPct)
+          scaleJson = { complete_min_pct: Number.isFinite(n) ? n : 50 }
+        }
+      }
+
+      let savedSettings = false
+      let savedScheme = false
+
+      if (isSettingsDirty) {
+        savedSettings = true
+        promises.push(
+          putCourseGradingSettings(courseCode, {
+            gradingScale,
+            assignmentGroups: groups.map((g, i) => {
+              const w = Number.parseFloat(g.weightPercent)
+              const dL = Number.parseInt(g.dropLowest, 10)
+              const dH = Number.parseInt(g.dropHighest, 10)
+              return {
+                id: g.id,
+                name: g.name.trim(),
+                sortOrder: i,
+                weightPercent: Number.isFinite(w) ? w : 0,
+                dropLowest: Number.isFinite(dL) ? Math.max(0, dL) : 0,
+                dropHighest: Number.isFinite(dH) ? Math.max(0, dH) : 0,
+                replaceLowestWithFinal: g.replaceLowestWithFinal,
+              }
+            }),
+            sbgEnabled,
+            sbgAggregationRule: sbgRule,
+            sbgProficiencyScaleJson: sbgEnabled ? sbgProficiencyScaleJson : null,
+          })
+        )
+      }
+
+      if (isSchemeDirty) {
+        savedScheme = true
+        promises.push(
+          putCourseGradingScheme(courseCode, { type: schemeType, scaleJson })
+        )
+      }
+
+      await Promise.all(promises)
+      await load()
+      void refreshCourseNav()
+      setSaveStatus('saved')
+      if (savedScheme) {
+        toastSaveOk('Grading scheme saved.')
+      }
+      if (savedSettings) {
+        toastSaveOk('Grading settings saved.')
+      }
+    } catch (e) {
+      setSaveStatus('error')
+      setSaveMessage(e instanceof Error ? e.message : 'Could not save configurations.')
+    }
+  }
 
   const weightTotal = useMemo(() => {
     let t = 0
@@ -172,92 +381,6 @@ export function CourseGradingSettingsSection({ courseCode }: { courseCode: strin
     }
     return out
   }, [structure])
-
-  async function onSaveGrading(e: React.FormEvent) {
-    e.preventDefault()
-    if (!canEdit) return
-    const named = groups.filter((g) => g.name.trim())
-    if (named.length === 0) {
-      setSaveStatus('error')
-      setSaveMessage('Add at least one assignment group with a name, or remove extra rows.')
-      return
-    }
-    if (named.length !== groups.length) {
-      setSaveStatus('error')
-      setSaveMessage('Each assignment group needs a name.')
-      return
-    }
-    setSaveStatus('saving')
-    setSaveMessage(null)
-    try {
-      let sbgProficiencyScaleJson: unknown = undefined
-      if (sbgEnabled) {
-        try {
-          sbgProficiencyScaleJson = JSON.parse(sbgScaleText || '{}')
-        } catch {
-          setSaveStatus('error')
-          setSaveMessage('SBG proficiency scale must be valid JSON.')
-          return
-        }
-      }
-      const payload = await putCourseGradingSettings(courseCode, {
-        gradingScale,
-        assignmentGroups: groups.map((g, i) => {
-          const w = Number.parseFloat(g.weightPercent)
-          const dL = Number.parseInt(g.dropLowest, 10)
-          const dH = Number.parseInt(g.dropHighest, 10)
-          return {
-            id: g.id,
-            name: g.name.trim(),
-            sortOrder: i,
-            weightPercent: Number.isFinite(w) ? w : 0,
-            dropLowest: Number.isFinite(dL) ? Math.max(0, dL) : 0,
-            dropHighest: Number.isFinite(dH) ? Math.max(0, dH) : 0,
-            replaceLowestWithFinal: g.replaceLowestWithFinal,
-          }
-        }),
-        sbgEnabled,
-        sbgAggregationRule: sbgRule,
-        sbgProficiencyScaleJson: sbgEnabled ? sbgProficiencyScaleJson : null,
-      })
-      setGradingScale(payload.gradingScale)
-      setGroups(groupsToEditable(payload.assignmentGroups))
-      if (payload.sbgEnabled != null) setSbgEnabled(payload.sbgEnabled)
-      if (payload.sbgAggregationRule) setSbgRule(payload.sbgAggregationRule)
-      const items = await fetchCourseStructure(courseCode)
-      setStructure(items)
-      void refreshCourseNav()
-      setSaveStatus('saved')
-      setSaveMessage('Grading settings saved.')
-    } catch (e) {
-      setSaveStatus('error')
-      setSaveMessage(e instanceof Error ? e.message : 'Could not save.')
-    }
-  }
-
-  async function onSaveGradingScheme() {
-    if (!canEdit) return
-    setSchemeStatus('saving')
-    setSchemeMessage(null)
-    try {
-      let scaleJson: unknown = {}
-      if (schemeType === 'letter' || schemeType === 'gpa') {
-        scaleJson = JSON.parse(schemeJsonText || '[]')
-      } else if (schemeType === 'pass_fail') {
-        const n = Number.parseFloat(passMinPct)
-        scaleJson = { pass_min_pct: Number.isFinite(n) ? n : 60 }
-      } else if (schemeType === 'complete_incomplete') {
-        const n = Number.parseFloat(completeMinPct)
-        scaleJson = { complete_min_pct: Number.isFinite(n) ? n : 50 }
-      }
-      await putCourseGradingScheme(courseCode, { type: schemeType, scaleJson })
-      setSchemeStatus('saved')
-      setSchemeMessage('Grading scheme saved.')
-    } catch (err) {
-      setSchemeStatus('error')
-      setSchemeMessage(err instanceof Error ? err.message : 'Could not save grading scheme.')
-    }
-  }
 
   async function onItemGroupChange(itemId: string, value: string) {
     if (!canEdit) return
@@ -306,7 +429,7 @@ export function CourseGradingSettingsSection({ courseCode }: { courseCode: strin
 
   return (
     <div className="space-y-8">
-      <form onSubmit={onSaveGrading} className="space-y-6">
+      <form onSubmit={(e) => e.preventDefault()} className="space-y-6">
         <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-900/5 dark:border-neutral-600 dark:bg-neutral-900 dark:shadow-none">
           <h2 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Grading scale</h2>
           <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
@@ -429,28 +552,6 @@ export function CourseGradingSettingsSection({ courseCode }: { courseCode: strin
                   className="mt-1 w-32 rounded-lg border border-slate-200 bg-white px-2 py-2 text-sm tabular-nums text-slate-900 outline-none focus:border-indigo-400 focus:ring-1 focus:ring-indigo-400 disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-400"
                 />
               </div>
-            )}
-            {schemeMessage && (
-              <p
-                className={
-                  schemeStatus === 'error'
-                    ? 'text-sm text-rose-700 dark:text-rose-400'
-                    : 'text-sm text-emerald-700 dark:text-emerald-400'
-                }
-                role="status"
-              >
-                {schemeMessage}
-              </p>
-            )}
-            {canEdit && (
-              <button
-                type="button"
-                disabled={schemeStatus === 'saving'}
-                onClick={() => void onSaveGradingScheme()}
-                className="rounded-xl bg-slate-800 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-neutral-200 dark:text-neutral-900 dark:hover:bg-white"
-              >
-                {schemeStatus === 'saving' ? 'Saving…' : 'Save grade display scheme'}
-              </button>
             )}
           </div>
         </section>
@@ -604,19 +705,19 @@ export function CourseGradingSettingsSection({ courseCode }: { courseCode: strin
                     <td className="py-2 pr-2">
                       <label className="flex cursor-pointer items-center gap-2 text-xs text-slate-600 dark:text-neutral-400">
                         <input
-                          type="checkbox"
-                          checked={g.replaceLowestWithFinal}
-                          disabled={!canEdit}
-                          onChange={(e) =>
-                            setGroups((prev) =>
-                              prev.map((x) =>
-                                x.clientKey === g.clientKey
-                                  ? { ...x, replaceLowestWithFinal: e.target.checked }
-                                  : x,
-                              ),
-                            )
-                          }
-                          className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-neutral-500"
+                           type="checkbox"
+                           checked={g.replaceLowestWithFinal}
+                           disabled={!canEdit}
+                           onChange={(e) =>
+                             setGroups((prev) =>
+                               prev.map((x) =>
+                                 x.clientKey === g.clientKey
+                                   ? { ...x, replaceLowestWithFinal: e.target.checked }
+                                   : x,
+                               ),
+                             )
+                           }
+                           className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-neutral-500"
                         />
                         <span>Final can replace a low score</span>
                       </label>
@@ -664,29 +765,6 @@ export function CourseGradingSettingsSection({ courseCode }: { courseCode: strin
             )}
           </p>
         </section>
-
-        {saveMessage && (
-          <p
-            className={
-              saveStatus === 'error'
-                ? 'text-sm text-rose-700 dark:text-rose-400'
-                : 'text-sm text-emerald-700 dark:text-emerald-400'
-            }
-            role="status"
-          >
-            {saveMessage}
-          </p>
-        )}
-
-        {canEdit && (
-          <button
-            type="submit"
-            disabled={saveStatus === 'saving'}
-            className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {saveStatus === 'saving' ? 'Saving…' : 'Save grading settings'}
-          </button>
-        )}
 
         {!canEdit && (
           <p className="text-sm text-slate-500 dark:text-neutral-400">
@@ -751,6 +829,51 @@ export function CourseGradingSettingsSection({ courseCode }: { courseCode: strin
           </div>
         )}
       </section>
+
+      {isDirty && (
+        <div className="fixed bottom-6 left-1/2 z-50 w-full max-w-2xl -translate-x-1/2 px-4 animate-in fade-in slide-in-from-bottom-4 duration-300">
+          <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white/90 px-6 py-4 shadow-xl backdrop-blur-md dark:border-neutral-800 dark:bg-neutral-900/90">
+            <div className="flex flex-col">
+              <span className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Unsaved changes</span>
+              <span className="text-xs text-slate-500 dark:text-neutral-400">
+                {saveStatus === 'error' && saveMessage ? (
+                  <span className="text-rose-600 dark:text-rose-400 font-medium">{saveMessage}</span>
+                ) : (
+                  "You have modified this course's grading settings."
+                )}
+              </span>
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={discardChanges}
+                disabled={saveStatus === 'saving'}
+                className="rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100 hover:text-slate-900 disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-850 dark:hover:text-neutral-200 transition"
+              >
+                Discard
+              </button>
+              <button
+                type="button"
+                onClick={() => void onSingleSaveChanges()}
+                disabled={saveStatus === 'saving'}
+                className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-md hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-60 transition active:scale-95"
+              >
+                {saveStatus === 'saving' ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  <>
+                    <Save className="h-4 w-4" />
+                    Save changes
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/clients/web/src/pages/lms/course-groups-page.tsx
+++ b/clients/web/src/pages/lms/course-groups-page.tsx
@@ -21,6 +21,9 @@ import { formatRelativeCompact } from '../../lib/format-datetime'
 import { LmsPage } from './lms-page'
 
 
+function isCourseStaff(roles: string[] | undefined): boolean {
+  return Boolean(roles?.some((r) => r === 'teacher' || r === 'instructor'))
+}
 
 
 

--- a/clients/web/src/pages/lms/course-groups-page.tsx
+++ b/clients/web/src/pages/lms/course-groups-page.tsx
@@ -21,12 +21,6 @@ import { formatRelativeCompact } from '../../lib/format-datetime'
 import { LmsPage } from './lms-page'
 
 
-function isCourseStaff(roles: string[] | undefined): boolean {
-  return Boolean(roles?.some((r) => r === 'teacher' || r === 'instructor'))
-}
-
-
-
 
 function authorLabel(m: GroupMessage): string {
   return m.authorDisplayName?.trim() || m.authorEmail

--- a/clients/web/src/pages/lms/course-outcomes-section.tsx
+++ b/clients/web/src/pages/lms/course-outcomes-section.tsx
@@ -5,6 +5,7 @@ import {
   Link2,
   Loader2,
   Plus,
+  Save,
   Target,
   Trash2,
   TrendingUp,
@@ -192,13 +193,64 @@ export function CourseOutcomesSection({ courseCode }: { courseCode: string }) {
     }
   }
 
-  async function onSaveOutcomeMeta(o: CourseOutcome, title: string, description: string) {
-    setLoadError(null)
+  const [drafts, setDrafts] = useState<Record<string, { title: string; description: string }>>({})
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const [saveMessage, setSaveMessage] = useState<string | null>(null)
+
+  const isDirty = useMemo(() => {
+    return Object.entries(drafts).some(([id, draft]) => {
+      const original = outcomes.find((o) => o.id === id)
+      if (!original) return false
+      return draft.title.trim() !== original.title || draft.description.trim() !== original.description
+    })
+  }, [drafts, outcomes])
+
+  const discardChanges = useCallback(() => {
+    setDrafts({})
+    setSaveStatus('idle')
+    setSaveMessage(null)
+  }, [])
+
+  async function onSingleSaveChanges() {
+    if (!canEdit) return
+    setSaveStatus('saving')
+    setSaveMessage(null)
+
+    const dirtyEntries = Object.entries(drafts).filter(([id, draft]) => {
+      const original = outcomes.find((o) => o.id === id)
+      if (!original) return false
+      return draft.title.trim() !== original.title || draft.description.trim() !== original.description
+    })
+
+    if (dirtyEntries.length === 0) {
+      setSaveStatus('saved')
+      return
+    }
+
+    for (const [, draft] of dirtyEntries) {
+      if (!draft.title.trim()) {
+        setSaveStatus('error')
+        setSaveMessage('Outcome title cannot be empty.')
+        return
+      }
+    }
+
     try {
-      const updated = await patchCourseOutcome(courseCode, o.id, { title, description })
-      setOutcomes((prev) => prev.map((x) => (x.id === o.id ? updated : x)))
+      await Promise.all(
+        dirtyEntries.map(([id, draft]) =>
+          patchCourseOutcome(courseCode, id, {
+            title: draft.title.trim(),
+            description: draft.description.trim(),
+          })
+        )
+      )
+
+      await load()
+      setDrafts({})
+      setSaveStatus('saved')
     } catch (e) {
-      setLoadError(e instanceof Error ? e.message : 'Could not save outcome.')
+      setSaveStatus('error')
+      setSaveMessage(e instanceof Error ? e.message : 'Could not save learning outcomes.')
     }
   }
 
@@ -308,8 +360,27 @@ export function CourseOutcomesSection({ courseCode }: { courseCode: string }) {
                 enrolledLearners={enrolledLearners}
                 gradableOptions={gradableOptions}
                 onDelete={() => requestDeleteOutcome(o.id)}
-                onSaveMeta={(title, description) => void onSaveOutcomeMeta(o, title, description)}
                 onLinksChanged={() => void load()}
+                draftTitle={drafts[o.id]?.title ?? o.title}
+                draftDescription={drafts[o.id]?.description ?? o.description}
+                onTitleChange={(val) =>
+                  setDrafts((prev) => ({
+                    ...prev,
+                    [o.id]: {
+                      title: val,
+                      description: prev[o.id]?.description ?? o.description,
+                    },
+                  }))
+                }
+                onDescriptionChange={(val) =>
+                  setDrafts((prev) => ({
+                    ...prev,
+                    [o.id]: {
+                      title: prev[o.id]?.title ?? o.title,
+                      description: val,
+                    },
+                  }))
+                }
               />
             ))}
           </div>
@@ -434,6 +505,51 @@ export function CourseOutcomesSection({ courseCode }: { courseCode: string }) {
         }}
         onConfirm={() => void confirmDeleteOutcome()}
       />
+
+      {isDirty && (
+        <div className="fixed bottom-6 left-1/2 z-50 w-full max-w-2xl -translate-x-1/2 px-4 animate-in fade-in slide-in-from-bottom-4 duration-300">
+          <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white/90 px-6 py-4 shadow-xl backdrop-blur-md dark:border-neutral-800 dark:bg-neutral-900/90">
+            <div className="flex flex-col">
+              <span className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Unsaved changes</span>
+              <span className="text-xs text-slate-500 dark:text-neutral-400">
+                {saveStatus === 'error' && saveMessage ? (
+                  <span className="text-rose-600 dark:text-rose-400 font-medium">{saveMessage}</span>
+                ) : (
+                  "You have modified this course's learning outcomes."
+                )}
+              </span>
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={discardChanges}
+                disabled={saveStatus === 'saving'}
+                className="rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100 hover:text-slate-900 disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-850 dark:hover:text-neutral-200 transition"
+              >
+                Discard
+              </button>
+              <button
+                type="button"
+                onClick={() => void onSingleSaveChanges()}
+                disabled={saveStatus === 'saving'}
+                className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-md hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-60 transition active:scale-95"
+              >
+                {saveStatus === 'saving' ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  <>
+                    <Save className="h-4 w-4" />
+                    Save changes
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -444,21 +560,23 @@ function OutcomeCard({
   enrolledLearners,
   gradableOptions,
   onDelete,
-  onSaveMeta,
   onLinksChanged,
+  draftTitle,
+  draftDescription,
+  onTitleChange,
+  onDescriptionChange,
 }: {
   courseCode: string
   outcome: CourseOutcome
   enrolledLearners: number
   gradableOptions: GradableOption[]
   onDelete: () => void
-  onSaveMeta: (title: string, description: string) => void
   onLinksChanged: () => void
+  draftTitle: string
+  draftDescription: string
+  onTitleChange: (val: string) => void
+  onDescriptionChange: (val: string) => void
 }) {
-  const [titleDraft, setTitleDraft] = useState(outcome.title)
-  const [descDraft, setDescDraft] = useState(outcome.description)
-  const [savingMeta, setSavingMeta] = useState(false)
-
   const [itemId, setItemId] = useState('')
   const [quizScope, setQuizScope] = useState<'whole' | 'question'>('whole')
   const [questionId, setQuestionId] = useState('')
@@ -468,11 +586,6 @@ function OutcomeCard({
   const [localError, setLocalError] = useState<string | null>(null)
   const [measurementLevel, setMeasurementLevel] = useState<string>('formative')
   const [intensityLevel, setIntensityLevel] = useState<string>('medium')
-
-  useEffect(() => {
-    setTitleDraft(outcome.title)
-    setDescDraft(outcome.description)
-  }, [outcome.title, outcome.description])
 
   const selectedGradable = gradableOptions.find((g) => g.id === itemId)
 
@@ -554,15 +667,7 @@ function OutcomeCard({
     }
   }
 
-  async function saveMeta() {
-    setSavingMeta(true)
-    setLocalError(null)
-    try {
-      onSaveMeta(titleDraft.trim(), descDraft)
-    } finally {
-      setSavingMeta(false)
-    }
-  }
+
 
   const rollup = outcome.rollupAvgScorePercent
 
@@ -581,8 +686,8 @@ function OutcomeCard({
                   Outcome title
                 </span>
                 <input
-                  value={titleDraft}
-                  onChange={(e) => setTitleDraft(e.target.value)}
+                  value={draftTitle}
+                  onChange={(e) => onTitleChange(e.target.value)}
                   className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
                 />
               </label>
@@ -591,22 +696,12 @@ function OutcomeCard({
                   Description
                 </span>
                 <textarea
-                  value={descDraft}
-                  onChange={(e) => setDescDraft(e.target.value)}
+                  value={draftDescription}
+                  onChange={(e) => onDescriptionChange(e.target.value)}
                   rows={2}
                   className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"
                 />
               </label>
-              <div className="flex flex-wrap items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => void saveMeta()}
-                  disabled={savingMeta || !titleDraft.trim()}
-                  className="rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {savingMeta ? 'Saving…' : 'Save changes'}
-                </button>
-              </div>
             </div>
           </div>
           <button

--- a/clients/web/src/pages/lms/course-settings.tsx
+++ b/clients/web/src/pages/lms/course-settings.tsx
@@ -1,6 +1,6 @@
-import { type FormEvent, useCallback, useEffect, useState } from 'react'
+import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, Navigate, useLocation, useParams } from 'react-router-dom'
-import { Check, ImageIcon, Move, Save, X } from 'lucide-react'
+import { Check, ImageIcon, Loader2, Move, Save, X } from 'lucide-react'
 import { LmsPage } from './lms-page'
 import { usePermissions } from '../../context/use-permissions'
 import { authorizedFetch } from '../../lib/api'
@@ -189,9 +189,8 @@ export default function CourseSettings() {
   const [positionSaveStatus, setPositionSaveStatus] = useState<'idle' | 'saving' | 'error'>('idle')
   const [positionMessage, setPositionMessage] = useState<string | null>(null)
 
-  const [mdThemeStatus, setMdThemeStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
-  const [mdThemeMessage, setMdThemeMessage] = useState<string | null>(null)
   const [customDraft, setCustomDraft] = useState<MarkdownThemeCustom>(markdownThemeCustomSeed)
+  const [markdownThemePreset, setMarkdownThemePreset] = useState<string>('default')
 
   const applyScheduleStateFromCourse = useCallback((c: CoursePublic) => {
     setStartsAt(isoToDatetimeLocal(c.startsAt))
@@ -226,6 +225,7 @@ export default function CourseSettings() {
       applyScheduleStateFromCourse(c)
       setCourseHomeLanding(normalizeCourseHomeLanding(c.courseHomeLanding))
       setCourseHomeContentItemId((c.courseHomeContentItemId ?? '').trim())
+      setMarkdownThemePreset(c.markdownThemePreset ?? 'default')
       try {
         const items = await fetchCourseStructure(courseCode)
         setStructureForHomePicker(items)
@@ -251,40 +251,98 @@ export default function CourseSettings() {
     })
   }, [course])
 
-  async function selectMarkdownPreset(preset: MarkdownThemePresetId) {
-    if (!courseCode) return
-    setMdThemeStatus('saving')
-    setMdThemeMessage(null)
-    try {
-      const updated = await patchCourseMarkdownTheme(courseCode, { preset })
-      setCourse(updated)
-      setMdThemeStatus('saved')
-      setMdThemeMessage('Reading theme saved.')
-    } catch (e) {
-      setMdThemeStatus('error')
-      setMdThemeMessage(e instanceof Error ? e.message : 'Could not save theme.')
-      void loadCourse()
-    }
+  const discardChanges = useCallback(() => {
+    if (!course) return
+    setTitle(course.title)
+    setDescription(course.description)
+    setPublished(course.published)
+    applyScheduleStateFromCourse(course)
+    setCourseHomeLanding(normalizeCourseHomeLanding(course.courseHomeLanding))
+    setCourseHomeContentItemId((course.courseHomeContentItemId ?? '').trim())
+    setMarkdownThemePreset(course.markdownThemePreset ?? 'default')
+    setCustomDraft({
+      ...markdownThemeCustomSeed,
+      ...(course.markdownThemeCustom ?? {}),
+    })
+    setSaveStatus('idle')
+    setSaveMessage(null)
+  }, [course, applyScheduleStateFromCourse])
+
+  function selectMarkdownPreset(preset: MarkdownThemePresetId) {
+    setMarkdownThemePreset(preset)
   }
 
-  async function saveCustomMarkdownTheme() {
-    if (!courseCode) return
-    setMdThemeStatus('saving')
-    setMdThemeMessage(null)
-    try {
-      const updated = await patchCourseMarkdownTheme(courseCode, {
-        preset: 'custom',
-        custom: customDraft,
-      })
-      setCourse(updated)
-      setMdThemeStatus('saved')
-      setMdThemeMessage('Custom reading theme saved.')
-    } catch (e) {
-      setMdThemeStatus('error')
-      setMdThemeMessage(e instanceof Error ? e.message : 'Could not save theme.')
-      void loadCourse()
-    }
+  const updateCustomDraft = (updater: (prev: MarkdownThemeCustom) => MarkdownThemeCustom) => {
+    setCustomDraft(updater)
+    setMarkdownThemePreset('custom')
   }
+
+  const normalizeIso = (iso: string | null) => datetimeLocalToIso(isoToDatetimeLocal(iso))
+
+  const isDirty = useMemo(() => {
+    if (!course) return false
+
+    // Check basic info
+    if (title.trim() !== course.title) return true
+    if (description.trim() !== course.description) return true
+    if (published !== course.published) return true
+
+    // Check course home landing
+    const normHome = normalizeCourseHomeLanding(course.courseHomeLanding)
+    if (courseHomeLanding !== normHome) return true
+    const origHomeContentId = (course.courseHomeContentItemId ?? '').trim()
+    if (courseHomeLanding === 'content_page' && courseHomeContentItemId.trim() !== origHomeContentId) return true
+
+    // Check schedule
+    if ((course.scheduleMode || 'fixed') !== scheduleMode) return true
+    if (scheduleMode === 'fixed') {
+      if (datetimeLocalToIso(startsAt) !== normalizeIso(course.startsAt)) return true
+      if (datetimeLocalToIso(endsAt) !== normalizeIso(course.endsAt)) return true
+      if (datetimeLocalToIso(visibleFrom) !== normalizeIso(course.visibleFrom)) return true
+      if (datetimeLocalToIso(hiddenAt) !== normalizeIso(course.hiddenAt)) return true
+    } else {
+      const currentEndAfter = partsToIsoDuration(relEndAmount, relEndUnit)
+      const origEndAfter = course.relativeEndAfter ?? null
+      if (currentEndAfter !== origEndAfter) return true
+
+      const currentHiddenAfter = partsToIsoDuration(relHiddenAmount, relHiddenUnit)
+      const origHiddenAfter = course.relativeHiddenAfter ?? null
+      if (currentHiddenAfter !== origHiddenAfter) return true
+    }
+
+    // Check theme
+    if ((course.markdownThemePreset ?? 'default') !== markdownThemePreset) return true
+    if (markdownThemePreset === 'custom') {
+      const origCustom = course.markdownThemeCustom ?? markdownThemeCustomSeed
+      if ((customDraft.headingColor ?? markdownThemeCustomSeed.headingColor) !== (origCustom.headingColor ?? markdownThemeCustomSeed.headingColor)) return true
+      if ((customDraft.bodyColor ?? markdownThemeCustomSeed.bodyColor) !== (origCustom.bodyColor ?? markdownThemeCustomSeed.bodyColor)) return true
+      if ((customDraft.linkColor ?? markdownThemeCustomSeed.linkColor) !== (origCustom.linkColor ?? markdownThemeCustomSeed.linkColor)) return true
+      if ((customDraft.codeBackground ?? markdownThemeCustomSeed.codeBackground) !== (origCustom.codeBackground ?? markdownThemeCustomSeed.codeBackground)) return true
+      if ((customDraft.blockquoteBorder ?? markdownThemeCustomSeed.blockquoteBorder) !== (origCustom.blockquoteBorder ?? markdownThemeCustomSeed.blockquoteBorder)) return true
+      if ((customDraft.articleWidth ?? markdownThemeCustomSeed.articleWidth) !== (origCustom.articleWidth ?? markdownThemeCustomSeed.articleWidth)) return true
+      if ((customDraft.fontFamily ?? markdownThemeCustomSeed.fontFamily) !== (origCustom.fontFamily ?? markdownThemeCustomSeed.fontFamily)) return true
+    }
+
+    return false
+  }, [
+    course,
+    title,
+    description,
+    published,
+    courseHomeLanding,
+    courseHomeContentItemId,
+    scheduleMode,
+    startsAt,
+    endsAt,
+    visibleFrom,
+    hiddenAt,
+    relEndAmount,
+    relEndUnit,
+    relHiddenAmount,
+    relHiddenUnit,
+    markdownThemePreset,
+    customDraft,
+  ])
 
   function buildPayload(overrides?: Partial<{ published: boolean }>): SavePayload {
     const mode = scheduleMode
@@ -309,75 +367,133 @@ export default function CourseSettings() {
     }
   }
 
-  async function persistCourse(payload: SavePayload) {
-    if (!courseCode) return
-    setSaveStatus('saving')
-    setSaveMessage(null)
-    try {
-      const res = await authorizedFetch(`/api/v1/courses/${encodeURIComponent(courseCode)}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          title: payload.title,
-          description: payload.description,
-          published: payload.published,
-          startsAt: payload.startsAt,
-          endsAt: payload.endsAt,
-          visibleFrom: payload.visibleFrom,
-          hiddenAt: payload.hiddenAt,
-          scheduleMode: payload.scheduleMode,
-          relativeEndAfter: payload.relativeEndAfter,
-          relativeHiddenAfter: payload.relativeHiddenAfter,
-          courseHomeLanding: payload.courseHomeLanding,
-          courseHomeContentItemId: payload.courseHomeContentItemId,
-        }),
-      })
-      const raw: unknown = await res.json().catch(() => ({}))
-      if (!res.ok) {
-        setSaveStatus('error')
-        const msg = readApiErrorMessage(raw)
-        setSaveMessage(msg)
-        toastMutationError(msg)
-        void loadCourse()
-        return
-      }
-      const updated = raw as CoursePublic
-      setCourse(updated)
-      setPublished(updated.published)
-      applyScheduleStateFromCourse(updated)
-      setCourseHomeLanding(normalizeCourseHomeLanding(updated.courseHomeLanding))
-      setCourseHomeContentItemId((updated.courseHomeContentItemId ?? '').trim())
-      setSaveStatus('saved')
-      setSaveMessage('Saved.')
-      toastSaveOk('Course settings saved')
-    } catch {
-      setSaveStatus('error')
-      setSaveMessage('Could not save.')
-      toastMutationError('Could not save course settings.')
-      void loadCourse()
-    }
-  }
-
-  async function onSaveForm(e: FormEvent) {
-    e.preventDefault()
+  async function onSingleSaveChanges() {
+    if (!courseCode || !course) return
+    
     const payload = buildPayload()
     if (!payload.title) {
       setSaveStatus('error')
       setSaveMessage('Title is required.')
+      toastMutationError('Title is required.')
       return
     }
     if (payload.courseHomeLanding === 'content_page' && !payload.courseHomeContentItemId) {
       setSaveStatus('error')
       setSaveMessage('Choose a content page for the course home, or switch to another layout.')
+      toastMutationError('Choose a content page for the course home.')
       return
     }
-    await persistCourse(payload)
+
+    setSaveStatus('saving')
+    setSaveMessage(null)
+
+    const courseSettingsDirty = (
+      title.trim() !== course.title ||
+      description.trim() !== course.description ||
+      published !== course.published ||
+      courseHomeLanding !== normalizeCourseHomeLanding(course.courseHomeLanding) ||
+      (courseHomeLanding === 'content_page' && courseHomeContentItemId.trim() !== (course.courseHomeContentItemId ?? '').trim()) ||
+      (course.scheduleMode || 'fixed') !== scheduleMode ||
+      (scheduleMode === 'fixed' && (
+        datetimeLocalToIso(startsAt) !== normalizeIso(course.startsAt) ||
+        datetimeLocalToIso(endsAt) !== normalizeIso(course.endsAt) ||
+        datetimeLocalToIso(visibleFrom) !== normalizeIso(course.visibleFrom) ||
+        datetimeLocalToIso(hiddenAt) !== normalizeIso(course.hiddenAt)
+      )) ||
+      (scheduleMode === 'relative' && (
+        partsToIsoDuration(relEndAmount, relEndUnit) !== (course.relativeEndAfter ?? null) ||
+        partsToIsoDuration(relHiddenAmount, relHiddenUnit) !== (course.relativeHiddenAfter ?? null)
+      ))
+    )
+
+    const origPreset = course.markdownThemePreset ?? 'default'
+    const themePresetDirty = origPreset !== markdownThemePreset
+    
+    let themeCustomDirty = false
+    if (markdownThemePreset === 'custom') {
+      const origCustom = course.markdownThemeCustom ?? markdownThemeCustomSeed
+      themeCustomDirty = (
+        (customDraft.headingColor ?? markdownThemeCustomSeed.headingColor) !== (origCustom.headingColor ?? markdownThemeCustomSeed.headingColor) ||
+        (customDraft.bodyColor ?? markdownThemeCustomSeed.bodyColor) !== (origCustom.bodyColor ?? markdownThemeCustomSeed.bodyColor) ||
+        (customDraft.linkColor ?? markdownThemeCustomSeed.linkColor) !== (origCustom.linkColor ?? markdownThemeCustomSeed.linkColor) ||
+        (customDraft.codeBackground ?? markdownThemeCustomSeed.codeBackground) !== (origCustom.codeBackground ?? markdownThemeCustomSeed.codeBackground) ||
+        (customDraft.blockquoteBorder ?? markdownThemeCustomSeed.blockquoteBorder) !== (origCustom.blockquoteBorder ?? markdownThemeCustomSeed.blockquoteBorder) ||
+        (customDraft.articleWidth ?? markdownThemeCustomSeed.articleWidth) !== (origCustom.articleWidth ?? markdownThemeCustomSeed.articleWidth) ||
+        (customDraft.fontFamily ?? markdownThemeCustomSeed.fontFamily) !== (origCustom.fontFamily ?? markdownThemeCustomSeed.fontFamily)
+      )
+    }
+
+    const themeDirty = themePresetDirty || themeCustomDirty
+
+    try {
+      let updatedCourse = course
+
+      if (courseSettingsDirty) {
+        const res = await authorizedFetch(`/api/v1/courses/${encodeURIComponent(courseCode)}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            title: payload.title,
+            description: payload.description,
+            published: payload.published,
+            startsAt: payload.startsAt,
+            endsAt: payload.endsAt,
+            visibleFrom: payload.visibleFrom,
+            hiddenAt: payload.hiddenAt,
+            scheduleMode: payload.scheduleMode,
+            relativeEndAfter: payload.relativeEndAfter,
+            relativeHiddenAfter: payload.relativeHiddenAfter,
+            courseHomeLanding: payload.courseHomeLanding,
+            courseHomeContentItemId: payload.courseHomeContentItemId,
+          }),
+        })
+        const raw: unknown = await res.json().catch(() => ({}))
+        if (!res.ok) {
+          const msg = readApiErrorMessage(raw)
+          setSaveStatus('error')
+          setSaveMessage(msg)
+          toastMutationError(msg)
+          return
+        }
+        updatedCourse = raw as CoursePublic
+      }
+
+      if (themeDirty) {
+        const themeBody = {
+          preset: markdownThemePreset,
+          custom: markdownThemePreset === 'custom' ? customDraft : null,
+        }
+        const updated = await patchCourseMarkdownTheme(courseCode, themeBody)
+        updatedCourse = {
+          ...updatedCourse,
+          markdownThemePreset: updated.markdownThemePreset,
+          markdownThemeCustom: updated.markdownThemeCustom,
+        }
+      }
+
+      setCourse(updatedCourse)
+      setPublished(updatedCourse.published)
+      applyScheduleStateFromCourse(updatedCourse)
+      setCourseHomeLanding(normalizeCourseHomeLanding(updatedCourse.courseHomeLanding))
+      setCourseHomeContentItemId((updatedCourse.courseHomeContentItemId ?? '').trim())
+      setMarkdownThemePreset(updatedCourse.markdownThemePreset ?? 'default')
+      setCustomDraft({
+        ...markdownThemeCustomSeed,
+        ...(updatedCourse.markdownThemeCustom ?? {}),
+      })
+
+      setSaveStatus('saved')
+      setSaveMessage('Saved successfully.')
+      toastSaveOk('Course settings saved')
+    } catch {
+      setSaveStatus('error')
+      setSaveMessage('Could not save settings.')
+      toastMutationError('Could not save course settings.')
+    }
   }
 
-  async function onPublishedToggle() {
-    const next = !published
-    setPublished(next)
-    await persistCourse(buildPayload({ published: next }))
+  function onPublishedToggle() {
+    setPublished((p) => !p)
   }
 
   const closeImageModal = useCallback(() => {
@@ -648,313 +764,272 @@ export default function CourseSettings() {
           className="mt-8 max-w-4xl space-y-6"
         >
           {section === 'general' && (
-            <>
-              <form onSubmit={onSaveForm} className="space-y-6">
-                <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-900/5">
-                  <h2 className="text-sm font-semibold text-slate-900">Basic information</h2>
-                  <div className="mt-4 space-y-4">
-                    <label className="block">
-                      <span className="mb-1.5 block text-sm font-medium text-slate-700">Title</span>
-                      <input
-                        type="text"
-                        value={title}
-                        onChange={(e) => setTitle(e.target.value)}
-                        required
-                        className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2"
-                      />
-                    </label>
-                    <label className="block">
-                      <span className="mb-1.5 block text-sm font-medium text-slate-700">
-                        Description
-                      </span>
-                      <textarea
-                        value={description}
-                        onChange={(e) => setDescription(e.target.value)}
-                        rows={5}
-                        className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none ring-indigo-500/20 placeholder:text-slate-400 focus:border-indigo-400 focus:ring-2"
-                        placeholder="What is this course about?"
-                      />
-                    </label>
-                  </div>
-                </section>
-
-                <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-900/5">
-                  <h2 className="text-sm font-semibold text-slate-900">Publishing</h2>
-                  <p className="mt-1 text-sm text-slate-500">
-                    Published courses appear in the catalog. Drafts are only reachable by direct link.
-                  </p>
-                  <div className="mt-4 flex items-center gap-3">
-                    <button
-                      type="button"
-                      role="switch"
-                      name="publishCourse"
-                      aria-checked={published}
-                      aria-label={
-                        published
-                          ? 'Published to catalog'
-                          : 'Draft — not published to catalog'
-                      }
-                      onClick={() => void onPublishedToggle()}
-                      disabled={saveStatus === 'saving'}
-                      className={`relative inline-flex h-7 w-12 shrink-0 rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:opacity-50 ${published ? 'bg-indigo-600' : 'bg-slate-200'
-                        }`}
-                    >
-                      <span
-                        className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition ${published ? 'translate-x-5' : 'translate-x-0.5'
-                          }`}
-                      />
-                    </button>
-                    <span className="text-sm font-medium text-slate-800">
-                      {published ? 'Published' : 'Draft'}
+            <form
+              onSubmit={(e) => {
+                e.preventDefault()
+                void onSingleSaveChanges()
+              }}
+              className="space-y-6 pb-24"
+            >
+              <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-900/5 dark:border-neutral-800 dark:bg-neutral-900">
+                <h2 className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Basic information</h2>
+                <div className="mt-4 space-y-4">
+                  <label className="block">
+                    <span className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-neutral-300">Title</span>
+                    <input
+                      type="text"
+                      value={title}
+                      onChange={(e) => setTitle(e.target.value)}
+                      required
+                      className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-50"
+                    />
+                  </label>
+                  <label className="block">
+                    <span className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-neutral-300">
+                      Description
                     </span>
-                  </div>
-                </section>
-
-                <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-900/5 dark:border-neutral-700 dark:bg-neutral-900">
-                  <h2 className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Course home</h2>
-                  <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
-                    What learners and staff see first when they open this course (the course dashboard).
-                  </p>
-                  <fieldset className="mt-4 space-y-3">
-                    <legend className="sr-only">Course home layout</legend>
-                    <label className="flex cursor-pointer gap-3 rounded-xl border border-slate-100 p-3 hover:border-indigo-200 dark:border-neutral-800 dark:hover:border-indigo-800">
-                      <input
-                        type="radio"
-                        name="courseHomeLanding"
-                        checked={courseHomeLanding === 'data'}
-                        onChange={() => {
-                          setCourseHomeLanding('data')
-                          setCourseHomeContentItemId('')
-                        }}
-                        className="mt-1"
-                      />
-                      <span>
-                        <span className="block text-sm font-medium text-slate-900 dark:text-neutral-50">
-                          Data dashboard
-                        </span>
-                        <span className="mt-0.5 block text-xs text-slate-500 dark:text-neutral-400">
-                          Deadlines, announcements, grades, and course details at a glance.
-                        </span>
-                      </span>
-                    </label>
-                    <label className="flex cursor-pointer gap-3 rounded-xl border border-slate-100 p-3 hover:border-indigo-200 dark:border-neutral-800 dark:hover:border-indigo-800">
-                      <input
-                        type="radio"
-                        name="courseHomeLanding"
-                        checked={courseHomeLanding === 'calendar'}
-                        onChange={() => {
-                          setCourseHomeLanding('calendar')
-                          setCourseHomeContentItemId('')
-                        }}
-                        className="mt-1"
-                      />
-                      <span>
-                        <span className="block text-sm font-medium text-slate-900 dark:text-neutral-50">
-                          Course calendar
-                        </span>
-                        <span className="mt-0.5 block text-xs text-slate-500 dark:text-neutral-400">
-                          Due dates and the month / week views as the landing experience.
-                        </span>
-                      </span>
-                    </label>
-                    <label className="flex cursor-pointer gap-3 rounded-xl border border-slate-100 p-3 hover:border-indigo-200 dark:border-neutral-800 dark:hover:border-indigo-800">
-                      <input
-                        type="radio"
-                        name="courseHomeLanding"
-                        checked={courseHomeLanding === 'content_page'}
-                        onChange={() => setCourseHomeLanding('content_page')}
-                        className="mt-1"
-                      />
-                      <span>
-                        <span className="block text-sm font-medium text-slate-900 dark:text-neutral-50">
-                          A specific content page
-                        </span>
-                        <span className="mt-0.5 block text-xs text-slate-500 dark:text-neutral-400">
-                          Open the course directly on a page from the module outline (for example, a welcome page).
-                        </span>
-                      </span>
-                    </label>
-                  </fieldset>
-                  {courseHomeLanding === 'content_page' ? (
-                    <label className="mt-4 block">
-                      <span className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-neutral-300">
-                        Content page
-                      </span>
-                      <select
-                        value={courseHomeContentItemId}
-                        onChange={(e) => setCourseHomeContentItemId(e.target.value)}
-                        className="w-full max-w-lg rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-50"
-                      >
-                        <option value="">Select a page…</option>
-                        {structureForHomePicker
-                          .filter((i) => i.kind === 'content_page')
-                          .map((i) => (
-                            <option key={i.id} value={i.id}>
-                              {i.title}
-                            </option>
-                          ))}
-                      </select>
-                      {structureForHomePicker.filter((i) => i.kind === 'content_page').length === 0 ? (
-                        <p className="mt-2 text-xs text-amber-800 dark:text-amber-200">
-                          Add a content page in Modules first, then pick it here.
-                        </p>
-                      ) : null}
-                    </label>
-                  ) : null}
-                </section>
-
-                {saveMessage && (
-                  <p
-                    className={
-                      saveStatus === 'error' ? 'text-sm text-rose-700' : 'text-sm text-emerald-700'
-                    }
-                    role="status"
-                  >
-                    {saveMessage}
-                  </p>
-                )}
-
-                <div className="flex flex-wrap items-center gap-3">
-                  <button
-                    type="submit"
-                    name="saveGeneral"
-                    disabled={saveStatus === 'saving'}
-                    className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    {saveStatus === 'saving' ? 'Saving…' : 'Save changes'}
-                  </button>
+                    <textarea
+                      value={description}
+                      onChange={(e) => setDescription(e.target.value)}
+                      rows={5}
+                      className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none ring-indigo-500/20 placeholder:text-slate-400 focus:border-indigo-400 focus:ring-2 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-50"
+                      placeholder="What is this course about?"
+                    />
+                  </label>
                 </div>
-              </form>
+              </section>
 
-              <form onSubmit={onSaveForm} className="space-y-6">
-                <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-900/5">
-                  <h2 className="text-sm font-semibold text-slate-900">Fixed Schedule & Visibility</h2>
-                  <p className="mt-1 text-sm text-slate-500">
-                    Control whether the course uses fixed calendar dates or a timeline from each
-                    student’s enrollment. Module release and due dates follow the same mode: relative
-                    courses shift those dates by the same offset.
-                  </p>
-                  <div className="mt-4 flex flex-wrap items-center gap-3">
-                    <button
-                      type="button"
-                      role="switch"
-                      aria-checked={scheduleMode === 'relative'}
-                      aria-label={
-                        scheduleMode === 'relative'
-                          ? 'Relative schedule from each enrollment'
-                          : 'Fixed calendar schedule (not relative to enrollment)'
-                      }
-                      onClick={() =>
-                        setScheduleMode((m) => (m === 'fixed' ? 'relative' : 'fixed'))
-                      }
-                      disabled={saveStatus === 'saving'}
-                      className={`relative inline-flex h-7 w-12 shrink-0 rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:opacity-50 ${scheduleMode === 'relative' ? 'bg-indigo-600' : 'bg-slate-200'
+              <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-900/5 dark:border-neutral-800 dark:bg-neutral-900">
+                <h2 className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Publishing</h2>
+                <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+                  Published courses appear in the catalog. Drafts are only reachable by direct link.
+                </p>
+                <div className="mt-4 flex items-center gap-3">
+                  <button
+                    type="button"
+                    role="switch"
+                    name="publishCourse"
+                    aria-checked={published}
+                    aria-label={
+                      published
+                        ? 'Published to catalog'
+                        : 'Draft — not published to catalog'
+                    }
+                    onClick={() => onPublishedToggle()}
+                    disabled={saveStatus === 'saving'}
+                    className={`relative inline-flex h-7 w-12 shrink-0 rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:opacity-50 ${published ? 'bg-indigo-600' : 'bg-slate-200 dark:bg-neutral-800'
+                      }`}
+                  >
+                    <span
+                      className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition ${published ? 'translate-x-5' : 'translate-x-0.5'
                         }`}
-                    >
-                      <span
-                        className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition ${scheduleMode === 'relative' ? 'translate-x-5' : 'translate-x-0.5'
-                          }`}
-                      />
-                    </button>
-                    <span className="text-sm font-medium text-slate-800">
-                      {scheduleMode === 'fixed'
-                        ? 'Fixed (calendar dates)'
-                        : 'Relative (from enrollment)'}
-                    </span>
-                  </div>
-                  {scheduleMode === 'fixed' ? (
-                    <>
-                      <p className="mt-3 text-sm text-slate-500">
-                        Clear a field to remove that date. Times use your local timezone.
-                      </p>
-                      <div className="mt-4 grid gap-4 sm:grid-cols-2">
-                        <DateField
-                          label="Start"
-                          value={startsAt}
-                          onChange={setStartsAt}
-                          onClear={() => setStartsAt('')}
-                        />
-                        <DateField
-                          label="End"
-                          value={endsAt}
-                          onChange={setEndsAt}
-                          onClear={() => setEndsAt('')}
-                        />
-                        <DateField
-                          label="Visible from"
-                          value={visibleFrom}
-                          onChange={setVisibleFrom}
-                          onClear={() => setVisibleFrom('')}
-                        />
-                        <DateField
-                          label="Hidden after"
-                          value={hiddenAt}
-                          onChange={setHiddenAt}
-                          onClear={() => setHiddenAt('')}
-                        />
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <p className="mt-3 text-sm text-slate-500">
-                        Start and catalog visibility begin when the student is enrolled. Set how long
-                        the course runs and when it drops from the catalog (optional). Durations use
-                        ISO-style lengths (days, weeks, months, or years).
-                      </p>
-                      <div className="mt-4 grid gap-4 sm:grid-cols-2">
-                        <RelativeDurationField
-                          label="End after"
-                          amount={relEndAmount}
-                          unit={relEndUnit}
-                          onAmountChange={setRelEndAmount}
-                          onUnitChange={setRelEndUnit}
-                          onClear={() => setRelEndAmount('')}
-                        />
-                        <RelativeDurationField
-                          label="Hidden from catalog after"
-                          amount={relHiddenAmount}
-                          unit={relHiddenUnit}
-                          onAmountChange={setRelHiddenAmount}
-                          onUnitChange={setRelHiddenUnit}
-                          onClear={() => setRelHiddenAmount('')}
-                        />
-                      </div>
-                    </>
-                  )}
-                </section>
-
-                {saveMessage && (
-                  <p
-                    className={
-                      saveStatus === 'error' ? 'text-sm text-rose-700' : 'text-sm text-emerald-700'
-                    }
-                    role="status"
-                  >
-                    {saveMessage}
-                  </p>
-                )}
-
-                <div className="flex flex-wrap items-center gap-3">
-                  <button
-                    type="submit"
-                    disabled={saveStatus === 'saving'}
-                    className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    {saveStatus === 'saving' ? 'Saving…' : 'Save changes'}
+                    />
                   </button>
+                  <span className="text-sm font-medium text-slate-800 dark:text-neutral-300">
+                    {published ? 'Published' : 'Draft'}
+                  </span>
                 </div>
-              </form>
+              </section>
 
-              <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-900/5">
-                <h2 className="text-sm font-semibold text-slate-900">Hero image</h2>
-                <p className="mt-1 text-sm text-slate-500">
+              <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-900/5 dark:border-neutral-800 dark:bg-neutral-900">
+                <h2 className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Course home</h2>
+                <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+                  What learners and staff see first when they open this course (the course dashboard).
+                </p>
+                <fieldset className="mt-4 space-y-3">
+                  <legend className="sr-only">Course home layout</legend>
+                  <label className="flex cursor-pointer gap-3 rounded-xl border border-slate-100 p-3 hover:border-indigo-200 dark:border-neutral-800/50 dark:hover:border-indigo-800">
+                    <input
+                      type="radio"
+                      name="courseHomeLanding"
+                      checked={courseHomeLanding === 'data'}
+                      onChange={() => {
+                        setCourseHomeLanding('data')
+                        setCourseHomeContentItemId('')
+                      }}
+                      className="mt-1"
+                    />
+                    <span>
+                      <span className="block text-sm font-medium text-slate-900 dark:text-neutral-50">
+                        Data dashboard
+                      </span>
+                      <span className="mt-0.5 block text-xs text-slate-500 dark:text-neutral-400">
+                        Deadlines, announcements, grades, and course details at a glance.
+                      </span>
+                    </span>
+                  </label>
+                  <label className="flex cursor-pointer gap-3 rounded-xl border border-slate-100 p-3 hover:border-indigo-200 dark:border-neutral-800/50 dark:hover:border-indigo-800">
+                    <input
+                      type="radio"
+                      name="courseHomeLanding"
+                      checked={courseHomeLanding === 'calendar'}
+                      onChange={() => {
+                        setCourseHomeLanding('calendar')
+                        setCourseHomeContentItemId('')
+                      }}
+                      className="mt-1"
+                    />
+                    <span>
+                      <span className="block text-sm font-medium text-slate-900 dark:text-neutral-50">
+                        Course calendar
+                      </span>
+                      <span className="mt-0.5 block text-xs text-slate-500 dark:text-neutral-400">
+                        Due dates and the month / week views as the landing experience.
+                      </span>
+                    </span>
+                  </label>
+                  <label className="flex cursor-pointer gap-3 rounded-xl border border-slate-100 p-3 hover:border-indigo-200 dark:border-neutral-800/50 dark:hover:border-indigo-800">
+                    <input
+                      type="radio"
+                      name="courseHomeLanding"
+                      checked={courseHomeLanding === 'content_page'}
+                      onChange={() => setCourseHomeLanding('content_page')}
+                      className="mt-1"
+                    />
+                    <span>
+                      <span className="block text-sm font-medium text-slate-900 dark:text-neutral-50">
+                        A specific content page
+                      </span>
+                      <span className="mt-0.5 block text-xs text-slate-500 dark:text-neutral-400">
+                        Open the course directly on a page from the module outline (for example, a welcome page).
+                      </span>
+                    </span>
+                  </label>
+                </fieldset>
+                {courseHomeLanding === 'content_page' ? (
+                  <label className="mt-4 block">
+                    <span className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-neutral-300">
+                      Content page
+                    </span>
+                    <select
+                      value={courseHomeContentItemId}
+                      onChange={(e) => setCourseHomeContentItemId(e.target.value)}
+                      className="w-full max-w-lg rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-50"
+                    >
+                      <option value="">Select a page…</option>
+                      {structureForHomePicker
+                        .filter((i) => i.kind === 'content_page')
+                        .map((i) => (
+                          <option key={i.id} value={i.id}>
+                            {i.title}
+                          </option>
+                        ))}
+                    </select>
+                    {structureForHomePicker.filter((i) => i.kind === 'content_page').length === 0 ? (
+                      <p className="mt-2 text-xs text-amber-800 dark:text-amber-200">
+                        Add a content page in Modules first, then pick it here.
+                      </p>
+                    ) : null}
+                  </label>
+                ) : null}
+              </section>
+
+              <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-900/5 dark:border-neutral-800 dark:bg-neutral-900">
+                <h2 className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Fixed Schedule & Visibility</h2>
+                <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+                  Control whether the course uses fixed calendar dates or a timeline from each
+                  student’s enrollment. Module release and due dates follow the same mode: relative
+                  courses shift those dates by the same offset.
+                </p>
+                <div className="mt-4 flex flex-wrap items-center gap-3">
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={scheduleMode === 'relative'}
+                    aria-label={
+                      scheduleMode === 'relative'
+                        ? 'Relative schedule from each enrollment'
+                        : 'Fixed calendar schedule (not relative to enrollment)'
+                    }
+                    onClick={() =>
+                      setScheduleMode((m) => (m === 'fixed' ? 'relative' : 'fixed'))
+                    }
+                    disabled={saveStatus === 'saving'}
+                    className={`relative inline-flex h-7 w-12 shrink-0 rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:opacity-50 ${scheduleMode === 'relative' ? 'bg-indigo-600' : 'bg-slate-200 dark:bg-neutral-800'
+                      }`}
+                  >
+                    <span
+                      className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition ${scheduleMode === 'relative' ? 'translate-x-5' : 'translate-x-0.5'
+                        }`}
+                    />
+                  </button>
+                  <span className="text-sm font-medium text-slate-800 dark:text-neutral-300">
+                    {scheduleMode === 'fixed'
+                      ? 'Fixed (calendar dates)'
+                      : 'Relative (from enrollment)'}
+                  </span>
+                </div>
+                {scheduleMode === 'fixed' ? (
+                  <>
+                    <p className="mt-3 text-sm text-slate-500 dark:text-neutral-400">
+                      Clear a field to remove that date. Times use your local timezone.
+                    </p>
+                    <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                      <DateField
+                        label="Start"
+                        value={startsAt}
+                        onChange={setStartsAt}
+                        onClear={() => setStartsAt('')}
+                      />
+                      <DateField
+                        label="End"
+                        value={endsAt}
+                        onChange={setEndsAt}
+                        onClear={() => setEndsAt('')}
+                      />
+                      <DateField
+                        label="Visible from"
+                        value={visibleFrom}
+                        onChange={setVisibleFrom}
+                        onClear={() => setVisibleFrom('')}
+                      />
+                      <DateField
+                        label="Hidden after"
+                        value={hiddenAt}
+                        onChange={setHiddenAt}
+                        onClear={() => setHiddenAt('')}
+                      />
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <p className="mt-3 text-sm text-slate-500 dark:text-neutral-400">
+                      Start and catalog visibility begin when the student is enrolled. Set how long
+                      the course runs and when it drops from the catalog (optional). Durations use
+                      ISO-style lengths (days, weeks, months, or years).
+                    </p>
+                    <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                      <RelativeDurationField
+                        label="End after"
+                        amount={relEndAmount}
+                        unit={relEndUnit}
+                        onAmountChange={setRelEndAmount}
+                        onUnitChange={setRelEndUnit}
+                        onClear={() => setRelEndAmount('')}
+                      />
+                      <RelativeDurationField
+                        label="Hidden from catalog after"
+                        amount={relHiddenAmount}
+                        unit={relHiddenUnit}
+                        onAmountChange={setRelHiddenAmount}
+                        onUnitChange={setRelHiddenUnit}
+                        onClear={() => setRelHiddenAmount('')}
+                      />
+                    </div>
+                  </>
+                )}
+              </section>
+
+              <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-900/5 dark:border-neutral-800 dark:bg-neutral-900">
+                <h2 className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Hero image</h2>
+                <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
                   Generate a cover image with AI (model is configured under Settings → AI).
                 </p>
                 {course.heroImageUrl && (
                   <img
                     src={course.heroImageUrl}
                     alt=""
-                    className="mt-4 max-h-48 w-full max-w-md rounded-xl border border-slate-200 object-cover"
+                    className="mt-4 max-h-48 w-full max-w-md rounded-xl border border-slate-200 object-cover dark:border-neutral-805"
                     style={heroImageObjectStyle(course.heroImageObjectPosition)}
                   />
                 )}
@@ -962,7 +1037,7 @@ export default function CourseSettings() {
                   <button
                     type="button"
                     onClick={openImageModal}
-                    className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900"
+                    className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-350 dark:hover:border-indigo-900 dark:hover:bg-indigo-950 dark:hover:text-indigo-100"
                   >
                     <ImageIcon className="h-4 w-4" aria-hidden />
                     Generate image
@@ -972,7 +1047,7 @@ export default function CourseSettings() {
                     onClick={openPositionModal}
                     disabled={!course.heroImageUrl}
                     title={!course.heroImageUrl ? 'Add a hero image first' : undefined}
-                    className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-350 dark:hover:border-indigo-900 dark:hover:bg-indigo-950 dark:hover:text-indigo-100"
                   >
                     <Move className="h-4 w-4" aria-hidden />
                     Position image
@@ -980,38 +1055,28 @@ export default function CourseSettings() {
                 </div>
               </section>
 
-              <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-900/5">
+              <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-900/5 dark:border-neutral-800 dark:bg-neutral-900">
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
-                    <h2 className="text-sm font-semibold text-slate-900">Reading theme</h2>
-                    <p className="mt-1 text-sm text-slate-500">
-                      Applies to the syllabus, content pages, and assignments. Choosing a preset saves immediately.
+                    <h2 className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Reading theme</h2>
+                    <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+                      Applies to the syllabus, content pages, and assignments. Choosing a preset is staged and saved via the main save bar.
                     </p>
                   </div>
-                  {(mdThemeStatus !== 'idle' || mdThemeMessage) && (
-                    <p
-                      className={
-                        mdThemeStatus === 'error' ? 'text-sm text-rose-700' : 'text-sm text-emerald-700'
-                      }
-                      role="status"
-                    >
-                      {mdThemeStatus === 'saving' ? 'Saving…' : mdThemeMessage}
-                    </p>
-                  )}
                 </div>
 
                 <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
                   {MARKDOWN_THEME_PRESET_META.map((meta) => {
-                    const selected = course.markdownThemePreset === meta.id
+                    const selected = markdownThemePreset === meta.id
                     return (
                       <button
                         key={meta.id}
                         type="button"
-                        onClick={() => void selectMarkdownPreset(meta.id)}
-                        disabled={mdThemeStatus === 'saving'}
+                        onClick={() => selectMarkdownPreset(meta.id)}
+                        disabled={saveStatus === 'saving'}
                         className={`relative flex flex-col rounded-xl border p-4 text-left transition ${selected
-                          ? 'border-indigo-500 bg-indigo-50/60 ring-2 ring-indigo-500/30'
-                          : 'border-slate-200 bg-white hover:border-indigo-200 hover:bg-slate-50/80'
+                          ? 'border-indigo-500 bg-indigo-50/60 ring-2 ring-indigo-500/30 dark:border-indigo-500 dark:bg-indigo-950/30'
+                          : 'border-slate-200 bg-white hover:border-indigo-200 hover:bg-slate-50/80 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:border-indigo-850 dark:hover:bg-neutral-900/50'
                           } disabled:opacity-60`}
                       >
                         {selected && (
@@ -1019,20 +1084,20 @@ export default function CourseSettings() {
                             <Check className="h-3.5 w-3.5" aria-hidden />
                           </span>
                         )}
-                        <span className="text-sm font-semibold text-slate-900">{meta.title}</span>
-                        <span className="mt-1 text-xs leading-snug text-slate-600">{meta.description}</span>
+                        <span className="text-sm font-semibold text-slate-900 dark:text-neutral-50">{meta.title}</span>
+                        <span className="mt-1 text-xs leading-snug text-slate-600 dark:text-neutral-400">{meta.description}</span>
                         <span
                           className={`mt-3 block h-8 rounded-md ${meta.id === 'night'
                             ? 'bg-slate-900'
                             : meta.id === 'reader'
-                              ? 'bg-stone-100 ring-1 ring-stone-200'
+                              ? 'bg-stone-100 ring-1 ring-stone-200 dark:ring-stone-850'
                               : meta.id === 'contrast'
-                                ? 'border-2 border-black bg-white'
+                                ? 'border-2 border-black bg-white dark:border-neutral-50 dark:bg-neutral-950'
                                 : meta.id === 'serif'
-                                  ? 'bg-amber-50/80'
+                                  ? 'bg-amber-50/80 dark:bg-amber-950/25'
                                   : meta.id === 'accent'
-                                    ? 'bg-violet-100/80'
-                                    : 'bg-slate-100'
+                                    ? 'bg-violet-100/80 dark:bg-violet-950/25'
+                                    : 'bg-slate-100 dark:bg-neutral-800'
                             }`}
                           aria-hidden
                         />
@@ -1041,76 +1106,79 @@ export default function CourseSettings() {
                   })}
                 </div>
 
-                <div className="mt-8 border-t border-slate-200 pt-6">
-                  <h3 className="text-sm font-semibold text-slate-900">Custom theme</h3>
-                  <p className="mt-1 text-sm text-slate-500">
-                    Set colors and layout, then save. Active when{' '}
-                    <span className="font-medium text-slate-700">Custom</span> is stored — use Save after editing,
-                    or pick a preset above to reset to a built-in look.
+                <div className="mt-8 border-t border-slate-200 pt-6 dark:border-neutral-800">
+                  <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Custom theme</h3>
+                  <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+                    Set colors and layout. Active when{' '}
+                    <span className="font-medium text-slate-700 dark:text-neutral-300">Custom</span> preset is active — edit values below, then save with the main save bar.
                   </p>
                   <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                    <label className="block text-xs font-medium text-slate-600">
+                    <label className="block text-xs font-medium text-slate-600 dark:text-neutral-400">
                       Heading color
                       <input
                         type="color"
                         value={customDraft.headingColor ?? markdownThemeCustomSeed.headingColor}
                         onChange={(e) =>
-                          setCustomDraft((d) => ({ ...d, headingColor: e.target.value }))
+                          updateCustomDraft((d) => ({ ...d, headingColor: e.target.value }))
                         }
-                        className="mt-1 h-9 w-full cursor-pointer rounded border border-slate-200 bg-white"
+                        className="mt-1 h-9 w-full cursor-pointer rounded border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-950"
                       />
                     </label>
-                    <label className="block text-xs font-medium text-slate-600">
+                    <label className="block text-xs font-medium text-slate-600 dark:text-neutral-400">
                       Body text
                       <input
                         type="color"
                         value={customDraft.bodyColor ?? markdownThemeCustomSeed.bodyColor}
-                        onChange={(e) => setCustomDraft((d) => ({ ...d, bodyColor: e.target.value }))}
-                        className="mt-1 h-9 w-full cursor-pointer rounded border border-slate-200 bg-white"
+                        onChange={(e) =>
+                          updateCustomDraft((d) => ({ ...d, bodyColor: e.target.value }))
+                        }
+                        className="mt-1 h-9 w-full cursor-pointer rounded border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-950"
                       />
                     </label>
-                    <label className="block text-xs font-medium text-slate-600">
+                    <label className="block text-xs font-medium text-slate-600 dark:text-neutral-400">
                       Links
                       <input
                         type="color"
                         value={customDraft.linkColor ?? markdownThemeCustomSeed.linkColor}
-                        onChange={(e) => setCustomDraft((d) => ({ ...d, linkColor: e.target.value }))}
-                        className="mt-1 h-9 w-full cursor-pointer rounded border border-slate-200 bg-white"
+                        onChange={(e) =>
+                          updateCustomDraft((d) => ({ ...d, linkColor: e.target.value }))
+                        }
+                        className="mt-1 h-9 w-full cursor-pointer rounded border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-950"
                       />
                     </label>
-                    <label className="block text-xs font-medium text-slate-600">
+                    <label className="block text-xs font-medium text-slate-600 dark:text-neutral-400">
                       Code &amp; blocks background
                       <input
                         type="color"
                         value={customDraft.codeBackground ?? markdownThemeCustomSeed.codeBackground}
                         onChange={(e) =>
-                          setCustomDraft((d) => ({ ...d, codeBackground: e.target.value }))
+                          updateCustomDraft((d) => ({ ...d, codeBackground: e.target.value }))
                         }
-                        className="mt-1 h-9 w-full cursor-pointer rounded border border-slate-200 bg-white"
+                        className="mt-1 h-9 w-full cursor-pointer rounded border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-950"
                       />
                     </label>
-                    <label className="block text-xs font-medium text-slate-600">
+                    <label className="block text-xs font-medium text-slate-600 dark:text-neutral-400">
                       Borders &amp; quotes
                       <input
                         type="color"
                         value={customDraft.blockquoteBorder ?? markdownThemeCustomSeed.blockquoteBorder}
                         onChange={(e) =>
-                          setCustomDraft((d) => ({ ...d, blockquoteBorder: e.target.value }))
+                          updateCustomDraft((d) => ({ ...d, blockquoteBorder: e.target.value }))
                         }
-                        className="mt-1 h-9 w-full cursor-pointer rounded border border-slate-200 bg-white"
+                        className="mt-1 h-9 w-full cursor-pointer rounded border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-950"
                       />
                     </label>
-                    <label className="block text-xs font-medium text-slate-600">
+                    <label className="block text-xs font-medium text-slate-600 dark:text-neutral-400">
                       Article width
                       <select
                         value={customDraft.articleWidth ?? markdownThemeCustomSeed.articleWidth}
                         onChange={(e) =>
-                          setCustomDraft((d) => ({
+                          updateCustomDraft((d) => ({
                             ...d,
                             articleWidth: e.target.value as MarkdownThemeCustom['articleWidth'],
                           }))
                         }
-                        className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                        className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50"
                       >
                         <option value="narrow">Narrow</option>
                         <option value="comfortable">Comfortable</option>
@@ -1118,39 +1186,31 @@ export default function CourseSettings() {
                         <option value="full">Full width</option>
                       </select>
                     </label>
-                    <label className="block text-xs font-medium text-slate-600">
+                    <label className="block text-xs font-medium text-slate-600 dark:text-neutral-400">
                       Font
                       <select
                         value={customDraft.fontFamily ?? markdownThemeCustomSeed.fontFamily}
                         onChange={(e) =>
-                          setCustomDraft((d) => ({
+                          updateCustomDraft((d) => ({
                             ...d,
                             fontFamily: e.target.value as MarkdownThemeCustom['fontFamily'],
                           }))
                         }
-                        className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900"
+                        className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50"
                       >
                         <option value="sans">Sans-serif</option>
                         <option value="serif">Serif</option>
                       </select>
                     </label>
                   </div>
-                  <div className="mt-4 flex flex-wrap items-center gap-3">
-                    <button
-                      type="button"
-                      onClick={() => void saveCustomMarkdownTheme()}
-                      disabled={mdThemeStatus === 'saving'}
-                      className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
-                    >
-                      {mdThemeStatus === 'saving' ? 'Saving…' : 'Save custom theme'}
-                    </button>
-                    {course.markdownThemePreset === 'custom' && (
-                      <span className="text-xs text-slate-500">Custom theme is active for this course.</span>
+                  <div className="mt-4">
+                    {markdownThemePreset === 'custom' && (
+                      <span className="text-xs font-medium text-indigo-600 dark:text-indigo-400">Custom theme will be saved when you apply changes.</span>
                     )}
                   </div>
                 </div>
               </section>
-            </>
+            </form>
           )}
 
           {section === 'grading' && <CourseGradingSettingsSection courseCode={courseCode} />}
@@ -1183,6 +1243,51 @@ export default function CourseSettings() {
             <CourseBlueprintSection courseCode={courseCode} course={course} onCourseUpdated={setCourse} />
           )}
           {section === 'archive' && <CourseArchivedContentSection courseCode={courseCode} />}
+        </div>
+      )}
+
+      {section === 'general' && isDirty && (
+        <div className="fixed bottom-6 left-1/2 z-50 w-full max-w-2xl -translate-x-1/2 px-4 animate-in fade-in slide-in-from-bottom-4 duration-300">
+          <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white/90 px-6 py-4 shadow-xl backdrop-blur-md dark:border-neutral-850 dark:bg-neutral-900/90">
+            <div className="flex flex-col">
+              <span className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Unsaved changes</span>
+              <span className="text-xs text-slate-500 dark:text-neutral-400">
+                {saveStatus === 'error' && saveMessage ? (
+                  <span className="text-rose-600 dark:text-rose-400 font-medium">{saveMessage}</span>
+                ) : (
+                  "You have modified this course's settings."
+                )}
+              </span>
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={discardChanges}
+                disabled={saveStatus === 'saving'}
+                className="rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100 hover:text-slate-900 disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-850 dark:hover:text-neutral-200 transition"
+              >
+                Discard
+              </button>
+              <button
+                type="button"
+                onClick={() => void onSingleSaveChanges()}
+                disabled={saveStatus === 'saving'}
+                className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-md hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-60 transition active:scale-95"
+              >
+                {saveStatus === 'saving' ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  <>
+                    <Save className="h-4 w-4" />
+                    Save changes
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
         </div>
       )}
 

--- a/clients/web/src/pages/lms/course-settings.tsx
+++ b/clients/web/src/pages/lms/course-settings.tsx
@@ -1204,9 +1204,11 @@ export default function CourseSettings() {
                     </label>
                   </div>
                   <div className="mt-4">
-                    {markdownThemePreset === 'custom' && (
+                    {course.markdownThemePreset === 'custom' && !isDirty ? (
+                      <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">Custom theme is active for this course.</span>
+                    ) : markdownThemePreset === 'custom' ? (
                       <span className="text-xs font-medium text-indigo-600 dark:text-indigo-400">Custom theme will be saved when you apply changes.</span>
-                    )}
+                    ) : null}
                   </div>
                 </div>
               </section>

--- a/e2e/scripts/e2e-local.sh
+++ b/e2e/scripts/e2e-local.sh
@@ -37,7 +37,13 @@ declare -a PLAYWRIGHT_TEST_ARGS=()
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PIDS=()
 PGDATA_DIR=""
-E2E_PG_PORT="${E2E_PG_PORT:-5454}"
+if [[ -z "${E2E_PG_PORT:-}" ]]; then
+  if command -v python3 &>/dev/null; then
+    E2E_PG_PORT="$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')"
+  else
+    E2E_PG_PORT="5454"
+  fi
+fi
 
 # `go run` and `npm run dev` are parents of the real long-lived processes. A plain
 # `kill $pid` often stops only the wrapper, leaving the API or Vite child alive.

--- a/e2e/tests/courses.spec.ts
+++ b/e2e/tests/courses.spec.ts
@@ -163,7 +163,10 @@ test.describe('Course settings', () => {
 
     // Toggle it.
     await publishSwitch.click()
-    await expect(page.getByText(/saved|published|draft/i).first()).toBeVisible()
+
+    // Save changes via the global single save bar.
+    await page.getByRole('button', { name: /^save changes$/i }).click()
+    await expect(page.getByText('Course settings saved')).toBeVisible({ timeout: 8000 })
 
     const isNowPublished = await publishSwitch.getAttribute('aria-checked') === 'true'
     expect(isNowPublished).not.toBe(isInitiallyPublished)
@@ -187,8 +190,9 @@ test.describe('Course settings', () => {
     await expect(nightTheme).toBeVisible()
     await nightTheme.click()
 
-    // Theme selection usually saves immediately as per UI note.
-    await expect(page.getByText(/reading theme saved/i)).toBeVisible()
+    // Preset selection is staged; save via the global single save bar.
+    await page.getByRole('button', { name: /^save changes$/i }).click()
+    await expect(page.getByText('Course settings saved')).toBeVisible({ timeout: 8000 })
   })
 
   test('toggle schedule mode between fixed and relative', async ({ coursePage: page, seededCourse }) => {

--- a/e2e/tests/grading-settings.spec.ts
+++ b/e2e/tests/grading-settings.spec.ts
@@ -45,7 +45,7 @@ test.describe('Course Settings - Grading', () => {
     await page.goto(`/courses/${seededCourse.courseCode}/settings/grading`)
     await page.getByRole('combobox', { name: /display as/i }).selectOption('letter')
     await expect(page.locator('#grading-scheme-json')).toContainText('"A"', { timeout: 8000 })
-    await page.getByRole('button', { name: /save grade display scheme/i }).click()
+    await page.getByRole('button', { name: /^save changes$/i }).click()
     await expect(page.getByText('Grading scheme saved.', { exact: true })).toBeVisible({
       timeout: 8000,
     })
@@ -70,7 +70,7 @@ test.describe('Course Settings - Grading', () => {
 
     await instructorPage.goto(`/courses/${seededCourse.courseCode}/settings/grading`)
     await instructorPage.getByRole('combobox', { name: /display as/i }).selectOption('letter')
-    await instructorPage.getByRole('button', { name: /save grade display scheme/i }).click()
+    await instructorPage.getByRole('button', { name: /^save changes$/i }).click()
     await expect(
       instructorPage.getByText('Grading scheme saved.', { exact: true }),
     ).toBeVisible({ timeout: 8000 })
@@ -90,7 +90,7 @@ test.describe('Course Settings - Grading', () => {
     await page.goto(`/courses/${seededCourse.courseCode}/settings/grading`)
     await page.getByRole('combobox', { name: /display as/i }).selectOption('pass_fail')
     await page.locator('#pass-min-pct').fill('70')
-    await page.getByRole('button', { name: /save grade display scheme/i }).click()
+    await page.getByRole('button', { name: /^save changes$/i }).click()
     await expect(page.getByText('Grading scheme saved.', { exact: true })).toBeVisible({
       timeout: 8000,
     })
@@ -114,7 +114,7 @@ test.describe('Course Settings - Grading', () => {
     await page.goto(`/courses/${seededCourse.courseCode}/settings/grading`)
     await page.getByRole('combobox', { name: /display as/i }).selectOption('complete_incomplete')
     await page.locator('#complete-min-pct').fill('80')
-    await page.getByRole('button', { name: /save grade display scheme/i }).click()
+    await page.getByRole('button', { name: /^save changes$/i }).click()
     await expect(page.getByText('Grading scheme saved.', { exact: true })).toBeVisible({
       timeout: 8000,
     })
@@ -132,7 +132,7 @@ test.describe('Course Settings - Grading', () => {
     await page.goto(`/courses/${seededCourse.courseCode}/settings/grading`)
 
     await page.getByRole('radio', { name: /pass \/ fail/i }).click()
-    await page.getByRole('button', { name: /^save grading settings$/i }).click()
+    await page.getByRole('button', { name: /^save changes$/i }).click()
     await expect(page.getByText(/grading settings saved/i)).toBeVisible({ timeout: 8000 })
 
     const g = await apiGetCourseGrading(seededCourse.instructorToken, seededCourse.courseCode)
@@ -146,7 +146,7 @@ test.describe('Course Settings - Grading', () => {
     await page.goto(`/courses/${seededCourse.courseCode}/settings/grading`)
     const nameInput = page.locator('input[placeholder="e.g. Homework"]').first()
     await nameInput.fill('E2E Category Alpha')
-    await page.getByRole('button', { name: /^save grading settings$/i }).click()
+    await page.getByRole('button', { name: /^save changes$/i }).click()
     await expect(page.getByText(/grading settings saved/i)).toBeVisible({ timeout: 8000 })
 
     await page.reload()
@@ -159,7 +159,7 @@ test.describe('Course Settings - Grading', () => {
     await page.goto(`/courses/${seededCourse.courseCode}/settings/grading`)
 
     await page.getByRole('checkbox', { name: /enable standards-based grading/i }).click()
-    await page.getByRole('button', { name: /^save grading settings$/i }).click()
+    await page.getByRole('button', { name: /^save changes$/i }).click()
     await expect(page.getByText(/grading settings saved/i)).toBeVisible({ timeout: 8000 })
 
     const g = await apiGetCourseGrading(seededCourse.instructorToken, seededCourse.courseCode)

--- a/e2e/tests/outcomes-settings.spec.ts
+++ b/e2e/tests/outcomes-settings.spec.ts
@@ -92,7 +92,7 @@ test.describe('Course Settings - Outcomes', () => {
     const card = await outcomeCard(page, 'E2E Meta Outcome')
     await card.locator('input').first().fill('E2E Meta Outcome Updated')
     await card.locator('textarea').first().fill('Rewritten outcome description.')
-    await card.getByRole('button', { name: /^Save changes$/i }).click()
+    await page.getByRole('button', { name: /^Save changes$/i }).click()
 
     await expect.poll(async () => {
       const d = await apiGetCourseOutcomes(seededCourse.instructorToken, seededCourse.courseCode)

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -59,6 +59,13 @@ test.describe('Course Settings - General - Course Home', () => {
   test('change the course home landing to data dashboard', async ({ coursePage: page, seededCourse }) => {
     await page.goto(`/courses/${seededCourse.courseCode}/settings/general`)
     const courseHomeRadios = page.locator('input[type="radio"][name="courseHomeLanding"]')
+    
+    // Set to calendar first and save to ensure we have a non-default initial value.
+    await courseHomeRadios.nth(1).click()
+    await page.getByRole('button', { name: /^save changes$/i }).first().click()
+    await expect(page.getByText('Course settings saved')).toBeVisible({ timeout: 8000 })
+
+    // Now change it back to data dashboard (index 0) and verify it stages, saves, and updates the landing.
     await courseHomeRadios.nth(0).click()
     await page.getByRole('button', { name: /^save changes$/i }).first().click()
     await expect(page.getByText('Course settings saved')).toBeVisible({

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -61,7 +61,7 @@ test.describe('Course Settings - General - Course Home', () => {
     const courseHomeRadios = page.locator('input[type="radio"][name="courseHomeLanding"]')
     await courseHomeRadios.nth(0).click()
     await page.getByRole('button', { name: /^save changes$/i }).first().click()
-    await expect(page.getByRole('status').filter({ hasText: /saved/i }).first()).toBeVisible({
+    await expect(page.getByText('Course settings saved')).toBeVisible({
       timeout: 8000,
     })
     await page.goto(`/courses/${seededCourse.courseCode}`)
@@ -73,7 +73,7 @@ test.describe('Course Settings - General - Course Home', () => {
     const courseHomeRadios = page.locator('input[type="radio"][name="courseHomeLanding"]')
     await courseHomeRadios.nth(1).click()
     await page.getByRole('button', { name: /^save changes$/i }).first().click()
-    await expect(page.getByRole('status').filter({ hasText: /saved/i }).first()).toBeVisible({
+    await expect(page.getByText('Course settings saved')).toBeVisible({
       timeout: 8000,
     })
     await page.goto(`/courses/${seededCourse.courseCode}`)
@@ -93,7 +93,7 @@ test.describe('Course Settings - General - Course Home', () => {
     await courseHomeRadios.nth(2).click()
     await page.getByRole('combobox', { name: /^content page$/i }).selectOption(welcomePage.id)
     await page.getByRole('button', { name: /^save changes$/i }).first().click()
-    await expect(page.getByRole('status').filter({ hasText: /saved/i }).first()).toBeVisible({
+    await expect(page.getByText('Course settings saved')).toBeVisible({
       timeout: 8000,
     })
     await page.goto(`/courses/${seededCourse.courseCode}`)
@@ -117,9 +117,10 @@ test.describe('Course Settings - General - Fixed Schedule & Visibility', () => {
     await visibleFromInput.fill('2026-01-01T00:00')
     const hiddenAfterInput = page.getByRole('textbox', { name: /^hidden after$/i })
     await hiddenAfterInput.fill('2026-12-31T23:59')
-    // Schedule fields live in the second general-settings form (after course home).
-    await page.getByRole('button', { name: /^save changes$/i }).nth(1).click()
-    await expect(page.getByRole('status').filter({ hasText: /saved/i }).first()).toBeVisible({
+    
+    // Save changes via global single save bar.
+    await page.getByRole('button', { name: /^save changes$/i }).click()
+    await expect(page.getByText('Course settings saved')).toBeVisible({
       timeout: 8000,
     })
   })
@@ -182,11 +183,14 @@ test.describe('Course Settings - General - Hero Image', () => {
 })
 
 test.describe('Course Settings - General - Reading Theme', () => {
-  test('select a reading theme preset saves immediately', async ({ coursePage: page, seededCourse }) => {
+  test('select a reading theme preset stages changes and saves with global bar', async ({ coursePage: page, seededCourse }) => {
     await page.goto(`/courses/${seededCourse.courseCode}/settings/general`)
     await expect(page.getByRole('heading', { name: /^reading theme$/i })).toBeVisible()
     await page.getByRole('button', { name: /night dark canvas/i }).click()
-    await expect(page.getByRole('status').filter({ hasText: /reading theme saved/i })).toBeVisible({
+    
+    // Save changes via global single save bar.
+    await page.getByRole('button', { name: /^save changes$/i }).click()
+    await expect(page.getByText('Course settings saved')).toBeVisible({
       timeout: 8000,
     })
   })
@@ -210,8 +214,9 @@ test.describe('Course Settings - General - Custom Theme', () => {
     await page.getByRole('combobox', { name: /^article width$/i }).selectOption('wide')
     await page.getByRole('combobox', { name: /^font$/i }).selectOption('serif')
 
-    await page.getByRole('button', { name: /^save custom theme$/i }).click()
-    await expect(page.getByRole('status').filter({ hasText: /custom reading theme saved/i })).toBeVisible({
+    // Preset selection is staged; save via global single save bar.
+    await page.getByRole('button', { name: /^save changes$/i }).click()
+    await expect(page.getByText('Course settings saved')).toBeVisible({
       timeout: 8000,
     })
     await expect(page.getByText(/custom theme is active for this course/i)).toBeVisible({ timeout: 8000 })


### PR DESCRIPTION
## Description

This PR expands the premium single-save experience introduced on the General settings page to all course settings tabs where persistent configurations are managed:

1. **Grading settings**:
   - Staged assignment group weights, standard/custom grading scale parameters, SBG proficiency rules, percentages, and scales.
   - Normalized JSON scale comparisons to prevent false-positives.
   - Removed legacy inline buttons, replacing them with a single global glassmorphic bottom save bar.
2. **Outcomes settings**:
   - Refactored Outcomes card edits to be managed as drafts at the section level, completely removing inline card-level save buttons.
   - Wired OutcomeCard inputs directly to parent-provided props.
   - Implemented global discard and parallel outcome patch saving.
3. **Blueprint settings**:
   - Introduced local staging of blueprint configuration with an elegant toggle switch.
   - Gated commits under the global floating bar.
4. **End-to-End Tests**:
   - Updated button queries in `grading-settings.spec.ts` and `outcomes-settings.spec.ts` to target the global 'Save changes' button instead of defunct inline buttons.
   - Integrated matching `toastSaveOk` events to keep E2E tests fully compatible and correct.
5. **Quality Assurance**:
   - Verified that the codebase typechecks and lint checks pass cleanly with exit code 0.