### PR TITLE
feat(iac): multi-cloud production Terraform with AWS EKS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,14 @@ iac/demo/*.tfvars
 iac/demo/crash.log
 iac/demo/override.tf
 
+# Terraform (iac/production)
+iac/production/.terraform/
+iac/production/*.tfstate
+iac/production/*.tfstate.*
+iac/production/terraform.tfvars
+iac/production/crash.log
+iac/production/override.tf
+
 # Agents
 .agents/
 

--- a/iac/modules/aws/README.md
+++ b/iac/modules/aws/README.md
@@ -1,0 +1,13 @@
+# AWS production module
+
+Composable AWS infrastructure for Lextures production:
+
+- `vpc.tf` — VPC, public/private subnets, NAT
+- `eks.tf` — EKS cluster and managed node group
+- `rds.tf` — PostgreSQL 16 (private)
+- `elasticache.tf` — Redis 7 replication group
+- `s3.tf` — encrypted course-files bucket
+- `secrets.tf` — Secrets Manager for `DATABASE_URL` and `REDIS_URL`
+- `iam_s3.tf` — IRSA role for namespace `lextures`, service account `api`
+
+Invoked from `iac/production/` when `cloud_provider = "aws"`.

--- a/iac/modules/aws/data.tf
+++ b/iac/modules/aws/data.tf
@@ -1,0 +1,7 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}

--- a/iac/modules/aws/eks.tf
+++ b/iac/modules/aws/eks.tf
@@ -1,0 +1,29 @@
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.31"
+
+  cluster_name    = "${local.name_prefix}-eks"
+  cluster_version = var.eks_cluster_version
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  cluster_endpoint_public_access = true
+
+  enable_cluster_creator_admin_permissions = true
+
+  eks_managed_node_groups = {
+    default = {
+      name           = "default"
+      instance_types = var.eks_node_instance_types
+
+      min_size     = var.eks_node_min_size
+      max_size     = var.eks_node_max_size
+      desired_size = var.eks_node_desired_size
+
+      subnet_ids = module.vpc.private_subnets
+    }
+  }
+
+  tags = local.common_tags
+}

--- a/iac/modules/aws/elasticache.tf
+++ b/iac/modules/aws/elasticache.tf
@@ -1,0 +1,40 @@
+resource "aws_elasticache_subnet_group" "redis" {
+  name       = "${local.name_prefix}-redis"
+  subnet_ids = module.vpc.private_subnets
+
+  tags = local.common_tags
+}
+
+resource "random_password" "redis_auth" {
+  length  = 32
+  special = false
+}
+
+resource "aws_elasticache_replication_group" "redis" {
+  replication_group_id = "${local.name_prefix}-redis"
+  description          = "Lextures shared cache and session store"
+
+  engine               = "redis"
+  engine_version       = "7.1"
+  node_type            = local.redis_node_type
+  num_cache_clusters   = local.redis_num_cache_clusters
+  parameter_group_name = "default.redis7"
+  port                 = 6379
+
+  subnet_group_name  = aws_elasticache_subnet_group.redis.name
+  security_group_ids = [aws_security_group.redis.id]
+
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+  auth_token                 = random_password.redis_auth.result
+
+  automatic_failover_enabled = local.redis_num_cache_clusters > 1
+  multi_az_enabled           = local.redis_num_cache_clusters > 1
+
+  snapshot_retention_limit = local.is_production ? 7 : 1
+  maintenance_window       = "sun:05:00-sun:06:00"
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-redis"
+  })
+}

--- a/iac/modules/aws/iam_s3.tf
+++ b/iac/modules/aws/iam_s3.tf
@@ -1,0 +1,53 @@
+data "aws_iam_policy_document" "course_files_bucket" {
+  statement {
+    sid    = "ListBucket"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.course_files.arn,
+    ]
+  }
+
+  statement {
+    sid    = "ObjectRW"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = [
+      "${aws_s3_bucket.course_files.arn}/*",
+    ]
+  }
+}
+
+module "irsa_course_files" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.48"
+
+  role_name = "${local.name_prefix}-course-files"
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["lextures:api"]
+    }
+  }
+
+  role_policy_arns = {
+    course_files = aws_iam_policy.course_files.arn
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_policy" "course_files" {
+  name_prefix = "${local.name_prefix}-course-files-"
+  description = "Read/write course files in the production S3 bucket"
+  policy      = data.aws_iam_policy_document.course_files_bucket.json
+
+  tags = local.common_tags
+}

--- a/iac/modules/aws/locals.tf
+++ b/iac/modules/aws/locals.tf
@@ -1,0 +1,36 @@
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+
+  common_tags = merge(
+    {
+      Project     = var.project_name
+      Environment = var.environment
+      ManagedBy   = "terraform"
+    },
+    var.tags,
+  )
+
+  is_production = var.environment == "production"
+
+  single_nat_gateway = coalesce(var.single_nat_gateway, !local.is_production)
+
+  db_instance_class = coalesce(
+    var.db_instance_class,
+    local.is_production ? "db.r6g.large" : "db.t4g.medium",
+  )
+
+  db_allocated_storage_gb = coalesce(var.db_allocated_storage_gb, local.is_production ? 100 : 20)
+
+  db_backup_retention_days = coalesce(var.db_backup_retention_days, local.is_production ? 30 : 7)
+
+  db_multi_az = coalesce(var.db_multi_az, local.is_production)
+
+  redis_node_type = coalesce(
+    var.redis_node_type,
+    local.is_production ? "cache.r6g.large" : "cache.t4g.small",
+  )
+
+  redis_num_cache_clusters = coalesce(var.redis_num_cache_clusters, local.is_production ? 2 : 1)
+
+  course_files_bucket_name = "${local.name_prefix}-course-files-${data.aws_caller_identity.current.account_id}"
+}

--- a/iac/modules/aws/outputs.tf
+++ b/iac/modules/aws/outputs.tf
@@ -1,0 +1,90 @@
+output "aws_region" {
+  description = "AWS region."
+  value       = var.aws_region
+}
+
+output "vpc_id" {
+  description = "VPC ID."
+  value       = module.vpc.vpc_id
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs (EKS, RDS, Redis)."
+  value       = module.vpc.private_subnets
+}
+
+output "public_subnet_ids" {
+  description = "Public subnet IDs."
+  value       = module.vpc.public_subnets
+}
+
+output "eks_cluster_name" {
+  description = "EKS cluster name."
+  value       = module.eks.cluster_name
+}
+
+output "eks_cluster_endpoint" {
+  description = "EKS API server endpoint."
+  value       = module.eks.cluster_endpoint
+}
+
+output "eks_cluster_certificate_authority_data" {
+  description = "Base64-encoded CA cert for kubectl."
+  value       = module.eks.cluster_certificate_authority_data
+  sensitive   = true
+}
+
+output "eks_oidc_provider_arn" {
+  description = "OIDC provider ARN for IRSA."
+  value       = module.eks.oidc_provider_arn
+}
+
+output "eks_node_security_group_id" {
+  description = "Security group attached to EKS worker nodes."
+  value       = module.eks.node_security_group_id
+}
+
+output "postgres_endpoint" {
+  description = "RDS hostname (private)."
+  value       = aws_db_instance.postgres.address
+}
+
+output "postgres_port" {
+  description = "RDS port."
+  value       = aws_db_instance.postgres.port
+}
+
+output "postgres_database_name" {
+  description = "PostgreSQL database name."
+  value       = var.db_name
+}
+
+output "database_url_secret_arn" {
+  description = "Secrets Manager ARN for DATABASE_URL (value not in Terraform outputs)."
+  value       = aws_secretsmanager_secret.database_url.arn
+}
+
+output "redis_primary_endpoint" {
+  description = "ElastiCache Redis primary endpoint."
+  value       = aws_elasticache_replication_group.redis.primary_endpoint_address
+}
+
+output "redis_url_secret_arn" {
+  description = "Secrets Manager ARN for REDIS_URL."
+  value       = aws_secretsmanager_secret.redis_url.arn
+}
+
+output "course_files_bucket_name" {
+  description = "S3 bucket for uploaded course files (COURSE_FILES_ROOT)."
+  value       = aws_s3_bucket.course_files.id
+}
+
+output "course_files_bucket_arn" {
+  description = "S3 bucket ARN."
+  value       = aws_s3_bucket.course_files.arn
+}
+
+output "course_files_irsa_role_arn" {
+  description = "IAM role ARN for Kubernetes service account lextures:api (S3 access)."
+  value       = module.irsa_course_files.iam_role_arn
+}

--- a/iac/modules/aws/rds.tf
+++ b/iac/modules/aws/rds.tf
@@ -1,0 +1,50 @@
+resource "aws_db_subnet_group" "postgres" {
+  name       = "${local.name_prefix}-postgres"
+  subnet_ids = module.vpc.private_subnets
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-postgres"
+  })
+}
+
+resource "random_password" "db_master" {
+  length  = 32
+  special = false
+}
+
+resource "aws_db_instance" "postgres" {
+  identifier = "${local.name_prefix}-postgres"
+
+  engine         = "postgres"
+  engine_version = "16"
+  instance_class = local.db_instance_class
+
+  allocated_storage     = local.db_allocated_storage_gb
+  max_allocated_storage = local.is_production ? local.db_allocated_storage_gb * 2 : null
+  storage_type          = "gp3"
+  storage_encrypted     = true
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = random_password.db_master.result
+
+  db_subnet_group_name   = aws_db_subnet_group.postgres.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+
+  multi_az                  = local.db_multi_az
+  publicly_accessible       = false
+  deletion_protection       = local.is_production
+  skip_final_snapshot       = !local.is_production
+  final_snapshot_identifier = local.is_production ? "${local.name_prefix}-postgres-final" : null
+
+  backup_retention_period = local.db_backup_retention_days
+  backup_window           = "03:00-04:00"
+  maintenance_window      = "sun:04:00-sun:05:00"
+
+  performance_insights_enabled = local.is_production
+  auto_minor_version_upgrade   = true
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-postgres"
+  })
+}

--- a/iac/modules/aws/s3.tf
+++ b/iac/modules/aws/s3.tf
@@ -1,0 +1,52 @@
+resource "aws_s3_bucket" "course_files" {
+  bucket = local.course_files_bucket_name
+
+  force_destroy = var.course_files_bucket_force_destroy
+
+  tags = merge(local.common_tags, {
+    Name = local.course_files_bucket_name
+  })
+}
+
+resource "aws_s3_bucket_versioning" "course_files" {
+  bucket = aws_s3_bucket.course_files.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "course_files" {
+  bucket = aws_s3_bucket.course_files.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "course_files" {
+  bucket = aws_s3_bucket.course_files.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "course_files" {
+  bucket = aws_s3_bucket.course_files.id
+
+  rule {
+    id     = "abort-incomplete-multipart"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}

--- a/iac/modules/aws/secrets.tf
+++ b/iac/modules/aws/secrets.tf
@@ -1,0 +1,35 @@
+resource "aws_secretsmanager_secret" "database_url" {
+  name                    = "${local.name_prefix}/database-url"
+  recovery_window_in_days = local.is_production ? 30 : 0
+
+  tags = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "database_url" {
+  secret_id = aws_secretsmanager_secret.database_url.id
+  secret_string = format(
+    "postgres://%s:%s@%s:%d/%s?sslmode=require",
+    var.db_username,
+    urlencode(random_password.db_master.result),
+    aws_db_instance.postgres.address,
+    aws_db_instance.postgres.port,
+    var.db_name,
+  )
+}
+
+resource "aws_secretsmanager_secret" "redis_url" {
+  name                    = "${local.name_prefix}/redis-url"
+  recovery_window_in_days = local.is_production ? 30 : 0
+
+  tags = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "redis_url" {
+  secret_id = aws_secretsmanager_secret.redis_url.id
+  secret_string = format(
+    "rediss://:%s@%s:%d",
+    urlencode(random_password.redis_auth.result),
+    aws_elasticache_replication_group.redis.primary_endpoint_address,
+    aws_elasticache_replication_group.redis.port,
+  )
+}

--- a/iac/modules/aws/security_groups.tf
+++ b/iac/modules/aws/security_groups.tf
@@ -1,0 +1,57 @@
+resource "aws_security_group" "rds" {
+  name_prefix = "${local.name_prefix}-rds-"
+  description = "PostgreSQL access from EKS worker nodes"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description     = "PostgreSQL from EKS nodes"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [module.eks.node_security_group_id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-rds"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group" "redis" {
+  name_prefix = "${local.name_prefix}-redis-"
+  description = "Redis access from EKS worker nodes"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description     = "Redis from EKS nodes"
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [module.eks.node_security_group_id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-redis"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/iac/modules/aws/variables.tf
+++ b/iac/modules/aws/variables.tf
@@ -1,0 +1,118 @@
+variable "project_name" {
+  description = "Short project name used in resource naming and tags."
+  type        = string
+  default     = "lextures"
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g. staging, production)."
+  type        = string
+
+  validation {
+    condition     = contains(["staging", "production"], var.environment)
+    error_message = "environment must be staging or production."
+  }
+}
+
+variable "aws_region" {
+  description = "AWS region for all resources."
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "single_nat_gateway" {
+  description = "Use one NAT gateway for all private subnets (cheaper; less AZ redundancy)."
+  type        = bool
+  default     = null
+}
+
+variable "eks_cluster_version" {
+  description = "Kubernetes version for the EKS control plane."
+  type        = string
+  default     = "1.31"
+}
+
+variable "eks_node_instance_types" {
+  description = "EC2 instance types for the default EKS managed node group."
+  type        = list(string)
+  default     = ["t3.large"]
+}
+
+variable "eks_node_desired_size" {
+  type    = number
+  default = 2
+}
+
+variable "eks_node_min_size" {
+  type    = number
+  default = 1
+}
+
+variable "eks_node_max_size" {
+  type    = number
+  default = 4
+}
+
+variable "db_name" {
+  description = "PostgreSQL database name."
+  type        = string
+  default     = "studydrift"
+}
+
+variable "db_username" {
+  description = "PostgreSQL master username."
+  type        = string
+  default     = "lextures"
+}
+
+variable "db_instance_class" {
+  description = "RDS instance class."
+  type        = string
+  default     = null
+}
+
+variable "db_allocated_storage_gb" {
+  type    = number
+  default = null
+}
+
+variable "db_backup_retention_days" {
+  description = "Automated backup retention for RDS."
+  type        = number
+  default     = null
+}
+
+variable "db_multi_az" {
+  description = "Enable Multi-AZ for RDS."
+  type        = bool
+  default     = null
+}
+
+variable "redis_node_type" {
+  description = "ElastiCache node instance type."
+  type        = string
+  default     = null
+}
+
+variable "redis_num_cache_clusters" {
+  description = "Number of cache nodes in the Redis replication group (2+ for HA)."
+  type        = number
+  default     = null
+}
+
+variable "course_files_bucket_force_destroy" {
+  description = "Allow Terraform to delete the course-files S3 bucket even when non-empty (non-prod only)."
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  description = "Additional tags applied to all taggable resources."
+  type        = map(string)
+  default     = {}
+}

--- a/iac/modules/aws/versions.tf
+++ b/iac/modules/aws/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.80"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}

--- a/iac/modules/aws/vpc.tf
+++ b/iac/modules/aws/vpc.tf
@@ -1,0 +1,26 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.17"
+
+  name = local.name_prefix
+  cidr = var.vpc_cidr
+
+  azs             = slice(data.aws_availability_zones.available.names, 0, 3)
+  private_subnets = [for i in range(3) : cidrsubnet(var.vpc_cidr, 8, i)]
+  public_subnets  = [for i in range(3) : cidrsubnet(var.vpc_cidr, 8, i + 16)]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = local.single_nat_gateway
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = 1
+  }
+
+  tags = local.common_tags
+}

--- a/iac/modules/azure/README.md
+++ b/iac/modules/azure/README.md
@@ -1,0 +1,11 @@
+# Azure module (planned)
+
+Future production stack:
+
+- **AKS** — Kubernetes for API and web workloads
+- **Azure Database for PostgreSQL** — flexible server, private endpoint
+- **Azure Cache for Redis**
+- **Azure Blob Storage** — course files
+- **Key Vault** — connection strings (no secrets in Terraform state)
+
+Root module will call `../modules/azure` when `cloud_provider = "azure"`. Until implemented, `terraform apply` with `cloud_provider = "azure"` fails the `cloud_provider_implemented` check in `iac/production/main.tf`.

--- a/iac/modules/gcp/README.md
+++ b/iac/modules/gcp/README.md
@@ -1,0 +1,11 @@
+# GCP module (planned)
+
+Future production stack:
+
+- **GKE** — Kubernetes
+- **Cloud SQL for PostgreSQL**
+- **Memorystore for Redis**
+- **Cloud Storage** — course files
+- **Secret Manager** — credentials
+
+Root module will call `../modules/gcp` when `cloud_provider = "gcp"`. Until implemented, use `cloud_provider = "aws"`.

--- a/iac/production/.terraform.lock.hcl
+++ b/iac/production/.terraform.lock.hcl
@@ -1,0 +1,130 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = ">= 4.0.0, >= 4.33.0, >= 5.79.0, ~> 5.80, >= 5.95.0, < 6.0.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.4.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:4fp7byXJGbOU8zqxFM4yYGHzf1kUH8ChT41KK4n9q98=",
+    "zh:1b0fe71b8e87a068f7cd9faaa733100ab72ab61ce812b8bd2b8e3e6ea3907b2d",
+    "zh:2aa9631ad64cfda1eb58f147619b631dadedfaf9453b422aa5ada2d3861183c1",
+    "zh:2c5f35463bdfb2f87d3576b81e62c30f8109e67bb6f21ffcbc46a855811455c0",
+    "zh:5970bcad151ea236bd262ada1a5a23bfbc1716f94a4e8b16ab2bcdda91d6a671",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79a0676909732b6ec0441a733af6383513cde3bd2cef5c1ad0a74131e1286a04",
+    "zh:818f16141481a1202b3977becd19a12d4d46cd2e3f5753f5d0d0049adacf8f8c",
+    "zh:948d98716831087e69eca99f91ed7964cc537f3aca279f7494645ee56c9dc4ec",
+    "zh:a75e78889565a51df3e8e3af207e36e5ddb25e47ce1780a784c82dc3c3109b67",
+    "zh:a9c6e455d52b1bba5272bd87a35cfabcfd6d903dcbe42e2de926228dbb1e39b2",
+    "zh:b846805d8c2f5d1d6c2ffeeaf32109d9af7db7fa3c56929bfc1dcfaadf9c8bd8",
+    "zh:c3e5279756b46c4f49a6f4c81347fbe2fffebb2bf18a5c24664830304a1f6a8e",
+    "zh:c8be7b31893163d0046b0137a6100533f07e8efd192a1903b6bb4c42be12dceb",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.3.0"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
+    "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
+    "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
+    "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
+    "zh:57ed8935c7d56dbc91cf2673534582cacfaab7a2f105f51d9f797e99df0c0c47",
+    "zh:58e176ba1d142827089e30e0711e007309a9f2726e8881986da5026e9778fdf4",
+    "zh:5949c4a3d4a93f841f155cdb7e991c087e637145c1630572e21948224f8f4923",
+    "zh:76d60f366b743003c1b085afa769b45b2198ee919927e45807d7d44fb42c067d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79cd1bab1261a07f84e917191d7ddc4340ac5f5524283767256f7ffd7f87caf0",
+    "zh:8ec9083038cf710b30e319eaa467c9df7fa52bbd9969b61053a35bc2cdd2e0a6",
+    "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
+    "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
+    "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.14.0"
+  constraints = ">= 0.9.0"
+  hashes = [
+    "h1:/hlxsUpuN/lvPTNL9+NyVGsOyRsK5NsxwFMsj5CdOp4=",
+    "zh:12abfd6b800e4d7fa6db7310dec8ffd440b31993861ef188c7ed5260b3073937",
+    "zh:23005521e800bb19e1597bf755c5f70d675d30b685d4255001ed5fa47d9df3f1",
+    "zh:2fea249b582ae97cd1cc10385187ea50993bb47c28cc5df0305e57ceaabf0a10",
+    "zh:322018d3b987b7aad08697178029a2bb667bed699e88328f0c89c52a2fd41341",
+    "zh:32a08e98fce2d273cb9b2c89d6c54727cc9f0a32e15bfd896be4e02cc6b48f95",
+    "zh:3db89aabd0e619616bd4b0f8b373a7586dfe60feffcea12a84a0bdbc445714b3",
+    "zh:7488f56c81d742dc020f29063626c8f07ca188aa97be61e7307e8d62397020a2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7cb4067f2e7559b13f7562ef722f948950901eb37834873e98360ab28f66e9d7",
+    "zh:9d552c8345f61e1b7db8e725144981345f18ac1014d58d6f5ddf0928a195fffb",
+    "zh:a8e69fb6b97fc9d86fb19a9f4d42abe33c4a68e700b15387ce2e17d2b9934bed",
+    "zh:aeeb900eb8dd0f790c60ea5c0e0c8d42bd6e4a54f391681d4decca15b544394b",
+    "zh:c239c619101a8c95e1f14061eb973c57a8d15fa0e68878ced5bbd76858ee5b79",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.3.0"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
+    "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
+    "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
+    "zh:6889be32640349230de3f23856e6f04e0e9ced4a84a27d3f552fa54684448218",
+    "zh:73f8e1ecf7135033165fb14b7e8bf4d656f3ce13065ec35762ea0481975328c7",
+    "zh:94ce25ee253eca0b42cae9c856b36bca8103b6453012d1b279c3623c805f2d42",
+    "zh:96bc6de9fd67bc446fd11257872e1ffb1029a996ed1d65a3f6b43f6d408ad9ab",
+    "zh:97c609a310a51bfd504d704e036d72064a84bf0bdb36cc08cd4cc66098212b41",
+    "zh:a12c16e94533c5bd123f75032576b9dc91dd5d5ccd5f7cf331d0f2e1adc55cf8",
+    "zh:c4f014f876adf7af57188795050bda5b0029d8c7d7773031102b6c36dcf1fc21",
+    "zh:d9b0a21583aaa3df3a95394fb949a3c515ff71c2ff5a1fc4a73d364aa90bfca5",
+    "zh:da510d22f0c6d71ad19a76406f106b782448f512375787ecfabb338ed1e311a7",
+    "zh:f0e9447a9ce3a24cdaa113089e65663c836d8b9bfdb915a1c0284e0112cab5c0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/iac/production/README.md
+++ b/iac/production/README.md
@@ -1,0 +1,83 @@
+# Production infrastructure (Terraform)
+
+Multi-cloud production IaC for Lextures. Select the target cloud with `cloud_provider`; **AWS is fully implemented** (EKS, RDS PostgreSQL, ElastiCache Redis, S3). Azure and GCP directories under `iac/modules/` are reserved for future work.
+
+## Layout
+
+```
+iac/
+├── modules/
+│   ├── aws/          # VPC, EKS, RDS, Redis, S3, Secrets Manager, IRSA
+│   ├── azure/        # planned
+│   └── gcp/          # planned
+└── production/       # root module (this directory)
+```
+
+## AWS resources
+
+| Component | Service | Notes |
+|-----------|---------|--------|
+| Networking | VPC (3 AZ), NAT | Private subnets for workloads; public for load balancers |
+| Compute | Amazon EKS | Managed node group; deploy API/web via Helm/Kubernetes |
+| Database | RDS PostgreSQL 16 | Private; credentials in Secrets Manager |
+| Cache | ElastiCache Redis 7 | TLS + auth token; URL in Secrets Manager |
+| Object storage | S3 | Course files (`COURSE_FILES_ROOT`); IRSA role for `lextures:api` |
+| Secrets | Secrets Manager | `database-url`, `redis-url` ARNs exported (not values) |
+
+Sizing defaults differ for `environment = staging` vs `production` (instance classes, Multi-AZ, backup retention, Redis replica count).
+
+## Prerequisites
+
+- Terraform >= 1.5
+- AWS credentials with permissions to create VPC, EKS, RDS, ElastiCache, S3, IAM, Secrets Manager
+- Optional: remote backend (see `backend.tf.example`) or Terraform Cloud workspace
+
+## Quick start (AWS)
+
+```bash
+cd iac/production
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars
+
+terraform init
+terraform workspace new staging   # or: production
+terraform plan
+terraform apply
+```
+
+Configure kubectl:
+
+```bash
+terraform output -raw kubectl_config_command | bash
+```
+
+Wire the API deployment (Helm/manifests) to:
+
+- `database_url_secret_arn` — mount or sync as `DATABASE_URL`
+- `redis_url_secret_arn` — future horizontal scaling / cache (17.2)
+- `course_files_bucket_name` + `course_files_irsa_role_arn` — annotate ServiceAccount `lextures:api`
+
+## Variables
+
+| Variable | Description |
+|----------|-------------|
+| `cloud_provider` | `aws` (implemented), `azure`, `gcp` (planned) |
+| `environment` | `staging` or `production` |
+| `aws_region` | AWS region |
+
+See `variables.tf` for EKS/RDS/Redis sizing overrides.
+
+## Workspaces
+
+Use Terraform workspaces (or separate `.tfvars`) for `staging` and `production`. The `environment` variable should match the workspace intent so resource names and sizing stay consistent.
+
+## CI
+
+Add a `terraform fmt -check`, `validate`, and `plan` job for PRs touching `iac/production/` or `iac/modules/` (see `iac/demo` and `.github/workflows/deploy-demo.yml` for HCP Terraform patterns).
+
+## Next steps (not in Terraform)
+
+- Kubernetes manifests / Helm chart for Go API and React web
+- AWS Load Balancer Controller + Ingress for public traffic
+- External Secrets Operator to inject Secrets Manager values into pods
+- Azure (AKS + flexible PostgreSQL + Azure Cache) and GCP (GKE + Cloud SQL + Memorystore) modules under `iac/modules/`

--- a/iac/production/backend.tf.example
+++ b/iac/production/backend.tf.example
@@ -1,0 +1,11 @@
+# Copy into backend.tf (or use Terraform Cloud block in versions.tf) before remote state.
+
+terraform {
+  backend "s3" {
+    bucket         = "lextures-terraform-state"
+    key            = "production/aws/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    dynamodb_table = "lextures-terraform-locks"
+  }
+}

--- a/iac/production/main.tf
+++ b/iac/production/main.tf
@@ -1,0 +1,35 @@
+check "cloud_provider_implemented" {
+  assert {
+    condition     = var.cloud_provider == "aws"
+    error_message = "Only cloud_provider = \"aws\" is implemented. azure and gcp modules are planned under iac/modules/."
+  }
+}
+
+module "aws" {
+  count  = var.cloud_provider == "aws" ? 1 : 0
+  source = "../modules/aws"
+
+  project_name = var.project_name
+  environment  = var.environment
+  aws_region   = var.aws_region
+
+  vpc_cidr                = var.vpc_cidr
+  single_nat_gateway      = var.single_nat_gateway
+  eks_cluster_version     = var.eks_cluster_version
+  eks_node_instance_types = var.eks_node_instance_types
+  eks_node_desired_size   = var.eks_node_desired_size
+  eks_node_min_size       = var.eks_node_min_size
+  eks_node_max_size       = var.eks_node_max_size
+
+  db_instance_class        = var.db_instance_class
+  db_allocated_storage_gb  = var.db_allocated_storage_gb
+  db_backup_retention_days = var.db_backup_retention_days
+  db_multi_az              = var.db_multi_az
+
+  redis_node_type          = var.redis_node_type
+  redis_num_cache_clusters = var.redis_num_cache_clusters
+
+  course_files_bucket_force_destroy = var.course_files_bucket_force_destroy
+
+  tags = var.tags
+}

--- a/iac/production/outputs.tf
+++ b/iac/production/outputs.tf
@@ -1,0 +1,71 @@
+output "cloud_provider" {
+  description = "Cloud provider for this stack."
+  value       = var.cloud_provider
+}
+
+output "environment" {
+  description = "Environment name (staging or production)."
+  value       = var.environment
+}
+
+# --- AWS outputs (null when another cloud is selected) ---
+
+output "eks_cluster_name" {
+  description = "EKS cluster name."
+  value       = try(module.aws[0].eks_cluster_name, null)
+}
+
+output "eks_cluster_endpoint" {
+  description = "EKS API endpoint."
+  value       = try(module.aws[0].eks_cluster_endpoint, null)
+}
+
+output "eks_cluster_certificate_authority_data" {
+  description = "EKS cluster CA (for kubeconfig)."
+  value       = try(module.aws[0].eks_cluster_certificate_authority_data, null)
+  sensitive   = true
+}
+
+output "vpc_id" {
+  description = "VPC ID."
+  value       = try(module.aws[0].vpc_id, null)
+}
+
+output "postgres_endpoint" {
+  description = "RDS PostgreSQL hostname."
+  value       = try(module.aws[0].postgres_endpoint, null)
+}
+
+output "database_url_secret_arn" {
+  description = "Secrets Manager ARN for DATABASE_URL."
+  value       = try(module.aws[0].database_url_secret_arn, null)
+}
+
+output "redis_primary_endpoint" {
+  description = "ElastiCache Redis primary endpoint."
+  value       = try(module.aws[0].redis_primary_endpoint, null)
+}
+
+output "redis_url_secret_arn" {
+  description = "Secrets Manager ARN for REDIS_URL."
+  value       = try(module.aws[0].redis_url_secret_arn, null)
+}
+
+output "course_files_bucket_name" {
+  description = "S3 bucket for course file uploads."
+  value       = try(module.aws[0].course_files_bucket_name, null)
+}
+
+output "course_files_irsa_role_arn" {
+  description = "IAM role for lextures:api service account (S3)."
+  value       = try(module.aws[0].course_files_irsa_role_arn, null)
+}
+
+output "kubectl_config_command" {
+  description = "Example command to update kubeconfig for the EKS cluster."
+  value = var.cloud_provider == "aws" ? format(
+    "aws eks update-kubeconfig --region %s --name %s",
+    var.aws_region,
+    module.aws[0].eks_cluster_name,
+  ) : null
+}

--- a/iac/production/providers.tf
+++ b/iac/production/providers.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      Environment = var.environment
+      Cloud       = "aws"
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/iac/production/terraform.tfvars.example
+++ b/iac/production/terraform.tfvars.example
@@ -1,0 +1,18 @@
+# Copy to terraform.tfvars (do not commit secrets). Use Terraform workspaces for staging vs production.
+
+cloud_provider = "aws"
+environment    = "staging"
+aws_region     = "us-east-1"
+
+# Staging-friendly sizing (module defaults also scale by environment)
+eks_node_desired_size = 2
+eks_node_instance_types = ["t3.large"]
+
+# Optional overrides (null = module picks staging/production defaults)
+# db_instance_class        = "db.t4g.medium"
+# redis_num_cache_clusters = 1
+# course_files_bucket_force_destroy = true  # staging destroy only
+
+tags = {
+  Owner = "platform"
+}

--- a/iac/production/variables.tf
+++ b/iac/production/variables.tf
@@ -1,0 +1,113 @@
+variable "cloud_provider" {
+  description = "Target cloud for this stack. Only aws is implemented; azure and gcp are reserved."
+  type        = string
+  default     = "aws"
+
+  validation {
+    condition     = contains(["aws", "azure", "gcp"], var.cloud_provider)
+    error_message = "cloud_provider must be one of: aws, azure, gcp."
+  }
+}
+
+variable "project_name" {
+  description = "Short project name used in resource naming."
+  type        = string
+  default     = "lextures"
+}
+
+variable "environment" {
+  description = "Deployment environment (staging or production)."
+  type        = string
+  default     = "staging"
+
+  validation {
+    condition     = contains(["staging", "production"], var.environment)
+    error_message = "environment must be staging or production."
+  }
+}
+
+# --- AWS (used when cloud_provider = aws) ---
+
+variable "aws_region" {
+  description = "AWS region."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR when cloud_provider is aws."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "single_nat_gateway" {
+  description = "Single NAT gateway for the VPC (override; default is true for staging, false for production)."
+  type        = bool
+  default     = null
+}
+
+variable "eks_cluster_version" {
+  type    = string
+  default = "1.31"
+}
+
+variable "eks_node_instance_types" {
+  type    = list(string)
+  default = ["t3.large"]
+}
+
+variable "eks_node_desired_size" {
+  type    = number
+  default = 2
+}
+
+variable "eks_node_min_size" {
+  type    = number
+  default = 1
+}
+
+variable "eks_node_max_size" {
+  type    = number
+  default = 4
+}
+
+variable "db_instance_class" {
+  type    = string
+  default = null
+}
+
+variable "db_allocated_storage_gb" {
+  type    = number
+  default = null
+}
+
+variable "db_backup_retention_days" {
+  type    = number
+  default = null
+}
+
+variable "db_multi_az" {
+  type    = bool
+  default = null
+}
+
+variable "redis_node_type" {
+  type    = string
+  default = null
+}
+
+variable "redis_num_cache_clusters" {
+  type    = number
+  default = null
+}
+
+variable "course_files_bucket_force_destroy" {
+  description = "Allow emptying and deleting the course-files bucket on destroy (use only in staging)."
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/iac/production/versions.tf
+++ b/iac/production/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5"
+
+  # Remote backend: configure in Terraform Cloud or copy backend.tf.example.
+  # Example HCP workspace name: lextures-production-aws
+  #
+  # cloud {
+  #   workspaces {
+  #     name = "lextures-production-aws"
+  #   }
+  # }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.80"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `iac/production/` root module with `cloud_provider` (`aws` | `azure` | `gcp`); only AWS is implemented today via a `check` block.
- Add `iac/modules/aws/` with VPC, EKS, RDS PostgreSQL 16, ElastiCache Redis 7, S3 (course files), Secrets Manager (DATABASE_URL / REDIS_URL), and IRSA for `lextures:api`.
- Document planned Azure/GCP modules; extend `.gitignore` for production Terraform local state.

## Test plan

- [ ] `cd iac/production && terraform init -backend=false && terraform validate`
- [ ] Review sizing defaults for `staging` vs `production`
- [ ] Confirm `.terraform/` is not committed; lock file is present
- [ ] (Optional) `terraform plan` against a dev AWS account