### PR TITLE
feat: add per-student gradebook link from enrollments roster

### DIFF
--- a/clients/web/src/pages/lms/course-enrollments.tsx
+++ b/clients/web/src/pages/lms/course-enrollments.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react'
 import { Link, Navigate, useParams } from 'react-router-dom'
 import { studentProgressFeatureEnabled } from '../../lib/student-progress'
-import { Pencil, Shuffle, Trash2, UsersRound, X } from 'lucide-react'
+import { ClipboardList, Pencil, Shuffle, Trash2, UsersRound, X } from 'lucide-react'
 import { EnrollmentRoleBadge } from './enrollment-role-badge'
 import { EnrollmentGroupsPanel } from './enrollment-groups-panel'
 import { EnrollmentsActionsMenu } from './enrollments-actions-menu'
@@ -19,6 +19,7 @@ import { authorizedFetch } from '../../lib/api'
 import {
   courseEnrollmentsReadPermission,
   courseEnrollmentsUpdatePermission,
+  courseGradebookViewPermission,
   fetchCourse,
   fetchCourseScopedRoles,
   fetchCourseSections,
@@ -96,6 +97,10 @@ export default function CourseEnrollments() {
   const canUpdateEnrollments = usePermission(
     courseCode ? courseEnrollmentsUpdatePermission(courseCode) : 'global:app:noop:noop',
   )
+  const canViewGradebook = usePermission(
+    courseCode ? courseGradebookViewPermission(courseCode) : 'global:app:noop:noop',
+  )
+  const showActionsColumn = canUpdateEnrollments || canViewGradebook
   const [enrollments, setEnrollments] = useState<CourseEnrollment[] | null>(null)
   /** enrollment id → has active accommodations (non-PII indicator for instructors). */
   const [accommodationActiveByEnrollment, setAccommodationActiveByEnrollment] = useState<
@@ -861,7 +866,7 @@ export default function CourseEnrollments() {
                 <th className="px-4 py-3">Role</th>
                 {sectionsEnabled ? <th className="px-4 py-3">Section</th> : null}
                 <th className="px-4 py-3">Last access</th>
-                {canUpdateEnrollments && (
+                {showActionsColumn && (
                   <th className="min-w-[4.5rem] px-2 py-3 text-end font-normal" aria-label="Actions" />
                 )}
               </tr>
@@ -880,6 +885,7 @@ export default function CourseEnrollments() {
                   enrollmentGroupsEnabled && canUpdateEnrollments && er === 'student'
                 const showSectionTransfer =
                   sectionsEnabled && canUpdateEnrollments && er === 'student' && sections.length > 1
+                const showGradebook = courseCode != null && er === 'student' && canViewGradebook
                 return (
                   <tr
                     key={e.id}
@@ -924,9 +930,9 @@ export default function CourseEnrollments() {
                     <td className="px-4 py-3 text-slate-600">
                       {formatTimeAgoFromIso(e.lastCourseAccessAt, relativeNowMs)}
                     </td>
-                    {canUpdateEnrollments && (
+                    {showActionsColumn && (
                       <td className="px-2 py-3 text-end align-middle">
-                        {showEdit || showRemove || showGroupAssign || showSectionTransfer ? (
+                        {showEdit || showRemove || showGroupAssign || showSectionTransfer || showGradebook ? (
                           <div className="inline-flex items-center justify-end gap-0.5">
                             {showSectionTransfer ? (
                               <button
@@ -963,6 +969,15 @@ export default function CourseEnrollments() {
                               >
                                 <Pencil className="h-4 w-4" aria-hidden />
                               </button>
+                            ) : null}
+                            {showGradebook ? (
+                              <Link
+                                to={`/courses/${encodeURIComponent(courseCode)}/gradebook?student=${encodeURIComponent(e.userId)}`}
+                                className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
+                                aria-label={`View gradebook for ${e.displayName?.trim() || 'this student'}`}
+                              >
+                                <ClipboardList className="h-4 w-4" aria-hidden />
+                              </Link>
                             ) : null}
                             {showRemove ? (
                               <button

--- a/clients/web/src/pages/lms/gradebook/gradebook-grid.tsx
+++ b/clients/web/src/pages/lms/gradebook/gradebook-grid.tsx
@@ -501,13 +501,15 @@ export function GradebookGrid({
   // specific student". The initializer + reset guard (preserve prev when highlight) + this effect
   // ensure it survives mount/reset sequencing. Only sets if currently empty.
   useEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect -- pre-populate student filter from ?student= URL param + loaded data (initializer handles keyed mount; this is safety net for updates; guard prevents loops) */
     if (!highlightStudentId) return
     if (studentFilter.trim() !== '') return
     const hi = sortedStudents.find((s) => s.id === highlightStudentId)
     if (hi?.name) {
       setStudentFilter(hi.name)
     }
-  }, [highlightStudentId, sortedStudents])
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [highlightStudentId, sortedStudents]) // eslint-disable-line react-hooks/exhaustive-deps -- intentional: studentFilter in guard would cause re-runs/loops on set; we only want to react to highlight + data arrival
 
   useEffect(() => {
     /* eslint-disable react-hooks/set-state-in-effect -- clear grade sort when its column is removed or filtered out */

--- a/clients/web/src/pages/lms/gradebook/gradebook-grid.tsx
+++ b/clients/web/src/pages/lms/gradebook/gradebook-grid.tsx
@@ -75,7 +75,9 @@ type GradebookGridProps = {
   onOpenGradeHistory?: (studentId: string, columnId: string) => void
   /** Used for empty-state links back to modules or enrollments. */
   courseCode?: string
-  /** Highlights and scrolls a learner row (e.g. from command palette `?student=`). */
+  /** Highlights and scrolls a learner row (e.g. from command palette, progress, or enrollments `?student=`).
+   * Also pre-populates the student name filter so the gradebook is filtered down to that specific student.
+   */
   highlightStudentId?: string | null
   /** Active course grading scheme (letter bands, pass threshold, etc.). */
   gradingScheme?: { type: string; scaleJson: unknown } | null
@@ -274,7 +276,13 @@ export function GradebookGrid({
   )
   const [activeSort, setActiveSort] = useState<GradebookActiveSort | null>(null)
   const [headerMenu, setHeaderMenu] = useState<HeaderMenuState>(null)
-  const [studentFilter, setStudentFilter] = useState('')
+  const [studentFilter, setStudentFilter] = useState(() => {
+    if (highlightStudentId && (students?.length ?? 0) > 0) {
+      const hi = students.find((s) => s.id === highlightStudentId)
+      if (hi?.name) return hi.name
+    }
+    return ''
+  })
   const [assignmentFilter, setAssignmentFilter] = useState('')
   const [focusRow, setFocusRow] = useState(0)
   const [focusCol, setFocusCol] = useState(0)
@@ -471,7 +479,7 @@ export function GradebookGrid({
     setGrades(structuredClone(initialGrades))
     setActiveSort(null)
     setHeaderMenu(null)
-    setStudentFilter('')
+    setStudentFilter((prev) => (highlightStudentId ? prev : ''))
     setAssignmentFilter('')
     setFocusRow(0)
     setFocusCol(0)
@@ -482,11 +490,24 @@ export function GradebookGrid({
     setFillDrag(null)
     focusStudentIdRef.current = students[0]?.id ?? null
     /* eslint-enable react-hooks/set-state-in-effect */
-  }, [initialGrades, students, columns])
+  }, [initialGrades, students, columns, highlightStudentId])
 
   useEffect(() => {
     onGradesChange?.(grades)
   }, [grades, onGradesChange])
+
+  // When ?student= is present (e.g. grade icon from enrollments, or person search), pre-populate
+  // the student filter input with the student's name. This "predefines the filter down to that
+  // specific student". The initializer + reset guard (preserve prev when highlight) + this effect
+  // ensure it survives mount/reset sequencing. Only sets if currently empty.
+  useEffect(() => {
+    if (!highlightStudentId) return
+    if (studentFilter.trim() !== '') return
+    const hi = sortedStudents.find((s) => s.id === highlightStudentId)
+    if (hi?.name) {
+      setStudentFilter(hi.name)
+    }
+  }, [highlightStudentId, sortedStudents])
 
   useEffect(() => {
     /* eslint-disable react-hooks/set-state-in-effect -- clear grade sort when its column is removed or filtered out */


### PR DESCRIPTION
## Summary

On the enrollments (roster) screen, student rows now have a grade icon (📋) next to the trash icon. Clicking it opens the gradebook pre-filtered down to that individual student.

- Added `ClipboardList` grade icon in the actions cell for `student` role enrollments (gated by `courseGradebookViewPermission`).
- Link goes to `/courses/<code>/gradebook?student=<userId>`.
- Gradebook grid now reliably pre-populates the student name filter (so only that student is shown in the list) when arriving via `?student=`.
  - Uses lazy `useState` initializer (leveraging keyed remount on data load).
  - Reset effect now preserves filter when `highlightStudentId` present.
  - Safety-net effect + updated docs.
- Actions column now visible to gradebook viewers even without enroll update perms (icon only appears for qualifying students).
- Reuses all existing patterns (permissions, `highlightStudentId`, `Link`, hover styles, ARIA, etc.).
- No backend, routes, or other pages changed.

This fulfills the request to quickly jump from roster management to a student's grade view with the filter applied.

## Changes

- `clients/web/src/pages/lms/course-enrollments.tsx`
- `clients/web/src/pages/lms/gradebook/gradebook-grid.tsx`

## Testing

- Verified via code review, diff inspection, and logic simulation for mount/reset/filter sequencing.
- Existing unit tests (which don't cover the `?student` path) unaffected.
- Manual intent: as staff with perms, go to course → Enrollments → hover student row → click grade icon → gradebook shows only that student with filter prefilled.

## Screenshots / Notes

N/A (text change + small icon in existing table).

(Generated from local worktree changes on branch feat/enrollments-student-gradebook-link)