### PR TITLE
feat(www): complete visual redesign of marketing site

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -19,7 +19,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Instrument+Serif:ital@0;1&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Instrument+Serif:ital@0;1&display=swap"
       rel="stylesheet"
     />
     <script>

--- a/www/src/app.tsx
+++ b/www/src/app.tsx
@@ -12,7 +12,6 @@ import {
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Header } from './components/header'
-import { HeroCanvas } from './hero-canvas'
 import { BlogIndex } from './pages/blog-index'
 import { BlogPost } from './pages/blog-post'
 import { DocsIndex } from './pages/docs-index'
@@ -39,76 +38,6 @@ const LINKS = {
   github: 'https://github.com/StudyDrift/lextures',
 } as const
 
-const FEATURES = [
-  {
-    title: 'Adaptive quiz delivery',
-    body: 'Quizzes adjust difficulty in real time using Item Response Theory. Every learner gets the right questions at the right moment—not a one-size-fits-all test.',
-    icon: BrainCircuit,
-  },
-  {
-    title: 'AI-generated content',
-    body: 'Generate quiz questions from learning objectives, build rubrics from assignment descriptions, and produce progressive hints that guide without giving answers.',
-    icon: Zap,
-  },
-  {
-    title: '14+ question types',
-    body: 'Multiple choice, essay, live code execution, image hotspots, matching, ordering, formula, and audio/video responses—built for every subject.',
-    icon: BookOpen,
-  },
-  {
-    title: 'Standards-based gradebook',
-    body: 'Map assignments to NGSS, CCSS, or your own standards. Track mastery by objective—not just points. Every grading change is logged with who, what, and why.',
-    icon: BarChart3,
-  },
-  {
-    title: 'Canvas, Moodle & Blackboard-ready',
-    body: 'LTI 1.3 provider: run Lextures inside any LMS your institution already uses. Import courses and question banks from Canvas with AI-assisted migration.',
-    icon: Unplug,
-  },
-  {
-    title: 'Enterprise identity & provisioning',
-    body: 'SAML 2.0, OIDC, Clever, and ClassLink SSO. OneRoster 1.2 CSV and SCIM 2.0 HTTP for bulk roster sync. TOTP and WebAuthn MFA for every account.',
-    icon: ShieldCheck,
-  },
-] as const
-
-const AI_CAPABILITIES = [
-  {
-    title: 'Item Response Theory engine',
-    body: "Questions are calibrated using IRT 2PL/3PL models. The system estimates each learner's mastery level in real time and routes them to the content they actually need next—not what's next in the syllabus.",
-    icon: BrainCircuit,
-  },
-  {
-    title: 'Misconception detection',
-    body: 'AI analyzes incorrect responses across the class and surfaces the most common errors to instructors—so they can address patterns in the next session instead of marking them wrong and moving on.',
-    icon: GraduationCap,
-  },
-  {
-    title: 'Spaced repetition scheduler',
-    body: 'The SRS engine schedules review material at scientifically optimal intervals. Knowledge sticks between sessions instead of fading before the final exam.',
-    icon: RefreshCw,
-  },
-] as const
-
-const INTEGRATIONS = [
-  {
-    term: 'LTI 1.3 provider & consumer',
-    desc: 'Launch Lextures inside Canvas, Blackboard, or Moodle. Roster sync via NRPS, grade passback via AGS, and deep linking for publisher content—all spec-compliant.',
-  },
-  {
-    term: 'Canvas import',
-    desc: 'Move courses, question banks, and grades from Canvas using WebSocket-based import with AI-assisted migration. QTI 2.1/3.0 question bank imports from any major LMS.',
-  },
-  {
-    term: 'SSO & roster provisioning',
-    desc: 'SAML 2.0, OIDC, Clever, and ClassLink for identity. OneRoster 1.2 CSV and SCIM 2.0 HTTP for roster sync. Auto-provision users on first login.',
-  },
-  {
-    term: 'Defensible exports',
-    desc: 'Grade exports structured for accreditation reviews and appeals. iCalendar feeds for due dates. QTI exports for question bank portability.',
-  },
-] as const
-
 function useHashRoute() {
   const [hash, setHash] = useState(() => window.location.hash)
   useEffect(() => {
@@ -119,20 +48,22 @@ function useHashRoute() {
   return hash
 }
 
+/* ─────────────────────────────────────────────────────────
+   HOMEPAGE
+   ───────────────────────────────────────────────────────── */
 function HomePage() {
   useEffect(() => {
     const hash = window.location.hash
     if (hash && !hash.startsWith('#/')) {
-      const el = document.querySelector(hash)
-      if (el) el.scrollIntoView({ behavior: 'smooth' })
+      document.querySelector(hash)?.scrollIntoView({ behavior: 'smooth' })
     }
   }, [])
 
   return (
-    <div className="relative min-h-screen overflow-x-hidden bg-stone-50 text-slate-700">
+    <div className="min-h-screen bg-white text-slate-900 antialiased">
       <a
         href="#main"
-        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-lg focus:bg-accent focus:px-4 focus:py-2 focus:text-sm focus:text-white"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-xl focus:bg-accent focus:px-4 focus:py-2 focus:text-sm focus:text-white"
       >
         Skip to content
       </a>
@@ -140,180 +71,405 @@ function HomePage() {
       <Header />
 
       <main id="main">
-        {/* Hero */}
-        <section className="relative flex min-h-[85vh] items-center justify-center overflow-hidden border-b border-stone-200/90 bg-white py-20">
-          <HeroCanvas />
+        {/* ═══════════════════════════════════════════ HERO ═══ */}
+        <section className="relative overflow-hidden bg-[#020617] pb-0 pt-16 sm:pt-20">
+          {/* Gradient orbs */}
           <div
-            className="pointer-events-none absolute inset-0 bg-gradient-to-b from-transparent via-white/40 to-white"
             aria-hidden
+            className="pointer-events-none absolute -left-48 -top-24 h-[600px] w-[600px] rounded-full bg-indigo-600/25 blur-[120px]"
           />
-          <div className="relative z-10 mx-auto max-w-5xl px-4 text-center sm:px-6 lg:px-8">
-            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-stone-500">
-              Adaptive learning management
-            </p>
-            <h1 className="font-display mt-8 text-5xl font-normal leading-[1.05] tracking-[-0.03em] text-stone-900 sm:text-7xl lg:text-[5.5rem]">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -right-32 bottom-0 h-[500px] w-[500px] rounded-full bg-violet-600/20 blur-[100px]"
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute left-1/2 top-1/3 h-[300px] w-[300px] -translate-x-1/2 rounded-full bg-indigo-500/10 blur-[80px]"
+          />
+
+          {/* Grid pattern */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0"
+            style={{
+              backgroundImage:
+                'linear-gradient(to right, rgba(99,102,241,0.06) 1px, transparent 1px), linear-gradient(to bottom, rgba(99,102,241,0.06) 1px, transparent 1px)',
+              backgroundSize: '48px 48px',
+              maskImage: 'linear-gradient(to bottom, transparent 0%, black 15%, black 75%, transparent 100%)',
+              WebkitMaskImage: 'linear-gradient(to bottom, transparent 0%, black 15%, black 75%, transparent 100%)',
+            }}
+          />
+
+          <div className="relative z-10 mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+            {/* Eyebrow */}
+            <div className="flex justify-center">
+              <div className="inline-flex items-center gap-2 rounded-full border border-indigo-500/30 bg-indigo-500/10 px-4 py-1.5 backdrop-blur-sm">
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-indigo-400" aria-hidden />
+                <span className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-300">
+                  Adaptive learning management
+                </span>
+              </div>
+            </div>
+
+            {/* Headline */}
+            <h1 className="mt-8 text-center text-[clamp(2.5rem,7vw,5.5rem)] font-bold leading-[1.02] tracking-[-0.03em] text-white">
               The LMS that{' '}
-              <span className="text-accent italic">adapts</span>
+              <span className="font-display bg-gradient-to-r from-indigo-400 via-violet-400 to-purple-400 bg-clip-text font-normal italic text-transparent">
+                adapts
+              </span>
             </h1>
-            <p className="mx-auto mt-8 max-w-2xl text-lg leading-relaxed text-stone-600 sm:text-xl">
-              Adaptive quizzes, instructor workflows, and integrations that fit schools and programs
-              running at real scale—not a slide deck with a gradebook attached.
+
+            <p className="mx-auto mt-6 max-w-2xl text-center text-lg leading-relaxed text-slate-400 sm:text-xl">
+              Adaptive quizzes, institutional workflows, and integrations built for schools and
+              programs running at real scale—not a slide deck with a gradebook attached.
             </p>
-            <div className="mt-12 flex flex-col items-center justify-center gap-4 sm:flex-row">
-              <a href="/get-started" className="btn-primary h-12 gap-2 px-8 text-base">
-                Get Started
-                <ArrowRight className="h-5 w-5" aria-hidden />
-              </a>
-              <a href={LINKS.github} className="btn-secondary h-12 px-8 text-base">
-                Browse the repository
-              </a>
-            </div>
-          </div>
-        </section>
 
-        {/* Features */}
-        <section id="features" className="bg-surface py-20 sm:py-28">
-          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <div className="max-w-2xl">
-              <h2 className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
-                Built for courses, grading, and the messy middle
-              </h2>
-              <p className="mt-4 text-lg leading-relaxed text-stone-600">
-                Course management, assessments, gradebook, and integrations—without treating
-                adaptation like a marketing bolt-on.
-              </p>
-            </div>
-            <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-              {FEATURES.map(({ title, body, icon: Icon }) => (
-                <article key={title} className="feature-card">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent-muted/70 text-accent">
-                    <Icon className="h-5 w-5" aria-hidden />
-                  </div>
-                  <h3 className="mt-5 text-base font-semibold text-stone-900">{title}</h3>
-                  <p className="mt-2 text-sm leading-relaxed text-stone-600">{body}</p>
-                </article>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Adaptive AI */}
-        <section id="ai" className="border-y border-stone-200/90 bg-white py-20 sm:py-28">
-          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <div className="max-w-2xl">
-              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-stone-500">
-                Delivery & outcomes
-              </p>
-              <h2 className="mt-3 text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
-                Adaptive mechanics, not buzzwords
-              </h2>
-              <p className="mt-4 text-lg leading-relaxed text-stone-600">
-                Routing, misconceptions, and review scheduling sit next to grading and content—because
-                that is where they actually affect outcomes.
-              </p>
-            </div>
-            <div className="mt-12 grid gap-8 lg:grid-cols-3">
-              {AI_CAPABILITIES.map(({ title, body, icon: Icon }) => (
-                <div key={title} className="flex flex-col gap-4 rounded-xl border border-stone-200/90 bg-stone-50/50 p-6">
-                  <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-stone-900 text-white shadow-sm">
-                    <Icon className="h-5 w-5" aria-hidden />
-                  </div>
-                  <h3 className="text-lg font-semibold text-stone-900">{title}</h3>
-                  <p className="text-sm leading-relaxed text-stone-600">{body}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Institutions */}
-        <section id="institutions" className="bg-surface py-20 sm:py-28">
-          <div className="mx-auto grid max-w-6xl gap-12 px-4 sm:px-6 lg:grid-cols-2 lg:items-center lg:gap-20 lg:px-8">
-            <div>
-              <h2 className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
-                Built around how institutions actually operate
-              </h2>
-              <p className="mt-5 text-lg leading-relaxed text-stone-600">
-                From K-12 districts to university programs, Lextures is modeled on the workflows
-                that break first at scale: enrollment drift, inconsistent accommodations, grading
-                that can't be audited, and content no one can keep synchronized.
-              </p>
-              <ul className="mt-8 space-y-3">
-                {[
-                  'Course blueprints let coordinators maintain master templates and push updates to every child section at once.',
-                  'Accommodations are managed at the platform level—extra time and reduced distraction mode apply automatically, without per-assignment workarounds.',
-                  'Every grading action is logged: who changed what, when, and why—so appeals and accreditation reviews have a real paper trail.',
-                ].map((line) => (
-                  <li key={line} className="flex gap-3 text-stone-700">
-                    <span className="mt-2.5 h-1.5 w-1.5 shrink-0 rounded-full bg-accent" />
-                    <span>{line}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-            <div className="rounded-xl border border-stone-200/90 bg-surface-2 p-8 shadow-[inset_0_1px_0_rgba(255,255,255,0.6)]">
-              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-stone-500">
-                Design principle
-              </p>
-              <p className="mt-4 text-xl font-medium leading-snug text-stone-900">
-                If a registrar would wince at the data model, it doesn't ship—operational honesty
-                beats feature checklists.
-              </p>
-              <p className="mt-5 text-sm leading-relaxed text-stone-500">
-                Lextures is under active development. The public demo is the fastest way to see
-                current capabilities and the direction the product is heading.
-              </p>
-              <a href="/get-started" className="btn-primary mt-6 inline-flex gap-2">
-                Get Started
+            {/* CTAs */}
+            <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
+              <a href="/get-started" className="btn-primary h-12 gap-2 px-8 text-[0.9375rem]">
+                Get Started free
                 <ArrowRight className="h-4 w-4" aria-hidden />
               </a>
+              <a href={LINKS.demo} className="btn-ghost-dark h-12 px-8 text-[0.9375rem]" target="_blank" rel="noopener noreferrer">
+                Live demo
+              </a>
+            </div>
+
+            <p className="mt-3 text-center text-xs text-slate-500">
+              Free tier included · No credit card required · AGPL-3.0 open source
+            </p>
+
+            {/* Stats row */}
+            <div className="mt-16 grid grid-cols-2 divide-x divide-slate-800 border-t border-slate-800 sm:grid-cols-4">
+              {[
+                { value: '$0', label: 'to get started' },
+                { value: '14+', label: 'question types' },
+                { value: 'IRT', label: 'adaptive engine' },
+                { value: 'K–12 & HE', label: 'institution ready' },
+              ].map(({ value, label }) => (
+                <div key={value} className="flex flex-col items-center py-6 text-center">
+                  <span className="text-2xl font-bold text-white">{value}</span>
+                  <span className="mt-1 text-[0.7rem] font-medium uppercase tracking-wider text-slate-500">
+                    {label}
+                  </span>
+                </div>
+              ))}
             </div>
           </div>
         </section>
 
-        {/* Integrations */}
-        <section id="integrations" className="border-t border-stone-200/90 bg-white py-20 sm:py-28">
+        {/* ══════════════════════════════════ FEATURES BENTO ═══ */}
+        <section id="features" className="bg-white py-20 sm:py-28">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <div className="max-w-2xl">
-              <h2 className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
-                Works inside the stack you already have
+            <div className="mb-12 max-w-xl">
+              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-500">
+                Platform
+              </p>
+              <h2 className="mt-3 text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+                Everything a serious institution needs
               </h2>
-              <p className="mt-4 text-lg text-stone-600">
-                No rip-and-replace. Lextures is designed to integrate with Canvas, Blackboard,
-                Moodle, and your district SIS—or stand alone as your primary LMS.
+              <p className="mt-4 text-lg leading-relaxed text-slate-500">
+                Course management, adaptive assessments, gradebook, and integrations—without
+                treating adaptation like a marketing bolt-on.
               </p>
             </div>
-            <dl className="mt-12 grid gap-5 sm:grid-cols-2">
-              {INTEGRATIONS.map((row) => (
-                <div key={row.term} className="feature-card">
-                  <dt className="text-sm font-semibold text-stone-900">{row.term}</dt>
-                  <dd className="mt-2 text-sm leading-relaxed text-stone-600">{row.desc}</dd>
+
+            {/* Bento grid */}
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-12">
+
+              {/* Card 1 — Large dark, Adaptive quiz */}
+              <article className="group relative overflow-hidden rounded-3xl bg-slate-950 p-7 md:col-span-7">
+                <div
+                  aria-hidden
+                  className="pointer-events-none absolute -right-16 -top-16 h-48 w-48 rounded-full bg-indigo-600/30 blur-[60px] transition-all duration-500 group-hover:bg-indigo-500/40"
+                />
+                <div className="relative z-10">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-indigo-500/20 text-indigo-400 ring-1 ring-indigo-500/30">
+                    <BrainCircuit className="h-5 w-5" aria-hidden />
+                  </div>
+                  <h3 className="mt-5 text-xl font-semibold text-white">Adaptive quiz delivery</h3>
+                  <p className="mt-3 max-w-sm text-sm leading-relaxed text-slate-400">
+                    Quizzes adjust difficulty in real time using Item Response Theory. Every learner
+                    gets the right questions at the right moment—not a one-size-fits-all test.
+                  </p>
+                  <div className="mt-6 inline-flex items-center gap-1.5 text-xs font-semibold text-indigo-400">
+                    IRT 2PL / 3PL models <ArrowRight className="h-3 w-3" aria-hidden />
+                  </div>
                 </div>
-              ))}
-            </dl>
-            <div className="mt-10 flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-stone-400">
-              {['LTI 1.3', 'SAML 2.0', 'OIDC', 'OneRoster 1.2', 'SCIM 2.0', 'Clever', 'ClassLink', 'QTI 2.1/3.0', 'Canvas import', 'iCalendar'].map((tag) => (
-                <span key={tag} className="font-medium text-stone-500">{tag}</span>
+              </article>
+
+              {/* Card 2 — AI content */}
+              <article className="group relative overflow-hidden rounded-3xl border border-slate-200 bg-white p-7 md:col-span-5">
+                <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-violet-50 text-violet-600 ring-1 ring-violet-200">
+                  <Zap className="h-5 w-5" aria-hidden />
+                </div>
+                <h3 className="mt-5 text-lg font-semibold text-slate-900">AI-generated content</h3>
+                <p className="mt-2.5 text-sm leading-relaxed text-slate-500">
+                  Generate quiz questions from learning objectives, build rubrics from assignment
+                  descriptions, and produce progressive hints that guide without giving answers.
+                </p>
+              </article>
+
+              {/* Card 3 — 14+ types, accent background */}
+              <article className="relative overflow-hidden rounded-3xl bg-indigo-600 p-7 md:col-span-4">
+                <div className="absolute right-4 top-4 text-[3.5rem] font-black leading-none text-white/20 select-none">14+</div>
+                <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-white/15 text-white ring-1 ring-white/20">
+                  <BookOpen className="h-5 w-5" aria-hidden />
+                </div>
+                <h3 className="mt-5 text-lg font-semibold text-white">Question types</h3>
+                <p className="mt-2 text-sm leading-relaxed text-indigo-200">
+                  Multiple choice, essay, live code execution, image hotspots, matching, ordering,
+                  formula, and audio/video responses.
+                </p>
+              </article>
+
+              {/* Card 4 — Gradebook */}
+              <article className="rounded-3xl border border-slate-200 bg-slate-50 p-7 md:col-span-4">
+                <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-emerald-50 text-emerald-600 ring-1 ring-emerald-200">
+                  <BarChart3 className="h-5 w-5" aria-hidden />
+                </div>
+                <h3 className="mt-5 text-lg font-semibold text-slate-900">Standards-based gradebook</h3>
+                <p className="mt-2 text-sm leading-relaxed text-slate-500">
+                  Map assignments to NGSS, CCSS, or your own standards. Track mastery by
+                  objective—not just points.
+                </p>
+              </article>
+
+              {/* Card 5 — LTI */}
+              <article className="rounded-3xl border border-slate-200 bg-white p-7 md:col-span-4">
+                <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-sky-50 text-sky-600 ring-1 ring-sky-200">
+                  <Unplug className="h-5 w-5" aria-hidden />
+                </div>
+                <h3 className="mt-5 text-lg font-semibold text-slate-900">Canvas, Moodle & Blackboard-ready</h3>
+                <p className="mt-2 text-sm leading-relaxed text-slate-500">
+                  LTI 1.3 provider: run Lextures inside any LMS your institution already uses.
+                  Import courses and question banks from Canvas.
+                </p>
+              </article>
+
+              {/* Card 6 — Wide, enterprise identity */}
+              <article className="flex flex-col gap-6 rounded-3xl border border-slate-200 bg-white p-7 md:col-span-12 md:flex-row md:items-center md:gap-12">
+                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-rose-50 text-rose-600 ring-1 ring-rose-200">
+                  <ShieldCheck className="h-5 w-5" aria-hidden />
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-lg font-semibold text-slate-900">Enterprise identity & provisioning</h3>
+                  <p className="mt-1.5 text-sm leading-relaxed text-slate-500">
+                    SAML 2.0, OIDC, Clever, and ClassLink SSO. OneRoster 1.2 CSV and SCIM 2.0 HTTP for bulk roster sync.
+                    TOTP and WebAuthn MFA for every account.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2 md:justify-end">
+                  {['SAML 2.0', 'OIDC', 'Clever', 'ClassLink', 'SCIM 2.0'].map(tag => (
+                    <span key={tag} className="rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-medium text-slate-600">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </article>
+
+            </div>
+          </div>
+        </section>
+
+        {/* ════════════════════════════════ ADAPTIVE SCIENCE ═══ */}
+        <section id="ai" className="bg-slate-950 py-20 sm:py-28">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+            <div className="max-w-2xl">
+              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-400">
+                The science behind it
+              </p>
+              <h2 className="mt-3 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+                Adaptive mechanics, not buzzwords
+              </h2>
+              <p className="mt-4 text-lg leading-relaxed text-slate-400">
+                Routing, misconceptions, and review scheduling live next to grading and content—because
+                that's where they actually affect outcomes.
+              </p>
+            </div>
+
+            <div className="mt-12 grid gap-5 lg:grid-cols-3">
+              {[
+                {
+                  icon: BrainCircuit,
+                  title: 'Item Response Theory engine',
+                  body: "Questions are calibrated using IRT 2PL/3PL models. The system estimates each learner's mastery level in real time and routes them to the content they actually need next—not what's next in the syllabus.",
+                  color: 'text-indigo-400',
+                  bg: 'bg-indigo-500/10 ring-indigo-500/20',
+                },
+                {
+                  icon: GraduationCap,
+                  title: 'Misconception detection',
+                  body: 'AI analyzes incorrect responses across the class and surfaces the most common errors to instructors—so they can address patterns in the next session instead of marking them wrong and moving on.',
+                  color: 'text-violet-400',
+                  bg: 'bg-violet-500/10 ring-violet-500/20',
+                },
+                {
+                  icon: RefreshCw,
+                  title: 'Spaced repetition scheduler',
+                  body: 'The SRS engine schedules review material at scientifically optimal intervals. Knowledge sticks between sessions instead of fading before the final exam.',
+                  color: 'text-emerald-400',
+                  bg: 'bg-emerald-500/10 ring-emerald-500/20',
+                },
+              ].map(({ icon: Icon, title, body, color, bg }) => (
+                <div key={title} className="feature-card-dark">
+                  <div className={`flex h-11 w-11 items-center justify-center rounded-xl ring-1 ${bg} ${color}`}>
+                    <Icon className="h-5 w-5" aria-hidden />
+                  </div>
+                  <h3 className="mt-5 text-base font-semibold text-white">{title}</h3>
+                  <p className="mt-2.5 text-sm leading-relaxed text-slate-400">{body}</p>
+                </div>
               ))}
             </div>
           </div>
         </section>
 
-        {/* Code section */}
-        <section className="border-y border-stone-200/90 bg-surface py-16 sm:py-20">
+        {/* ══════════════════════════════════ INSTITUTIONS ═══ */}
+        <section id="institutions" className="bg-surface py-20 sm:py-28">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:gap-16">
+            <div className="grid gap-12 lg:grid-cols-2 lg:items-center lg:gap-20">
+              <div>
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-500">
+                  For institutions
+                </p>
+                <h2 className="mt-3 text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+                  Built around how institutions actually operate
+                </h2>
+                <p className="mt-5 text-lg leading-relaxed text-slate-600">
+                  From K-12 districts to university programs, Lextures is modeled on the workflows
+                  that break first at scale: enrollment drift, inconsistent accommodations, grading
+                  that can't be audited, and content no one can keep synchronized.
+                </p>
+                <ul className="mt-8 space-y-4">
+                  {[
+                    'Course blueprints let coordinators push updates to every child section at once—syllabus changes, rubrics, new items.',
+                    'Accommodations are configured once at the platform level and applied to every assessment automatically.',
+                    'Every grading action is logged with who changed what, when, and why—a complete paper trail for appeals and accreditation.',
+                  ].map((line) => (
+                    <li key={line} className="flex gap-3 text-slate-700">
+                      <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-500" aria-hidden />
+                      <span className="text-[0.9375rem] leading-relaxed">{line}</span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="mt-9 flex flex-wrap gap-3">
+                  <a href="/higher-ed" className="btn-primary gap-2">
+                    Higher Education
+                    <ArrowRight className="h-4 w-4" aria-hidden />
+                  </a>
+                  <a href="/k-12" className="btn-secondary">
+                    K–12
+                  </a>
+                </div>
+              </div>
+
+              {/* Quote card */}
+              <div className="relative rounded-3xl border border-slate-200 bg-white p-8 shadow-[0_4px_40px_rgba(15,23,42,0.06)]">
+                <div
+                  aria-hidden
+                  className="pointer-events-none absolute -right-10 -top-10 h-40 w-40 rounded-full bg-indigo-100 blur-[50px]"
+                />
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-400">
+                  Design principle
+                </p>
+                <blockquote className="relative mt-5">
+                  <span aria-hidden className="absolute -left-1 -top-3 text-6xl leading-none text-indigo-200 select-none font-display">"</span>
+                  <p className="relative z-10 pl-5 text-xl font-medium leading-snug text-slate-900">
+                    If a registrar would wince at the data model, it doesn't ship—operational
+                    honesty beats feature checklists.
+                  </p>
+                </blockquote>
+                <p className="mt-5 text-sm leading-relaxed text-slate-500">
+                  Lextures is under active development. The public demo is the fastest way to see
+                  current capabilities and where the product is heading.
+                </p>
+                <a href="/get-started" className="btn-primary mt-6 inline-flex gap-2">
+                  Try the live demo
+                  <ArrowRight className="h-4 w-4" aria-hidden />
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ════════════════════════════════ INTEGRATIONS ═══ */}
+        <section id="integrations" className="bg-white py-20 sm:py-28">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+            <div className="grid gap-12 lg:grid-cols-[1fr_1.2fr] lg:items-start">
+              <div>
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-500">
+                  Integrations
+                </p>
+                <h2 className="mt-3 text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+                  Works inside the stack you already have
+                </h2>
+                <p className="mt-4 text-lg leading-relaxed text-slate-500">
+                  No rip-and-replace. Lextures integrates with Canvas, Blackboard, Moodle, and
+                  your district SIS—or stands alone as your primary LMS.
+                </p>
+                <div className="mt-8 flex flex-wrap gap-2">
+                  {[
+                    'LTI 1.3', 'SAML 2.0', 'OIDC', 'OneRoster 1.2',
+                    'SCIM 2.0', 'Clever', 'ClassLink', 'QTI 2.1/3.0', 'Canvas import', 'iCalendar',
+                  ].map(tag => (
+                    <span
+                      key={tag}
+                      className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold text-slate-600"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {[
+                  {
+                    term: 'LTI 1.3 provider & consumer',
+                    desc: 'Launch Lextures inside Canvas, Blackboard, or Moodle. Roster sync via NRPS, grade passback via AGS, and deep linking for publisher content—all spec-compliant.',
+                  },
+                  {
+                    term: 'Canvas import',
+                    desc: 'Move courses, question banks, and grades from Canvas using WebSocket-based import with AI-assisted migration. QTI 2.1/3.0 from any major LMS.',
+                  },
+                  {
+                    term: 'SSO & roster provisioning',
+                    desc: 'SAML 2.0, OIDC, Clever, and ClassLink for identity. OneRoster 1.2 CSV and SCIM 2.0 HTTP for roster sync. Auto-provision users on first login.',
+                  },
+                  {
+                    term: 'Defensible exports',
+                    desc: 'Grade exports structured for accreditation reviews and appeals. iCalendar feeds for due dates. QTI exports for question bank portability.',
+                  },
+                ].map(row => (
+                  <div key={row.term} className="feature-card">
+                    <dt className="text-sm font-semibold text-slate-900">{row.term}</dt>
+                    <dd className="mt-2 text-sm leading-relaxed text-slate-500">{row.desc}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          </div>
+        </section>
+
+        {/* ═══════════════════════════════════ OPEN SOURCE ═══ */}
+        <section className="relative overflow-hidden bg-slate-950 py-20 sm:py-24">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute left-0 top-0 h-full w-1/2 bg-gradient-to-r from-indigo-600/10 to-transparent"
+          />
+          <div className="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+            <div className="flex flex-col gap-10 lg:flex-row lg:items-center lg:gap-16">
               <div className="lg:max-w-md">
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent-muted/70 text-accent">
+                <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-indigo-500/10 text-indigo-400 ring-1 ring-indigo-500/20">
                   <Code2 className="h-5 w-5" aria-hidden />
                 </div>
-                <h2 className="mt-5 text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
-                  Open source, AGPL-3.0 Licensed
+                <h2 className="mt-5 text-2xl font-bold tracking-tight text-white sm:text-3xl">
+                  Open source, AGPL-3.0 licensed
                 </h2>
-                <p className="mt-4 leading-relaxed text-stone-600">
-                  The full application stack—Go backend, React frontend, database migrations—is
-                  public on GitHub. Deploy on your own infrastructure, fork it, or contribute.
-                  No vendor lock-in, no usage fees.
+                <p className="mt-4 leading-relaxed text-slate-400">
+                  The full stack—Go backend, React frontend, database migrations—is public on
+                  GitHub. Deploy on your own infrastructure, fork it, or contribute. No vendor
+                  lock-in, no usage fees.
                 </p>
                 <div className="mt-6 flex gap-3">
                   <a href={LINKS.github} className="btn-primary gap-2">
@@ -322,51 +478,89 @@ function HomePage() {
                   </a>
                 </div>
               </div>
-              <div className="flex-1 rounded-xl border border-stone-800 bg-stone-950 p-6 font-mono text-sm leading-relaxed shadow-sm">
-                <p className="text-stone-500"># Get started in minutes</p>
-                <p className="mt-3">
-                  <span className="text-teal-400">git clone</span>{' '}
-                  <span className="text-stone-300">https://github.com/StudyDrift/lextures</span>
-                </p>
-                <p className="mt-1">
-                  <span className="text-teal-400">cd</span>{' '}
-                  <span className="text-stone-300">lextures</span>
-                </p>
-                <p className="mt-3 text-stone-500"># Start with Docker Compose</p>
-                <p className="mt-1">
-                  <span className="text-teal-400">docker compose up</span>{' '}
-                  <span className="text-stone-500">-d</span>
-                </p>
-                <p className="mt-3 text-stone-500"># Or run locally with your own Postgres</p>
-                <p className="mt-1">
-                  <span className="text-teal-400">make</span>{' '}
-                  <span className="text-stone-300">dev</span>
-                </p>
+
+              {/* Terminal */}
+              <div className="flex-1 overflow-hidden rounded-2xl border border-slate-700/60 bg-[#0d1117] shadow-[0_20px_60px_rgba(0,0,0,0.5)]">
+                <div className="flex items-center gap-1.5 border-b border-slate-700/60 px-4 py-3">
+                  <span className="h-3 w-3 rounded-full bg-red-500/70" aria-hidden />
+                  <span className="h-3 w-3 rounded-full bg-yellow-500/70" aria-hidden />
+                  <span className="h-3 w-3 rounded-full bg-green-500/70" aria-hidden />
+                  <span className="ml-3 text-[0.68rem] font-medium text-slate-500">zsh — lextures</span>
+                </div>
+                <div className="p-5 font-mono text-sm leading-[1.8]">
+                  <p className="text-slate-500"># Get started in minutes</p>
+                  <p className="mt-2">
+                    <span className="text-emerald-400">$</span>{' '}
+                    <span className="text-indigo-300">git clone</span>{' '}
+                    <span className="text-slate-300">https://github.com/StudyDrift/lextures</span>
+                  </p>
+                  <p>
+                    <span className="text-emerald-400">$</span>{' '}
+                    <span className="text-indigo-300">cd</span>{' '}
+                    <span className="text-slate-300">lextures</span>
+                  </p>
+                  <p className="mt-2 text-slate-500"># Start with Docker Compose</p>
+                  <p>
+                    <span className="text-emerald-400">$</span>{' '}
+                    <span className="text-indigo-300">docker compose up</span>{' '}
+                    <span className="text-slate-500">-d</span>
+                  </p>
+                  <p className="mt-2 text-slate-500"># Or run locally</p>
+                  <p>
+                    <span className="text-emerald-400">$</span>{' '}
+                    <span className="text-indigo-300">make</span>{' '}
+                    <span className="text-slate-300">dev</span>
+                  </p>
+                  <p className="mt-2">
+                    <span className="text-slate-500">✓</span>{' '}
+                    <span className="text-emerald-400">Server running on</span>{' '}
+                    <span className="text-indigo-400 underline underline-offset-2">http://localhost:8080</span>
+                  </p>
+                </div>
               </div>
             </div>
           </div>
         </section>
 
-        {/* CTA */}
-        <section className="py-20 sm:py-28">
-          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <div className="rounded-2xl border border-stone-200/90 bg-white px-8 py-14 text-center shadow-[0_12px_40px_-24px_rgba(28,25,23,0.35)] sm:px-14">
-              <h2 className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
-                Try the product on the hosted demo
-              </h2>
-              <p className="mx-auto mt-4 max-w-xl text-lg leading-relaxed text-stone-600">
-                Walk learner and instructor flows—quizzes, gradebook, imports—then decide if the stack
-                matches your institution.
-              </p>
-              <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
-                <a href="/get-started" className="btn-primary gap-2 px-6 py-3">
-                  Get Started
-                  <ArrowRight className="h-4 w-4" aria-hidden />
-                </a>
-                <a href={LINKS.github} className="btn-secondary px-6 py-3">
-                  Study the source
-                </a>
-              </div>
+        {/* ══════════════════════════════════════ FINAL CTA ═══ */}
+        <section className="relative overflow-hidden bg-gradient-to-br from-indigo-600 via-indigo-600 to-violet-700 py-24 sm:py-32">
+          {/* Subtle dot pattern */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 opacity-30"
+            style={{
+              backgroundImage: 'radial-gradient(circle, rgba(255,255,255,0.15) 1px, transparent 1px)',
+              backgroundSize: '24px 24px',
+            }}
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -left-20 top-0 h-80 w-80 rounded-full bg-white/10 blur-[80px]"
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -right-20 bottom-0 h-80 w-80 rounded-full bg-violet-400/20 blur-[80px]"
+          />
+
+          <div className="relative mx-auto max-w-4xl px-4 text-center sm:px-6 lg:px-8">
+            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-200">
+              Ready to explore?
+            </p>
+            <h2 className="font-display mt-5 text-4xl font-normal italic leading-tight tracking-tight text-white sm:text-5xl">
+              Try the product on the hosted demo
+            </h2>
+            <p className="mx-auto mt-5 max-w-xl text-lg leading-relaxed text-indigo-200">
+              Walk learner and instructor flows—quizzes, gradebook, imports—then decide if the
+              stack matches your institution. No login required.
+            </p>
+            <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
+              <a href="/get-started" className="inline-flex h-12 cursor-pointer items-center justify-center gap-2 rounded-xl bg-white px-8 text-[0.9375rem] font-semibold text-indigo-700 shadow-sm transition-all duration-150 hover:bg-indigo-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">
+                Get Started free
+                <ArrowRight className="h-4 w-4" aria-hidden />
+              </a>
+              <a href={LINKS.github} className="btn-ghost-dark h-12 px-8 text-[0.9375rem]">
+                Study the source
+              </a>
             </div>
           </div>
         </section>
@@ -377,6 +571,9 @@ function HomePage() {
   )
 }
 
+/* ─────────────────────────────────────────────────────────
+   ROUTER
+   ───────────────────────────────────────────────────────── */
 export default function App() {
   const hash = useHashRoute()
   const path = window.location.pathname

--- a/www/src/components/header.tsx
+++ b/www/src/components/header.tsx
@@ -12,8 +12,15 @@ const INDUSTRIES = [
   { label: 'Self-Learner', href: '/self-learner' },
 ]
 
-function LogoMark({ className = '' }: { className?: string }) {
-  return <img src="/logo.svg" className={className} alt="" aria-hidden />
+function Logo() {
+  return (
+    <a href="/" className="flex items-center gap-2 no-underline" aria-label="Lextures home">
+      <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-accent text-white shadow-sm">
+        <img src="/logo.svg" className="h-4 w-4 brightness-0 invert" alt="" aria-hidden />
+      </span>
+      <span className="text-[0.9375rem] font-semibold tracking-tight text-slate-900">Lextures</span>
+    </a>
+  )
 }
 
 function IndustriesDropdown({ onNavigate }: { onNavigate?: () => void }) {
@@ -21,25 +28,23 @@ function IndustriesDropdown({ onNavigate }: { onNavigate?: () => void }) {
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    function handleClick(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false)
-      }
+    function handler(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
     }
-    document.addEventListener('mousedown', handleClick)
-    return () => document.removeEventListener('mousedown', handleClick)
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
   }, [])
 
   return (
     <div ref={ref} className="relative">
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setOpen(v => !v)}
         aria-expanded={open}
         aria-haspopup="true"
-        className="flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-stone-600 transition-colors hover:bg-stone-200/60 hover:text-stone-900"
+        className="flex cursor-pointer items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900"
       >
-        Industries
+        Solutions
         <ChevronDown
           className={`h-3.5 w-3.5 transition-transform duration-150 ${open ? 'rotate-180' : ''}`}
           aria-hidden
@@ -47,13 +52,13 @@ function IndustriesDropdown({ onNavigate }: { onNavigate?: () => void }) {
       </button>
 
       {open && (
-        <div className="absolute left-0 top-full z-50 mt-1.5 w-44 overflow-hidden rounded-xl border border-stone-200 bg-white shadow-lg shadow-stone-900/10">
-          {INDUSTRIES.map((item) => (
+        <div className="absolute left-0 top-full z-50 mt-2 w-48 overflow-hidden rounded-xl border border-slate-200 bg-white p-1 shadow-xl shadow-slate-900/10">
+          {INDUSTRIES.map(item => (
             <a
               key={item.href}
               href={item.href}
               onClick={() => { setOpen(false); onNavigate?.() }}
-              className="block px-4 py-2.5 text-sm font-medium text-stone-700 no-underline transition-colors hover:bg-stone-50 hover:text-stone-900"
+              className="block rounded-lg px-3 py-2 text-sm font-medium text-slate-700 no-underline transition-colors hover:bg-slate-50 hover:text-slate-900"
             >
               {item.label}
             </a>
@@ -63,6 +68,12 @@ function IndustriesDropdown({ onNavigate }: { onNavigate?: () => void }) {
     </div>
   )
 }
+
+const NAV_LINKS = [
+  { label: 'Pricing', href: '/pricing' },
+  { label: 'Blog', href: '/blog' },
+  { label: 'Docs', href: '/docs' },
+]
 
 export function Header() {
   const [menuOpen, setMenuOpen] = useState(false)
@@ -80,107 +91,107 @@ export function Header() {
 
   return (
     <>
-      <header className="sticky top-0 z-50 border-b border-stone-200/80 bg-stone-50/90 backdrop-blur-md">
-        <div className="mx-auto flex h-16 max-w-6xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
-          <a href="/" className="flex items-center gap-2.5 no-underline">
-            <LogoMark className="h-8 w-8 shrink-0" />
-            <span className="text-base font-semibold tracking-tight text-stone-900">Lextures</span>
-          </a>
+      <header className="sticky top-0 z-50 px-3 pt-3 pb-0 sm:px-4">
+        <div className="mx-auto max-w-6xl">
+          <div className="flex h-[52px] items-center justify-between rounded-2xl border border-slate-200/80 bg-white/95 px-3 shadow-sm shadow-slate-900/5 backdrop-blur-xl sm:px-4">
+            <Logo />
 
-          <nav className="hidden items-center gap-1 md:flex" aria-label="Primary">
-            <IndustriesDropdown />
-            <a
-              href="/pricing"
-              className="rounded-lg px-3 py-2 text-sm font-medium text-stone-600 no-underline transition-colors hover:bg-stone-200/60 hover:text-stone-900"
-            >
-              Pricing
-            </a>
-            <a
-              href="/blog"
-              className="rounded-lg px-3 py-2 text-sm font-medium text-stone-600 no-underline transition-colors hover:bg-stone-200/60 hover:text-stone-900"
-            >
-              Blog
-            </a>
-            <a
-              href="/docs"
-              className="rounded-lg px-3 py-2 text-sm font-medium text-stone-600 no-underline transition-colors hover:bg-stone-200/60 hover:text-stone-900"
-            >
-              Documentation
-            </a>
-          </nav>
+            {/* Desktop nav */}
+            <nav className="hidden items-center gap-0.5 md:flex" aria-label="Primary">
+              <IndustriesDropdown />
+              {NAV_LINKS.map(({ label, href }) => (
+                <a
+                  key={href}
+                  href={href}
+                  className="rounded-lg px-3 py-1.5 text-sm font-medium text-slate-600 no-underline transition-colors hover:bg-slate-100 hover:text-slate-900"
+                >
+                  {label}
+                </a>
+              ))}
+            </nav>
 
-          <div className="hidden items-center gap-3 md:flex">
-            <a
-              href={LINKS.github}
-              className="p-2 text-stone-600 transition-colors hover:text-stone-900"
-              aria-label="View on GitHub"
-              target="_blank"
-              rel="noopener noreferrer"
+            {/* Desktop actions */}
+            <div className="hidden items-center gap-2 md:flex">
+              <a
+                href={LINKS.demo}
+                className="rounded-lg px-3 py-1.5 text-sm font-medium text-slate-600 no-underline transition-colors hover:bg-slate-100 hover:text-slate-900"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Live demo
+              </a>
+              <a
+                href={LINKS.github}
+                className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900"
+                aria-label="View on GitHub"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Github className="h-4 w-4" />
+              </a>
+              <a href="/get-started" className="btn-primary py-2 text-xs">
+                Get Started
+              </a>
+            </div>
+
+            {/* Mobile menu button */}
+            <button
+              type="button"
+              onClick={() => setMenuOpen(true)}
+              className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-slate-200 text-slate-600 transition hover:bg-slate-100 md:hidden"
+              aria-expanded={menuOpen}
+              aria-controls="mobile-nav"
+              aria-label="Open menu"
             >
-              <Github className="h-5 w-5" />
-            </a>
-            <a href="/get-started" className="btn-primary">Get Started</a>
+              <Menu className="h-4 w-4" />
+            </button>
           </div>
-
-          <button
-            type="button"
-            onClick={() => setMenuOpen(true)}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-stone-200 text-stone-600 transition hover:bg-stone-200/50 md:hidden"
-            aria-expanded={menuOpen}
-            aria-controls="mobile-nav"
-            aria-label="Open menu"
-          >
-            <Menu className="h-4 w-4" />
-          </button>
         </div>
       </header>
 
+      {/* Mobile overlay */}
       {menuOpen && (
         <div
-          className="fixed inset-0 z-[60] flex flex-col bg-stone-50 md:hidden"
+          className="fixed inset-0 z-[60] flex flex-col bg-white md:hidden"
           id="mobile-nav"
           role="dialog"
           aria-modal="true"
           aria-label="Navigation"
         >
-          <div className="flex h-16 items-center justify-between border-b border-stone-200 px-4">
-            <div className="flex items-center gap-2.5">
-              <LogoMark className="h-8 w-8" />
-              <span className="text-base font-semibold text-stone-900">Lextures</span>
-            </div>
+          <div className="flex h-[52px] items-center justify-between border-b border-slate-100 px-4">
+            <Logo />
             <button
               type="button"
               onClick={closeMenu}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-stone-200 text-stone-600 hover:bg-stone-200/50"
+              className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-slate-200 text-slate-600 hover:bg-slate-100"
               aria-label="Close menu"
             >
               <X className="h-4 w-4" />
             </button>
           </div>
 
-          <nav className="flex flex-1 flex-col gap-1 overflow-y-auto p-4" aria-label="Mobile primary">
-            {/* Industries accordion */}
+          <nav className="flex flex-1 flex-col gap-1 overflow-y-auto p-3" aria-label="Mobile primary">
             <div>
               <button
                 type="button"
-                onClick={() => setMobileIndustriesOpen((v) => !v)}
-                className="flex w-full items-center justify-between rounded-lg px-4 py-3.5 text-base font-medium text-stone-800 transition hover:bg-stone-200/50"
+                onClick={() => setMobileIndustriesOpen(v => !v)}
+                className="flex w-full cursor-pointer items-center justify-between rounded-xl px-4 py-3 text-sm font-medium text-slate-800 transition hover:bg-slate-50"
                 aria-expanded={mobileIndustriesOpen}
               >
-                Industries
+                Solutions
                 <ChevronDown
                   className={`h-4 w-4 transition-transform duration-150 ${mobileIndustriesOpen ? 'rotate-180' : ''}`}
                   aria-hidden
                 />
               </button>
               {mobileIndustriesOpen && (
-                <div className="ml-4 mt-1 flex flex-col gap-1 border-l-2 border-stone-200 pl-4">
-                  {INDUSTRIES.map((item) => (
+                <div className="ml-4 mt-1 flex flex-col gap-1 border-l-2 border-slate-100 pl-4">
+                  {INDUSTRIES.map(item => (
                     <a
                       key={item.href}
                       href={item.href}
                       onClick={closeMenu}
-                      className="rounded-lg px-3 py-2.5 text-sm font-medium text-stone-700 no-underline transition hover:bg-stone-200/50 hover:text-stone-900"
+                      className="rounded-lg px-3 py-2.5 text-sm font-medium text-slate-700 no-underline transition hover:bg-slate-50 hover:text-slate-900"
                     >
                       {item.label}
                     </a>
@@ -189,37 +200,35 @@ export function Header() {
               )}
             </div>
 
-            <a
-              href="/pricing"
-              onClick={closeMenu}
-              className="rounded-lg px-4 py-3.5 text-base font-medium text-stone-800 no-underline transition hover:bg-stone-200/50"
-            >
-              Pricing
-            </a>
-            <a
-              href="/blog"
-              onClick={closeMenu}
-              className="rounded-lg px-4 py-3.5 text-base font-medium text-stone-800 no-underline transition hover:bg-stone-200/50"
-            >
-              Blog
-            </a>
-            <a
-              href="/docs"
-              onClick={closeMenu}
-              className="rounded-lg px-4 py-3.5 text-base font-medium text-stone-800 no-underline transition hover:bg-stone-200/50"
-            >
-              Documentation
-            </a>
+            {NAV_LINKS.map(({ label, href }) => (
+              <a
+                key={href}
+                href={href}
+                onClick={closeMenu}
+                className="rounded-xl px-4 py-3 text-sm font-medium text-slate-800 no-underline transition hover:bg-slate-50"
+              >
+                {label}
+              </a>
+            ))}
           </nav>
 
-          <div className="flex flex-col gap-3 border-t border-stone-200 p-4 pb-8">
-            <a href="/get-started" onClick={closeMenu} className="btn-primary w-full justify-center">
+          <div className="flex flex-col gap-2 border-t border-slate-100 p-4 pb-8">
+            <a href="/get-started" onClick={closeMenu} className="btn-primary w-full justify-center py-3">
               Get Started
+            </a>
+            <a
+              href={LINKS.demo}
+              onClick={closeMenu}
+              className="btn-secondary w-full justify-center py-3"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Live Demo
             </a>
             <a
               href={LINKS.github}
               onClick={closeMenu}
-              className="btn-secondary w-full justify-center gap-2"
+              className="flex cursor-pointer items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-medium text-slate-600 no-underline transition hover:bg-slate-50"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/www/src/components/site-footer.tsx
+++ b/www/src/components/site-footer.tsx
@@ -1,63 +1,93 @@
+import { Github } from 'lucide-react'
 import { SITE_LINKS } from '../lib/site-links'
+
+const NAV_COLUMNS = [
+  {
+    heading: 'Product',
+    links: [
+      { label: 'Pricing', href: '/pricing' },
+      { label: 'Blog', href: '/blog' },
+      { label: 'Documentation', href: '/docs' },
+      { label: 'Live Demo', href: SITE_LINKS.demo },
+    ],
+  },
+  {
+    heading: 'Solutions',
+    links: [
+      { label: 'Higher Education', href: '/higher-ed' },
+      { label: 'K–12', href: '/k-12' },
+      { label: 'Self-Learner', href: '/self-learner' },
+      { label: 'Get Started', href: '/get-started' },
+    ],
+  },
+  {
+    heading: 'Legal',
+    links: [
+      { label: 'Privacy Policy', href: SITE_LINKS.privacy },
+      { label: 'Terms of Service', href: SITE_LINKS.terms },
+      { label: 'Security', href: SITE_LINKS.security },
+      { label: 'Accessibility', href: SITE_LINKS.accessibility },
+      { label: 'California Privacy Rights', href: SITE_LINKS.californiaPrivacyRights },
+    ],
+  },
+]
 
 export function SiteFooter() {
   return (
-    <footer className="border-t border-stone-200/90 bg-white py-12">
-      <div className="mx-auto flex max-w-6xl flex-col gap-10 px-4 sm:flex-row sm:items-start sm:justify-between sm:px-6 lg:px-8">
-        <div>
-          <div className="flex items-center gap-2.5">
-            <img src="/logo.svg" className="h-8 w-8" alt="" aria-hidden />
-            <span className="text-base font-semibold text-stone-900">Lextures</span>
+    <footer className="bg-[#020617] text-slate-400">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        {/* Main grid */}
+        <div className="grid gap-10 border-b border-slate-800 py-14 sm:grid-cols-2 lg:grid-cols-[2fr_1fr_1fr_1fr]">
+          {/* Brand column */}
+          <div>
+            <div className="flex items-center gap-2.5">
+              <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-indigo-600 text-white">
+                <img src="/logo.svg" className="h-4 w-4 brightness-0 invert" alt="" aria-hidden />
+              </span>
+              <span className="text-[0.9375rem] font-semibold text-white">Lextures</span>
+            </div>
+            <p className="mt-4 max-w-xs text-sm leading-relaxed text-slate-500">
+              Open-source adaptive LMS for courses, assessments, and institutional workflows.
+              Built in public under AGPL-3.0.
+            </p>
+            <a
+              href={SITE_LINKS.github}
+              className="mt-5 inline-flex items-center gap-2 text-sm text-slate-500 no-underline transition-colors hover:text-slate-300"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="View Lextures on GitHub"
+            >
+              <Github className="h-4 w-4" />
+              GitHub
+            </a>
           </div>
-          <p className="mt-3 max-w-xs text-sm leading-relaxed text-stone-500">
-            Open-source LMS for courses, assessments, and institutional workflows. Developed in public
-            on GitHub.
-          </p>
-          <p className="mt-4 text-sm text-stone-400">© {new Date().getFullYear()} Lextures contributors</p>
+
+          {/* Nav columns */}
+          {NAV_COLUMNS.map(({ heading, links }) => (
+            <div key={heading}>
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                {heading}
+              </p>
+              <ul className="mt-4 space-y-3">
+                {links.map(({ label, href }) => (
+                  <li key={label}>
+                    <a
+                      href={href}
+                      className="text-sm text-slate-500 no-underline transition-colors hover:text-slate-200"
+                    >
+                      {label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
-        <div className="flex flex-wrap gap-x-8 gap-y-2 text-sm font-medium text-stone-500">
-          <a href={SITE_LINKS.demo} className="no-underline transition-colors hover:text-stone-900">
-            Live demo
-          </a>
-          <a href={SITE_LINKS.github} className="no-underline transition-colors hover:text-stone-900">
-            GitHub
-          </a>
-          <a href="/features" className="no-underline transition-colors hover:text-stone-900">
-            Features
-          </a>
-          <a href="/higher-ed" className="no-underline transition-colors hover:text-stone-900">
-            Higher Education
-          </a>
-          <a href="/k-12" className="no-underline transition-colors hover:text-stone-900">
-            K–12
-          </a>
-          <a href="/self-learner" className="no-underline transition-colors hover:text-stone-900">
-            Self-Learner
-          </a>
-          <a href="/pricing" className="no-underline transition-colors hover:text-stone-900">
-            Pricing
-          </a>
-          <a href="/blog" className="no-underline transition-colors hover:text-stone-900">
-            Blog
-          </a>
-          <a href="/docs" className="no-underline transition-colors hover:text-stone-900">
-            Documentation
-          </a>
-          <a href={SITE_LINKS.privacy} className="no-underline transition-colors hover:text-stone-900">
-            Privacy Policy
-          </a>
-          <a href={SITE_LINKS.terms} className="no-underline transition-colors hover:text-stone-900">
-            Terms of Service
-          </a>
-          <a href={SITE_LINKS.security} className="no-underline transition-colors hover:text-stone-900">
-            Security
-          </a>
-          <a href={SITE_LINKS.accessibility} className="no-underline transition-colors hover:text-stone-900">
-            Accessibility
-          </a>
-          <a href={SITE_LINKS.californiaPrivacyRights} className="no-underline transition-colors hover:text-stone-900">
-            California Privacy Rights
-          </a>
+
+        {/* Bottom bar */}
+        <div className="flex flex-col items-center justify-between gap-3 py-6 text-xs text-slate-600 sm:flex-row">
+          <p>© {new Date().getFullYear()} Lextures contributors. Released under AGPL-3.0.</p>
+          <p>Built in public · Self-host for free</p>
         </div>
       </div>
     </footer>

--- a/www/src/index.css
+++ b/www/src/index.css
@@ -1,36 +1,45 @@
 @import "tailwindcss";
 
 @theme {
-  --font-sans: "DM Sans", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
   --font-display: "Instrument Serif", ui-serif, Georgia, serif;
 
-  --color-surface: #fafaf9;
-  --color-surface-2: #f5f5f4;
-  /* Teal accent: distinct from default "SaaS indigo", still serious for education */
-  --color-accent: #0f766e;
-  --color-accent-hover: #115e59;
-  --color-accent-muted: #ccfbf1;
-  --color-accent-border: #99f6e4;
+  /* Surfaces */
+  --color-surface: #f8fafc;
+  --color-surface-2: #f1f5f9;
+
+  /* Indigo accent */
+  --color-accent: #6366f1;
+  --color-accent-hover: #4f46e5;
+  --color-accent-muted: #eef2ff;
+  --color-accent-border: #c7d2fe;
+  --color-accent-light: #e0e7ff;
+
+  /* Dark palette */
+  --color-dark-bg: #020617;
+  --color-dark-surface: #0f172a;
+  --color-dark-card: #1e293b;
+  --color-dark-border: #334155;
 }
 
+/* ─────────────────────────────────────────────── Base ─── */
 @layer base {
   html {
     scroll-behavior: smooth;
   }
 
   @media (prefers-reduced-motion: reduce) {
-    html {
-      scroll-behavior: auto;
-    }
+    html { scroll-behavior: auto; }
+    *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
   }
 
   body {
     @apply bg-white text-slate-700 antialiased font-sans;
-    font-optical-sizing: auto;
+    font-feature-settings: "cv02", "cv03", "cv04", "cv11";
   }
 
   ::selection {
-    @apply bg-teal-100 text-teal-950;
+    @apply bg-indigo-100 text-indigo-950;
   }
 
   a:not([class]) {
@@ -38,86 +47,53 @@
   }
 }
 
+/* ──────────────────────────────────────────── Buttons ─── */
 @utility btn-primary {
-  @apply inline-flex items-center justify-center gap-2 rounded-lg bg-accent px-5 py-2.5 text-sm font-semibold text-white shadow-[0_1px_2px_rgba(15,118,110,0.18)] transition-colors duration-150 hover:bg-accent-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent;
+  @apply inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl bg-accent px-5 py-2.5 text-sm font-semibold text-white shadow-[0_1px_3px_rgba(99,102,241,0.3),0_1px_2px_-1px_rgba(99,102,241,0.2)] transition-all duration-150 hover:bg-accent-hover hover:shadow-[0_4px_12px_rgba(99,102,241,0.35)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent;
 }
 
 @utility btn-secondary {
-  @apply inline-flex items-center justify-center gap-2 rounded-lg border border-stone-300 bg-white px-5 py-2.5 text-sm font-semibold text-stone-800 transition-colors duration-150 hover:border-stone-400 hover:bg-stone-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent;
+  @apply inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 shadow-[0_1px_2px_rgba(15,23,42,0.05)] transition-all duration-150 hover:border-slate-300 hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent;
 }
 
+@utility btn-ghost-dark {
+  @apply inline-flex cursor-pointer items-center justify-center gap-2 rounded-xl border border-white/15 bg-white/8 px-5 py-2.5 text-sm font-semibold text-white backdrop-blur-sm transition-all duration-150 hover:border-white/25 hover:bg-white/15 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white;
+}
+
+/* ───────────────────────────────────────────── Cards ─── */
 @utility feature-card {
-  @apply rounded-xl border border-stone-200/90 bg-white p-6 shadow-[0_1px_2px_rgba(28,25,23,0.04)] transition-[box-shadow,border-color] duration-150 hover:border-stone-300 hover:shadow-[0_4px_14px_rgba(28,25,23,0.07)];
+  @apply rounded-2xl border border-slate-200 bg-white p-6 transition-all duration-200 hover:border-indigo-200 hover:shadow-[0_8px_30px_rgba(99,102,241,0.08)];
 }
 
+@utility feature-card-dark {
+  @apply rounded-2xl border border-slate-700/50 bg-slate-800/60 p-6 transition-all duration-200 hover:border-slate-600 hover:bg-slate-800/80;
+}
+
+/* ──────────────────────────────────────────────── Prose ─── */
 @utility prose-content {
-  @apply text-stone-700 leading-relaxed;
+  @apply text-slate-700 leading-relaxed;
 
-  h2 {
-    @apply mt-10 mb-4 text-2xl font-semibold tracking-tight text-stone-900 first:mt-0;
-  }
+  h2 { @apply mt-10 mb-4 text-2xl font-semibold tracking-tight text-slate-900 first:mt-0; }
+  h3 { @apply mt-8 mb-3 text-xl font-semibold text-slate-900; }
+  p  { @apply mb-5 leading-[1.75]; }
 
-  h3 {
-    @apply mt-8 mb-3 text-xl font-semibold text-stone-900;
-  }
+  ul, ol { @apply mb-5 pl-6 space-y-2; }
+  ul { @apply list-disc; }
+  ol { @apply list-decimal; }
+  li { @apply leading-relaxed text-slate-700; }
 
-  p {
-    @apply mb-5 leading-[1.75];
-  }
+  strong { @apply font-semibold text-slate-900; }
+  em     { @apply italic; }
 
-  ul, ol {
-    @apply mb-5 pl-6 space-y-2;
-  }
+  a { @apply text-accent underline-offset-4 transition-colors hover:text-accent-hover hover:underline; }
 
-  ul {
-    @apply list-disc;
-  }
+  blockquote { @apply my-6 border-l-4 border-accent-border pl-5 italic text-slate-600; }
 
-  ol {
-    @apply list-decimal;
-  }
+  pre { @apply my-6 overflow-x-auto rounded-2xl border border-slate-800 bg-slate-950 p-5 text-sm leading-relaxed; }
+  code { @apply font-mono text-sm; }
+  pre code { @apply text-slate-300; }
+  :not(pre) > code { @apply rounded-lg bg-slate-100 px-1.5 py-0.5 text-[0.85em] text-slate-800; }
 
-  li {
-    @apply leading-relaxed text-stone-700;
-  }
-
-  strong {
-    @apply font-semibold text-stone-900;
-  }
-
-  em {
-    @apply italic;
-  }
-
-  a {
-    @apply text-accent underline-offset-4 transition-colors hover:text-accent-hover hover:underline;
-  }
-
-  blockquote {
-    @apply my-6 border-l-4 border-accent-border pl-5 italic text-stone-600;
-  }
-
-  pre {
-    @apply my-6 overflow-x-auto rounded-xl border border-stone-800 bg-stone-950 p-5 text-sm leading-relaxed;
-  }
-
-  code {
-    @apply font-mono text-sm;
-  }
-
-  pre code {
-    @apply text-stone-300;
-  }
-
-  :not(pre) > code {
-    @apply rounded bg-stone-100 px-1.5 py-0.5 text-[0.85em] text-stone-800;
-  }
-
-  img {
-    @apply my-8 w-full rounded-xl border border-stone-200 shadow-sm transition-shadow duration-300 hover:shadow-md;
-  }
-
-  hr {
-    @apply my-10 border-stone-200;
-  }
+  img { @apply my-8 w-full rounded-2xl border border-slate-200 shadow-sm transition-shadow duration-300 hover:shadow-md; }
+  hr  { @apply my-10 border-slate-200; }
 }

--- a/www/src/pages/blog-index.tsx
+++ b/www/src/pages/blog-index.tsx
@@ -40,36 +40,36 @@ export function BlogIndex() {
   }
 
   return (
-    <div className="relative min-h-screen overflow-x-hidden bg-stone-50 text-slate-700">
+    <div className="relative min-h-screen overflow-x-hidden bg-white text-slate-900">
       <Header />
 
       <main>
-        <section className="border-b border-stone-200/90 bg-white py-16 sm:py-20">
+        <section className="border-b border-slate-200 bg-white py-16 sm:py-20">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent-muted/70 text-accent">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600 ring-1 ring-indigo-200">
                 <BookOpen className="h-5 w-5" aria-hidden />
               </div>
-              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-stone-500">
+              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-500">
                 Lextures Blog
               </p>
             </div>
-            <h1 className="mt-5 text-4xl font-semibold tracking-tight text-stone-900 sm:text-5xl">
+            <h1 className="mt-5 text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl">
               Writing
             </h1>
-            <p className="mt-4 max-w-xl text-lg leading-relaxed text-stone-600">
+            <p className="mt-4 max-w-xl text-lg leading-relaxed text-slate-600">
               Thoughts on adaptive learning, educational technology, and building software for institutions that run at scale.
             </p>
 
             <div className="mt-10 max-w-md">
               <div className="relative">
                 <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-                  <Search className="h-4 w-4 text-stone-400" aria-hidden />
+                  <Search className="h-4 w-4 text-slate-400" aria-hidden />
                 </div>
                 <input
                   type="text"
                   placeholder="Search articles..."
-                  className="block w-full rounded-lg border border-stone-200 bg-stone-50 py-2.5 pl-10 pr-3 text-sm placeholder-stone-400 outline-none transition-colors focus:border-accent focus:ring-1 focus:ring-accent"
+                  className="block w-full rounded-lg border border-slate-200 bg-slate-50 py-2.5 pl-10 pr-3 text-sm placeholder-stone-400 outline-none transition-colors focus:border-indigo-500 focus:ring-1 focus:ring-accent"
                   value={searchQuery}
                   onChange={handleSearchChange}
                 />
@@ -82,7 +82,7 @@ export function BlogIndex() {
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             {filteredPosts.length === 0 ? (
               <div className="py-20 text-center">
-                <p className="text-lg text-stone-500">No posts found matching your search.</p>
+                <p className="text-lg text-slate-500">No posts found matching your search.</p>
                 <button
                   onClick={() => setSearchQuery('')}
                   className="mt-4 text-sm font-semibold text-accent hover:underline"
@@ -99,11 +99,11 @@ export function BlogIndex() {
                         <div className="flex-1">
                           <time
                             dateTime={post.date}
-                            className="text-xs font-medium uppercase tracking-widest text-stone-400"
+                            className="text-xs font-medium uppercase tracking-widest text-slate-400"
                           >
                             {formatDate(post.date)}
                           </time>
-                          <h2 className="mt-2 text-xl font-semibold leading-snug text-stone-900 sm:text-2xl">
+                          <h2 className="mt-2 text-xl font-semibold leading-snug text-slate-900 sm:text-2xl">
                             <a
                               href={`#/blog/${post.slug}`}
                               className="no-underline transition-colors hover:text-accent"
@@ -111,10 +111,10 @@ export function BlogIndex() {
                               {post.title}
                             </a>
                           </h2>
-                          <p className="mt-3 max-w-2xl text-base leading-relaxed text-stone-600">
+                          <p className="mt-3 max-w-2xl text-base leading-relaxed text-slate-600">
                             {post.description}
                           </p>
-                          <p className="mt-2 text-sm text-stone-400">By {post.author}</p>
+                          <p className="mt-2 text-sm text-slate-400">By {post.author}</p>
                         </div>
                         <a
                           href={`#/blog/${post.slug}`}
@@ -130,7 +130,7 @@ export function BlogIndex() {
                 </div>
 
                 {totalPages > 1 && (
-                  <nav className="mt-16 flex items-center justify-between border-t border-stone-200 pt-8" aria-label="Pagination">
+                  <nav className="mt-16 flex items-center justify-between border-t border-slate-200 pt-8" aria-label="Pagination">
                     <div className="flex flex-1 justify-between sm:hidden">
                       <button
                         onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
@@ -149,7 +149,7 @@ export function BlogIndex() {
                     </div>
                     <div className="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
                       <div>
-                        <p className="text-sm text-stone-500">
+                        <p className="text-sm text-slate-500">
                           Showing <span className="font-medium">{(currentPage - 1) * POSTS_PER_PAGE + 1}</span> to{' '}
                           <span className="font-medium">
                             {Math.min(currentPage * POSTS_PER_PAGE, filteredPosts.length)}
@@ -162,7 +162,7 @@ export function BlogIndex() {
                           <button
                             onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
                             disabled={currentPage === 1}
-                            className="relative inline-flex items-center rounded-l-md px-2 py-2 text-stone-400 ring-1 ring-inset ring-stone-200 hover:bg-stone-50 focus:z-20 focus:outline-offset-0 disabled:opacity-50"
+                            className="relative inline-flex items-center rounded-l-md px-2 py-2 text-slate-400 ring-1 ring-inset ring-stone-200 hover:bg-slate-50 focus:z-20 focus:outline-offset-0 disabled:opacity-50"
                           >
                             <span className="sr-only">Previous</span>
                             <ArrowLeft className="h-5 w-5" aria-hidden />
@@ -177,7 +177,7 @@ export function BlogIndex() {
                               Math.abs(pageNumber - currentPage) > 1
                             ) {
                               if (Math.abs(pageNumber - currentPage) === 2) {
-                                return <span key={pageNumber} className="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-stone-400 ring-1 ring-inset ring-stone-200 focus:outline-offset-0">...</span>
+                                return <span key={pageNumber} className="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-400 ring-1 ring-inset ring-stone-200 focus:outline-offset-0">...</span>
                               }
                               return null
                             }
@@ -187,10 +187,10 @@ export function BlogIndex() {
                                 key={pageNumber}
                                 onClick={() => setCurrentPage(pageNumber)}
                                 aria-current={currentPage === pageNumber ? 'page' : undefined}
-                                className={`relative inline-flex items-center px-4 py-2 text-sm font-semibold focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${
+                                className={`relative inline-flex items-center px-4 py-2 text-sm font-semibold focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 ${
                                   currentPage === pageNumber
-                                    ? 'z-10 bg-accent text-white focus-visible:outline-accent'
-                                    : 'text-stone-900 ring-1 ring-inset ring-stone-200 hover:bg-stone-50 focus:outline-offset-0'
+                                    ? 'z-10 bg-accent text-white focus-visible:outline-indigo-500'
+                                    : 'text-slate-900 ring-1 ring-inset ring-stone-200 hover:bg-slate-50 focus:outline-offset-0'
                                 }`}
                               >
                                 {pageNumber}
@@ -200,7 +200,7 @@ export function BlogIndex() {
                           <button
                             onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
                             disabled={currentPage === totalPages}
-                            className="relative inline-flex items-center rounded-r-md px-2 py-2 text-stone-400 ring-1 ring-inset ring-stone-200 hover:bg-stone-50 focus:z-20 focus:outline-offset-0 disabled:opacity-50"
+                            className="relative inline-flex items-center rounded-r-md px-2 py-2 text-slate-400 ring-1 ring-inset ring-stone-200 hover:bg-slate-50 focus:z-20 focus:outline-offset-0 disabled:opacity-50"
                           >
                             <span className="sr-only">Next</span>
                             <ArrowRight className="h-5 w-5" aria-hidden />

--- a/www/src/pages/blog-post.tsx
+++ b/www/src/pages/blog-post.tsx
@@ -10,10 +10,10 @@ export function BlogPost({ slug }: { slug: string }) {
 
   if (!post) {
     return (
-      <div className="relative min-h-screen bg-stone-50 text-slate-700">
+      <div className="relative min-h-screen bg-white text-slate-900">
         <Header />
         <main className="mx-auto max-w-3xl px-4 py-24 sm:px-6 lg:px-8">
-          <p className="text-stone-500">Post not found.</p>
+          <p className="text-slate-500">Post not found.</p>
           <a href="#/blog" className="btn-secondary mt-6 inline-flex gap-2">
             <ArrowLeft className="h-4 w-4" aria-hidden />
             Back to blog
@@ -24,31 +24,31 @@ export function BlogPost({ slug }: { slug: string }) {
   }
 
   return (
-    <div className="relative min-h-screen overflow-x-hidden bg-stone-50 text-slate-700">
+    <div className="relative min-h-screen overflow-x-hidden bg-white text-slate-900">
       <Header />
 
       <main>
         {/* Post header */}
-        <div className="border-b border-stone-200/90 bg-white py-12 sm:py-16">
+        <div className="border-b border-slate-200 bg-white py-12 sm:py-16">
           <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
             <a
               href="#/blog"
-              className="inline-flex items-center gap-1.5 text-sm font-medium text-stone-500 no-underline transition-colors hover:text-stone-800"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 no-underline transition-colors hover:text-slate-900"
             >
               <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
               Blog
             </a>
             <time
               dateTime={post.date}
-              className="mt-6 block text-xs font-medium uppercase tracking-widest text-stone-400"
+              className="mt-6 block text-xs font-medium uppercase tracking-widest text-slate-400"
             >
               {formatDate(post.date)}
             </time>
-            <h1 className="font-display mt-3 text-3xl font-normal leading-tight tracking-tight text-stone-900 sm:text-4xl lg:text-[2.5rem]">
+            <h1 className="font-display mt-3 text-3xl font-normal leading-tight tracking-tight text-slate-900 sm:text-4xl lg:text-[2.5rem]">
               {post.title}
             </h1>
-            <p className="mt-4 text-lg leading-relaxed text-stone-600">{post.description}</p>
-            <p className="mt-4 text-sm text-stone-400">By {post.author}</p>
+            <p className="mt-4 text-lg leading-relaxed text-slate-600">{post.description}</p>
+            <p className="mt-4 text-sm text-slate-400">By {post.author}</p>
           </div>
         </div>
 
@@ -61,7 +61,7 @@ export function BlogPost({ slug }: { slug: string }) {
               </ReactMarkdown>
             </div>
 
-            <div className="mt-16 border-t border-stone-200/80 pt-10">
+            <div className="mt-16 border-t border-slate-200/80 pt-10">
               <a href="#/blog" className="btn-secondary inline-flex gap-2">
                 <ArrowLeft className="h-4 w-4" aria-hidden />
                 Back to all posts

--- a/www/src/pages/docs-index.tsx
+++ b/www/src/pages/docs-index.tsx
@@ -40,36 +40,36 @@ export function DocsIndex() {
   }
 
   return (
-    <div className="relative min-h-screen overflow-x-hidden bg-stone-50 text-slate-700">
+    <div className="relative min-h-screen overflow-x-hidden bg-white text-slate-900">
       <Header />
 
       <main>
-        <section className="border-b border-stone-200/90 bg-white py-16 sm:py-20">
+        <section className="border-b border-slate-200 bg-white py-16 sm:py-20">
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent-muted/70 text-accent">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600 ring-1 ring-indigo-200">
                 <HelpCircle className="h-5 w-5" aria-hidden />
               </div>
-              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-stone-500">
+              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-500">
                 Lextures Documentation
               </p>
             </div>
-            <h1 className="mt-5 text-4xl font-semibold tracking-tight text-stone-900 sm:text-5xl">
+            <h1 className="mt-5 text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl">
               Knowledge Base
             </h1>
-            <p className="mt-4 max-w-xl text-lg leading-relaxed text-stone-600">
+            <p className="mt-4 max-w-xl text-lg leading-relaxed text-slate-600">
               Guides, tutorials, and documentation to help you get the most out of Lextures.
             </p>
 
             <div className="mt-10 w-full">
               <div className="relative group">
                 <div className="pointer-events-none absolute inset-y-0 left-4 flex items-center">
-                  <Search className="h-5 w-5 text-stone-400 group-focus-within:text-accent transition-colors" aria-hidden />
+                  <Search className="h-5 w-5 text-slate-400 group-focus-within:text-accent transition-colors" aria-hidden />
                 </div>
                 <input
                   type="text"
                   placeholder="Search documentation..."
-                  className="block w-full rounded-full border border-stone-200 bg-white py-3.5 pl-12 pr-6 text-base placeholder-stone-400 shadow-sm outline-none transition-all hover:border-stone-300 hover:shadow-md focus:border-accent focus:ring-2 focus:ring-accent-muted/30 focus:shadow-md"
+                  className="block w-full rounded-full border border-slate-200 bg-white py-3.5 pl-12 pr-6 text-base placeholder-stone-400 shadow-sm outline-none transition-all hover:border-stone-300 hover:shadow-md focus:border-indigo-500 focus:ring-2 focus:ring-accent-muted/30 focus:shadow-md"
                   value={searchQuery}
                   onChange={handleSearchChange}
                 />
@@ -82,7 +82,7 @@ export function DocsIndex() {
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
             {filteredArticles.length === 0 ? (
               <div className="py-20 text-center">
-                <p className="text-lg text-stone-500">No articles found matching your search.</p>
+                <p className="text-lg text-slate-500">No articles found matching your search.</p>
                 <button
                   onClick={() => setSearchQuery('')}
                   className="mt-4 text-sm font-semibold text-accent hover:underline"
@@ -99,11 +99,11 @@ export function DocsIndex() {
                         <div className="flex-1">
                           <time
                             dateTime={article.date}
-                            className="text-xs font-medium uppercase tracking-widest text-stone-400"
+                            className="text-xs font-medium uppercase tracking-widest text-slate-400"
                           >
                             {formatDate(article.date)}
                           </time>
-                          <h2 className="mt-2 text-xl font-semibold leading-snug text-stone-900 sm:text-2xl">
+                          <h2 className="mt-2 text-xl font-semibold leading-snug text-slate-900 sm:text-2xl">
                             <a
                               href={`/docs/${article.slug}`}
                               className="no-underline transition-colors hover:text-accent"
@@ -111,10 +111,10 @@ export function DocsIndex() {
                               {article.title}
                             </a>
                           </h2>
-                          <p className="mt-3 max-w-2xl text-base leading-relaxed text-stone-600">
+                          <p className="mt-3 max-w-2xl text-base leading-relaxed text-slate-600">
                             {article.description}
                           </p>
-                          <p className="mt-2 text-sm text-stone-400">By {article.author}</p>
+                          <p className="mt-2 text-sm text-slate-400">By {article.author}</p>
                         </div>
                         <a
                           href={`/docs/${article.slug}`}
@@ -130,7 +130,7 @@ export function DocsIndex() {
                 </div>
 
                 {totalPages > 1 && (
-                  <nav className="mt-16 flex items-center justify-between border-t border-stone-200 pt-8" aria-label="Pagination">
+                  <nav className="mt-16 flex items-center justify-between border-t border-slate-200 pt-8" aria-label="Pagination">
                     <div className="flex flex-1 justify-between sm:hidden">
                       <button
                         onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
@@ -149,7 +149,7 @@ export function DocsIndex() {
                     </div>
                     <div className="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
                       <div>
-                        <p className="text-sm text-stone-500">
+                        <p className="text-sm text-slate-500">
                           Showing <span className="font-medium">{(currentPage - 1) * ARTICLES_PER_PAGE + 1}</span> to{' '}
                           <span className="font-medium">
                             {Math.min(currentPage * ARTICLES_PER_PAGE, filteredArticles.length)}
@@ -162,7 +162,7 @@ export function DocsIndex() {
                           <button
                             onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
                             disabled={currentPage === 1}
-                            className="relative inline-flex items-center rounded-l-md px-2 py-2 text-stone-400 ring-1 ring-inset ring-stone-200 hover:bg-stone-50 focus:z-20 focus:outline-offset-0 disabled:opacity-50"
+                            className="relative inline-flex items-center rounded-l-md px-2 py-2 text-slate-400 ring-1 ring-inset ring-stone-200 hover:bg-slate-50 focus:z-20 focus:outline-offset-0 disabled:opacity-50"
                           >
                             <span className="sr-only">Previous</span>
                             <ArrowLeft className="h-5 w-5" aria-hidden />
@@ -177,7 +177,7 @@ export function DocsIndex() {
                               Math.abs(pageNumber - currentPage) > 1
                             ) {
                               if (Math.abs(pageNumber - currentPage) === 2) {
-                                return <span key={pageNumber} className="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-stone-400 ring-1 ring-inset ring-stone-200 focus:outline-offset-0">...</span>
+                                return <span key={pageNumber} className="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-slate-400 ring-1 ring-inset ring-stone-200 focus:outline-offset-0">...</span>
                               }
                               return null
                             }
@@ -187,10 +187,10 @@ export function DocsIndex() {
                                 key={pageNumber}
                                 onClick={() => setCurrentPage(pageNumber)}
                                 aria-current={currentPage === pageNumber ? 'page' : undefined}
-                                className={`relative inline-flex items-center px-4 py-2 text-sm font-semibold focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${
+                                className={`relative inline-flex items-center px-4 py-2 text-sm font-semibold focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 ${
                                   currentPage === pageNumber
-                                    ? 'z-10 bg-accent text-white focus-visible:outline-accent'
-                                    : 'text-stone-900 ring-1 ring-inset ring-stone-200 hover:bg-stone-50 focus:outline-offset-0'
+                                    ? 'z-10 bg-accent text-white focus-visible:outline-indigo-500'
+                                    : 'text-slate-900 ring-1 ring-inset ring-stone-200 hover:bg-slate-50 focus:outline-offset-0'
                                 }`}
                               >
                                 {pageNumber}
@@ -200,7 +200,7 @@ export function DocsIndex() {
                           <button
                             onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
                             disabled={currentPage === totalPages}
-                            className="relative inline-flex items-center rounded-r-md px-2 py-2 text-stone-400 ring-1 ring-inset ring-stone-200 hover:bg-stone-50 focus:z-20 focus:outline-offset-0 disabled:opacity-50"
+                            className="relative inline-flex items-center rounded-r-md px-2 py-2 text-slate-400 ring-1 ring-inset ring-stone-200 hover:bg-slate-50 focus:z-20 focus:outline-offset-0 disabled:opacity-50"
                           >
                             <span className="sr-only">Next</span>
                             <ArrowRight className="h-5 w-5" aria-hidden />

--- a/www/src/pages/docs-post.tsx
+++ b/www/src/pages/docs-post.tsx
@@ -10,10 +10,10 @@ export function DocsPost({ slug }: { slug: string }) {
 
   if (!article) {
     return (
-      <div className="relative min-h-screen bg-stone-50 text-slate-700">
+      <div className="relative min-h-screen bg-white text-slate-900">
         <Header />
         <main className="mx-auto max-w-3xl px-4 py-24 sm:px-6 lg:px-8">
-          <p className="text-stone-500">Article not found.</p>
+          <p className="text-slate-500">Article not found.</p>
           <a href="/docs" className="btn-secondary mt-6 inline-flex gap-2">
             <ArrowLeft className="h-4 w-4" aria-hidden />
             Back to documentation
@@ -24,31 +24,31 @@ export function DocsPost({ slug }: { slug: string }) {
   }
 
   return (
-    <div className="relative min-h-screen overflow-x-hidden bg-stone-50 text-slate-700">
+    <div className="relative min-h-screen overflow-x-hidden bg-white text-slate-900">
       <Header />
 
       <main>
         {/* Post header */}
-        <div className="border-b border-stone-200/90 bg-white py-12 sm:py-16">
+        <div className="border-b border-slate-200 bg-white py-12 sm:py-16">
           <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
             <a
               href="/docs"
-              className="inline-flex items-center gap-1.5 text-sm font-medium text-stone-500 no-underline transition-colors hover:text-stone-800"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 no-underline transition-colors hover:text-slate-900"
             >
               <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
               Documentation
             </a>
             <time
               dateTime={article.date}
-              className="mt-6 block text-xs font-medium uppercase tracking-widest text-stone-400"
+              className="mt-6 block text-xs font-medium uppercase tracking-widest text-slate-400"
             >
               {formatDate(article.date)}
             </time>
-            <h1 className="font-display mt-3 text-3xl font-normal leading-tight tracking-tight text-stone-900 sm:text-4xl lg:text-[2.5rem]">
+            <h1 className="font-display mt-3 text-3xl font-normal leading-tight tracking-tight text-slate-900 sm:text-4xl lg:text-[2.5rem]">
               {article.title}
             </h1>
-            <p className="mt-4 text-lg leading-relaxed text-stone-600">{article.description}</p>
-            <p className="mt-4 text-sm text-stone-400">By {article.author}</p>
+            <p className="mt-4 text-lg leading-relaxed text-slate-600">{article.description}</p>
+            <p className="mt-4 text-sm text-slate-400">By {article.author}</p>
           </div>
         </div>
 
@@ -61,7 +61,7 @@ export function DocsPost({ slug }: { slug: string }) {
               </ReactMarkdown>
             </div>
 
-            <div className="mt-16 border-t border-stone-200/80 pt-10">
+            <div className="mt-16 border-t border-slate-200/80 pt-10">
               <a href="/docs" className="btn-secondary inline-flex gap-2">
                 <ArrowLeft className="h-4 w-4" aria-hidden />
                 Back to documentation

--- a/www/src/pages/get-started-page.tsx
+++ b/www/src/pages/get-started-page.tsx
@@ -57,10 +57,10 @@ function ProgramStep({ onSelect }: { onSelect: (p: Program) => void }) {
   return (
     <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-24 lg:px-8">
       <div className="text-center">
-        <h1 className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
+        <h1 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
           How are you using Lextures?
         </h1>
-        <p className="mt-3 text-base leading-relaxed text-stone-500">
+        <p className="mt-3 text-base leading-relaxed text-slate-500">
           Select the option that best describes you so we can point you in the right direction.
         </p>
       </div>
@@ -71,14 +71,14 @@ function ProgramStep({ onSelect }: { onSelect: (p: Program) => void }) {
             key={id}
             type="button"
             onClick={() => onSelect(id)}
-            className="group flex flex-col items-start gap-4 rounded-2xl border border-stone-200 bg-white p-6 text-left shadow-[0_1px_3px_rgba(28,25,23,0.05)] transition-all duration-150 hover:border-accent hover:shadow-[0_4px_16px_rgba(15,118,110,0.12)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent cursor-pointer"
+            className="group flex flex-col items-start gap-4 rounded-2xl border border-slate-200 bg-white p-6 text-left shadow-[0_1px_3px_rgba(28,25,23,0.05)] transition-all duration-150 hover:border-accent hover:shadow-[0_4px_16px_rgba(15,118,110,0.12)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 cursor-pointer"
           >
-            <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-accent-muted/70 text-accent transition-colors group-hover:bg-accent group-hover:text-white">
+            <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 ring-1 ring-indigo-200 transition-colors group-hover:bg-accent group-hover:text-white">
               <Icon className="h-5 w-5" aria-hidden />
             </div>
             <div>
-              <p className="font-semibold text-stone-900">{title}</p>
-              <p className="mt-1.5 text-sm leading-relaxed text-stone-500">{description}</p>
+              <p className="font-semibold text-slate-900">{title}</p>
+              <p className="mt-1.5 text-sm leading-relaxed text-slate-500">{description}</p>
             </div>
           </button>
         ))}
@@ -105,23 +105,23 @@ function SchoolStep({ program, onBack }: { program: 'k-12' | 'higher-ed'; onBack
       <button
         type="button"
         onClick={onBack}
-        className="mb-8 flex items-center gap-1.5 text-sm font-medium text-stone-500 transition-colors hover:text-stone-800"
+        className="mb-8 flex items-center gap-1.5 text-sm font-medium text-slate-500 transition-colors hover:text-slate-900"
       >
         <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
         Back
       </button>
 
-      <h1 className="text-3xl font-semibold tracking-tight text-stone-900 sm:text-4xl">
+      <h1 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
         Find your {label}
       </h1>
-      <p className="mt-3 text-base leading-relaxed text-stone-500">
+      <p className="mt-3 text-base leading-relaxed text-slate-500">
         Enter the name of your {label} so your account is connected to the right place.
       </p>
 
       <div className="mt-10 space-y-4">
         <div className="relative">
           <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3.5">
-            <Search className="h-4 w-4 text-stone-400" aria-hidden />
+            <Search className="h-4 w-4 text-slate-400" aria-hidden />
           </div>
           <input
             type="text"
@@ -130,7 +130,7 @@ function SchoolStep({ program, onBack }: { program: 'k-12' | 'higher-ed'; onBack
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && handleContinue()}
             placeholder={placeholder}
-            className="block w-full rounded-xl border border-stone-200 bg-white py-3 pl-10 pr-4 text-base text-stone-900 placeholder-stone-400 shadow-sm outline-none transition-colors focus:border-accent focus:ring-2 focus:ring-accent/20"
+            className="block w-full rounded-xl border border-slate-200 bg-white py-3 pl-10 pr-4 text-base text-slate-900 placeholder-stone-400 shadow-sm outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
           />
         </div>
 
@@ -162,7 +162,7 @@ export function GetStartedPage() {
   }
 
   return (
-    <div className="relative min-h-screen overflow-x-hidden bg-stone-50 text-slate-700">
+    <div className="relative min-h-screen overflow-x-hidden bg-white text-slate-900">
       <Header />
 
       <main className="flex min-h-[calc(100vh-4rem)] items-start justify-center">

--- a/www/src/pages/higher-ed-page.tsx
+++ b/www/src/pages/higher-ed-page.tsx
@@ -62,20 +62,20 @@ const INTEGRATIONS = [
 
 export function HigherEdPage() {
   return (
-    <div className="relative min-h-screen overflow-x-hidden bg-stone-50 text-slate-700">
+    <div className="relative min-h-screen overflow-x-hidden bg-white text-slate-900">
       <Header />
 
       <main>
         {/* Hero */}
-        <section className="border-b border-stone-200/90 bg-white py-20 sm:py-28">
+        <section className="border-b border-slate-200 bg-white py-20 sm:py-28">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-stone-500">
+            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-500">
               Higher Education
             </p>
-            <h1 className="mt-5 max-w-3xl text-4xl font-semibold leading-tight tracking-tight text-stone-900 sm:text-5xl lg:text-[3.25rem]">
+            <h1 className="mt-5 max-w-3xl text-4xl font-semibold leading-tight tracking-tight text-slate-900 sm:text-5xl lg:text-[3.25rem]">
               Assessment infrastructure built for how universities actually run
             </h1>
-            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-stone-600">
+            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-slate-600">
               Adaptive quizzing at section scale, LTI integration with every major LMS, and grading records that hold up under accreditation review—without replacing the tools your faculty already use.
             </p>
             <div className="mt-10 flex flex-wrap gap-4">
@@ -93,14 +93,14 @@ export function HigherEdPage() {
         {/* Challenges */}
         <section className="py-16 sm:py-20">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-            <h2 className="text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+            <h2 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
               Where higher education assessment actually breaks down
             </h2>
             <div className="mt-10 grid gap-5 sm:grid-cols-3">
               {CHALLENGES.map(({ title, body }) => (
-                <div key={title} className="rounded-xl border border-stone-200/90 bg-white p-6">
-                  <h3 className="font-semibold text-stone-900">{title}</h3>
-                  <p className="mt-3 text-sm leading-relaxed text-stone-600">{body}</p>
+                <div key={title} className="rounded-2xl border border-slate-200 bg-white p-6">
+                  <h3 className="font-semibold text-slate-900">{title}</h3>
+                  <p className="mt-3 text-sm leading-relaxed text-slate-600">{body}</p>
                 </div>
               ))}
             </div>
@@ -108,24 +108,24 @@ export function HigherEdPage() {
         </section>
 
         {/* Features */}
-        <section className="border-t border-stone-200/90 bg-white py-16 sm:py-20">
+        <section className="border-t border-slate-200 bg-white py-16 sm:py-20">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
             <div className="max-w-2xl">
-              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-stone-500">
+              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-500">
                 How Lextures helps
               </p>
-              <h2 className="mt-3 text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+              <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
                 Built around the workflows that break first at scale
               </h2>
             </div>
             <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
               {FEATURES.map(({ icon: Icon, title, body }) => (
                 <article key={title} className="feature-card">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent-muted/70 text-accent">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600 ring-1 ring-indigo-200">
                     <Icon className="h-5 w-5" aria-hidden />
                   </div>
-                  <h3 className="mt-5 text-base font-semibold text-stone-900">{title}</h3>
-                  <p className="mt-2 text-sm leading-relaxed text-stone-600">{body}</p>
+                  <h3 className="mt-5 text-base font-semibold text-slate-900">{title}</h3>
+                  <p className="mt-2 text-sm leading-relaxed text-slate-600">{body}</p>
                 </article>
               ))}
             </div>
@@ -133,28 +133,28 @@ export function HigherEdPage() {
         </section>
 
         {/* Multi-section callout */}
-        <section className="border-t border-stone-200/90 bg-stone-50 py-16 sm:py-20">
+        <section className="border-t border-slate-200 bg-slate-50 py-16 sm:py-20">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
             <div className="grid gap-10 lg:grid-cols-2 lg:items-center lg:gap-20">
               <div>
-                <h2 className="text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+                <h2 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
                   Course blueprints for multi-section departments
                 </h2>
-                <p className="mt-4 text-base leading-relaxed text-stone-600">
+                <p className="mt-4 text-base leading-relaxed text-slate-600">
                   When ten instructors teach the same course, consistency is a policy problem, not a technical one. Course blueprints let a department coordinator maintain a master template and push updates to every child section simultaneously—syllabus changes, new question bank items, updated rubrics—without requiring individual faculty action.
                 </p>
-                <p className="mt-4 text-base leading-relaxed text-stone-600">
+                <p className="mt-4 text-base leading-relaxed text-slate-600">
                   Each section retains the ability to add local content while inheriting the shared foundation. Gradebook exports from all sections roll up into a single outcome report for accreditation.
                 </p>
               </div>
-              <div className="rounded-xl border border-stone-200/90 bg-white p-8 shadow-[inset_0_1px_0_rgba(255,255,255,0.6)]">
-                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-stone-500">
+              <div className="rounded-xl border border-slate-200 bg-white p-8 shadow-[inset_0_1px_0_rgba(255,255,255,0.6)]">
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-400">
                   Design principle
                 </p>
-                <p className="mt-4 text-xl font-medium leading-snug text-stone-900">
+                <p className="mt-4 text-xl font-medium leading-snug text-slate-900">
                   If a registrar would wince at the data model, it does not ship.
                 </p>
-                <p className="mt-4 text-sm leading-relaxed text-stone-500">
+                <p className="mt-4 text-sm leading-relaxed text-slate-500">
                   Every schema decision in Lextures is made with the assumption that the data will eventually need to be exported, audited, or explained to someone outside your institution.
                 </p>
               </div>
@@ -163,24 +163,24 @@ export function HigherEdPage() {
         </section>
 
         {/* Integrations */}
-        <section className="border-t border-stone-200/90 bg-white py-14">
+        <section className="border-t border-slate-200 bg-white py-14">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-            <p className="text-sm font-semibold text-stone-900">Standards and protocols supported</p>
+            <p className="text-sm font-semibold text-slate-900">Standards and protocols supported</p>
             <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2">
               {INTEGRATIONS.map((tag) => (
-                <span key={tag} className="text-sm font-medium text-stone-500">{tag}</span>
+                <span key={tag} className="text-sm font-medium text-slate-500">{tag}</span>
               ))}
             </div>
           </div>
         </section>
 
         {/* CTA */}
-        <section className="border-t border-stone-200/90 bg-stone-50 py-16 sm:py-20">
+        <section className="border-t border-slate-200 bg-slate-50 py-16 sm:py-20">
           <div className="mx-auto max-w-3xl px-4 text-center sm:px-6 lg:px-8">
-            <h2 className="text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+            <h2 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
               Walk the instructor and learner flows
             </h2>
-            <p className="mx-auto mt-4 max-w-md text-base leading-relaxed text-stone-600">
+            <p className="mx-auto mt-4 max-w-md text-base leading-relaxed text-slate-600">
               The live demo includes a full course with adaptive quizzes, gradebook, and LMS integration flows you can explore without a login.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">

--- a/www/src/pages/k12-page.tsx
+++ b/www/src/pages/k12-page.tsx
@@ -59,20 +59,20 @@ const STANDARDS = ['CCSS', 'NGSS', 'Custom standards', 'Clever SSO', 'ClassLink 
 
 export function K12Page() {
   return (
-    <div className="relative min-h-screen overflow-x-hidden bg-stone-50 text-slate-700">
+    <div className="relative min-h-screen overflow-x-hidden bg-white text-slate-900">
       <Header />
 
       <main>
         {/* Hero */}
-        <section className="border-b border-stone-200/90 bg-white py-20 sm:py-28">
+        <section className="border-b border-slate-200 bg-white py-20 sm:py-28">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-stone-500">
+            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-500">
               K–12
             </p>
-            <h1 className="mt-5 max-w-3xl text-4xl font-semibold leading-tight tracking-tight text-stone-900 sm:text-5xl lg:text-[3.25rem]">
+            <h1 className="mt-5 max-w-3xl text-4xl font-semibold leading-tight tracking-tight text-slate-900 sm:text-5xl lg:text-[3.25rem]">
               Built for the standards, systems, and realities of K–12
             </h1>
-            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-stone-600">
+            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-slate-600">
               Standards-aligned assessments, automatic roster sync from your district SIS, and accommodations that apply without teacher intervention—so the administrative layer of teaching gets out of the way.
             </p>
             <div className="mt-10 flex flex-wrap gap-4">
@@ -90,14 +90,14 @@ export function K12Page() {
         {/* Challenges */}
         <section className="py-16 sm:py-20">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-            <h2 className="text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+            <h2 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
               Where K–12 assessment tools usually fall short
             </h2>
             <div className="mt-10 grid gap-5 sm:grid-cols-3">
               {CHALLENGES.map(({ title, body }) => (
-                <div key={title} className="rounded-xl border border-stone-200/90 bg-white p-6">
-                  <h3 className="font-semibold text-stone-900">{title}</h3>
-                  <p className="mt-3 text-sm leading-relaxed text-stone-600">{body}</p>
+                <div key={title} className="rounded-2xl border border-slate-200 bg-white p-6">
+                  <h3 className="font-semibold text-slate-900">{title}</h3>
+                  <p className="mt-3 text-sm leading-relaxed text-slate-600">{body}</p>
                 </div>
               ))}
             </div>
@@ -105,24 +105,24 @@ export function K12Page() {
         </section>
 
         {/* Features */}
-        <section className="border-t border-stone-200/90 bg-white py-16 sm:py-20">
+        <section className="border-t border-slate-200 bg-white py-16 sm:py-20">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
             <div className="max-w-2xl">
-              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-stone-500">
+              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-500">
                 How Lextures helps
               </p>
-              <h2 className="mt-3 text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+              <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
                 Compliance built in. Insight built up.
               </h2>
             </div>
             <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
               {FEATURES.map(({ icon: Icon, title, body }) => (
                 <article key={title} className="feature-card">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent-muted/70 text-accent">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600 ring-1 ring-indigo-200">
                     <Icon className="h-5 w-5" aria-hidden />
                   </div>
-                  <h3 className="mt-5 text-base font-semibold text-stone-900">{title}</h3>
-                  <p className="mt-2 text-sm leading-relaxed text-stone-600">{body}</p>
+                  <h3 className="mt-5 text-base font-semibold text-slate-900">{title}</h3>
+                  <p className="mt-2 text-sm leading-relaxed text-slate-600">{body}</p>
                 </article>
               ))}
             </div>
@@ -130,17 +130,17 @@ export function K12Page() {
         </section>
 
         {/* Spaced repetition callout */}
-        <section className="border-t border-stone-200/90 bg-stone-50 py-16 sm:py-20">
+        <section className="border-t border-slate-200 bg-slate-50 py-16 sm:py-20">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
             <div className="grid gap-10 lg:grid-cols-2 lg:items-center lg:gap-20">
               <div>
-                <h2 className="text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+                <h2 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
                   Retention across the school year, not just the unit
                 </h2>
-                <p className="mt-4 text-base leading-relaxed text-stone-600">
+                <p className="mt-4 text-base leading-relaxed text-slate-600">
                   The forgetting curve is not a metaphor. Content mastered in a September unit test is largely gone by the time state assessments arrive in spring. Spaced repetition scheduling (SRS) attacks this directly: the system schedules short, low-stakes review at scientifically optimal intervals—close together at first, then increasingly spaced as the student demonstrates retention.
                 </p>
-                <p className="mt-4 text-base leading-relaxed text-stone-600">
+                <p className="mt-4 text-base leading-relaxed text-slate-600">
                   For teachers, this means the platform is doing active instructional work between formal class sessions. Students who stay engaged with scheduled review arrive at high-stakes tests having maintained mastery, not scrambling to re-learn.
                 </p>
               </div>
@@ -151,9 +151,9 @@ export function K12Page() {
                   { label: 'December', desc: 'Second review, now spaced two months out. Still retained.' },
                   { label: 'April', desc: 'State assessment. No cramming required.' },
                 ].map(({ label, desc }) => (
-                  <div key={label} className="flex gap-4 rounded-xl border border-stone-200/90 bg-white px-5 py-4">
+                  <div key={label} className="flex gap-4 rounded-xl border border-slate-200 bg-white px-5 py-4">
                     <span className="mt-0.5 text-xs font-semibold uppercase tracking-widest text-accent">{label}</span>
-                    <span className="text-sm leading-relaxed text-stone-600">{desc}</span>
+                    <span className="text-sm leading-relaxed text-slate-600">{desc}</span>
                   </div>
                 ))}
               </div>
@@ -162,24 +162,24 @@ export function K12Page() {
         </section>
 
         {/* Standards tags */}
-        <section className="border-t border-stone-200/90 bg-white py-14">
+        <section className="border-t border-slate-200 bg-white py-14">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-            <p className="text-sm font-semibold text-stone-900">Standards, identity, and roster protocols supported</p>
+            <p className="text-sm font-semibold text-slate-900">Standards, identity, and roster protocols supported</p>
             <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2">
               {STANDARDS.map((tag) => (
-                <span key={tag} className="text-sm font-medium text-stone-500">{tag}</span>
+                <span key={tag} className="text-sm font-medium text-slate-500">{tag}</span>
               ))}
             </div>
           </div>
         </section>
 
         {/* CTA */}
-        <section className="border-t border-stone-200/90 bg-stone-50 py-16 sm:py-20">
+        <section className="border-t border-slate-200 bg-slate-50 py-16 sm:py-20">
           <div className="mx-auto max-w-3xl px-4 text-center sm:px-6 lg:px-8">
-            <h2 className="text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+            <h2 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
               See what your teachers and students would actually use
             </h2>
-            <p className="mx-auto mt-4 max-w-md text-base leading-relaxed text-stone-600">
+            <p className="mx-auto mt-4 max-w-md text-base leading-relaxed text-slate-600">
               The live demo walks through both the instructor and learner experience—standards alignment, adaptive quizzes, and the teacher dashboard included.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">

--- a/www/src/pages/legal-document-page.tsx
+++ b/www/src/pages/legal-document-page.tsx
@@ -70,7 +70,7 @@ export function LegalDocumentPage({ document: doc, showHistory }: LegalDocumentP
   }, [doc.title, showHistory])
 
   return (
-    <div className="relative min-h-screen overflow-x-hidden bg-stone-50 text-slate-700">
+    <div className="relative min-h-screen overflow-x-hidden bg-white text-slate-900">
       <LegalJsonLd legalDoc={doc} />
       <Header />
 
@@ -79,9 +79,9 @@ export function LegalDocumentPage({ document: doc, showHistory }: LegalDocumentP
           <aside className="lg:w-56 lg:shrink-0">
             <nav
               aria-label="Table of contents"
-              className="sticky top-24 rounded-xl border border-stone-200/90 bg-white p-4 text-sm shadow-sm"
+              className="sticky top-24 rounded-xl border border-slate-200 bg-white p-4 text-sm shadow-sm"
             >
-              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-stone-500">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
                 On this page
               </p>
               <ol className="space-y-1.5">
@@ -89,7 +89,7 @@ export function LegalDocumentPage({ document: doc, showHistory }: LegalDocumentP
                   <li key={entry.id}>
                     <a
                       href={`#${entry.id}`}
-                      className="text-stone-700 no-underline underline-offset-2 transition-colors hover:text-accent hover:underline"
+                      className="text-slate-700 no-underline underline-offset-2 transition-colors hover:text-accent hover:underline"
                     >
                       {entry.title}
                     </a>
@@ -97,7 +97,7 @@ export function LegalDocumentPage({ document: doc, showHistory }: LegalDocumentP
                 ))}
               </ol>
               {doc.id === 'privacy_policy' ? (
-                <p className="mt-4 border-t border-stone-100 pt-3">
+                <p className="mt-4 border-t border-slate-100 pt-3">
                   <a
                     href="#your-rights-under-gdpr"
                     className="font-medium text-accent no-underline underline-offset-2 hover:underline"
@@ -111,13 +111,13 @@ export function LegalDocumentPage({ document: doc, showHistory }: LegalDocumentP
         ) : null}
 
         <article className="min-w-0 flex-1">
-          <header className="mb-6 border-b border-stone-200/90 pb-6">
+          <header className="mb-6 border-b border-slate-200 pb-6">
             <LegalNav />
-            <h1 className="font-display text-3xl font-normal tracking-tight text-stone-900 sm:text-4xl">
+            <h1 className="font-display text-3xl font-normal tracking-tight text-slate-900 sm:text-4xl">
               {showHistory ? `${doc.title} — History of changes` : doc.title}
             </h1>
             {!showHistory ? (
-              <dl className="mt-3 flex flex-wrap gap-x-6 gap-y-1 text-sm text-stone-600">
+              <dl className="mt-3 flex flex-wrap gap-x-6 gap-y-1 text-sm text-slate-600">
                 <div>
                   <dt className="inline font-medium text-stone-800">Effective date: </dt>
                   <dd className="inline">{doc.effectiveDateLabel}</dd>
@@ -138,7 +138,7 @@ export function LegalDocumentPage({ document: doc, showHistory }: LegalDocumentP
             </p>
           </header>
 
-          <div className="prose-content legal-prose [&_h2]:scroll-mt-28 [&_h2]:border-b [&_h2]:border-stone-200/90 [&_h2]:pb-2 [&_table]:w-full [&_table]:border-collapse [&_td]:border [&_td]:border-stone-200 [&_td]:p-2 [&_th]:border [&_th]:border-stone-200 [&_th]:bg-stone-50 [&_th]:p-2">
+          <div className="prose-content legal-prose [&_h2]:scroll-mt-28 [&_h2]:border-b [&_h2]:border-slate-200 [&_h2]:pb-2 [&_table]:w-full [&_table]:border-collapse [&_td]:border [&_td]:border-slate-200 [&_td]:p-2 [&_th]:border [&_th]:border-slate-200 [&_th]:bg-slate-50 [&_th]:p-2">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               components={{

--- a/www/src/pages/pricing-page.tsx
+++ b/www/src/pages/pricing-page.tsx
@@ -73,7 +73,7 @@ function FeatureLine({ label }: { label: string }) {
   return (
     <li className="flex items-start gap-2.5">
       <Check className="mt-0.5 h-4 w-4 shrink-0 text-accent" aria-hidden />
-      <span className="text-sm text-stone-700">{label}</span>
+      <span className="text-sm text-slate-700">{label}</span>
     </li>
   )
 }
@@ -85,27 +85,27 @@ function ComparisonCell({ included }: { included: boolean }) {
     </td>
   ) : (
     <td className="px-6 py-3.5 text-center">
-      <Minus className="mx-auto h-4 w-4 text-stone-300" aria-label="Not included" />
+      <Minus className="mx-auto h-4 w-4 text-slate-300" aria-label="Not included" />
     </td>
   )
 }
 
 export function PricingPage() {
   return (
-    <div className="relative min-h-screen overflow-x-hidden bg-stone-50 text-slate-700">
+    <div className="relative min-h-screen overflow-x-hidden bg-white text-slate-900">
       <Header />
 
       <main>
         {/* Hero */}
-        <section className="border-b border-stone-200/90 bg-white py-16 sm:py-20">
+        <section className="border-b border-slate-200 bg-white py-16 sm:py-20">
           <div className="mx-auto max-w-3xl px-4 text-center sm:px-6 lg:px-8">
-            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-stone-500">
+            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-500">
               Pricing
             </p>
-            <h1 className="mt-5 text-4xl font-semibold tracking-tight text-stone-900 sm:text-5xl">
+            <h1 className="mt-5 text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl">
               Free until you need to scale
             </h1>
-            <p className="mx-auto mt-5 max-w-xl text-lg leading-relaxed text-stone-600">
+            <p className="mx-auto mt-5 max-w-xl text-lg leading-relaxed text-slate-600">
               Full-featured for small courses. Pay only when you grow beyond 30 students or 5 courses—and then only $9.99 per student per year.
             </p>
           </div>
@@ -117,26 +117,26 @@ export function PricingPage() {
             <div className="grid gap-6 lg:grid-cols-2 lg:items-start">
 
               {/* Free */}
-              <div className="rounded-2xl border border-stone-200/90 bg-white p-8 shadow-[0_1px_4px_rgba(28,25,23,0.06)]">
+              <div className="rounded-2xl border border-slate-200 bg-white p-8 shadow-[0_1px_4px_rgba(28,25,23,0.06)]">
                 <div>
-                  <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-stone-400">Free</p>
+                  <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-400">Free</p>
                   <div className="mt-3 flex items-baseline gap-1">
-                    <span className="text-5xl font-semibold tracking-tight text-stone-900">$0</span>
-                    <span className="text-sm text-stone-500">forever</span>
+                    <span className="text-5xl font-semibold tracking-tight text-slate-900">$0</span>
+                    <span className="text-sm text-slate-500">forever</span>
                   </div>
-                  <p className="mt-3 text-sm leading-relaxed text-stone-500">
+                  <p className="mt-3 text-sm leading-relaxed text-slate-500">
                     No trial period, no credit card required. Ideal for a single class section or a pilot course.
                   </p>
                 </div>
 
-                <div className="mt-6 space-y-2 rounded-lg bg-stone-50 px-4 py-3 text-sm">
+                <div className="mt-6 space-y-2 rounded-lg bg-slate-50 px-4 py-3 text-sm">
                   <div className="flex justify-between">
-                    <span className="text-stone-600">Students per course</span>
-                    <span className="font-semibold text-stone-900">Up to 30</span>
+                    <span className="text-slate-600">Students per course</span>
+                    <span className="font-semibold text-slate-900">Up to 30</span>
                   </div>
-                  <div className="flex justify-between border-t border-stone-100 pt-2">
-                    <span className="text-stone-600">Courses</span>
-                    <span className="font-semibold text-stone-900">Up to 5</span>
+                  <div className="flex justify-between border-t border-slate-100 pt-2">
+                    <span className="text-slate-600">Courses</span>
+                    <span className="font-semibold text-slate-900">Up to 5</span>
                   </div>
                 </div>
 
@@ -159,29 +159,29 @@ export function PricingPage() {
                     </span>
                   </div>
                   <div className="mt-3 flex items-baseline gap-1">
-                    <span className="text-5xl font-semibold tracking-tight text-stone-900">$9.99</span>
-                    <span className="text-sm text-stone-500">/ student / year</span>
+                    <span className="text-5xl font-semibold tracking-tight text-slate-900">$9.99</span>
+                    <span className="text-sm text-slate-500">/ student / year</span>
                   </div>
-                  <p className="mt-3 text-sm leading-relaxed text-stone-500">
+                  <p className="mt-3 text-sm leading-relaxed text-slate-500">
                     Billed annually based on unique enrolled students across all your courses. Unlimited courses included.
                   </p>
                 </div>
 
-                <div className="mt-6 space-y-2 rounded-lg bg-stone-50 px-4 py-3 text-sm">
+                <div className="mt-6 space-y-2 rounded-lg bg-slate-50 px-4 py-3 text-sm">
                   <div className="flex justify-between">
-                    <span className="text-stone-600">Students per course</span>
-                    <span className="font-semibold text-stone-900">Unlimited</span>
+                    <span className="text-slate-600">Students per course</span>
+                    <span className="font-semibold text-slate-900">Unlimited</span>
                   </div>
-                  <div className="flex justify-between border-t border-stone-100 pt-2">
-                    <span className="text-stone-600">Courses</span>
-                    <span className="font-semibold text-stone-900">Unlimited</span>
+                  <div className="flex justify-between border-t border-slate-100 pt-2">
+                    <span className="text-slate-600">Courses</span>
+                    <span className="font-semibold text-slate-900">Unlimited</span>
                   </div>
                 </div>
 
                 <ul className="mt-6 space-y-3">
                   {FREE_FEATURES.map((f) => <FeatureLine key={f} label={f} />)}
-                  <li className="border-t border-stone-100 pt-3">
-                    <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-stone-400">
+                  <li className="border-t border-slate-100 pt-3">
+                    <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-slate-400">
                       Also includes
                     </p>
                     <ul className="space-y-3">
@@ -198,11 +198,11 @@ export function PricingPage() {
             </div>
 
             {/* Example calculation */}
-            <div className="mt-10 rounded-xl border border-stone-200/90 bg-white px-6 py-5">
-              <p className="text-sm font-semibold text-stone-900">Example</p>
-              <p className="mt-1 text-sm leading-relaxed text-stone-600">
+            <div className="mt-10 rounded-xl border border-slate-200 bg-white px-6 py-5">
+              <p className="text-sm font-semibold text-slate-900">Example</p>
+              <p className="mt-1 text-sm leading-relaxed text-slate-600">
                 An instructor with 3 courses and 90 unique enrolled students pays{' '}
-                <span className="font-semibold text-stone-900">90 × $9.99 = $897.10 / year</span>.
+                <span className="font-semibold text-slate-900">90 × $9.99 = $897.10 / year</span>.
                 A student taking two of those courses counts as one.
               </p>
             </div>
@@ -210,24 +210,24 @@ export function PricingPage() {
         </section>
 
         {/* Feature comparison table */}
-        <section className="border-t border-stone-200/90 bg-white py-16 sm:py-20">
+        <section className="border-t border-slate-200 bg-white py-16 sm:py-20">
           <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
-            <h2 className="text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+            <h2 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
               Full feature comparison
             </h2>
-            <div className="mt-8 overflow-x-auto rounded-xl border border-stone-200/90">
+            <div className="mt-8 overflow-x-auto rounded-xl border border-slate-200">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="border-b border-stone-200/90 bg-stone-50">
-                    <th className="px-6 py-4 text-left font-semibold text-stone-900">Feature</th>
-                    <th className="px-6 py-4 text-center font-semibold text-stone-900">Free</th>
+                  <tr className="border-b border-slate-200 bg-slate-50">
+                    <th className="px-6 py-4 text-left font-semibold text-slate-900">Feature</th>
+                    <th className="px-6 py-4 text-center font-semibold text-slate-900">Free</th>
                     <th className="px-6 py-4 text-center font-semibold text-accent">Education</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-stone-100">
+                <tbody className="divide-y divide-slate-100">
                   {COMPARISON.map((row) => (
-                    <tr key={row.label} className="bg-white transition-colors hover:bg-stone-50/60">
-                      <td className="px-6 py-3.5 text-stone-700">{row.label}</td>
+                    <tr key={row.label} className="bg-white transition-colors hover:bg-slate-50/60">
+                      <td className="px-6 py-3.5 text-slate-700">{row.label}</td>
                       <ComparisonCell included={row.free} />
                       <ComparisonCell included={row.education} />
                     </tr>
@@ -239,16 +239,16 @@ export function PricingPage() {
         </section>
 
         {/* FAQ */}
-        <section className="border-t border-stone-200/90 bg-stone-50 py-16 sm:py-20">
+        <section className="border-t border-slate-200 bg-slate-50 py-16 sm:py-20">
           <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
-            <h2 className="text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+            <h2 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
               Common questions
             </h2>
-            <dl className="mt-8 divide-y divide-stone-200/90">
+            <dl className="mt-8 divide-y divide-slate-200">
               {FAQS.map(({ q, a }) => (
                 <div key={q} className="py-6">
-                  <dt className="font-semibold text-stone-900">{q}</dt>
-                  <dd className="mt-2 text-sm leading-relaxed text-stone-600">{a}</dd>
+                  <dt className="font-semibold text-slate-900">{q}</dt>
+                  <dd className="mt-2 text-sm leading-relaxed text-slate-600">{a}</dd>
                 </div>
               ))}
             </dl>
@@ -256,12 +256,12 @@ export function PricingPage() {
         </section>
 
         {/* CTA */}
-        <section className="border-t border-stone-200/90 bg-white py-16 sm:py-20">
+        <section className="border-t border-slate-200 bg-white py-16 sm:py-20">
           <div className="mx-auto max-w-3xl px-4 text-center sm:px-6 lg:px-8">
-            <h2 className="text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+            <h2 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
               See it before you commit
             </h2>
-            <p className="mx-auto mt-4 max-w-md text-base leading-relaxed text-stone-600">
+            <p className="mx-auto mt-4 max-w-md text-base leading-relaxed text-slate-600">
               The live demo has full instructor and learner flows — quizzes, gradebook, imports, and adaptive delivery.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">

--- a/www/src/pages/self-learner-page.tsx
+++ b/www/src/pages/self-learner-page.tsx
@@ -42,20 +42,20 @@ const FEATURES = [
 
 export function SelfLearnerPage() {
   return (
-    <div className="relative min-h-screen overflow-x-hidden bg-stone-50 text-slate-700">
+    <div className="relative min-h-screen overflow-x-hidden bg-white text-slate-900">
       <Header />
 
       <main>
         {/* Hero */}
-        <section className="border-b border-stone-200/90 bg-white py-20 sm:py-28">
+        <section className="border-b border-slate-200 bg-white py-20 sm:py-28">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-stone-500">
+            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-500">
               Self-Learner
             </p>
-            <h1 className="mt-5 max-w-3xl text-4xl font-semibold leading-tight tracking-tight text-stone-900 sm:text-5xl lg:text-[3.25rem]">
+            <h1 className="mt-5 max-w-3xl text-4xl font-semibold leading-tight tracking-tight text-slate-900 sm:text-5xl lg:text-[3.25rem]">
               Stop guessing what to study next
             </h1>
-            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-stone-600">
+            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-slate-600">
               An adaptive engine that builds a model of exactly what you know, schedules review before you forget, and always puts the right question in front of you—without an instructor in the loop.
             </p>
             <div className="mt-10 flex flex-wrap gap-4">
@@ -73,14 +73,14 @@ export function SelfLearnerPage() {
         {/* Problems */}
         <section className="py-16 sm:py-20">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-            <h2 className="text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+            <h2 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
               Why self-directed studying usually fails
             </h2>
             <div className="mt-10 grid gap-5 sm:grid-cols-3">
               {PROBLEMS.map(({ title, body }) => (
-                <div key={title} className="rounded-xl border border-stone-200/90 bg-white p-6">
-                  <h3 className="font-semibold text-stone-900">{title}</h3>
-                  <p className="mt-3 text-sm leading-relaxed text-stone-600">{body}</p>
+                <div key={title} className="rounded-2xl border border-slate-200 bg-white p-6">
+                  <h3 className="font-semibold text-slate-900">{title}</h3>
+                  <p className="mt-3 text-sm leading-relaxed text-slate-600">{body}</p>
                 </div>
               ))}
             </div>
@@ -88,24 +88,24 @@ export function SelfLearnerPage() {
         </section>
 
         {/* Features */}
-        <section className="border-t border-stone-200/90 bg-white py-16 sm:py-20">
+        <section className="border-t border-slate-200 bg-white py-16 sm:py-20">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
             <div className="max-w-2xl">
-              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-stone-500">
+              <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-indigo-500">
                 How it works
               </p>
-              <h2 className="mt-3 text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+              <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
                 A system that works the way your memory actually works
               </h2>
             </div>
             <div className="mt-12 grid gap-5 sm:grid-cols-2">
               {FEATURES.map(({ icon: Icon, title, body }) => (
                 <article key={title} className="feature-card">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent-muted/70 text-accent">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600 ring-1 ring-indigo-200">
                     <Icon className="h-5 w-5" aria-hidden />
                   </div>
-                  <h3 className="mt-5 text-base font-semibold text-stone-900">{title}</h3>
-                  <p className="mt-2 text-sm leading-relaxed text-stone-600">{body}</p>
+                  <h3 className="mt-5 text-base font-semibold text-slate-900">{title}</h3>
+                  <p className="mt-2 text-sm leading-relaxed text-slate-600">{body}</p>
                 </article>
               ))}
             </div>
@@ -113,20 +113,20 @@ export function SelfLearnerPage() {
         </section>
 
         {/* How it fits into a study session */}
-        <section className="border-t border-stone-200/90 bg-stone-50 py-16 sm:py-20">
+        <section className="border-t border-slate-200 bg-slate-50 py-16 sm:py-20">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
             <div className="grid gap-10 lg:grid-cols-2 lg:items-center lg:gap-20">
               <div>
-                <h2 className="text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+                <h2 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
                   What a study session actually looks like
                 </h2>
-                <p className="mt-4 text-base leading-relaxed text-stone-600">
+                <p className="mt-4 text-base leading-relaxed text-slate-600">
                   You open Lextures. The dashboard shows you what is due for review today—concepts you learned earlier that are approaching the edge of your predicted recall window. You answer fifteen questions in twelve minutes. Ten are review; five are new material calibrated to your current ability level.
                 </p>
-                <p className="mt-4 text-base leading-relaxed text-stone-600">
+                <p className="mt-4 text-base leading-relaxed text-slate-600">
                   After each session, your ability estimates update. The concepts you answered correctly push their next review further out. The ones you missed come back sooner. Tomorrow\'s session is shorter because today\'s was efficient.
                 </p>
-                <p className="mt-4 text-base leading-relaxed text-stone-600">
+                <p className="mt-4 text-base leading-relaxed text-slate-600">
                   There is no syllabus to follow, no chapter to "finish." The system tracks what you know and builds toward what you want to know—at whatever pace fits your schedule.
                 </p>
               </div>
@@ -137,13 +137,13 @@ export function SelfLearnerPage() {
                   { step: '3', title: 'Come back for scheduled review', desc: 'The SRS engine queues up the right concepts at the right time. Sessions stay short because they stay targeted.' },
                   { step: '4', title: 'Watch mastery accumulate', desc: 'Ability estimates update in real time. Your dashboard shows where you stand on every concept, not just your last score.' },
                 ].map(({ step, title, desc }) => (
-                  <div key={step} className="flex gap-4 rounded-xl border border-stone-200/90 bg-white px-5 py-4">
-                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent text-xs font-bold text-white">
+                  <div key={step} className="flex gap-4 rounded-xl border border-slate-200 bg-white px-5 py-4">
+                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-indigo-600 text-xs font-bold text-white">
                       {step}
                     </span>
                     <div>
-                      <p className="text-sm font-semibold text-stone-900">{title}</p>
-                      <p className="mt-1 text-sm leading-relaxed text-stone-500">{desc}</p>
+                      <p className="text-sm font-semibold text-slate-900">{title}</p>
+                      <p className="mt-1 text-sm leading-relaxed text-slate-500">{desc}</p>
                     </div>
                   </div>
                 ))}
@@ -153,9 +153,9 @@ export function SelfLearnerPage() {
         </section>
 
         {/* Use cases */}
-        <section className="border-t border-stone-200/90 bg-white py-16 sm:py-20">
+        <section className="border-t border-slate-200 bg-white py-16 sm:py-20">
           <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-            <h2 className="text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+            <h2 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
               Who uses Lextures as a self-learner
             </h2>
             <div className="mt-8 grid gap-5 sm:grid-cols-3">
@@ -173,9 +173,9 @@ export function SelfLearnerPage() {
                   desc: 'Working through a textbook, an online course, or a structured curriculum on your own timeline—with the scaffolding of an adaptive system rather than just a reading list.',
                 },
               ].map(({ label, desc }) => (
-                <div key={label} className="rounded-xl border border-stone-200/90 bg-stone-50 p-6">
-                  <h3 className="font-semibold text-stone-900">{label}</h3>
-                  <p className="mt-3 text-sm leading-relaxed text-stone-600">{desc}</p>
+                <div key={label} className="rounded-xl border border-slate-200 bg-slate-50 p-6">
+                  <h3 className="font-semibold text-slate-900">{label}</h3>
+                  <p className="mt-3 text-sm leading-relaxed text-slate-600">{desc}</p>
                 </div>
               ))}
             </div>
@@ -183,12 +183,12 @@ export function SelfLearnerPage() {
         </section>
 
         {/* CTA */}
-        <section className="border-t border-stone-200/90 bg-stone-50 py-16 sm:py-20">
+        <section className="border-t border-slate-200 bg-slate-50 py-16 sm:py-20">
           <div className="mx-auto max-w-3xl px-4 text-center sm:px-6 lg:px-8">
-            <h2 className="text-2xl font-semibold tracking-tight text-stone-900 sm:text-3xl">
+            <h2 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
               Free for your first five courses
             </h2>
-            <p className="mx-auto mt-4 max-w-md text-base leading-relaxed text-stone-600">
+            <p className="mx-auto mt-4 max-w-md text-base leading-relaxed text-slate-600">
               Create an account, import your materials, and start a study session today. No credit card required.
             </p>
             <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">


### PR DESCRIPTION
## Summary

- **New design system**: Inter font, indigo/violet accent, slate palette — replaces DM Sans, teal, and warm stone throughout
- **Homepage rebuilt from scratch**: dark hero with gradient orbs + grid pattern, bento-grid features layout, dark AI section, indigo CTA gradient, dark footer
- **Floating pill header**: rounded-2xl with white/95 glass background, detached from viewport edges
- **All content pages updated**: higher-ed, k-12, self-learner, pricing, get-started, blog, docs, and legal pages all migrated to the new slate/indigo token classes

## Key visual changes

| Area | Before | After |
|------|--------|-------|
| Font | DM Sans + Instrument Serif | **Inter** + Instrument Serif |
| Accent | Teal `#0f766e` | **Indigo** `#6366f1` |
| Palette | Warm stone/amber | **Slate** |
| Hero | White + canvas animation | **Dark slate-950** + gradient orbs + CSS grid pattern |
| Features | Uniform 3-col cards | **Bento grid** (12-col asymmetric, varied bg per card) |
| Header | Sticky full-width stone bar | **Floating pill** (glass, rounded, shadow) |
| Footer | White flat links | **Dark slate-950** with columnar nav |
| Final CTA | White card on white | **Indigo-to-violet gradient** section |

## Test plan

- [ ] Homepage renders correctly at 375px, 768px, 1024px, 1440px
- [ ] Hero gradient orbs and grid pattern display without overflow
- [ ] Bento grid collapses to single column on mobile
- [ ] Floating header sticks correctly and glass blur is visible on scroll
- [ ] Dark sections (hero, AI, open source, footer) have readable contrast
- [ ] CTA gradient section renders the dot pattern and ambient blobs
- [ ] All internal nav links work (higher-ed, k-12, self-learner, pricing, get-started)
- [ ] Industry pages (higher-ed, k-12, self-learner) show new slate/indigo styling
- [ ] `prefers-reduced-motion` respected (no animated orb pulse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)