### PR TITLE
feat(compliance): backup/restore RPO-RTO (10.15)

### DIFF
--- a/clients/web/src/app.tsx
+++ b/clients/web/src/app.tsx
@@ -67,6 +67,7 @@ import TermsOfUsePage from './pages/terms-of-use-page'
 import TermsOfUseHistoryPage from './pages/terms-of-use-history-page'
 import TrustCenterPage from './pages/trust-center-page'
 import IsoComplianceAdminPage from './pages/iso-compliance-admin-page'
+import BackupOpsAdminPage from './pages/backup-ops-admin-page'
 import PrivacyCentrePage from './pages/privacy-centre-page'
 import CaliforniaPrivacyRightsPage from './pages/california-privacy-rights-page'
 import AccessibilityConformancePage from './pages/accessibility-conformance-page'
@@ -189,6 +190,7 @@ export default function App() {
           <Route path="/admin/accommodations" element={<AdminAccommodationsPage />} />
           <Route path="/admin/quarantine" element={<AdminQuarantinePage />} />
           <Route path="/admin/compliance/iso" element={<IsoComplianceAdminPage />} />
+          <Route path="/admin/compliance/backup" element={<BackupOpsAdminPage />} />
           <Route path="/reports" element={<Reports />} />
           <Route path="/inbox" element={<Inbox />} />
           <Route path="/settings" element={<Navigate to="/settings/account" replace />} />

--- a/clients/web/src/pages/__tests__/backup-ops-admin-page.test.tsx
+++ b/clients/web/src/pages/__tests__/backup-ops-admin-page.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import BackupOpsAdminPage from '../backup-ops-admin-page'
+
+vi.mock('../../lib/api', () => ({
+  authorizedFetch: (input: string, init?: RequestInit) => globalThis.fetch(input, init),
+}))
+
+describe('BackupOpsAdminPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows disabled message when API returns 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 404 }))
+    render(
+      <MemoryRouter>
+        <BackupOpsAdminPage />
+      </MemoryRouter>,
+    )
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/not enabled/i)
+    })
+  })
+
+  it('renders tier status when API succeeds', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          targets: { postgresRpoMinutes: 60, postgresRtoMinutes: 240, objectStorageRpoHours: 24 },
+          tiers: [
+            { tier: 'postgres', lastSuccessAt: '2026-05-27T02:00:00Z', healthy: true, walLagSeconds: 10 },
+            { tier: 'object_storage', healthy: true },
+          ],
+          alerts: [],
+          restoreDrills: [],
+        }),
+        { status: 200 },
+      ),
+    )
+    render(
+      <MemoryRouter>
+        <BackupOpsAdminPage />
+      </MemoryRouter>,
+    )
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /Backup & restore/i })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: /^postgres$/i })).toBeInTheDocument()
+    })
+  })
+})

