### PR TITLE
fix(www): fix GitHub Pages SPA routing for /docs and sub-pages

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && cp dist/index.html dist/404.html",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- Navigating directly to `lextures.com/docs` or any sub-page returned a 404 on GitHub Pages
- GitHub Pages is a static file server — it has no fallback to `index.html` for unknown paths, it returns `404.html` instead
- Added `&& cp dist/index.html dist/404.html` to the `build` script so every build produces a `404.html` that serves the SPA shell
- The existing JS router already reads `window.location.pathname`, so it routes correctly once the page loads

## Test plan

- [ ] Merge and wait for the Pages deploy to complete
- [ ] Navigate directly to `https://lextures.com/docs` — should load the docs index
- [ ] Navigate directly to `https://lextures.com/docs/creating-a-new-course` — should load the doc page
- [ ] Confirm the home page still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)