### PR TITLE
feat: update ClamAV configuration for Apple Silicon compatibility

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -28,6 +28,7 @@ services:
 
   clamav:
     image: clamav/clamav:1.4
+    platform: linux/amd64
     healthcheck:
       test: ["CMD", "/usr/local/bin/clamdcheck.sh"]
       interval: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,9 @@ services:
       retries: 5
 
   clamav:
+    # Official image is amd64-only; emulate on Apple Silicon (linux/arm64).
     image: clamav/clamav:1.4
+    platform: linux/amd64
     ports:
       - "3310:3310"
     healthcheck:

--- a/docs/runbooks/clamav.md
+++ b/docs/runbooks/clamav.md
@@ -1,5 +1,9 @@
 # ClamAV runbook (plan 8.6)
 
+## Apple Silicon (arm64)
+
+The official `clamav/clamav` image is **amd64-only**. `docker-compose.yml` sets `platform: linux/amd64` so Docker emulates it on Mac/arm64 hosts (first start is slower). For local API dev without real scans, skip the container and use `CLAMAV_STUB=true` (see below).
+
 ## Services
 
 - **clamd** — scans uploaded files via INSTREAM (`CLAMAV_ADDR`, default `localhost:3310`).

--- a/server/migrations/167_equation_editor_open_audit.sql
+++ b/server/migrations/167_equation_editor_open_audit.sql
@@ -1,0 +1,22 @@
+-- 8.11 follow-up: allow equation_editor_open audit events.
+-- Early applies of migration 164 only added equation_inserted; this brings constraints in line
+-- with server/internal/httpserver/course_context.go.
+
+ALTER TABLE "user".user_audit DROP CONSTRAINT IF EXISTS user_audit_event_kind_check;
+ALTER TABLE "user".user_audit ADD CONSTRAINT user_audit_event_kind_check CHECK (
+    event_kind IN (
+        'course_visit',
+        'content_open',
+        'content_leave',
+        'equation_inserted',
+        'equation_editor_open'
+    )
+);
+
+ALTER TABLE "user".user_audit DROP CONSTRAINT IF EXISTS user_audit_structure_item_kind;
+ALTER TABLE "user".user_audit DROP CONSTRAINT IF EXISTS user_audit_structure_item_kind_check;
+ALTER TABLE "user".user_audit ADD CONSTRAINT user_audit_structure_item_kind_check CHECK (
+    (event_kind = 'course_visit' AND structure_item_id IS NULL)
+    OR (event_kind IN ('content_open', 'content_leave') AND structure_item_id IS NOT NULL)
+    OR (event_kind IN ('equation_inserted', 'equation_editor_open'))
+);


### PR DESCRIPTION
Added platform specification for ClamAV service in docker-compose files to ensure compatibility with Apple Silicon (arm64) by emulating amd64. Updated documentation to reflect this change and included a new SQL migration to support additional audit events for the equation editor.