--- a/clients/web/src/pages/backup-ops-admin-page.tsx
+++ b/clients/web/src/pages/backup-ops-admin-page.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { authorizedFetch } from '../lib/api'
+
+const API = '/api/v1/internal/ops'
+
+interface TierStatus {
+  tier: string
+  lastSuccessAt?: string
+  walLagSeconds?: number
+  nextScheduledAt?: string
+  lastError?: string
+  healthy: boolean
+}
+
+interface BackupStatus {
+  targets: {
+    postgresRpoMinutes: number
+    postgresRtoMinutes: number
+    objectStorageRpoHours: number
+  }
+  tiers: TierStatus[]
+  alerts: { tier: string; reason: string }[]
+  restoreDrills: {
+    id: string
+    drillDate: string
+    pass?: boolean
+    rpoAchievedMinutes?: number
+    rtoAchievedMinutes?: number
+  }[]
+}
+
+export default function BackupOpsAdminPage() {
+  const [status, setStatus] = useState<BackupStatus | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [message, setMessage] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await authorizedFetch(`${API}/backup-status`)
+      if (res.status === 404) {
+        setError('Backup module is not enabled on this environment.')
+        return
+      }
+      if (res.status === 403) {
+        setError('You need Global Admin / compliance:backup:admin permission.')
+        return
+      }
+      if (!res.ok) {
+        setError('Failed to load backup status.')
+        return
+      }
+      setStatus((await res.json()) as BackupStatus)
+    } catch {
+      setError('Network error loading backup status.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    document.title = 'Backup & restore — Lextures'
+    void load()
+  }, [load])
+
+  async function recordDrill(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setMessage(null)
+    const form = new FormData(e.currentTarget)
+    const now = new Date()
+    const body = {
+      drillDate: String(form.get('drillDate') || now.toISOString().slice(0, 10)),
+      backupTimestamp: String(form.get('backupTimestamp') || now.toISOString()),
+      restoreStart: String(form.get('restoreStart') || now.toISOString()),
+      restoreEnd: now.toISOString(),
+      rpoAchievedMinutes: Number(form.get('rpoMinutes') || 0),
+      rtoAchievedMinutes: Number(form.get('rtoMinutes') || 0),
+      pass: form.get('pass') === 'on',
+      smokeTestOutput: String(form.get('smokeOutput') || ''),
+      notes: String(form.get('notes') || ''),
+    }
+    const res = await authorizedFetch(`${API}/restore-drill`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) {
+      setMessage('Could not record restore drill.')
+      return
+    }
+    setMessage('Restore drill recorded.')
+    void load()
+  }
+
+  if (loading) {
+    return <p className="p-6 text-slate-600 dark:text-neutral-400">Loading backup status…</p>
+  }
+
+  if (error) {
+    return (
+      <div className="p-6 max-w-3xl">
+        <p role="alert" className="text-red-700 dark:text-red-300">{error}</p>
+        <Link to="/settings/account" className="mt-4 inline-block text-sm underline">Back to settings</Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 max-w-4xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-neutral-50">Backup &amp; restore</h1>
+        <p className="mt-1 text-sm text-slate-600 dark:text-neutral-400">
+          RPO/RTO ops dashboard (plan 10.15). Targets: Postgres RPO ≤ {status?.targets.postgresRpoMinutes} min, RTO ≤ {status?.targets.postgresRtoMinutes} min.
+        </p>
+      </div>
+
+      {status && status.alerts.length > 0 && (
+        <div role="alert" className="rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/40 p-4 text-sm">
+          <p className="font-medium text-amber-900 dark:text-amber-200">Active alerts</p>
+          <ul className="mt-2 list-disc pl-5 space-y-1">
+            {status.alerts.map((a) => (
+              <li key={`${a.tier}-${a.reason}`}>{a.tier}: {a.reason}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {status && (
+        <section className="grid gap-4 sm:grid-cols-2">
+          {status.tiers.map((t) => (
+            <div key={t.tier} className="rounded-lg border border-slate-200 dark:border-neutral-800 p-4">
+              <h2 className="font-medium capitalize">{t.tier.replace('_', ' ')}</h2>
+              <dl className="mt-2 text-sm space-y-1">
+                <div><dt className="inline text-slate-500">Last success: </dt><dd className="inline">{t.lastSuccessAt ?? '—'}</dd></div>
+                {t.walLagSeconds != null && (
+                  <div><dt className="inline text-slate-500">WAL lag (s): </dt><dd className="inline">{t.walLagSeconds}</dd></div>
+                )}
+                <div><dt className="inline text-slate-500">Next scheduled: </dt><dd className="inline">{t.nextScheduledAt ?? '—'}</dd></div>
+                <div><dt className="inline text-slate-500">Healthy: </dt><dd className="inline">{t.healthy ? 'yes' : 'no'}</dd></div>
+              </dl>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {status && status.restoreDrills.length > 0 && (
+        <section>
+          <h2 className="text-lg font-medium">Restore drill history</h2>
+          <ul className="mt-2 text-sm space-y-2">
+            {status.restoreDrills.map((d) => (
+              <li key={d.id} className="border-b border-slate-100 dark:border-neutral-800 pb-2">
+                {d.drillDate} — {d.pass ? 'PASS' : d.pass === false ? 'FAIL' : 'pending'}
+                {d.rpoAchievedMinutes != null && ` · RPO ${d.rpoAchievedMinutes}m`}
+                {d.rtoAchievedMinutes != null && ` · RTO ${d.rtoAchievedMinutes}m`}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <section>
+        <h2 className="text-lg font-medium">Record restore drill</h2>
+        <form onSubmit={(e) => void recordDrill(e)} className="mt-3 space-y-3 text-sm max-w-md">
+          <label className="flex flex-col gap-1">
+            Drill date
+            <input name="drillDate" type="date" className="border rounded px-2 py-1 dark:bg-neutral-900" />
+          </label>
+          <label className="flex items-center gap-2">
+            <input name="pass" type="checkbox" defaultChecked />
+            Drill passed smoke tests
+          </label>
+          <label className="flex flex-col gap-1">
+            RPO achieved (minutes)
+            <input name="rpoMinutes" type="number" min={0} defaultValue={45} className="border rounded px-2 py-1 dark:bg-neutral-900" />
+          </label>
+          <label className="flex flex-col gap-1">
+            RTO achieved (minutes)
+            <input name="rtoMinutes" type="number" min={0} defaultValue={90} className="border rounded px-2 py-1 dark:bg-neutral-900" />
+          </label>
+          <label className="flex flex-col gap-1">
+            Smoke test output
+            <textarea name="smokeOutput" rows={2} className="border rounded px-2 py-1 dark:bg-neutral-900" placeholder="grade reads, quiz attempts, auth: ok" />
+          </label>
+          <label className="flex flex-col gap-1">
+            Notes
+            <textarea name="notes" rows={2} className="border rounded px-2 py-1 dark:bg-neutral-900" />
+          </label>
+          <button type="submit" className="rounded bg-slate-900 text-white px-3 py-1.5 dark:bg-neutral-100 dark:text-neutral-900">
+            Save drill
+          </button>
+        </form>
+        {message && <p className="mt-2 text-sm text-emerald-700 dark:text-emerald-300">{message}</p>}
+      </section>
+    </div>
+  )
+}

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -51,6 +51,7 @@ services:
       EMAIL_NOTIFICATIONS_ENABLED: ${EMAIL_NOTIFICATIONS_ENABLED:-false}
       COPPA_WORKFLOW_ENABLED: "true"
       ISO_ISMS_ENABLED: "true"
+      BACKUP_MODULE_ENABLED: "true"
     ports:
       - "8080:8080"
     depends_on:

--- a/docs/completed/10-compliance-privacy-security/10.15-backup-restore-rpo-rto.md
+++ b/docs/completed/10-compliance-privacy-security/10.15-backup-restore-rpo-rto.md
@@ -10,7 +10,7 @@
 | **Section** | Compliance, Privacy & Security |
 | **Severity** | BLOCKER |
 | **Markets** | K12, HE |
-| **Status (today)** | MISSING |
+| **Status (today)** | DONE |
 | **Estimated effort** | M (2–4 weeks) |
 | **Owner (proposed)** | Infrastructure Lead |
 | **Depends on** | 17.1 (Production IaC), 10.13 (Encryption at rest — backups must be encrypted), 8.1 (Object storage — backup destination) |

--- a/docs/isms/bcm_policy.md
+++ b/docs/isms/bcm_policy.md
@@ -1,0 +1,23 @@
+# Business continuity management (BCM) policy
+
+**Control mapping:** ISO/IEC 27001:2022 A.5.29, A.5.30; SOC 2 Availability TSC A1.2; NIST SP 800-53 CP-9, CP-10.
+
+## Objectives
+
+Lextures maintains backup and recovery capabilities so that loss of Postgres or object storage does not result in unrecoverable loss of student or grade data.
+
+## Recovery targets
+
+- **Postgres:** RPO ≤ 1 hour, RTO ≤ 4 hours (see plan 10.15).
+- **Course files (object storage):** RPO ≤ 24 hours, RTO ≤ 4 hours.
+
+## Controls
+
+1. Automated backups codified in `iac/production/backup.tf` and `iac/modules/aws/backup.tf`.
+2. Encrypted backup storage with Object Lock (30-day WORM) on production buckets.
+3. Quarterly restore drills logged in `compliance.restore_drills`.
+4. Ops dashboard and `GET /api/v1/internal/ops/backup-status` for continuous monitoring.
+
+## Review
+
+This policy is reviewed annually and after any failed restore drill or production data-loss incident.

--- a/docs/runbooks/database-backup-restore.md
+++ b/docs/runbooks/database-backup-restore.md
@@ -1,0 +1,23 @@
+# Database backup and restore procedure
+
+Plan 10.15 — RPO ≤ 1 hour (Postgres WAL streaming), RTO ≤ 4 hours (full restore).
+
+## Daily operations
+
+1. **Continuous WAL archive** — `archive_command` pushes segments via WAL-G to the encrypted backup bucket (`iac/modules/aws/backup.tf`).
+2. **Daily base backup** — Cron at 02:00–04:00 UTC runs `wal-g backup-push` (see `server/backup/walg.env.example`).
+3. **Heartbeat** — After each job: `go run ./cmd/backup-report -tier=postgres -success -wal-lag-seconds=N -duration-seconds=N`.
+4. **Verify** — Global Admin opens **Admin → Backup & restore** or `GET /api/v1/internal/ops/backup-status`. Alert if `alerts` is non-empty.
+
+## Full restore (disaster recovery)
+
+1. Provision an isolated Postgres 16 instance in the same region.
+2. Restore the latest base: `wal-g backup-fetch LATEST /var/lib/postgresql/data`.
+3. Replay WAL to the target time: `wal-g wal-fetch` / point-in-time recovery per WAL-G docs.
+4. Point `DATABASE_URL` at the restored instance only after smoke tests pass.
+5. Record the drill: `POST /api/v1/internal/ops/restore-drill` with RPO/RTO achieved minutes and smoke test output.
+
+## Retention
+
+- Daily: 30 days (RDS `backup_retention_period` + S3 lifecycle).
+- Weekly/monthly: S3 lifecycle transitions (see `backup.tf`).

--- a/docs/runbooks/disaster-recovery-rpo-rto.md
+++ b/docs/runbooks/disaster-recovery-rpo-rto.md
@@ -1,0 +1,24 @@
+# Disaster recovery playbook (RPO / RTO)
+
+| Tier | RPO target | RTO target | Mechanism |
+|------|------------|------------|-----------|
+| Postgres | ≤ 1 hour | ≤ 4 hours | WAL-G continuous WAL + daily base backup |
+| Object storage (course files) | ≤ 24 hours | ≤ 4 hours | S3 versioning + daily snapshot to backup bucket |
+
+## Roles
+
+- **Incident commander** — Declares DR, coordinates comms.
+- **Ops engineer** — Executes restore runbook (`database-backup-restore.md`).
+- **Compliance** — Records restore drill results in Lextures (`restore_drills` table).
+
+## Quarterly restore drill (FR-7)
+
+1. Spin up an isolated environment (staging VPC or ephemeral RDS).
+2. Restore from the most recent production base backup + WAL to a fixed timestamp.
+3. Run smoke tests: auth login, grade read, quiz attempt list, course module fetch.
+4. Submit results via **Admin → Backup & restore** or `POST /api/v1/internal/ops/restore-drill`.
+5. File evidence in the SOC 2 / ISO BCM package.
+
+## Escalation
+
+If `backup-status` reports WAL lag > 15 minutes or last success > 25 hours, page on-call and inspect WAL-G / RDS storage IOPS.

--- a/e2e/tests/backup-restore.spec.ts
+++ b/e2e/tests/backup-restore.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * Backup / restore ops (plan 10.15)
+ *
+ *   [x] GET backup-status without auth returns 401
+ *   [x] POST restore-drill without auth returns 401
+ *   [x] Endpoints return 404 when feature disabled
+ *   [x] Global Admin can read backup status when enabled
+ *   [x] Global Admin can record a restore drill
+ */
+import { test, expect } from '../fixtures/test.js'
+import { apiSignup } from '../fixtures/api.js'
+
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:8080'
+const PASSWORD = 'E2eTestPass1!'
+const BACKUP_ENABLED =
+  process.env.BACKUP_MODULE_ENABLED === 'true' || process.env.FEATURE_BACKUP_MODULE === 'true'
+
+test('Backup: GET backup-status unauthenticated returns 401', async () => {
+  test.skip(!BACKUP_ENABLED, 'requires BACKUP_MODULE_ENABLED=true')
+  const res = await fetch(`${API_BASE}/api/v1/internal/ops/backup-status`)
+  expect(res.status).toBe(401)
+})
+
+test('Backup: POST restore-drill unauthenticated returns 401', async () => {
+  test.skip(!BACKUP_ENABLED, 'requires BACKUP_MODULE_ENABLED=true')
+  const res = await fetch(`${API_BASE}/api/v1/internal/ops/restore-drill`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  })
+  expect(res.status).toBe(401)
+})
+
+test('Backup: endpoints return 404 when module disabled', async ({ request }) => {
+  test.skip(BACKUP_ENABLED, 'only when BACKUP_MODULE_ENABLED is not set')
+  const res = await request.get(`${API_BASE}/api/v1/internal/ops/backup-status`, {
+    headers: { Authorization: 'Bearer invalid' },
+  })
+  expect([401, 404]).toContain(res.status())
+})
+
+test('Backup: admin can read status and record drill', async () => {
+  test.skip(!BACKUP_ENABLED, 'requires BACKUP_MODULE_ENABLED=true')
+
+  const email = process.env.E2E_ADMIN_EMAIL ?? `e2e-backup-${Date.now()}@test.invalid`
+  const { access_token: token } = await apiSignup({
+    email,
+    password: PASSWORD,
+    displayName: 'Backup E2E Admin',
+  })
+
+  const statusRes = await fetch(`${API_BASE}/api/v1/internal/ops/backup-status`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  expect(statusRes.status).toBe(200)
+  const status = (await statusRes.json()) as { tiers: unknown[]; targets: { postgresRpoMinutes: number } }
+  expect(status.targets.postgresRpoMinutes).toBe(60)
+  expect(Array.isArray(status.tiers)).toBe(true)
+
+  const now = new Date()
+  const drillRes = await fetch(`${API_BASE}/api/v1/internal/ops/restore-drill`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      drillDate: now.toISOString().slice(0, 10),
+      backupTimestamp: new Date(now.getTime() - 3600000).toISOString(),
+      restoreStart: new Date(now.getTime() - 1800000).toISOString(),
+      restoreEnd: now.toISOString(),
+      rpoAchievedMinutes: 30,
+      rtoAchievedMinutes: 60,
+      pass: true,
+      smokeTestOutput: 'e2e smoke ok',
+    }),
+  })
+  expect(drillRes.status).toBe(201)
+  const created = (await drillRes.json()) as { id: string }
+  expect(created.id).toBeTruthy()
+})

--- a/iac/modules/aws/backup.tf
+++ b/iac/modules/aws/backup.tf
@@ -1,0 +1,107 @@
+# Plan 10.15: encrypted backup destination with Object Lock (WORM) for ransomware protection.
+
+locals {
+  backup_bucket_name = "${local.name_prefix}-backups-${data.aws_caller_identity.current.account_id}"
+}
+
+resource "aws_s3_bucket" "backups" {
+  bucket = local.backup_bucket_name
+
+  force_destroy = !local.is_production
+
+  tags = merge(local.common_tags, {
+    Name    = local.backup_bucket_name
+    Purpose = "database-wal-g-object-storage-backups"
+  })
+}
+
+resource "aws_s3_bucket_versioning" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_object_lock_configuration" "backups" {
+  count  = local.is_production ? 1 : 0
+  bucket = aws_s3_bucket.backups.id
+
+  rule {
+    default_retention {
+      mode = "GOVERNANCE"
+      days = 30
+    }
+  }
+
+  depends_on = [aws_s3_bucket_versioning.backups]
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  rule {
+    id     = "daily-weekly-monthly-retention"
+    status = "Enabled"
+
+    filter {}
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+
+    expiration {
+      days = 395
+    }
+  }
+}
+
+resource "aws_iam_policy" "backup_writer" {
+  name        = "${local.name_prefix}-backup-writer"
+  description = "WAL-G / backup cron write-only access to the backup bucket (plan 10.15)."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "BackupWrite"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:AbortMultipartUpload",
+        ]
+        Resource = [
+          aws_s3_bucket.backups.arn,
+          "${aws_s3_bucket.backups.arn}/*",
+        ]
+      },
+    ]
+  })
+}

--- a/iac/modules/aws/outputs.tf
+++ b/iac/modules/aws/outputs.tf
@@ -88,3 +88,13 @@ output "course_files_irsa_role_arn" {
   description = "IAM role ARN for Kubernetes service account lextures:api (S3 access)."
   value       = module.irsa_course_files.iam_role_arn
 }
+
+output "backup_bucket_name" {
+  description = "Encrypted S3 bucket for WAL-G and object-storage backups (plan 10.15)."
+  value       = aws_s3_bucket.backups.id
+}
+
+output "backup_writer_policy_arn" {
+  description = "IAM policy for backup cron / WAL-G (write-only to backup bucket)."
+  value       = aws_iam_policy.backup_writer.arn
+}

--- a/iac/production/backup.tf
+++ b/iac/production/backup.tf
@@ -1,0 +1,12 @@
+# Plan 10.15 — Backup / restore infrastructure (production root).
+# WAL-G archives Postgres WAL + daily base backups; object storage snapshots land in the backup bucket.
+
+output "backup_bucket_name" {
+  description = "Encrypted S3 bucket for Postgres WAL-G and object-storage backups."
+  value       = module.aws[0].backup_bucket_name
+}
+
+output "backup_writer_policy_arn" {
+  description = "IAM policy ARN for the backup cron / WAL-G role (no application runtime access)."
+  value       = module.aws[0].backup_writer_policy_arn
+}

--- a/server/backup/walg.env.example
+++ b/server/backup/walg.env.example
@@ -1,0 +1,16 @@
+# WAL-G configuration for Postgres continuous WAL archiving + daily base backups (plan 10.15).
+# Copy to walg.env on the backup host; credentials come from the backup IAM role / secrets manager.
+
+WALG_S3_PREFIX=s3://lextures-production-backups-ACCOUNT_ID/postgres
+AWS_REGION=us-east-1
+
+# AES-256 server-side encryption is enforced on the bucket (see iac/modules/aws/backup.tf).
+# For client-side encryption, set WALG_LIBSODIUM_KEY from Secrets Manager.
+
+PGDATA=/var/lib/postgresql/data
+PGHOST=127.0.0.1
+PGPORT=5432
+PGUSER=backup
+
+# Daily base backup cron (02:00 UTC): wal-g backup-push
+# Continuous archive: archive_command = 'wal-g wal-push %p'

--- a/server/cmd/backup-report/main.go
+++ b/server/cmd/backup-report/main.go
@@ -1,0 +1,85 @@
+// Command backup-report records a backup heartbeat in compliance.backup_tier_status (plan 10.15).
+// Intended for cron after WAL-G base backup or object-storage snapshot jobs.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/lextures/lextures/server/internal/db"
+	backupservice "github.com/lextures/lextures/server/internal/service/backup"
+	repobackup "github.com/lextures/lextures/server/internal/repos/backup"
+)
+
+func main() {
+	tierFlag := flag.String("tier", "postgres", "postgres or object_storage")
+	success := flag.Bool("success", true, "whether the backup job succeeded")
+	duration := flag.Int("duration-seconds", 0, "job duration in seconds")
+	walLag := flag.Int("wal-lag-seconds", -1, "WAL lag in seconds (postgres tier only; omit if unknown)")
+	next := flag.String("next-scheduled", "", "RFC3339 timestamp for next scheduled backup")
+	errMsg := flag.String("error", "", "last error message when success=false")
+	flag.Parse()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		fmt.Fprintln(os.Stderr, "DATABASE_URL is required")
+		os.Exit(1)
+	}
+
+	var tier repobackup.Tier
+	switch *tierFlag {
+	case "postgres":
+		tier = repobackup.TierPostgres
+	case "object_storage":
+		tier = repobackup.TierObjectStorage
+	default:
+		fmt.Fprintln(os.Stderr, "tier must be postgres or object_storage")
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pool: %v\n", err)
+		os.Exit(1)
+	}
+	defer pool.Close()
+
+	var lastSuccess *time.Time
+	var lastErr *string
+	if *success {
+		now := time.Now().UTC()
+		lastSuccess = &now
+	} else if *errMsg != "" {
+		lastErr = errMsg
+	}
+
+	var durationPtr *int
+	if *duration > 0 {
+		durationPtr = duration
+	}
+	var walPtr *int
+	if *walLag >= 0 {
+		walPtr = walLag
+	}
+	var nextPtr *time.Time
+	if *next != "" {
+		t, err := time.Parse(time.RFC3339, *next)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "next-scheduled: %v\n", err)
+			os.Exit(1)
+		}
+		nextPtr = &t
+	}
+
+	if err := backupservice.ReportTierHeartbeat(ctx, pool, tier, lastSuccess, durationPtr, walPtr, nextPtr, lastErr); err != nil {
+		fmt.Fprintf(os.Stderr, "report: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("recorded backup heartbeat for tier=%s success=%v\n", tier, *success)
+}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -252,6 +252,8 @@ type Config struct {
 	AdminAuditLogEnabled bool
 	// DataResidencyEnabled gates per-tenant region pinning enforcement and the data residency compliance admin API (plan 10.12).
 	DataResidencyEnabled bool
+	// BackupModuleEnabled gates backup/restore ops: backup status and restore drill APIs (plan 10.15).
+	BackupModuleEnabled bool
 }
 
 // Load reads configuration from the environment.
@@ -395,6 +397,7 @@ func Load() Config {
 		IsoIsmsEnabled:       boolEnv("ISO_ISMS_ENABLED") || boolEnv("FEATURE_ISO_ISMS"),
 		AdminAuditLogEnabled: true, // plan 10.11 default on; disable via platform settings
 		DataResidencyEnabled: boolEnv("DATA_RESIDENCY_ENABLED") || boolEnv("FEATURE_DATA_RESIDENCY"),
+		BackupModuleEnabled:  boolEnv("BACKUP_MODULE_ENABLED") || boolEnv("FEATURE_BACKUP_MODULE"),
 	}
 }
 

--- a/server/internal/httpserver/backup_ops_http.go
+++ b/server/internal/httpserver/backup_ops_http.go
@@ -1,0 +1,137 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/lextures/lextures/server/internal/apierr"
+	backupservice "github.com/lextures/lextures/server/internal/service/backup"
+)
+
+func (d Deps) backupModuleEnabled(w http.ResponseWriter) bool {
+	if !d.effectiveConfig().BackupModuleEnabled {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Backup module is not enabled.")
+		return false
+	}
+	return true
+}
+
+func (d Deps) requireBackupAdmin(w http.ResponseWriter, r *http.Request) (userID uuid.UUID, ok bool) {
+	uid, ok := d.meUserID(w, r)
+	if !ok {
+		return uuid.UUID{}, false
+	}
+	isAdmin, err := backupservice.CheckAdmin(r.Context(), d.Pool, uid)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Permission check failed.")
+		return uuid.UUID{}, false
+	}
+	if !isAdmin {
+		apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission for this action.")
+		return uuid.UUID{}, false
+	}
+	return uid, true
+}
+
+func (d Deps) registerBackupOpsRoutes(r chi.Router) {
+	r.Get("/api/v1/internal/ops/backup-status", d.handleGetBackupStatus())
+	r.Post("/api/v1/internal/ops/restore-drill", d.handlePostRestoreDrill())
+}
+
+// GET /api/v1/internal/ops/backup-status
+func (d Deps) handleGetBackupStatus() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.backupModuleEnabled(w) {
+			return
+		}
+		if _, ok := d.requireBackupAdmin(w, r); !ok {
+			return
+		}
+		status, err := backupservice.GetBackupStatus(r.Context(), d.Pool)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not load backup status.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(status)
+	}
+}
+
+type postRestoreDrillBody struct {
+	DrillDate          string  `json:"drillDate"`          // YYYY-MM-DD
+	BackupTimestamp    string  `json:"backupTimestamp"`    // RFC3339
+	RestoreStart       string  `json:"restoreStart"`       // RFC3339
+	RestoreEnd         *string `json:"restoreEnd"`         // RFC3339
+	RPOAchievedMinutes *int    `json:"rpoAchievedMinutes"`
+	RTOAchievedMinutes *int    `json:"rtoAchievedMinutes"`
+	Pass               *bool   `json:"pass"`
+	SmokeTestOutput    *string `json:"smokeTestOutput"`
+	Notes              *string `json:"notes"`
+}
+
+// POST /api/v1/internal/ops/restore-drill
+func (d Deps) handlePostRestoreDrill() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.backupModuleEnabled(w) {
+			return
+		}
+		conductorID, ok := d.requireBackupAdmin(w, r)
+		if !ok {
+			return
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		var body postRestoreDrillBody
+		if err := json.Unmarshal(b, &body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		drillDate, err := time.Parse("2006-01-02", body.DrillDate)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "drillDate must be YYYY-MM-DD.")
+			return
+		}
+		backupTS, err := time.Parse(time.RFC3339, body.BackupTimestamp)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "backupTimestamp must be RFC3339.")
+			return
+		}
+		restoreStart, err := time.Parse(time.RFC3339, body.RestoreStart)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "restoreStart must be RFC3339.")
+			return
+		}
+		var restoreEnd *time.Time
+		if body.RestoreEnd != nil {
+			t, err := time.Parse(time.RFC3339, *body.RestoreEnd)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "restoreEnd must be RFC3339.")
+				return
+			}
+			restoreEnd = &t
+		}
+		id, err := backupservice.RecordRestoreDrill(r.Context(), d.Pool, backupservice.RecordRestoreDrillInput{
+			DrillDate:          drillDate,
+			BackupTimestamp:    backupTS,
+			RestoreStart:       restoreStart,
+			RestoreEnd:         restoreEnd,
+			RPOAchievedMinutes: body.RPOAchievedMinutes,
+			RTOAchievedMinutes: body.RTOAchievedMinutes,
+			Pass:               body.Pass,
+			SmokeTestOutput:    body.SmokeTestOutput,
+			ConductedBy:        &conductorID,
+			Notes:              body.Notes,
+		})
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not record restore drill.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": id.String()})
+	}
+}

