### PR TITLE
Speed up CI E2E with Playwright parallelism and sharding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,10 @@ jobs:
         with:
           name: e2e-build
 
+      # upload-artifact does not preserve the executable bit on the API binary.
+      - name: Restore server binary permissions
+        run: chmod +x "${{ github.workspace }}/.cache/e2e/server"
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,10 +147,57 @@ jobs:
       - name: Build
         run: npm run build
 
-  e2e:
-    name: E2E (Playwright, no Docker)
+  e2e-build:
+    name: E2E build (API + web)
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.10"
+          cache-dependency-path: server/go.sum
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: clients/web/package-lock.json
+
+      - name: Build API server binary
+        working-directory: server
+        run: |
+          mkdir -p "${{ github.workspace }}/.cache/e2e"
+          go build -trimpath -ldflags="-s -w" -o "${{ github.workspace }}/.cache/e2e/server" ./cmd/server
+
+      - name: Install and build web client
+        working-directory: clients/web
+        env:
+          VITE_API_URL: http://localhost:8080
+        run: |
+          npm ci
+          npm run build
+
+      - name: Upload e2e build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-build
+          path: |
+            .cache/e2e/server
+            clients/web/dist
+          retention-days: 1
+
+  e2e:
+    name: E2E shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+    needs: e2e-build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     env:
       E2E_USE_DOCKER: "0"
       E2E_DATABASE_URL: postgres://e2e:e2e@localhost:5432/e2e?sslmode=disable
@@ -160,6 +207,7 @@ jobs:
       E2E_SKIP_DEPS: "1"
       E2E_HEALTH_POLL_SECS: "1"
       E2E_HEALTH_MAX_ATTEMPTS: "45"
+      E2E_ADMIN_EMAIL: admin@e2e.test
       CI: "true"
     services:
       postgres:
@@ -178,10 +226,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
+      - name: Download e2e build artifacts
+        uses: actions/download-artifact@v4
         with:
-          go-version: "1.25.10"
-          cache-dependency-path: server/go.sum
+          name: e2e-build
 
       - uses: actions/setup-node@v4
         with:
@@ -199,19 +247,9 @@ jobs:
           restore-keys: |
             playwright-chromium-${{ runner.os }}-
 
-      - name: Build API server binary
-        working-directory: server
-        run: |
-          mkdir -p "${{ github.workspace }}/.cache/e2e"
-          go build -trimpath -ldflags="-s -w" -o "${{ env.E2E_SERVER_BIN }}" ./cmd/server
-
-      - name: Install and build web client
+      - name: Install web client (preview runtime)
         working-directory: clients/web
-        env:
-          VITE_API_URL: http://localhost:8080
-        run: |
-          npm ci
-          npm run build
+        run: npm ci --prefer-offline --quiet
 
       - name: Install e2e dependencies and Playwright browser
         working-directory: e2e
@@ -219,5 +257,50 @@ jobs:
           npm ci --prefer-offline --quiet
           npx playwright install --with-deps chromium
 
-      - name: Run e2e suite (local stack)
-        run: bash e2e/scripts/e2e-local.sh
+      - name: Run e2e shard (local stack)
+        run: bash e2e/scripts/e2e-local.sh --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+
+      - name: Upload blob report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: blob-report-${{ matrix.shardIndex }}
+          path: e2e/blob-report
+          retention-days: 1
+
+  e2e-report:
+    name: E2E report (merge shards)
+    needs: [e2e]
+    if: ${{ !cancelled() && always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+
+      - name: Install e2e dependencies
+        working-directory: e2e
+        run: npm ci --prefer-offline --quiet
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          path: e2e/all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge Playwright reports
+        working-directory: e2e
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload merged HTML report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: e2e/playwright-report
+          retention-days: 7

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,12 +6,18 @@ const apiURL = process.env.E2E_API_URL ?? 'http://localhost:8080'
 export default defineConfig({
   globalSetup: './global-setup.ts',
   testDir: './tests',
-  // Spec files are isolated (unique users via fixtures); parallelize across files in CI.
-  fullyParallel: false,
+  // Spec files use unique users via fixtures; safe to parallelize tests within files.
+  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 4 : 1,
-  reporter: process.env.CI ? 'github' : 'list',
+  // Local: single worker for easier debugging. CI: default (~50% of cores per shard job).
+  ...(process.env.CI ? {} : { workers: 1 }),
+  reporter: process.env.CI
+    ? [
+        ['blob'],
+        ['github'],
+      ]
+    : 'list',
   use: {
     baseURL,
     trace: 'on-first-retry',

--- a/e2e/scripts/e2e-local.sh
+++ b/e2e/scripts/e2e-local.sh
@@ -227,9 +227,12 @@ fi
 echo "==> Starting Go API server on port ${E2E_API_PORT}..."
 cd "${REPO_ROOT}/server"
 if [[ -n "${E2E_SERVER_BIN:-}" ]]; then
-  if [[ ! -x "${E2E_SERVER_BIN}" ]]; then
-    echo "ERROR: E2E_SERVER_BIN is not executable: ${E2E_SERVER_BIN}"
+  if [[ ! -f "${E2E_SERVER_BIN}" ]]; then
+    echo "ERROR: E2E_SERVER_BIN not found: ${E2E_SERVER_BIN}"
     exit 1
+  fi
+  if [[ ! -x "${E2E_SERVER_BIN}" ]]; then
+    chmod +x "${E2E_SERVER_BIN}"
   fi
   DATABASE_URL="${DATABASE_URL}" \
     JWT_SECRET="${E2E_JWT_SECRET}" \

--- a/e2e/scripts/e2e-local.sh
+++ b/e2e/scripts/e2e-local.sh
@@ -5,7 +5,8 @@
 #   ./e2e/scripts/e2e-local.sh              # full suite (cwd: repo root)
 #   ./e2e/scripts/e2e-local.sh tests/inbox.spec.ts
 #   ./e2e/scripts/e2e-local.sh e2e/tests/inbox.spec.ts   # same; e2e/ prefix is stripped
-# Any extra arguments are passed through to `playwright test` (e.g. --headed, --grep).
+# Any extra arguments are passed through to `playwright test` (e.g. --headed, --grep,
+# --shard=2/4 for CI sharding).
 #
 # Steps:
 #   1. Locate system PostgreSQL binaries (Homebrew, Linux packages, pg_config).


### PR DESCRIPTION
## Summary
- Enable `fullyParallel` and default CI workers per shard instead of a fixed 4-worker cap.
- Split E2E into four sharded jobs with blob reports merged into a single HTML artifact.
- Build API + web once in `e2e-build` and reuse artifacts across shard jobs.

## Test plan
- [ ] CI `e2e-build`, all four `e2e` shards, and `e2e-report` jobs pass on this PR
- [ ] Merged `playwright-report` artifact is downloadable and complete
- [ ] Local suite still runs: `./e2e/scripts/e2e-local.sh`