### PR TITLE
fix(demo): add v220 behavior_pbis to checksum repair list

### DIFF
--- a/server/internal/migrate/repair.go
+++ b/server/internal/migrate/repair.go
@@ -22,10 +22,10 @@ func migrateRepairChecksumsEnabled() bool {
 }
 
 // demoChecksumRepairMigrations lists versions whose SQL files may legitimately drift
-// from what the demo droplet recorded (abbreviated deploys, follow-up PR edits) while
-// remaining idempotent (IF NOT EXISTS / ON CONFLICT DO NOTHING). When
-// MIGRATE_REPAIR_CHECKSUMS is enabled (docker-compose.deploy.yml), stored checksums
-// are updated to match the embedded files so migrate can proceed.
+// from what the demo droplet (or a persistent dev DB) recorded (abbreviated deploys,
+// follow-up PR edits) while remaining idempotent (IF NOT EXISTS / ON CONFLICT DO NOTHING).
+// When MIGRATE_REPAIR_CHECKSUMS is enabled (docker-compose.yml and docker-compose.deploy.yml),
+// stored checksums are updated to match the embedded files so migrate can proceed.
 var demoChecksumRepairMigrations = []struct {
 	version int64
 	file    string
@@ -35,6 +35,8 @@ var demoChecksumRepairMigrations = []struct {
 	{171, "171_mastery_heatmap_cache.sql"},
 	// Idempotent ADD COLUMN IF NOT EXISTS; file may change while feature-flag columns evolve.
 	{172, "172_platform_feature_flags.sql"},
+	// Idempotent (CREATE ... IF NOT EXISTS + ADD COLUMN IF NOT EXISTS); file drifted on persistent dev/demo DBs.
+	{220, "220_behavior_pbis.sql"},
 }
 
 // repairDemoMigrationChecksums updates _sqlx_migrations when a listed version's stored


### PR DESCRIPTION
## Summary

Adds migration 220 (`220_behavior_pbis.sql`) to the `demoChecksumRepairMigrations` list so that `MIGRATE_REPAIR_CHECKSUMS=1` (already set in `docker-compose.yml` and `docker-compose.deploy.yml`) will automatically repair drifted checksums in `_sqlx_migrations` on persistent dev/demo databases.

## Context

- Migration 220 (Plan 13.3 — PBIS/behavior tracking) was introduced in #205.
- Like 120, 135, 171, and 172, it uses the standard idempotent pattern (`CREATE ... IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`).
- After follow-up edits to the migration file (or abbreviated deploys), the stored SHA-384 checksum in persistent databases no longer matches the embedded file, causing the migrator to fail with "was modified after apply".

## Behavior after this change

When `MIGRATE_REPAIR_CHECKSUMS=1` is present, the migrator now repairs the checksum for v220 (if drifted) before the normal apply loop, allowing startup to succeed without manual intervention.

## Testing

- Existing unit test for the env var flag continues to pass.
- Verified the repair path is exercised for the other listed migrations in similar scenarios.

## Related

- Follow-up to #205 (feat(k12): plan 13.3 — behavior / PBIS tracking)
- Same pattern as #81 (fix for 120/135) and the 171/172 additions.