--- a/server/internal/httpserver/backup_ops_nodb_test.go
+++ b/server/internal/httpserver/backup_ops_nodb_test.go
@@ -1,0 +1,65 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/config"
+)
+
+func TestBackupOps_FeatureDisabled_Returns404(t *testing.T) {
+	d := Deps{Config: config.Config{BackupModuleEnabled: false}}
+	h := NewHandler(d)
+
+	paths := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/internal/ops/backup-status"},
+		{http.MethodPost, "/api/v1/internal/ops/restore-drill"},
+	}
+	for _, p := range paths {
+		r := httptest.NewRequest(p.method, p.path, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("%s %s: status=%d want 404", p.method, p.path, w.Code)
+		}
+	}
+}
+
+func TestBackupOps_Unauthenticated_Returns401(t *testing.T) {
+	d := Deps{Config: config.Config{BackupModuleEnabled: true}}
+	h := NewHandler(d)
+
+	paths := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/internal/ops/backup-status"},
+		{http.MethodPost, "/api/v1/internal/ops/restore-drill"},
+	}
+	for _, p := range paths {
+		r := httptest.NewRequest(p.method, p.path, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s: status=%d want 401", p.method, p.path, w.Code)
+		}
+	}
+}
+
+func TestBackupOps_PostRestoreDrill_InvalidJSON_Returns401WhenUnauthenticated(t *testing.T) {
+	d := Deps{Config: config.Config{BackupModuleEnabled: true}}
+	h := NewHandler(d)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/internal/ops/restore-drill",
+		strings.NewReader("{bad json}"))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status=%d want 401", w.Code)
+	}
+}

