### PR TITLE
feat(web): plan 7.2 mobile-responsive review (gradebook, modules, toolbars, quiz)

### DIFF
--- a/clients/web/CONTRIBUTING.md
+++ b/clients/web/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Web client (`clients/web`)
+
+## Mobile-first standards (plan 7.2)
+
+- **Breakpoints:** Tailwind defaults — `sm` 640px, `md` 768px, `lg` 1024px. Prefer mobile-first utilities (`flex-col` then `md:flex-row`) over desktop-first overrides.
+- **Touch targets:** Interactive controls (buttons, icon hits, quiz options) should be at least **44×44 CSS pixels** on narrow viewports (`min-h-11 min-w-11` or equivalent padding). Desktop may use denser `sm:` / `md:` sizes.
+- **Horizontal overflow:** Wide grids and tables must live in a **`min-w-0 max-w-full overflow-x-auto`** (or `overflow-x-scroll`) container so the page shell does not gain horizontal scroll on phones.
+- **Drag-and-drop:** Where `@dnd-kit` drag handles are hard to use on touch, provide **explicit reorder controls** at `max-md` (e.g. move up / move down) while keeping drag for pointer-first desktop layouts.

--- a/clients/web/src/components/editor/block-editor/block-floating-toolbar.tsx
+++ b/clients/web/src/components/editor/block-editor/block-floating-toolbar.tsx
@@ -35,14 +35,14 @@ export function BlockFloatingToolbar({
   return (
     <div
       data-toolbar-anchor
-      className="pointer-events-auto flex h-9 max-w-[min(100vw-2rem,520px)] flex-wrap items-center gap-0.5 rounded-md border border-slate-200 bg-white px-1 py-0.5 shadow-md shadow-slate-900/10 dark:border-neutral-600 dark:bg-neutral-800 dark:shadow-black/40 sm:max-w-none sm:flex-nowrap"
+      className="pointer-events-auto flex min-h-11 max-w-[min(100vw-2rem,520px)] flex-wrap items-center gap-0.5 rounded-md border border-slate-200 bg-white px-1 py-0.5 shadow-md shadow-slate-900/10 dark:border-neutral-600 dark:bg-neutral-800 dark:shadow-black/40 sm:h-9 sm:min-h-0 sm:max-w-none sm:flex-nowrap"
       onClick={(e) => e.stopPropagation()}
       onKeyDown={(e) => e.stopPropagation()}
       role="toolbar"
       aria-label={`${label} block tools`}
     >
       <span
-        className="flex h-7 max-w-[148px] items-center gap-1 rounded px-1.5 text-slate-600 dark:text-neutral-300 sm:max-w-[200px]"
+        className="flex h-11 max-w-[min(148px,46vw)] items-center gap-1 rounded px-1.5 text-slate-600 dark:text-neutral-300 sm:h-7 sm:max-w-[200px]"
         title={label}
       >
         <span className="flex h-6 w-6 shrink-0 items-center justify-center text-slate-500 dark:text-neutral-400" aria-hidden>
@@ -52,7 +52,7 @@ export function BlockFloatingToolbar({
       </span>
       <span className="mx-0.5 h-5 w-px shrink-0 bg-slate-200 dark:bg-neutral-600" aria-hidden />
       <span
-        className="flex h-7 w-7 shrink-0 cursor-grab items-center justify-center rounded text-slate-400 hover:bg-slate-100 hover:text-slate-600 active:cursor-grabbing dark:hover:bg-neutral-700 dark:hover:text-neutral-200"
+        className="flex h-11 w-11 shrink-0 cursor-grab items-center justify-center rounded text-slate-400 hover:bg-slate-100 hover:text-slate-600 active:cursor-grabbing sm:h-7 sm:w-7 dark:hover:bg-neutral-700 dark:hover:text-neutral-200"
         aria-hidden
       >
         <GripVertical className="h-4 w-4" />
@@ -62,7 +62,7 @@ export function BlockFloatingToolbar({
           type="button"
           disabled={disabled || moveUpDisabled}
           onClick={onMoveUp}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-300 dark:hover:bg-neutral-700"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 sm:h-7 sm:w-7 dark:text-neutral-300 dark:hover:bg-neutral-700"
           aria-label="Move block up"
         >
           <ChevronUp className="h-4 w-4" />
@@ -73,7 +73,7 @@ export function BlockFloatingToolbar({
           type="button"
           disabled={disabled || moveDownDisabled}
           onClick={onMoveDown}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-300 dark:hover:bg-neutral-700"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 sm:h-7 sm:w-7 dark:text-neutral-300 dark:hover:bg-neutral-700"
           aria-label="Move block down"
         >
           <ChevronDown className="h-4 w-4" />
@@ -85,7 +85,7 @@ export function BlockFloatingToolbar({
           type="button"
           disabled={disabled}
           onClick={onRemove}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-500 hover:bg-rose-50 hover:text-rose-700 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-400 dark:hover:bg-rose-950/50 dark:hover:text-rose-400"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded text-slate-500 hover:bg-rose-50 hover:text-rose-700 disabled:cursor-not-allowed disabled:opacity-40 sm:h-7 sm:w-7 dark:text-neutral-400 dark:hover:bg-rose-950/50 dark:hover:text-rose-400"
           aria-label={removeLabel}
         >
           <Trash2 className="h-4 w-4" />

--- a/clients/web/src/components/editor/block-editor/markdown-format-toolbar.tsx
+++ b/clients/web/src/components/editor/block-editor/markdown-format-toolbar.tsx
@@ -7,9 +7,10 @@ import {
   Link as LinkIcon,
   List,
   ListOrdered,
+  MoreHorizontal,
   Sigma,
 } from 'lucide-react'
-import type { MouseEvent } from 'react'
+import { useEffect, useId, useRef, useState, useSyncExternalStore, type MouseEvent as ReactMouseEvent } from 'react'
 import type { MarkdownEditKind } from './markdown-insert'
 
 export type MarkdownFormatToolbarProps = {
@@ -28,24 +29,63 @@ export type MarkdownFormatToolbarProps = {
   }
 }
 
+const iconBtnClass =
+  'flex h-11 w-11 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-300 dark:hover:bg-neutral-700 sm:h-7 sm:w-7'
+
+function subscribeMinSm(onChange: () => void) {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return () => {}
+  const mq = window.matchMedia('(min-width: 640px)')
+  mq.addEventListener('change', onChange)
+  return () => mq.removeEventListener('change', onChange)
+}
+
+function snapshotMinSm(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return true
+  return window.matchMedia('(min-width: 640px)').matches
+}
+
 /**
  * Markdown formatting buttons for use inside BlockFloatingToolbar children.
  * Uses mousedown preventDefault so the textarea keeps focus while clicking.
+ * Below the `sm` (640px) breakpoint, primary actions stay on the bar and the rest move under “More”.
  */
 export function MarkdownFormatToolbar({ disabled, onApply, courseImage, mathInsert }: MarkdownFormatToolbarProps) {
-  function preventBlur(e: MouseEvent) {
+  const isSmUp = useSyncExternalStore(subscribeMinSm, snapshotMinSm, () => true)
+  const [moreOpen, setMoreOpen] = useState(false)
+  const moreRootRef = useRef<HTMLDivElement>(null)
+  const moreMenuId = useId()
+
+  useEffect(() => {
+    if (!moreOpen) return
+    function onDocMouseDown(e: globalThis.MouseEvent) {
+      if (!moreRootRef.current?.contains(e.target as Node)) setMoreOpen(false)
+    }
+    function onKey(e: globalThis.KeyboardEvent) {
+      if (e.key === 'Escape') setMoreOpen(false)
+    }
+    document.addEventListener('mousedown', onDocMouseDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocMouseDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [moreOpen])
+
+  function preventBlur(e: ReactMouseEvent) {
     e.preventDefault()
   }
 
-  return (
+  const divider = <span className="mx-0.5 h-5 w-px shrink-0 bg-slate-200 dark:bg-neutral-600" aria-hidden />
+
+  const primaryRow = (
     <>
-      <span className="mx-0.5 h-5 w-px shrink-0 bg-slate-200 dark:bg-neutral-600" aria-hidden />
+      {divider}
       <button
         type="button"
         disabled={disabled}
         onMouseDown={preventBlur}
         onClick={() => onApply('bulletList')}
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-300 dark:hover:bg-neutral-700"
+        className={iconBtnClass}
         aria-label="Bullet list"
         title="Bullet list"
       >
@@ -56,7 +96,7 @@ export function MarkdownFormatToolbar({ disabled, onApply, courseImage, mathInse
         disabled={disabled}
         onMouseDown={preventBlur}
         onClick={() => onApply('orderedList')}
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-300 dark:hover:bg-neutral-700"
+        className={iconBtnClass}
         aria-label="Numbered list"
         title="Numbered list"
       >
@@ -67,7 +107,7 @@ export function MarkdownFormatToolbar({ disabled, onApply, courseImage, mathInse
         disabled={disabled}
         onMouseDown={preventBlur}
         onClick={() => onApply('bold')}
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded font-bold text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-200 dark:hover:bg-neutral-700"
+        className={`${iconBtnClass} font-bold text-slate-700 dark:text-neutral-200`}
         aria-label="Bold"
         title="Bold"
       >
@@ -78,18 +118,23 @@ export function MarkdownFormatToolbar({ disabled, onApply, courseImage, mathInse
         disabled={disabled}
         onMouseDown={preventBlur}
         onClick={() => onApply('italic')}
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-700 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-200 dark:hover:bg-neutral-700"
+        className={`${iconBtnClass} text-slate-700 dark:text-neutral-200`}
         aria-label="Italic"
         title="Italic"
       >
         <Italic className="h-4 w-4" />
       </button>
+    </>
+  )
+
+  const extendedRow = (
+    <>
       <button
         type="button"
         disabled={disabled}
         onMouseDown={preventBlur}
         onClick={() => onApply('inlineCode')}
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-300 dark:hover:bg-neutral-700"
+        className={iconBtnClass}
         aria-label="Inline code"
         title="Inline code"
       >
@@ -100,7 +145,7 @@ export function MarkdownFormatToolbar({ disabled, onApply, courseImage, mathInse
         disabled={disabled}
         onMouseDown={preventBlur}
         onClick={() => onApply('codeBlock')}
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-300 dark:hover:bg-neutral-700"
+        className={iconBtnClass}
         aria-label="Code block"
         title="Code block"
       >
@@ -111,7 +156,7 @@ export function MarkdownFormatToolbar({ disabled, onApply, courseImage, mathInse
         disabled={disabled}
         onMouseDown={preventBlur}
         onClick={() => onApply('link')}
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-300 dark:hover:bg-neutral-700"
+        className={iconBtnClass}
         aria-label="Link"
         title="Link"
       >
@@ -125,8 +170,11 @@ export function MarkdownFormatToolbar({ disabled, onApply, courseImage, mathInse
           }}
           disabled={disabled}
           onMouseDown={preventBlur}
-          onClick={() => mathInsert.onOpen()}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-300 dark:hover:bg-neutral-700"
+          onClick={() => {
+            mathInsert.onOpen()
+            setMoreOpen(false)
+          }}
+          className={iconBtnClass}
           aria-label="Insert math"
           title="Insert math (LaTeX)"
         >
@@ -135,12 +183,15 @@ export function MarkdownFormatToolbar({ disabled, onApply, courseImage, mathInse
       ) : null}
       {courseImage ? (
         <>
-          <span className="mx-0.5 h-5 w-px shrink-0 bg-slate-200 dark:bg-neutral-600" aria-hidden />
+          {divider}
           <button
             type="button"
             disabled={disabled}
             onMouseDown={preventBlur}
-            onClick={() => courseImage.onPickClick()}
+            onClick={() => {
+              courseImage.onPickClick()
+              setMoreOpen(false)
+            }}
             onDragOver={(e) => {
               if (disabled) return
               e.preventDefault()
@@ -152,7 +203,7 @@ export function MarkdownFormatToolbar({ disabled, onApply, courseImage, mathInse
               const files = [...e.dataTransfer.files].filter((f) => f.type.startsWith('image/'))
               if (files.length) courseImage.onFiles(files)
             }}
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-neutral-300 dark:hover:bg-neutral-700"
+            className={iconBtnClass}
             aria-label="Insert image"
             title="Insert image (drop file here or click)"
           >
@@ -160,6 +211,123 @@ export function MarkdownFormatToolbar({ disabled, onApply, courseImage, mathInse
           </button>
         </>
       ) : null}
+    </>
+  )
+
+  if (isSmUp) {
+    return (
+      <>
+        {primaryRow}
+        {extendedRow}
+      </>
+    )
+  }
+
+  return (
+    <>
+      {primaryRow}
+      <div ref={moreRootRef} className="relative flex shrink-0 items-center">
+        <button
+          type="button"
+          disabled={disabled}
+          onMouseDown={preventBlur}
+          aria-haspopup="menu"
+          aria-expanded={moreOpen}
+          aria-controls={moreOpen ? moreMenuId : undefined}
+          className={iconBtnClass}
+          aria-label="More formatting"
+          title="More"
+          onClick={() => setMoreOpen((o) => !o)}
+        >
+          <MoreHorizontal className="h-4 w-4" aria-hidden />
+        </button>
+        {moreOpen ? (
+          <div
+            id={moreMenuId}
+            role="menu"
+            aria-label="More formatting"
+            className="absolute right-0 top-full z-[250] mt-1 flex min-w-[10rem] flex-col gap-0.5 rounded-lg border border-slate-200 bg-white p-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-900"
+          >
+            <button
+              type="button"
+              role="menuitem"
+              disabled={disabled}
+              onMouseDown={preventBlur}
+              onClick={() => {
+                onApply('inlineCode')
+                setMoreOpen(false)
+              }}
+              className="flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-left text-sm text-slate-800 hover:bg-slate-50 disabled:opacity-40 dark:text-neutral-100 dark:hover:bg-neutral-800"
+            >
+              <Code className="h-4 w-4 shrink-0 opacity-70" aria-hidden />
+              Inline code
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              disabled={disabled}
+              onMouseDown={preventBlur}
+              onClick={() => {
+                onApply('codeBlock')
+                setMoreOpen(false)
+              }}
+              className="flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-left text-sm text-slate-800 hover:bg-slate-50 disabled:opacity-40 dark:text-neutral-100 dark:hover:bg-neutral-800"
+            >
+              <Braces className="h-4 w-4 shrink-0 opacity-70" aria-hidden />
+              Code block
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              disabled={disabled}
+              onMouseDown={preventBlur}
+              onClick={() => {
+                onApply('link')
+                setMoreOpen(false)
+              }}
+              className="flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-left text-sm text-slate-800 hover:bg-slate-50 disabled:opacity-40 dark:text-neutral-100 dark:hover:bg-neutral-800"
+            >
+              <LinkIcon className="h-4 w-4 shrink-0 opacity-70" aria-hidden />
+              Link
+            </button>
+            {mathInsert ? (
+              <button
+                type="button"
+                role="menuitem"
+                ref={(node) => {
+                  mathInsert.registerMathAnchor?.(node)
+                }}
+                disabled={disabled}
+                onMouseDown={preventBlur}
+                onClick={() => {
+                  mathInsert.onOpen()
+                  setMoreOpen(false)
+                }}
+                className="flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-left text-sm text-slate-800 hover:bg-slate-50 disabled:opacity-40 dark:text-neutral-100 dark:hover:bg-neutral-800"
+              >
+                <Sigma className="h-4 w-4 shrink-0 opacity-70" aria-hidden />
+                Math
+              </button>
+            ) : null}
+            {courseImage ? (
+              <button
+                type="button"
+                role="menuitem"
+                disabled={disabled}
+                onMouseDown={preventBlur}
+                onClick={() => {
+                  courseImage.onPickClick()
+                  setMoreOpen(false)
+                }}
+                className="flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-left text-sm text-slate-800 hover:bg-slate-50 disabled:opacity-40 dark:text-neutral-100 dark:hover:bg-neutral-800"
+              >
+                <ImageIcon className="h-4 w-4 shrink-0 opacity-70" aria-hidden />
+                Image
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
     </>
   )
 }

--- a/clients/web/src/components/quiz/quiz-student-take-panel.tsx
+++ b/clients/web/src/components/quiz/quiz-student-take-panel.tsx
@@ -1125,7 +1125,7 @@ export function QuizStudentTakePanel({
                     {currentAdaptive.choices.map((label, i) => (
                       <label
                         key={`ad-${i}`}
-                        className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-800 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100"
+                        className="flex min-h-11 w-full min-w-0 cursor-pointer items-center gap-3 rounded-lg border border-slate-200 bg-white px-3 py-3 text-sm text-slate-800 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 sm:min-h-0 sm:items-start sm:py-2.5"
                       >
                         <input
                           type="radio"
@@ -1392,7 +1392,7 @@ function StaticTakeBody({
             {choices.map((label, i) => (
               <label
                 key={`${q.id}-c-${i}`}
-                className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-slate-50/50 px-3 py-2.5 text-sm dark:border-neutral-600 dark:bg-neutral-800/50"
+                className="flex min-h-11 w-full min-w-0 cursor-pointer items-center gap-3 rounded-lg border border-slate-200 bg-slate-50/50 px-3 py-3 text-sm dark:border-neutral-600 dark:bg-neutral-800/50 sm:min-h-0 sm:items-start sm:py-2.5"
               >
                 <input
                   type="radio"

--- a/clients/web/src/pages/lms/course-modules.tsx
+++ b/clients/web/src/pages/lms/course-modules.tsx
@@ -24,6 +24,7 @@ import {
   Check,
   ChevronDown,
   ChevronRight,
+  ChevronUp,
   CircleHelp,
   ClipboardList,
   ExternalLink,
@@ -585,6 +586,9 @@ type SortableChildRowProps = {
   canManageItemRow: boolean
   busyChildItemId: string | null
   dragHandlesVisible: boolean
+  childOrderIndex: number
+  childCount: number
+  onReorderChildDelta: (childId: string, delta: -1 | 1) => void
   onChildTogglePublished: (child: CourseStructureItem) => void
   onOpenEditChildTitle: (child: CourseStructureItem) => void
   onArchiveChild: (child: CourseStructureItem) => void
@@ -599,6 +603,9 @@ function SortableChildRow({
   canManageItemRow,
   busyChildItemId,
   dragHandlesVisible,
+  childOrderIndex,
+  childCount,
+  onReorderChildDelta,
   onChildTogglePublished,
   onOpenEditChildTitle,
   onArchiveChild,
@@ -625,7 +632,7 @@ function SortableChildRow({
           {(!disabled || dragHandlesVisible || isDragging) && (
             <button
               type="button"
-              className={`flex h-11 w-11 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg border-0 bg-transparent p-0 text-slate-400 shadow-none transition hover:text-slate-600 active:cursor-grabbing sm:h-9 sm:w-9 dark:text-neutral-500 dark:hover:text-neutral-300 ${
+              className={`hidden h-11 w-11 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg border-0 bg-transparent p-0 text-slate-400 shadow-none transition hover:text-slate-600 active:cursor-grabbing md:flex md:h-9 md:w-9 dark:text-neutral-500 dark:hover:text-neutral-300 ${
                 gripAlwaysOn
                   ? 'opacity-100'
                   : 'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto'
@@ -637,6 +644,32 @@ function SortableChildRow({
               <GripVertical className="h-4 w-4" strokeWidth={2} aria-hidden />
             </button>
           )}
+          {canManageItemRow && !child.archived && childCount > 1 ? (
+            <div
+              className="flex shrink-0 flex-col gap-1 md:hidden"
+              role="group"
+              aria-label="Reorder item in module"
+            >
+              <button
+                type="button"
+                className="inline-flex h-11 w-11 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                aria-label="Move item up in module"
+                disabled={disabled || childOrderIndex <= 0}
+                onClick={() => onReorderChildDelta(child.id, -1)}
+              >
+                <ChevronUp className="h-5 w-5" strokeWidth={2} aria-hidden />
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-11 w-11 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                aria-label="Move item down in module"
+                disabled={disabled || childOrderIndex >= childCount - 1}
+                onClick={() => onReorderChildDelta(child.id, 1)}
+              >
+                <ChevronDown className="h-5 w-5" strokeWidth={2} aria-hidden />
+              </button>
+            </div>
+          ) : null}
           <div
             className={`min-w-0 flex-1 ${child.archived ? 'opacity-70' : ''}`}
           >
@@ -652,7 +685,7 @@ function SortableChildRow({
         </div>
         {showRowChrome ? (
           <div
-            className={`flex shrink-0 justify-end sm:items-center sm:self-center sm:pl-0 ${!disabled ? 'pl-[3.25rem]' : 'pl-0'}`}
+            className={`flex shrink-0 justify-end md:items-center md:self-center md:pl-0 ${!disabled ? 'pl-0 md:pl-[3.25rem]' : 'pl-0'}`}
           >
             <ModuleItemRowActions
               child={child}
@@ -1031,6 +1064,10 @@ type SortableModuleCardProps = {
   onArchiveChild: (child: CourseStructureItem) => void
   courseAdaptivePathsEnabled: boolean
   studentGradeContext: { columns: CourseGradebookGridColumn[]; grades: Record<string, string> } | null
+  moduleOrderIndex: number
+  moduleCount: number
+  onReorderModuleDelta: (delta: -1 | 1) => void
+  onReorderChildDelta: (childId: string, delta: -1 | 1) => void
 }
 
 function SortableModuleCard({
@@ -1053,6 +1090,10 @@ function SortableModuleCard({
   onArchiveChild,
   courseAdaptivePathsEnabled,
   studentGradeContext,
+  moduleOrderIndex,
+  moduleCount,
+  onReorderModuleDelta,
+  onReorderChildDelta,
 }: SortableModuleCardProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: item.id,
@@ -1081,7 +1122,7 @@ function SortableModuleCard({
           id={`module-items-${item.id}`}
           className="mt-4 divide-y divide-slate-200/55 border-t border-slate-200/55 pt-4 dark:divide-neutral-700/80 dark:border-neutral-700/80"
         >
-          {children.map((child) => (
+          {children.map((child, cIdx) => (
             <SortableChildRow
               key={child.id}
               child={child}
@@ -1091,6 +1132,9 @@ function SortableModuleCard({
               canManageItemRow={canEditModules}
               busyChildItemId={busyChildItemId}
               dragHandlesVisible={gripsPinned}
+              childOrderIndex={cIdx}
+              childCount={children.length}
+              onReorderChildDelta={onReorderChildDelta}
               onChildTogglePublished={onChildTogglePublished}
               onOpenEditChildTitle={onOpenEditChildTitle}
               onArchiveChild={onArchiveChild}
@@ -1117,19 +1161,45 @@ function SortableModuleCard({
         onOpenModuleSettings={onOpenModuleSettings}
         moduleDragHandle={
           canEditModules ? (
-            <button
-              type="button"
-              className={`mt-0.5 flex h-11 w-11 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg border-0 bg-transparent p-0 text-slate-400 shadow-none transition hover:text-slate-600 active:cursor-grabbing sm:h-9 sm:w-9 dark:text-neutral-500 dark:hover:text-neutral-300 ${
-                gripsPinned || isDragging
-                  ? 'opacity-100'
-                  : 'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto'
-              }`}
-              aria-label="Drag to reorder module"
-              {...listeners}
-              {...attributes}
-            >
-              <GripVertical className="h-4 w-4" strokeWidth={2} aria-hidden />
-            </button>
+            <>
+              <button
+                type="button"
+                className={`mt-0.5 hidden h-11 w-11 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg border-0 bg-transparent p-0 text-slate-400 shadow-none transition hover:text-slate-600 active:cursor-grabbing md:flex md:h-9 md:w-9 dark:text-neutral-500 dark:hover:text-neutral-300 ${
+                  gripsPinned || isDragging
+                    ? 'opacity-100'
+                    : 'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto'
+                }`}
+                aria-label="Drag to reorder module"
+                {...listeners}
+                {...attributes}
+              >
+                <GripVertical className="h-4 w-4" strokeWidth={2} aria-hidden />
+              </button>
+              <div
+                className="mt-0.5 flex shrink-0 flex-col gap-1 md:hidden"
+                role="group"
+                aria-label="Reorder module"
+              >
+                <button
+                  type="button"
+                  className="inline-flex h-11 w-11 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                  aria-label="Move module up"
+                  disabled={anyModalBusy || moduleOrderIndex <= 0}
+                  onClick={() => onReorderModuleDelta(-1)}
+                >
+                  <ChevronUp className="h-5 w-5" strokeWidth={2} aria-hidden />
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex h-11 w-11 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                  aria-label="Move module down"
+                  disabled={anyModalBusy || moduleOrderIndex >= moduleCount - 1}
+                  onClick={() => onReorderModuleDelta(1)}
+                >
+                  <ChevronDown className="h-5 w-5" strokeWidth={2} aria-hidden />
+                </button>
+              </div>
+            </>
           ) : null
         }
         footerExtra={
@@ -1860,6 +1930,40 @@ export default function CourseModules() {
     [courseCode, load],
   )
 
+  const reorderModuleByDelta = useCallback(
+    (moduleId: string, delta: -1 | 1) => {
+      if (!courseCode || reorderSaving) return
+      const idx = moduleIds.indexOf(moduleId)
+      const newIdx = idx + delta
+      if (idx < 0 || newIdx < 0 || newIdx >= moduleIds.length) return
+      const nextModuleOrder = arrayMove(moduleIds, idx, newIdx)
+      const base = buildReorderPayloadFromItems(items)
+      void persistReorder({
+        moduleOrder: nextModuleOrder,
+        childOrderByModule: base.childOrderByModule,
+      })
+    },
+    [courseCode, items, moduleIds, persistReorder, reorderSaving],
+  )
+
+  const reorderChildByDelta = useCallback(
+    (moduleId: string, childId: string, delta: -1 | 1) => {
+      if (!courseCode || reorderSaving) return
+      const childList = moduleChildrenById.get(moduleId) ?? []
+      const childIds = childList.map((c) => c.id)
+      const idx = childIds.indexOf(childId)
+      const newIdx = idx + delta
+      if (idx < 0 || newIdx < 0 || newIdx >= childIds.length) return
+      const nextChildren = arrayMove(childIds, idx, newIdx)
+      const base = buildReorderPayloadFromItems(items)
+      void persistReorder({
+        moduleOrder: base.moduleOrder,
+        childOrderByModule: { ...base.childOrderByModule, [moduleId]: nextChildren },
+      })
+    },
+    [courseCode, items, moduleChildrenById, persistReorder, reorderSaving],
+  )
+
   const handleDragStart = useCallback((event: DragStartEvent) => {
     setActiveDragId(String(event.active.id))
     if (event.active.data.current?.type === 'module') {
@@ -2017,7 +2121,7 @@ export default function CourseModules() {
             >
               {sortedTopLevel
                 .filter((i) => i.kind === 'module')
-                .map((item) => (
+                .map((item, moduleIdx) => (
                   <SortableModuleCard
                     key={item.id}
                     item={item}
@@ -2039,6 +2143,10 @@ export default function CourseModules() {
                     onArchiveChild={requestArchiveChild}
                     courseAdaptivePathsEnabled={courseMeta?.adaptivePathsEnabled === true}
                     studentGradeContext={studentGradeContext}
+                    moduleOrderIndex={moduleIdx}
+                    moduleCount={moduleIds.length}
+                    onReorderModuleDelta={(delta) => reorderModuleByDelta(item.id, delta)}
+                    onReorderChildDelta={(childId, delta) => reorderChildByDelta(item.id, childId, delta)}
                   />
                 ))}
             </ul>

--- a/clients/web/src/pages/lms/gradebook/gradebook-grid.tsx
+++ b/clients/web/src/pages/lms/gradebook/gradebook-grid.tsx
@@ -1108,7 +1108,7 @@ export function GradebookGrid({
   }
 
   return (
-    <div className="mt-6 space-y-3">
+    <div className="mt-6 min-w-0 max-w-full space-y-3">
       <div className="flex flex-wrap items-end gap-4 rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-3 dark:border-neutral-700 dark:bg-neutral-900/50">
         <label className="flex min-w-[10rem] flex-1 flex-col gap-1">
           <span className="text-xs font-medium text-slate-600 dark:text-neutral-400">Student</span>
@@ -1176,7 +1176,10 @@ export function GradebookGrid({
       )}
 
       {rowCount > 0 && baseColCount > 0 && (
-        <div className="overflow-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
+        <div
+          data-testid="gradebook-scroll"
+          className="max-w-full min-w-0 touch-pan-x overflow-x-auto overflow-y-visible rounded-xl border border-slate-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-900"
+        >
           <table
             role="grid"
             aria-label="Grades by student and assignment"

--- a/clients/web/src/pages/lms/lms-page.tsx
+++ b/clients/web/src/pages/lms/lms-page.tsx
@@ -31,10 +31,10 @@ export function LmsPage({
 }: LmsPageProps) {
   const outerClass =
     omitHeader && fillHeight
-      ? 'flex min-h-0 flex-1 flex-col px-3 pb-3 pt-2 sm:px-4 sm:pb-4 md:px-6 md:pb-5'
+      ? 'flex min-h-0 min-w-0 flex-1 flex-col px-3 pb-3 pt-2 sm:px-4 sm:pb-4 md:px-6 md:pb-5'
       : fillHeight
-        ? 'flex min-h-0 flex-1 flex-col px-4 py-5 sm:p-6 md:p-8'
-        : 'px-4 py-5 sm:p-6 md:p-8'
+        ? 'flex min-h-0 min-w-0 flex-1 flex-col px-4 py-5 sm:p-6 md:p-8'
+        : 'min-w-0 px-4 py-5 sm:p-6 md:p-8'
 
   return (
     <div className={outerClass}>

--- a/docs/completed/7.2-mobile-responsive-review.md
+++ b/docs/completed/7.2-mobile-responsive-review.md
@@ -164,5 +164,5 @@ Not applicable.
 ## 19. References
 
 - Existing files: `clients/web/src/pages/lms/CourseGradebook.tsx`, `clients/web/src/pages/lms/CourseModules.tsx`, `clients/web/src/components/editor/`, `clients/web/src/components/layout/`.
-- Related plans: `docs/plan/07-mobile-offline-cross-platform/7.1-native-mobile-apps.md`, `docs/plan/07-mobile-offline-cross-platform/7.3-offline-pwa.md`.
+- Related plans: `docs/plan/07-mobile-offline-cross-platform/7.1-native-mobile-apps.md`, `docs/completed/7.3-offline-pwa.md`.
 - External standards: WCAG 2.2 Success Criterion 2.5.8 (Minimum Target Size); Apple Human Interface Guidelines (44 pt tap target); Google Material Design (touch target 48×48 dp); Lighthouse Performance scoring.

--- a/docs/completed/7.3-offline-pwa.md
+++ b/docs/completed/7.3-offline-pwa.md
@@ -191,5 +191,5 @@ AI Tutor (6.9) and RAG notebook require connectivity; both are disabled and show
 ## 19. References
 
 - Existing files: `clients/web/vite.config.ts`, `clients/web/public/`, `clients/web/src/pages/lms/CourseModuleQuizPage.tsx`.
-- Related plans: `docs/plan/07-mobile-offline-cross-platform/7.1-native-mobile-apps.md`, `docs/plan/07-mobile-offline-cross-platform/7.2-mobile-responsive-review.md`.
+- Related plans: `docs/plan/07-mobile-offline-cross-platform/7.1-native-mobile-apps.md`, `docs/completed/7.2-mobile-responsive-review.md`.
 - External standards: W3C Web App Manifest specification; W3C Service Workers specification; Workbox (Google) cache strategies; Background Sync API (WICG); IndexedDB API; Dexie.js v3; `vite-plugin-pwa`.

--- a/docs/plan/07-mobile-offline-cross-platform/7.1-native-mobile-apps.md
+++ b/docs/plan/07-mobile-offline-cross-platform/7.1-native-mobile-apps.md
@@ -178,5 +178,5 @@ AI Tutor (6.9) should be accessible via a floating button in the mobile app, ren
 ## 19. References
 
 - Existing files: `clients/web/src/pages/lms/`, `server/internal/httpserver/course_*.go`, `server/internal/httpserver/me.go`.
-- Related plans: `docs/plan/07-mobile-offline-cross-platform/7.2-mobile-responsive-review.md`, `docs/plan/07-mobile-offline-cross-platform/7.3-offline-pwa.md`, `docs/plan/07-mobile-offline-cross-platform/7.4-app-store-presence.md`, `docs/plan/07-mobile-offline-cross-platform/7.5-push-notification-service.md`.
+- Related plans: `docs/completed/7.2-mobile-responsive-review.md`, `docs/plan/07-mobile-offline-cross-platform/7.3-offline-pwa.md`, `docs/plan/07-mobile-offline-cross-platform/7.4-app-store-presence.md`, `docs/plan/07-mobile-offline-cross-platform/7.5-push-notification-service.md`.
 - External standards: Apple App Store Review Guidelines; Google Play Developer Policy; Apple DEP / Apple School Manager; Android Enterprise (Android for Work); Expo SDK; Capacitor.js.

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 7'] },
+    },
   ],
   outputDir: 'test-results/',
 })

--- a/e2e/tests/mobile-responsive.spec.ts
+++ b/e2e/tests/mobile-responsive.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Mobile viewport regressions (plan 7.2 — mobile-responsive review).
+ */
+import { test, expect } from '../fixtures/test.js'
+import { apiCreateModule } from '../fixtures/api.js'
+
+test.describe('Mobile responsive (390×844)', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('gradebook page does not introduce horizontal page overflow', async ({ coursePage: page, seededCourse }) => {
+    await page.goto(`/courses/${seededCourse.courseCode}/gradebook`)
+    await expect(page.getByRole('heading', { name: /gradebook/i })).toBeVisible({ timeout: 15000 })
+
+    const metrics = await page.evaluate(() => {
+      const doc = document.documentElement
+      const main = document.querySelector('main.lms-scope')
+      const gb = document.querySelector('[data-testid="gradebook-scroll"]')
+      return {
+        docScrollWidth: doc.scrollWidth,
+        docClientWidth: doc.clientWidth,
+        mainScrollWidth: main?.scrollWidth ?? 0,
+        mainClientWidth: main?.clientWidth ?? 0,
+        hasGradebookScroll: gb instanceof HTMLElement,
+        gbScrollWidth: gb instanceof HTMLElement ? gb.scrollWidth : 0,
+        gbClientWidth: gb instanceof HTMLElement ? gb.clientWidth : 0,
+      }
+    })
+
+    expect(metrics.docScrollWidth).toBeLessThanOrEqual(metrics.docClientWidth + 1)
+    expect(metrics.mainScrollWidth).toBeLessThanOrEqual(metrics.mainClientWidth + 1)
+
+    if (metrics.hasGradebookScroll && metrics.gbScrollWidth > metrics.gbClientWidth) {
+      const scroll = page.getByTestId('gradebook-scroll')
+      await expect(scroll).toBeVisible()
+    }
+  })
+
+  test('modules page shows touch reorder controls on narrow viewports', async ({
+    coursePage: page,
+    seededCourse,
+  }) => {
+    await apiCreateModule(seededCourse.instructorToken, seededCourse.courseCode, 'Unit 2 — mobile')
+    await page.goto(`/courses/${seededCourse.courseCode}/modules`)
+    await expect(page.getByRole('heading', { name: /modules/i })).toBeVisible({ timeout: 15000 })
+
+    await expect(page.getByRole('button', { name: /move module up/i }).first()).toBeVisible({ timeout: 8000 })
+    await expect(page.getByRole('button', { name: /move module down/i }).first()).toBeVisible()
+
+    if (process.env.SAVE_PR_SCREENSHOT === '1') {
+      await page.screenshot({
+        path: '/opt/cursor/artifacts/7.2-mobile-modules.png',
+        fullPage: false,
+      })
+    }
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **plan 7.2 — Mobile-responsive review** (moved to `docs/completed/7.2-mobile-responsive-review.md`).

### Web UX

- **Gradebook:** `min-w-0` / `max-w-full` on the grid shell, `data-testid="gradebook-scroll"`, and `touch-pan-x overflow-x-auto` so wide tables scroll inside the card instead of widening the viewport.
- **Modules:** Under **768px**, drag handles are hidden; **Move module up/down** and **Move item up/down** buttons call the same reorder API as dnd-kit. Desktop keeps drag-and-drop.
- **Markdown block toolbar:** Below **640px**, primary formatting stays visible; the rest moves under a **More** menu (`useSyncExternalStore` + `matchMedia`). Toolbar and block chrome use **44px** touch targets on small viewports (`h-11 w-11` scaling to `sm:h-7 sm:w-7`).
- **Quiz take:** Multiple-choice labels use full width and `min-h-11` on narrow viewports for better tap targets.
- **`LmsPage`:** `min-w-0` on outer wrappers so nested flex children can shrink correctly.

### Tests & docs

- New Playwright file `e2e/tests/mobile-responsive.spec.ts` (390×844): document/main overflow checks on gradebook; modules page asserts touch reorder buttons when two modules exist.
- `e2e/playwright.config.ts`: added **`mobile-chrome`** project (Pixel 7 profile).
- `clients/web/CONTRIBUTING.md`: mobile-first / tap-target guidelines.
- Optional artifact: set `SAVE_PR_SCREENSHOT=1` when running that spec to write `/opt/cursor/artifacts/7.2-mobile-modules.png`.

### Cross-links

- Updated references in `7.1-native-mobile-apps.md`, `7.3-offline-pwa.md`, and the completed 7.2 plan.

### Verification

- `npm run typecheck` and ESLint (pre-commit) on touched TS/TSX.
- `go test ./... -short` (server).
- Full Docker Playwright was **not** run here (docker.sock permission denied in the agent VM).

### Visual (illustrative narrow layout)

This image is an **illustrative mockup** of the mobile modules chrome (stacked chevron reorder controls). It is not a literal browser capture because the full e2e stack was not runnable in this environment.

[Illustrative mobile modules UI with touch reorder chevron buttons](https://cursor.com/agents/bc-88885d94-e181-46f6-98dd-1c99a0fc0caa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fassets%2F7.2-mobile-modules-feature.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88885d94-e181-46f6-98dd-1c99a0fc0caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88885d94-e181-46f6-98dd-1c99a0fc0caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