--- a/server/internal/httpserver/server.go
+++ b/server/internal/httpserver/server.go
@@ -135,6 +135,7 @@ func NewHandler(d Deps) http.Handler {
 	d.registerISORoutes(r)
 	d.registerAdminAuditLogRoutes(r)
 	d.registerDataResidencyRoutes(r)
+	d.registerBackupOpsRoutes(r)
 	d.registerUnimplementedV1(r)
 	d.mountRouterErrorHandlers(r)
 	return r

--- a/server/internal/repos/backup/repo.go
+++ b/server/internal/repos/backup/repo.go
@@ -1,0 +1,151 @@
+// Package backup persists backup tier status and restore drill records (plan 10.15).
+package backup
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Tier identifies a backup data tier.
+type Tier string
+
+const (
+	TierPostgres        Tier = "postgres"
+	TierObjectStorage   Tier = "object_storage"
+)
+
+// TierStatus is one row from compliance.backup_tier_status.
+type TierStatus struct {
+	Tier                Tier
+	LastSuccessAt       *time.Time
+	LastDurationSeconds *int
+	WALLagSeconds       *int
+	NextScheduledAt     *time.Time
+	LastError           *string
+	UpdatedAt           time.Time
+}
+
+// RestoreDrill is one row from compliance.restore_drills.
+type RestoreDrill struct {
+	ID                 uuid.UUID
+	DrillDate          time.Time
+	BackupTimestamp    time.Time
+	RestoreStart       time.Time
+	RestoreEnd         *time.Time
+	RPOAchievedMinutes *int
+	RTOAchievedMinutes *int
+	Pass               *bool
+	SmokeTestOutput    *string
+	ConductedBy        *uuid.UUID
+	Notes              *string
+	CreatedAt          time.Time
+}
+
+// ListTierStatus returns all tier status rows.
+func ListTierStatus(ctx context.Context, pool *pgxpool.Pool) ([]TierStatus, error) {
+	rows, err := pool.Query(ctx, `
+SELECT tier, last_success_at, last_duration_seconds, wal_lag_seconds, next_scheduled_at, last_error, updated_at
+  FROM compliance.backup_tier_status
+ ORDER BY tier
+`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []TierStatus
+	for rows.Next() {
+		var s TierStatus
+		var tier string
+		if err := rows.Scan(&tier, &s.LastSuccessAt, &s.LastDurationSeconds, &s.WALLagSeconds, &s.NextScheduledAt, &s.LastError, &s.UpdatedAt); err != nil {
+			return nil, err
+		}
+		s.Tier = Tier(tier)
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// UpsertTierStatus records a backup heartbeat for a tier.
+func UpsertTierStatus(ctx context.Context, pool *pgxpool.Pool, tier Tier, lastSuccess *time.Time, durationSec, walLagSec *int, nextScheduled *time.Time, lastErr *string) error {
+	_, err := pool.Exec(ctx, `
+INSERT INTO compliance.backup_tier_status (tier, last_success_at, last_duration_seconds, wal_lag_seconds, next_scheduled_at, last_error, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, NOW())
+ON CONFLICT (tier) DO UPDATE SET
+  last_success_at       = COALESCE(EXCLUDED.last_success_at, compliance.backup_tier_status.last_success_at),
+  last_duration_seconds = COALESCE(EXCLUDED.last_duration_seconds, compliance.backup_tier_status.last_duration_seconds),
+  wal_lag_seconds       = COALESCE(EXCLUDED.wal_lag_seconds, compliance.backup_tier_status.wal_lag_seconds),
+  next_scheduled_at     = COALESCE(EXCLUDED.next_scheduled_at, compliance.backup_tier_status.next_scheduled_at),
+  last_error            = EXCLUDED.last_error,
+  updated_at            = NOW()
+`, string(tier), lastSuccess, durationSec, walLagSec, nextScheduled, lastErr)
+	return err
+}
+
+// InsertRestoreDrill creates a restore drill record.
+func InsertRestoreDrill(ctx context.Context, pool *pgxpool.Pool, drill RestoreDrill) (uuid.UUID, error) {
+	var id uuid.UUID
+	err := pool.QueryRow(ctx, `
+INSERT INTO compliance.restore_drills (
+  drill_date, backup_timestamp, restore_start, restore_end,
+  rpo_achieved_minutes, rto_achieved_minutes, pass, smoke_test_output, conducted_by, notes
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+RETURNING id
+`, drill.DrillDate, drill.BackupTimestamp, drill.RestoreStart, drill.RestoreEnd,
+		drill.RPOAchievedMinutes, drill.RTOAchievedMinutes, drill.Pass, drill.SmokeTestOutput, drill.ConductedBy, drill.Notes,
+	).Scan(&id)
+	return id, err
+}
+
+// ListRestoreDrills returns recent drills ordered by drill_date DESC.
+func ListRestoreDrills(ctx context.Context, pool *pgxpool.Pool, limit int) ([]RestoreDrill, error) {
+	rows, err := pool.Query(ctx, `
+SELECT id, drill_date, backup_timestamp, restore_start, restore_end,
+       rpo_achieved_minutes, rto_achieved_minutes, pass, smoke_test_output, conducted_by, notes, created_at
+  FROM compliance.restore_drills
+ ORDER BY drill_date DESC, created_at DESC
+ LIMIT $1
+`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []RestoreDrill
+	for rows.Next() {
+		var d RestoreDrill
+		if err := rows.Scan(
+			&d.ID, &d.DrillDate, &d.BackupTimestamp, &d.RestoreStart, &d.RestoreEnd,
+			&d.RPOAchievedMinutes, &d.RTOAchievedMinutes, &d.Pass, &d.SmokeTestOutput, &d.ConductedBy, &d.Notes, &d.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// GetRestoreDrill returns a drill by ID or nil if not found.
+func GetRestoreDrill(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID) (*RestoreDrill, error) {
+	var d RestoreDrill
+	err := pool.QueryRow(ctx, `
+SELECT id, drill_date, backup_timestamp, restore_start, restore_end,
+       rpo_achieved_minutes, rto_achieved_minutes, pass, smoke_test_output, conducted_by, notes, created_at
+  FROM compliance.restore_drills
+ WHERE id = $1
+`, id).Scan(
+		&d.ID, &d.DrillDate, &d.BackupTimestamp, &d.RestoreStart, &d.RestoreEnd,
+		&d.RPOAchievedMinutes, &d.RTOAchievedMinutes, &d.Pass, &d.SmokeTestOutput, &d.ConductedBy, &d.Notes, &d.CreatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &d, nil
+}

--- a/server/internal/repos/platformconfig/features.go
+++ b/server/internal/repos/platformconfig/features.go
@@ -59,4 +59,5 @@ func applyPlatformBools(out *config.Config, db *Row, def Defaults) {
 	out.IsoIsmsEnabled = mergeBool(db.IsoIsmsEnabled, out.IsoIsmsEnabled)
 	out.AdminAuditLogEnabled = mergeBool(db.AdminAuditLogEnabled, out.AdminAuditLogEnabled)
 	out.DataResidencyEnabled = mergeBool(db.DataResidencyEnabled, out.DataResidencyEnabled)
+	out.BackupModuleEnabled = mergeBool(db.BackupModuleEnabled, out.BackupModuleEnabled)
 }

--- a/server/internal/repos/platformconfig/platformconfig.go
+++ b/server/internal/repos/platformconfig/platformconfig.go
@@ -71,6 +71,7 @@ type Row struct {
 	IsoIsmsEnabled             *bool
 	AdminAuditLogEnabled       *bool
 	DataResidencyEnabled       *bool
+	BackupModuleEnabled        *bool
 
 	MFAEnabled     *bool
 	MFAEnforcement *string
@@ -142,6 +143,7 @@ type Write struct {
 	IsoIsmsEnabled             *bool
 	AdminAuditLogEnabled       *bool
 	DataResidencyEnabled       *bool
+	BackupModuleEnabled        *bool
 
 	MFAEnabled     *bool
 	MFAEnforcement *string
@@ -211,6 +213,7 @@ SELECT
 	iso_isms_enabled,
 	admin_audit_log_enabled,
 	data_residency_enabled,
+	backup_module_enabled,
 	mfa_enabled,
 	mfa_enforcement,
 	smtp_host,
@@ -275,6 +278,7 @@ WHERE id = 1
 		&r.IsoIsmsEnabled,
 		&r.AdminAuditLogEnabled,
 		&r.DataResidencyEnabled,
+		&r.BackupModuleEnabled,
 		&r.MFAEnabled,
 		&r.MFAEnforcement,
 		&r.SMTPHost,
@@ -379,6 +383,7 @@ INSERT INTO settings.platform_app_settings (
 	iso_isms_enabled,
 	admin_audit_log_enabled,
 	data_residency_enabled,
+	backup_module_enabled,
 	mfa_enabled,
 	mfa_enforcement,
 	smtp_host,
@@ -391,7 +396,7 @@ INSERT INTO settings.platform_app_settings (
 	1,
 	$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18,
 	$19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40,
-	$41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60,
+	$41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61,
 	NOW()
 )
 ON CONFLICT (id) DO UPDATE SET
@@ -448,6 +453,7 @@ ON CONFLICT (id) DO UPDATE SET
 	iso_isms_enabled = COALESCE(EXCLUDED.iso_isms_enabled, settings.platform_app_settings.iso_isms_enabled),
 	admin_audit_log_enabled = COALESCE(EXCLUDED.admin_audit_log_enabled, settings.platform_app_settings.admin_audit_log_enabled),
 	data_residency_enabled = COALESCE(EXCLUDED.data_residency_enabled, settings.platform_app_settings.data_residency_enabled),
+	backup_module_enabled = COALESCE(EXCLUDED.backup_module_enabled, settings.platform_app_settings.backup_module_enabled),
 	mfa_enabled = COALESCE(EXCLUDED.mfa_enabled, settings.platform_app_settings.mfa_enabled),
 	mfa_enforcement = COALESCE(EXCLUDED.mfa_enforcement, settings.platform_app_settings.mfa_enforcement),
 	smtp_host = COALESCE(EXCLUDED.smtp_host, settings.platform_app_settings.smtp_host),
@@ -510,6 +516,7 @@ ON CONFLICT (id) DO UPDATE SET
 		w.IsoIsmsEnabled,
 		w.AdminAuditLogEnabled,
 		w.DataResidencyEnabled,
+		w.BackupModuleEnabled,
 		w.MFAEnabled,
 		w.MFAEnforcement,
 		w.SMTPHost,

--- a/server/internal/service/backup/service.go
+++ b/server/internal/service/backup/service.go
@@ -1,0 +1,297 @@
+// Package backup implements backup/restore ops: status, alerts, and restore drills (plan 10.15).
+package backup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	repobackup "github.com/lextures/lextures/server/internal/repos/backup"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+)
+
+const (
+	AdminPermission = "compliance:backup:admin:*"
+
+	postgresRPOTargetMinutes       = 60
+	postgresRTOTargetMinutes       = 240
+	objectStorageRPOTargetHours    = 24
+	dailyBackupStaleThresholdHours = 25
+	walLagAlertSeconds             = 900 // 15 minutes per plan risk mitigation
+)
+
+// CheckAdmin returns true when the user holds backup ops admin permission.
+func CheckAdmin(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) (bool, error) {
+	return rbac.UserHasPermission(ctx, pool, userID, AdminPermission)
+}
+
+// Targets documents contractual RPO/RTO targets (FR-1, FR-2).
+type Targets struct {
+	PostgresRPOMinutes        int `json:"postgresRpoMinutes"`
+	PostgresRTOMinutes        int `json:"postgresRtoMinutes"`
+	ObjectStorageRPOHours     int `json:"objectStorageRpoHours"`
+	ObjectStorageRTOHours     int `json:"objectStorageRtoHours"`
+}
+
+// TierStatusJSON is backup health for one tier.
+type TierStatusJSON struct {
+	Tier                string  `json:"tier"`
+	LastSuccessAt       *string `json:"lastSuccessAt,omitempty"`
+	LastDurationSeconds *int    `json:"lastDurationSeconds,omitempty"`
+	WALLagSeconds       *int    `json:"walLagSeconds,omitempty"`
+	NextScheduledAt     *string `json:"nextScheduledAt,omitempty"`
+	LastError           *string `json:"lastError,omitempty"`
+	Healthy             bool    `json:"healthy"`
+}
+
+// Alert describes a backup observability alert (FR-8, AC-4).
+type Alert struct {
+	Tier   string `json:"tier"`
+	Reason string `json:"reason"`
+}
+
+// RestoreDrillJSON is API shape for a restore drill row.
+type RestoreDrillJSON struct {
+	ID                 string  `json:"id"`
+	DrillDate          string  `json:"drillDate"`
+	BackupTimestamp    string  `json:"backupTimestamp"`
+	RestoreStart       string  `json:"restoreStart"`
+	RestoreEnd         *string `json:"restoreEnd,omitempty"`
+	RPOAchievedMinutes *int    `json:"rpoAchievedMinutes,omitempty"`
+	RTOAchievedMinutes *int    `json:"rtoAchievedMinutes,omitempty"`
+	Pass               *bool   `json:"pass,omitempty"`
+	SmokeTestOutput    *string `json:"smokeTestOutput,omitempty"`
+	ConductedBy        *string `json:"conductedBy,omitempty"`
+	Notes              *string `json:"notes,omitempty"`
+}
+
+// BackupStatus is GET /api/v1/internal/ops/backup-status response.
+type BackupStatus struct {
+	Targets       Targets            `json:"targets"`
+	Tiers         []TierStatusJSON   `json:"tiers"`
+	Alerts        []Alert            `json:"alerts"`
+	RestoreDrills []RestoreDrillJSON `json:"restoreDrills"`
+}
+
+// RecordRestoreDrillInput is POST /api/v1/internal/ops/restore-drill body.
+type RecordRestoreDrillInput struct {
+	DrillDate          time.Time
+	BackupTimestamp    time.Time
+	RestoreStart       time.Time
+	RestoreEnd         *time.Time
+	RPOAchievedMinutes *int
+	RTOAchievedMinutes *int
+	Pass               *bool
+	SmokeTestOutput    *string
+	ConductedBy        *uuid.UUID
+	Notes              *string
+}
+
+// GetBackupStatus aggregates tier status, alerts, and drill history.
+func GetBackupStatus(ctx context.Context, pool *pgxpool.Pool) (BackupStatus, error) {
+	rows, err := repobackup.ListTierStatus(ctx, pool)
+	if err != nil {
+		return BackupStatus{}, fmt.Errorf("backup: list tier status: %w", err)
+	}
+	tiers := mergeEnvTierStatus(rows)
+	alerts := computeAlerts(tiers)
+
+	drills, err := repobackup.ListRestoreDrills(ctx, pool, 50)
+	if err != nil {
+		return BackupStatus{}, fmt.Errorf("backup: list restore drills: %w", err)
+	}
+
+	return BackupStatus{
+		Targets: Targets{
+			PostgresRPOMinutes:    postgresRPOTargetMinutes,
+			PostgresRTOMinutes:    postgresRTOTargetMinutes,
+			ObjectStorageRPOHours: objectStorageRPOTargetHours,
+			ObjectStorageRTOHours: postgresRTOTargetMinutes / 60,
+		},
+		Tiers:         tiers,
+		Alerts:        alerts,
+		RestoreDrills: drillsToJSON(drills),
+	}, nil
+}
+
+// RecordRestoreDrill persists a quarterly restore drill (FR-7).
+func RecordRestoreDrill(ctx context.Context, pool *pgxpool.Pool, in RecordRestoreDrillInput) (uuid.UUID, error) {
+	id, err := repobackup.InsertRestoreDrill(ctx, pool, repobackup.RestoreDrill{
+		DrillDate:          in.DrillDate,
+		BackupTimestamp:    in.BackupTimestamp,
+		RestoreStart:       in.RestoreStart,
+		RestoreEnd:         in.RestoreEnd,
+		RPOAchievedMinutes: in.RPOAchievedMinutes,
+		RTOAchievedMinutes: in.RTOAchievedMinutes,
+		Pass:               in.Pass,
+		SmokeTestOutput:    in.SmokeTestOutput,
+		ConductedBy:        in.ConductedBy,
+		Notes:              in.Notes,
+	})
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf("backup: record restore drill: %w", err)
+	}
+	return id, nil
+}
+
+// ReportTierHeartbeat updates tier status (used by backup-report CLI / cron).
+func ReportTierHeartbeat(ctx context.Context, pool *pgxpool.Pool, tier repobackup.Tier, lastSuccess *time.Time, durationSec, walLagSec *int, nextScheduled *time.Time, lastErr *string) error {
+	if err := repobackup.UpsertTierStatus(ctx, pool, tier, lastSuccess, durationSec, walLagSec, nextScheduled, lastErr); err != nil {
+		return fmt.Errorf("backup: report heartbeat: %w", err)
+	}
+	return nil
+}
+
+func mergeEnvTierStatus(rows []repobackup.TierStatus) []TierStatusJSON {
+	byTier := map[repobackup.Tier]repobackup.TierStatus{
+		repobackup.TierPostgres:      {},
+		repobackup.TierObjectStorage: {},
+	}
+	for _, r := range rows {
+		byTier[r.Tier] = r
+	}
+	pg := byTier[repobackup.TierPostgres]
+	obj := byTier[repobackup.TierObjectStorage]
+	applyEnvOverlay(&pg, "POSTGRES")
+	applyEnvOverlay(&obj, "OBJECT_STORAGE")
+	byTier[repobackup.TierPostgres] = pg
+	byTier[repobackup.TierObjectStorage] = obj
+
+	order := []repobackup.Tier{repobackup.TierPostgres, repobackup.TierObjectStorage}
+	out := make([]TierStatusJSON, 0, len(order))
+	for _, tier := range order {
+		out = append(out, tierToJSON(byTier[tier]))
+	}
+	return out
+}
+
+func applyEnvOverlay(s *repobackup.TierStatus, prefix string) {
+	if t := envTime(prefix + "_LAST_SUCCESS"); t != nil {
+		s.LastSuccessAt = t
+	}
+	if v := envInt(prefix + "_WAL_LAG_SECONDS"); v != nil {
+		s.WALLagSeconds = v
+	}
+	if v := envInt(prefix + "_DURATION_SECONDS"); v != nil {
+		s.LastDurationSeconds = v
+	}
+	if t := envTime(prefix + "_NEXT_SCHEDULED"); t != nil {
+		s.NextScheduledAt = t
+	}
+	if e := strings.TrimSpace(os.Getenv("BACKUP_" + prefix + "_LAST_ERROR")); e != "" {
+		s.LastError = &e
+	}
+}
+
+func envTime(key string) *time.Time {
+	s := strings.TrimSpace(os.Getenv("BACKUP_" + key))
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return nil
+	}
+	u := t.UTC()
+	return &u
+}
+
+func envInt(key string) *int {
+	s := strings.TrimSpace(os.Getenv("BACKUP_" + key))
+	if s == "" {
+		return nil
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return nil
+	}
+	return &v
+}
+
+func tierToJSON(s repobackup.TierStatus) TierStatusJSON {
+	j := TierStatusJSON{
+		Tier:                string(s.Tier),
+		LastDurationSeconds: s.LastDurationSeconds,
+		WALLagSeconds:       s.WALLagSeconds,
+		LastError:           s.LastError,
+		Healthy:             true,
+	}
+	if s.LastSuccessAt != nil {
+		iso := s.LastSuccessAt.UTC().Format(time.RFC3339)
+		j.LastSuccessAt = &iso
+	}
+	if s.NextScheduledAt != nil {
+		iso := s.NextScheduledAt.UTC().Format(time.RFC3339)
+		j.NextScheduledAt = &iso
+	}
+	if s.LastError != nil && strings.TrimSpace(*s.LastError) != "" {
+		j.Healthy = false
+	}
+	return j
+}
+
+func computeAlerts(tiers []TierStatusJSON) []Alert {
+	var alerts []Alert
+	now := time.Now().UTC()
+	stale := time.Duration(dailyBackupStaleThresholdHours) * time.Hour
+
+	for _, t := range tiers {
+		if t.LastError != nil && strings.TrimSpace(*t.LastError) != "" {
+			alerts = append(alerts, Alert{Tier: t.Tier, Reason: "last job failed: " + strings.TrimSpace(*t.LastError)})
+		}
+		if t.LastSuccessAt == nil {
+			alerts = append(alerts, Alert{Tier: t.Tier, Reason: "no successful backup recorded"})
+			continue
+		}
+		last, err := time.Parse(time.RFC3339, *t.LastSuccessAt)
+		if err != nil {
+			continue
+		}
+		if now.Sub(last) > stale {
+			alerts = append(alerts, Alert{
+				Tier:   t.Tier,
+				Reason: fmt.Sprintf("last success older than %d hours", dailyBackupStaleThresholdHours),
+			})
+		}
+		if t.Tier == string(repobackup.TierPostgres) && t.WALLagSeconds != nil && *t.WALLagSeconds > walLagAlertSeconds {
+			alerts = append(alerts, Alert{
+				Tier:   t.Tier,
+				Reason: fmt.Sprintf("WAL lag %d seconds exceeds %d second threshold", *t.WALLagSeconds, walLagAlertSeconds),
+			})
+		}
+	}
+	return alerts
+}
+
+func drillsToJSON(drills []repobackup.RestoreDrill) []RestoreDrillJSON {
+	out := make([]RestoreDrillJSON, 0, len(drills))
+	for _, d := range drills {
+		j := RestoreDrillJSON{
+			ID:              d.ID.String(),
+			DrillDate:         d.DrillDate.Format("2006-01-02"),
+			BackupTimestamp:   d.BackupTimestamp.UTC().Format(time.RFC3339),
+			RestoreStart:      d.RestoreStart.UTC().Format(time.RFC3339),
+			RPOAchievedMinutes: d.RPOAchievedMinutes,
+			RTOAchievedMinutes: d.RTOAchievedMinutes,
+			Pass:              d.Pass,
+			SmokeTestOutput:   d.SmokeTestOutput,
+			Notes:             d.Notes,
+		}
+		if d.RestoreEnd != nil {
+			iso := d.RestoreEnd.UTC().Format(time.RFC3339)
+			j.RestoreEnd = &iso
+		}
+		if d.ConductedBy != nil {
+			s := d.ConductedBy.String()
+			j.ConductedBy = &s
+		}
+		out = append(out, j)
+	}
+	return out
+}

--- a/server/internal/service/backup/service_test.go
+++ b/server/internal/service/backup/service_test.go
@@ -1,0 +1,64 @@
+package backup
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestComputeAlerts_StaleBackup(t *testing.T) {
+	old := time.Now().UTC().Add(-30 * time.Hour).Format(time.RFC3339)
+	tiers := []TierStatusJSON{{
+		Tier:          "postgres",
+		LastSuccessAt: &old,
+		Healthy:       true,
+	}}
+	alerts := computeAlerts(tiers)
+	if len(alerts) == 0 {
+		t.Fatal("expected stale backup alert")
+	}
+	if alerts[0].Tier != "postgres" {
+		t.Errorf("tier=%q want postgres", alerts[0].Tier)
+	}
+}
+
+func TestComputeAlerts_WALLag(t *testing.T) {
+	recent := time.Now().UTC().Format(time.RFC3339)
+	lag := 1200
+	tiers := []TierStatusJSON{{
+		Tier:          "postgres",
+		LastSuccessAt: &recent,
+		WALLagSeconds: &lag,
+		Healthy:       true,
+	}}
+	alerts := computeAlerts(tiers)
+	found := false
+	for _, a := range alerts {
+		if a.Tier == "postgres" && a.Reason != "" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected WAL lag alert")
+	}
+}
+
+func TestEnvOverlay_Postgres(t *testing.T) {
+	t.Setenv("BACKUP_POSTGRES_LAST_SUCCESS", "2026-05-27T12:00:00Z")
+	t.Setenv("BACKUP_POSTGRES_WAL_LAG_SECONDS", "42")
+	rows := []TierStatusJSON{}
+	_ = rows
+	var s struct {
+		LastSuccess *time.Time
+		WALLag      *int
+	}
+	if ts := envTime("POSTGRES_LAST_SUCCESS"); ts == nil {
+		t.Fatal("expected parsed time")
+	} else {
+		s.LastSuccess = ts
+	}
+	if v := envInt("POSTGRES_WAL_LAG_SECONDS"); v == nil || *v != 42 {
+		t.Fatalf("wal lag: %#v", v)
+	}
+	_ = os.Getenv // keep import
+}

--- a/server/migrations/197_backup_restore_rpo_rto.sql
+++ b/server/migrations/197_backup_restore_rpo_rto.sql
@@ -1,0 +1,58 @@
+-- 10.15 Backup / Restore / RPO-RTO: restore drill records, backup tier status, feature flag.
+-- Depends on: compliance schema (179_ferpa), "user".users (011).
+
+CREATE TABLE IF NOT EXISTS compliance.restore_drills (
+  id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  drill_date           DATE NOT NULL,
+  backup_timestamp     TIMESTAMPTZ NOT NULL,
+  restore_start        TIMESTAMPTZ NOT NULL,
+  restore_end          TIMESTAMPTZ,
+  rpo_achieved_minutes INTEGER,
+  rto_achieved_minutes INTEGER,
+  pass                 BOOLEAN,
+  smoke_test_output    TEXT,
+  conducted_by         UUID REFERENCES "user".users(id) ON DELETE SET NULL,
+  notes                TEXT,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_restore_drills_drill_date
+  ON compliance.restore_drills(drill_date DESC);
+
+COMMENT ON TABLE compliance.restore_drills IS
+  'Quarterly restore drill results (plan 10.15 FR-7, AC-3).';
+
+-- Last-known backup health per data tier (updated by WAL-G cron / backup-report CLI).
+CREATE TABLE IF NOT EXISTS compliance.backup_tier_status (
+  tier                  TEXT PRIMARY KEY CHECK (tier IN ('postgres', 'object_storage')),
+  last_success_at       TIMESTAMPTZ,
+  last_duration_seconds INTEGER,
+  wal_lag_seconds       INTEGER,
+  next_scheduled_at     TIMESTAMPTZ,
+  last_error            TEXT,
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO compliance.backup_tier_status (tier)
+VALUES ('postgres'), ('object_storage')
+ON CONFLICT (tier) DO NOTHING;
+
+COMMENT ON TABLE compliance.backup_tier_status IS
+  'Backup job heartbeats for ops dashboard (plan 10.15 FR-1, FR-3, observability).';
+
+INSERT INTO "user".permissions (permission_string, description)
+VALUES (
+  'compliance:backup:admin:*',
+  'May access backup/restore ops: backup status and restore drill records (plan 10.15).'
+)
+ON CONFLICT (permission_string) DO NOTHING;
+
+INSERT INTO "user".rbac_role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+  FROM "user".app_roles r
+  JOIN "user".permissions p ON p.permission_string = 'compliance:backup:admin:*'
+ WHERE r.name = 'Global Admin'
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE settings.platform_app_settings
+  ADD COLUMN IF NOT EXISTS backup_module_enabled BOOLEAN;

--- a/server/test/backup_restore_e2e_test.go
+++ b/server/test/backup_restore_e2e_test.go
@@ -1,0 +1,226 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	serverdata "github.com/lextures/lextures/server"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/config"
+	"github.com/lextures/lextures/server/internal/db"
+	"github.com/lextures/lextures/server/internal/httpserver"
+	"github.com/lextures/lextures/server/internal/migrate"
+	repobackup "github.com/lextures/lextures/server/internal/repos/backup"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+	"github.com/lextures/lextures/server/internal/repos/user"
+)
+
+type backupEnv struct {
+	srv    *httptest.Server
+	pool   *pgxpool.Pool
+	signer *auth.JWTSigner
+	userID uuid.UUID
+	email  string
+}
+
+func setupBackupOps(t *testing.T) *backupEnv {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set — skipping backup/restore e2e tests")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	signer := auth.NewJWTSigner("backup-e2e-jwt-secret-min32chars-xx")
+
+	email := fmt.Sprintf("backup-e2e-%d@test.example", time.Now().UnixNano())
+	ph, err := auth.HashPassword("Passw0rd!backup")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	dn := "Backup Test User"
+	u, err := user.InsertUser(ctx, pool, email, ph, &dn)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	userID := uuid.MustParse(u.ID)
+
+	if err := rbac.AssignUserRoleByName(ctx, pool, userID, "Global Admin"); err != nil {
+		t.Fatalf("assign Global Admin: %v", err)
+	}
+
+	now := time.Now().UTC()
+	next := now.Add(24 * time.Hour)
+	if err := repobackup.UpsertTierStatus(ctx, pool, repobackup.TierPostgres, &now, intPtr(120), intPtr(30), &next, nil); err != nil {
+		t.Fatalf("seed postgres tier: %v", err)
+	}
+	if err := repobackup.UpsertTierStatus(ctx, pool, repobackup.TierObjectStorage, &now, intPtr(600), nil, &next, nil); err != nil {
+		t.Fatalf("seed object_storage tier: %v", err)
+	}
+
+	srv := httptest.NewServer(httpserver.NewHandler(httpserver.Deps{
+		Pool:      pool,
+		JWTSigner: signer,
+		Config: config.Config{
+			BackupModuleEnabled: true,
+		},
+	}))
+	t.Cleanup(srv.Close)
+
+	return &backupEnv{srv: srv, pool: pool, signer: signer, userID: userID, email: email}
+}
+
+func intPtr(v int) *int { return &v }
+
+func (e *backupEnv) token(t *testing.T) string {
+	t.Helper()
+	tok, err := e.signer.Sign(context.Background(), e.userID.String(), e.email, "", "", nil)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return tok
+}
+
+func backupDo(t *testing.T, srv *httptest.Server, method, path string, body any, token string) *http.Response {
+	t.Helper()
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+	}
+	req, err := http.NewRequest(method, srv.URL+path, bytes.NewReader(bodyBytes))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+func TestBackupOps_StatusAndRestoreDrill(t *testing.T) {
+	env := setupBackupOps(t)
+	tok := env.token(t)
+
+	resp := backupDo(t, env.srv, http.MethodGet, "/api/v1/internal/ops/backup-status", nil, tok)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("backup-status: status=%d want 200", resp.StatusCode)
+	}
+	var status struct {
+		Targets struct {
+			PostgresRPOMinutes int `json:"postgresRpoMinutes"`
+		} `json:"targets"`
+		Tiers []struct {
+			Tier          string  `json:"tier"`
+			LastSuccessAt *string `json:"lastSuccessAt"`
+		} `json:"tiers"`
+		RestoreDrills []any `json:"restoreDrills"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if status.Targets.PostgresRPOMinutes != 60 {
+		t.Errorf("postgresRpoMinutes=%d want 60", status.Targets.PostgresRPOMinutes)
+	}
+	if len(status.Tiers) < 2 {
+		t.Fatalf("tiers=%d want at least 2", len(status.Tiers))
+	}
+
+	now := time.Now().UTC()
+	drillBody := map[string]any{
+		"drillDate":          now.Format("2006-01-02"),
+		"backupTimestamp":    now.Add(-1 * time.Hour).Format(time.RFC3339),
+		"restoreStart":       now.Add(-30 * time.Minute).Format(time.RFC3339),
+		"restoreEnd":         now.Format(time.RFC3339),
+		"rpoAchievedMinutes": 45,
+		"rtoAchievedMinutes": 90,
+		"pass":               true,
+		"smokeTestOutput":    "grade reads, quiz attempts, auth: ok",
+	}
+	resp2 := backupDo(t, env.srv, http.MethodPost, "/api/v1/internal/ops/restore-drill", drillBody, tok)
+	defer func() { _ = resp2.Body.Close() }()
+	if resp2.StatusCode != http.StatusCreated {
+		t.Fatalf("restore-drill: status=%d want 201", resp2.StatusCode)
+	}
+	var created map[string]string
+	if err := json.NewDecoder(resp2.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if created["id"] == "" {
+		t.Fatal("expected drill id")
+	}
+
+	resp3 := backupDo(t, env.srv, http.MethodGet, "/api/v1/internal/ops/backup-status", nil, tok)
+	defer func() { _ = resp3.Body.Close() }()
+	if resp3.StatusCode != http.StatusOK {
+		t.Fatalf("backup-status after drill: status=%d", resp3.StatusCode)
+	}
+	var status2 struct {
+		RestoreDrills []struct {
+			ID   string `json:"id"`
+			Pass *bool  `json:"pass"`
+		} `json:"restoreDrills"`
+	}
+	if err := json.NewDecoder(resp3.Body).Decode(&status2); err != nil {
+		t.Fatalf("decode status2: %v", err)
+	}
+	if len(status2.RestoreDrills) == 0 {
+		t.Fatal("expected restore drill in history")
+	}
+	if status2.RestoreDrills[0].Pass == nil || !*status2.RestoreDrills[0].Pass {
+		t.Errorf("pass=%v want true", status2.RestoreDrills[0].Pass)
+	}
+}
+
+func TestBackupOps_ForbiddenWithoutPermission(t *testing.T) {
+	env := setupBackupOps(t)
+	ctx := context.Background()
+	email := fmt.Sprintf("backup-noadmin-%d@test.example", time.Now().UnixNano())
+	ph, _ := auth.HashPassword("Passw0rd!backup2")
+	dn := "No Admin"
+	u, err := user.InsertUser(ctx, env.pool, email, ph, &dn)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	tok, err := env.signer.Sign(ctx, u.ID, email, "", "", nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	resp := backupDo(t, env.srv, http.MethodGet, "/api/v1/internal/ops/backup-status", nil, tok)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status=%d want 403", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements plan 10.15: migration **197** (`compliance.restore_drills`, `compliance.backup_tier_status`, `backup_module_enabled` flag, `compliance:backup:admin:*` permission).
- Adds ops APIs: `GET /api/v1/internal/ops/backup-status` and `POST /api/v1/internal/ops/restore-drill` (Global Admin), plus `backup-report` CLI for cron heartbeats.
- Codifies encrypted backup S3 bucket with Object Lock in `iac/modules/aws/backup.tf`; WAL-G example env and DR runbooks.
- Adds **Admin → Backup & restore** UI (`/admin/compliance/backup`) with Playwright and Go e2e coverage.

## Test plan

- [x] `go test ./... -short` (server)
- [x] `golangci-lint run` on new backup packages
- [x] `npm run typecheck` + vitest for `backup-ops-admin-page`
- [ ] `docker compose -f docker-compose.e2e.yml up` + Playwright `e2e/tests/backup-restore.spec.ts` (requires Docker; not available in agent environment)
- [ ] `DATABASE_URL=... go test ./test -run Backup` for DB-backed e2e

Enable locally with `BACKUP_MODULE_ENABLED=true` (also set in `docker-compose.e2e.yml`).