### PR TITLE
feat: inbox notifications, quiz analytics, transposed gradebook, and Canvas quiz submissions

### DIFF
--- a/clients/web/src/components/layout/app-shell.tsx
+++ b/clients/web/src/components/layout/app-shell.tsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation } from 'react-router-dom'
 import { CommandPaletteProvider } from '../command-palette/command-palette-provider'
 import { KeyboardShortcutsProvider } from '../keyboard-shortcuts/keyboard-shortcuts-provider'
 import { CourseFeedUnreadProvider } from '../../context/course-feed-unread-provider'
+import { InboxNotificationsProvider } from '../../context/inbox-notifications-provider'
 import { InboxUnreadProvider } from '../../context/inbox-unread-provider'
 import { CourseNavFeaturesProvider } from '../../context/course-nav-features-context'
 import { PlatformFeaturesProvider } from '../../context/platform-features-context'
@@ -78,6 +79,7 @@ export function AppShell() {
     <PlatformFeaturesProvider>
     <ReadingPreferencesProvider>
     <InboxUnreadProvider>
+      <InboxNotificationsProvider>
       <CourseFeedUnreadProvider>
         <CommandPaletteProvider>
           <KeyboardShortcutsProvider>
@@ -91,6 +93,7 @@ export function AppShell() {
           </KeyboardShortcutsProvider>
         </CommandPaletteProvider>
       </CourseFeedUnreadProvider>
+      </InboxNotificationsProvider>
     </InboxUnreadProvider>
     </ReadingPreferencesProvider>
     </PlatformFeaturesProvider>

--- a/clients/web/src/components/layout/notifications-drawer.tsx
+++ b/clients/web/src/components/layout/notifications-drawer.tsx
@@ -1,17 +1,30 @@
 import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Bell, BellRing, ClipboardCheck, Inbox, Megaphone, MessageCircle, X } from 'lucide-react'
+import {
+  Bell,
+  BellRing,
+  ClipboardCheck,
+  Inbox,
+  LayoutGrid,
+  Megaphone,
+  MessageCircle,
+  type LucideIcon,
+  X,
+} from 'lucide-react'
 import { Link } from 'react-router-dom'
 import {
   fetchUnifiedNotifications,
   inboxAlertsToUnified,
   notificationActionHref,
+  parseFeedNotificationChannel,
+  parseInboxNotificationMessageId,
   type UnifiedNotification,
   type UnifiedNotificationKind,
 } from '../../lib/unified-notifications'
+import { markAllInboxMessagesRead, patchMailbox } from '../../lib/communication-api'
 import { formatTimeAgoFromIso } from '../../lib/format-time-ago'
 import { useCourseFeedUnread } from '../../context/use-course-feed-unread'
-import { useInboxUnreadCount, useMailboxRevision } from '../../context/use-inbox-unread'
+import { useInboxUnreadCount, useMailboxRevision, useRefreshInboxUnread } from '../../context/use-inbox-unread'
 import { useInboxNotifications } from '../../context/use-push-notifications'
 
 /** Easing: strong deceleration (not linear) for panel + backdrop. */
@@ -32,14 +45,16 @@ function usePrefersReducedMotion(): boolean {
   return reduced
 }
 
-const FILTER_TABS: { id: 'all' | UnifiedNotificationKind | 'alerts'; label: string }[] = [
-  { id: 'all', label: 'All' },
-  { id: 'alerts', label: 'Alerts' },
-  { id: 'inbox', label: 'Inbox' },
-  { id: 'feed_mention', label: 'Feed' },
-  { id: 'graded', label: 'Grades' },
-  { id: 'announcement', label: 'Announcements' },
-]
+const FILTER_OPTIONS = [
+  { id: 'all', label: 'All notifications', icon: LayoutGrid },
+  { id: 'alerts', label: 'Alerts', icon: BellRing },
+  { id: 'inbox', label: 'Inbox', icon: Inbox },
+  { id: 'feed_mention', label: 'Feed', icon: MessageCircle },
+  { id: 'graded', label: 'Grades', icon: ClipboardCheck },
+  { id: 'announcement', label: 'Announcements', icon: Megaphone },
+] as const satisfies ReadonlyArray<{ id: string; label: string; icon: LucideIcon }>
+
+type NotificationFilter = (typeof FILTER_OPTIONS)[number]['id']
 
 function kindIcon(kind: UnifiedNotificationKind) {
   switch (kind) {
@@ -94,11 +109,14 @@ export function NotificationsDrawer({ open, onClose }: { open: boolean; onClose:
   const reducedMotion = usePrefersReducedMotion()
   const [portalVisible, setPortalVisible] = useState(open)
   const [entered, setEntered] = useState(false)
-  const [filter, setFilter] = useState<'all' | UnifiedNotificationKind | 'alerts'>('all')
+  const [filter, setFilter] = useState<NotificationFilter>('all')
   const [items, setItems] = useState<UnifiedNotification[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const mailboxRevision = useMailboxRevision()
+  const refreshInboxUnread = useRefreshInboxUnread()
+  const inboxUnread = useInboxUnreadCount()
+  const { totalFeedUnread, clearFeedChannelUnread, clearAllFeedUnread } = useCourseFeedUnread()
   const {
     notifications: alertItems,
     unreadCount: alertsUnread,
@@ -106,6 +124,32 @@ export function NotificationsDrawer({ open, onClose }: { open: boolean; onClose:
     markAllRead,
     refresh: refreshAlerts,
   } = useInboxNotifications()
+  const [markAllBusy, setMarkAllBusy] = useState(false)
+
+  const totalUnread = inboxUnread + totalFeedUnread + alertsUnread
+
+  const filterHasUnread = useCallback(
+    (id: NotificationFilter) => {
+      switch (id) {
+        case 'all':
+          return totalUnread > 0
+        case 'alerts':
+          return alertsUnread > 0
+        case 'inbox':
+          return inboxUnread > 0
+        case 'feed_mention':
+          return totalFeedUnread > 0
+        case 'graded':
+        case 'announcement':
+          return false
+        default: {
+          const _exhaustive: never = id
+          return _exhaustive
+        }
+      }
+    },
+    [totalUnread, alertsUnread, inboxUnread, totalFeedUnread],
+  )
 
   useEffect(() => {
     if (open) return
@@ -195,11 +239,67 @@ export function NotificationsDrawer({ open, onClose }: { open: boolean; onClose:
     return combined
   }, [alertItems, items])
 
+  const handleNotificationOpen = useCallback(
+    (row: UnifiedNotification) => {
+      if (row.kind === 'alert' && row.alertId && !row.isRead) {
+        void markAlertRead(row.alertId)
+        return
+      }
+      if (row.kind === 'inbox') {
+        const messageId = parseInboxNotificationMessageId(row.id)
+        if (messageId) {
+          void patchMailbox(messageId, { read: true })
+            .then(() => refreshInboxUnread())
+            .catch(() => {})
+          setItems((prev) => prev.filter((item) => item.id !== row.id))
+        }
+        return
+      }
+      if (row.kind === 'feed_mention' || row.kind === 'announcement') {
+        const feed = parseFeedNotificationChannel(row.id)
+        if (feed) clearFeedChannelUnread(feed.courseCode, feed.channelId)
+      }
+    },
+    [markAlertRead, refreshInboxUnread, clearFeedChannelUnread],
+  )
+
+  const handleMarkAllAsRead = useCallback(async () => {
+    if (markAllBusy || totalUnread === 0) return
+    setMarkAllBusy(true)
+    try {
+      await Promise.all([
+        markAllRead(),
+        markAllInboxMessagesRead().then(() => refreshInboxUnread()),
+      ])
+      clearAllFeedUnread()
+      setItems((prev) => prev.filter((item) => item.kind !== 'inbox'))
+      await load()
+      await refreshAlerts()
+    } catch {
+      /* ignore partial failures; refresh to reconcile */
+      void load()
+      void refreshAlerts()
+      void refreshInboxUnread()
+    } finally {
+      setMarkAllBusy(false)
+    }
+  }, [
+    markAllBusy,
+    totalUnread,
+    markAllRead,
+    refreshInboxUnread,
+    clearAllFeedUnread,
+    load,
+    refreshAlerts,
+  ])
+
   const filtered = useMemo(() => {
     if (filter === 'all') return mergedAll
     if (filter === 'alerts') return []
     return items.filter((i) => i.kind === filter)
   }, [filter, mergedAll, items])
+
+  const activeFilterLabel = FILTER_OPTIONS.find((option) => option.id === filter)?.label ?? 'All notifications'
 
   if (!open && !portalVisible) return null
 
@@ -235,12 +335,26 @@ export function NotificationsDrawer({ open, onClose }: { open: boolean; onClose:
         }`}
       >
         <div className="flex shrink-0 items-start justify-between gap-3 border-b border-slate-200 px-4 py-3 dark:border-neutral-700">
-          <div className="min-w-0">
-            <h2 id={titleId} className="text-base font-semibold tracking-tight text-slate-900 dark:text-neutral-100">
-              Notifications
-            </h2>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <h2 id={titleId} className="text-base font-semibold tracking-tight text-slate-900 dark:text-neutral-100">
+                Notifications
+              </h2>
+              {totalUnread > 0 ? (
+                <button
+                  type="button"
+                  disabled={markAllBusy}
+                  onClick={() => void handleMarkAllAsRead()}
+                  className="rounded-lg px-2 py-1 text-xs font-medium text-indigo-600 hover:bg-indigo-50 disabled:opacity-60 dark:text-indigo-400 dark:hover:bg-neutral-800"
+                >
+                  {markAllBusy ? 'Marking…' : 'Mark all as read'}
+                </button>
+              ) : null}
+            </div>
             <p id={descId} className="mt-0.5 text-xs text-slate-500 dark:text-neutral-400">
-              Inbox, alerts, feed, grades, and announcements.
+              {filter === 'all'
+                ? 'Inbox, alerts, feed, grades, and announcements.'
+                : `Showing ${activeFilterLabel.toLowerCase()} only.`}
             </p>
           </div>
           <button
@@ -255,25 +369,43 @@ export function NotificationsDrawer({ open, onClose }: { open: boolean; onClose:
         </div>
 
         <div
-          role="group"
+          role="tablist"
           aria-label="Filter notifications by type"
-          className="flex shrink-0 gap-1 overflow-x-auto border-b border-slate-100 px-2 py-2 dark:border-neutral-800"
+          className="grid shrink-0 grid-cols-6 border-b border-slate-100 dark:border-neutral-800"
         >
-          {FILTER_TABS.map((tab) => {
-            const active = filter === tab.id
+          {FILTER_OPTIONS.map(({ id, label, icon: Icon }) => {
+            const active = filter === id
+            const hasUnread = filterHasUnread(id)
             return (
               <button
-                key={tab.id}
+                key={id}
                 type="button"
-                aria-pressed={active}
-                onClick={() => setFilter(tab.id)}
-                className={`shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition ${
+                role="tab"
+                aria-selected={active}
+                aria-label={label}
+                title={label}
+                onClick={() => setFilter(id)}
+                className={`relative flex flex-col items-center justify-center gap-1 py-2.5 transition ${
                   active
-                    ? 'bg-indigo-600 text-white dark:bg-indigo-500'
-                    : 'bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700'
+                    ? 'text-indigo-600 dark:text-indigo-400'
+                    : 'text-slate-400 hover:bg-slate-50 hover:text-slate-700 dark:text-neutral-500 dark:hover:bg-neutral-800/60 dark:hover:text-neutral-200'
                 }`}
               >
-                {tab.label}
+                <span className="relative">
+                  <Icon className="h-[18px] w-[18px]" strokeWidth={active ? 2.25 : 1.75} aria-hidden />
+                  {hasUnread && !active ? (
+                    <span
+                      className="absolute -end-0.5 -top-0.5 h-1.5 w-1.5 rounded-full bg-indigo-500 ring-2 ring-white dark:ring-neutral-900"
+                      aria-hidden
+                    />
+                  ) : null}
+                </span>
+                {active ? (
+                  <span
+                    className="absolute inset-x-2 bottom-0 h-0.5 rounded-full bg-indigo-600 dark:bg-indigo-400"
+                    aria-hidden
+                  />
+                ) : null}
               </button>
             )
           })}
@@ -283,17 +415,6 @@ export function NotificationsDrawer({ open, onClose }: { open: boolean; onClose:
           {/* Alerts tab — system/push notifications from the notifications inbox */}
           {filter === 'alerts' ? (
             <div>
-              {alertsUnread > 0 ? (
-                <div className="mb-2 flex justify-end">
-                  <button
-                    type="button"
-                    onClick={() => void markAllRead()}
-                    className="rounded-lg px-3 py-1 text-xs font-medium text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-neutral-800"
-                  >
-                    Mark all read
-                  </button>
-                </div>
-              ) : null}
               {alertItems.length === 0 ? (
                 <p className="px-2 py-8 text-center text-sm text-slate-500 dark:text-neutral-400">No alerts.</p>
               ) : null}
@@ -354,9 +475,7 @@ export function NotificationsDrawer({ open, onClose }: { open: boolean; onClose:
                   <Link
                     to={row.href}
                     onClick={() => {
-                      if (row.alertId && !row.isRead) {
-                        void markAlertRead(row.alertId)
-                      }
+                      handleNotificationOpen(row)
                       onClose()
                     }}
                     className={[

--- a/clients/web/src/components/quiz/quiz-analytics-modal.tsx
+++ b/clients/web/src/components/quiz/quiz-analytics-modal.tsx
@@ -1,0 +1,323 @@
+import { useCallback, useEffect, useId, useState } from 'react'
+import { RefreshCw, X } from 'lucide-react'
+import {
+  fetchQuizAnalytics,
+  type QuizAnalyticsReport,
+  type QuizQuestionStat,
+  type QuizScoreBucket,
+} from '../../lib/quiz-analytics-api'
+import { QuizItemAnalysisPanel } from './quiz-item-analysis-panel'
+
+type Props = {
+  open: boolean
+  onClose: () => void
+  courseCode: string
+  itemId: string
+  quizTitle: string
+}
+
+export function QuizAnalyticsModal({ open, onClose, courseCode, itemId, quizTitle }: Props) {
+  const titleId = useId()
+  const [report, setReport] = useState<QuizAnalyticsReport | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await fetchQuizAnalytics(courseCode, itemId)
+      setReport(data)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load analytics.')
+      setReport(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [courseCode, itemId])
+
+  useEffect(() => {
+    if (!open) return
+    void load()
+  }, [load, open])
+
+  useEffect(() => {
+    if (!open) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose, open])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-slate-900/40 p-4 sm:items-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="flex max-h-[min(90vh,56rem)] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl dark:border-neutral-600 dark:bg-neutral-950">
+        <div className="flex shrink-0 items-center justify-between border-b border-slate-200 px-4 py-3 dark:border-neutral-700">
+          <div>
+            <h2 id={titleId} className="text-base font-semibold text-slate-900 dark:text-neutral-100">
+              Quiz analytics
+            </h2>
+            <p className="mt-0.5 text-sm text-slate-500 dark:text-neutral-400">{quizTitle}</p>
+          </div>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => void load()}
+              disabled={loading}
+              aria-label="Refresh analytics"
+              className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 disabled:opacity-50 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+            >
+              <RefreshCw className={`h-5 w-5 ${loading ? 'animate-spin' : ''}`} aria-hidden />
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close analytics"
+              className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+            >
+              <X className="h-5 w-5" aria-hidden />
+            </button>
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6">
+          {error ? (
+            <p role="alert" className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-300">
+              {error}
+            </p>
+          ) : null}
+
+          {loading && !report ? (
+            <p className="text-sm text-slate-500 dark:text-neutral-400">Loading analytics…</p>
+          ) : null}
+
+          {report ? (
+            <div className="space-y-8">
+              <AnalyticsSummary report={report} />
+              <ScoreDistributionChart buckets={report.scoreBuckets} nAttempts={report.nAttempts} />
+              <QuestionPerformanceSection questions={report.questionStats} />
+              <QuizItemAnalysisPanel courseCode={courseCode} itemId={itemId} />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function AnalyticsSummary({ report }: { report: QuizAnalyticsReport }) {
+  return (
+    <dl className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      <SummaryCard label="Submitted attempts" value={String(report.nAttempts)} />
+      <SummaryCard
+        label="Mean score"
+        value={report.meanScore != null ? `${report.meanScore.toFixed(1)}%` : '—'}
+      />
+      <SummaryCard
+        label="Questions"
+        value={String(report.questionStats.length)}
+        className="col-span-2 sm:col-span-1"
+      />
+    </dl>
+  )
+}
+
+function SummaryCard({
+  label,
+  value,
+  className = '',
+}: {
+  label: string
+  value: string
+  className?: string
+}) {
+  return (
+    <div
+      className={`rounded-xl border border-slate-100 bg-slate-50 px-3 py-2.5 dark:border-neutral-700 dark:bg-neutral-900 ${className}`}
+    >
+      <dt className="text-[11px] uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+        {label}
+      </dt>
+      <dd className="mt-0.5 text-lg font-semibold tabular-nums text-slate-900 dark:text-neutral-100">
+        {value}
+      </dd>
+    </div>
+  )
+}
+
+function ScoreDistributionChart({
+  buckets,
+  nAttempts,
+}: {
+  buckets: QuizScoreBucket[]
+  nAttempts: number
+}) {
+  const captionId = useId()
+  const maxCount = Math.max(1, ...buckets.map((b) => b.count))
+  const chartBarMaxHeight = 112
+
+  if (nAttempts === 0) {
+    return (
+      <section aria-labelledby={captionId}>
+        <h3 id={captionId} className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+          Overall score distribution
+        </h3>
+        <p className="mt-3 text-sm text-slate-500 dark:text-neutral-400">
+          No submitted attempts yet.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section aria-labelledby={captionId}>
+      <h3 id={captionId} className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+        Overall score distribution
+      </h3>
+      <p className="mt-1 text-xs text-slate-500 dark:text-neutral-400">
+        Percent of total score across {nAttempts} submitted attempt{nAttempts === 1 ? '' : 's'}.
+      </p>
+      <figure className="mt-4">
+        <div
+          role="img"
+          aria-label={`Score histogram across ${nAttempts} attempts`}
+          className="flex h-40 items-end gap-1.5 sm:gap-2"
+        >
+          {buckets.map((bucket) => {
+            return (
+              <div key={bucket.label} className="flex min-w-0 flex-1 flex-col items-center justify-end gap-1">
+                <span className="text-[10px] tabular-nums text-slate-500 dark:text-neutral-400">
+                  {bucket.count > 0 ? bucket.count : ''}
+                </span>
+                <div
+                  title={`${bucket.label}: ${bucket.count} attempt${bucket.count === 1 ? '' : 's'}`}
+                  className="w-full rounded-t-md bg-indigo-500 dark:bg-indigo-400"
+                  style={{
+                    height:
+                      bucket.count > 0
+                        ? `${Math.max((bucket.count / maxCount) * chartBarMaxHeight, 6)}px`
+                        : 0,
+                  }}
+                />
+                <span className="max-w-full truncate text-[10px] text-slate-600 dark:text-neutral-400">
+                  {bucket.min}
+                </span>
+              </div>
+            )
+          })}
+        </div>
+        <figcaption className="sr-only">
+          Histogram of quiz scores in 10-point buckets from 0% to 100%
+        </figcaption>
+      </figure>
+      <table className="mt-4 w-full text-sm">
+        <caption className="text-start text-xs font-medium text-slate-600 dark:text-neutral-400">
+          Score distribution data
+        </caption>
+        <thead>
+          <tr className="border-b border-slate-200 dark:border-neutral-700">
+            <th scope="col" className="py-1 pe-3 text-start font-medium">
+              Score range
+            </th>
+            <th scope="col" className="py-1 text-end font-medium">
+              Attempts
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {buckets.map((bucket) => (
+            <tr key={bucket.label} className="border-b border-slate-100 dark:border-neutral-800">
+              <td className="py-1 pe-3">{bucket.label}</td>
+              <td className="py-1 text-end tabular-nums">{bucket.count}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  )
+}
+
+function QuestionPerformanceSection({ questions }: { questions: QuizQuestionStat[] }) {
+  const headingId = useId()
+
+  if (questions.length === 0) {
+    return (
+      <section aria-labelledby={headingId}>
+        <h3 id={headingId} className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+          Question performance
+        </h3>
+        <p className="mt-3 text-sm text-slate-500 dark:text-neutral-400">
+          No graded responses yet.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section aria-labelledby={headingId}>
+      <h3 id={headingId} className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+        Question performance
+      </h3>
+      <p className="mt-1 text-xs text-slate-500 dark:text-neutral-400">
+        Average score earned on each question, shown as percent correct.
+      </p>
+      <ul className="mt-4 space-y-4">
+        {questions.map((q) => (
+          <li key={q.questionIndex}>
+            <QuestionPerformanceRow question={q} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function QuestionPerformanceRow({ question }: { question: QuizQuestionStat }) {
+  const truncated =
+    question.questionText.length > 120
+      ? `${question.questionText.slice(0, 120)}…`
+      : question.questionText
+  const pct = Math.round(question.pctCorrect)
+  const barColor =
+    pct < 40 ? 'bg-rose-500' : pct < 70 ? 'bg-amber-400' : 'bg-emerald-500'
+
+  return (
+    <div>
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm text-slate-800 dark:text-neutral-200">
+          <span className="font-medium text-slate-500 dark:text-neutral-400">
+            Q{question.questionIndex + 1}.
+          </span>{' '}
+          {truncated || <span className="italic text-slate-400">No question text</span>}
+        </p>
+        <span className="shrink-0 text-sm font-semibold tabular-nums text-slate-900 dark:text-neutral-100">
+          {question.pctCorrect.toFixed(1)}%
+        </span>
+      </div>
+      <div
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={pct}
+        aria-label={`Question ${question.questionIndex + 1}: ${question.pctCorrect.toFixed(1)}% correct from ${question.nResponses} responses`}
+        className="mt-2 h-2.5 w-full overflow-hidden rounded-full bg-slate-100 dark:bg-neutral-800"
+      >
+        <div className={`h-full rounded-full ${barColor}`} style={{ width: `${pct}%` }} />
+      </div>
+      <p className="mt-1 text-[11px] text-slate-500 dark:text-neutral-400">
+        {question.nResponses} response{question.nResponses === 1 ? '' : 's'}
+      </p>
+    </div>
+  )
+}

--- a/clients/web/src/context/course-feed-unread-context.ts
+++ b/clients/web/src/context/course-feed-unread-context.ts
@@ -4,6 +4,7 @@ export type CourseFeedUnreadValue = {
   /** New posts in a channel while you are not viewing that channel (for this course in the URL). */
   feedUnreadForChannel: (courseCode: string, channelId: string) => number
   clearFeedChannelUnread: (courseCode: string, channelId: string) => void
+  clearAllFeedUnread: () => void
   /** Feed page sets this so bumps are suppressed for the channel currently on screen. */
   setViewedFeedChannel: (courseCode: string | null, channelId: string | null) => void
   /** Sum of channel bump counts (WebSocket updates while any course route is open). */

--- a/clients/web/src/context/course-feed-unread-provider.tsx
+++ b/clients/web/src/context/course-feed-unread-provider.tsx
@@ -62,6 +62,10 @@ export function CourseFeedUnreadProvider({ children }: { children: ReactNode }) 
     })
   }, [])
 
+  const clearAllFeedUnread = useCallback(() => {
+    setCounts({})
+  }, [])
+
   const feedUnreadForChannel = useCallback(
     (code: string, channelId: string) => counts[code]?.[channelId.toLowerCase()] ?? 0,
     [counts],
@@ -142,10 +146,11 @@ export function CourseFeedUnreadProvider({ children }: { children: ReactNode }) 
     () => ({
       feedUnreadForChannel,
       clearFeedChannelUnread,
+      clearAllFeedUnread,
       setViewedFeedChannel,
       totalFeedUnread,
     }),
-    [feedUnreadForChannel, clearFeedChannelUnread, setViewedFeedChannel, totalFeedUnread],
+    [feedUnreadForChannel, clearFeedChannelUnread, clearAllFeedUnread, setViewedFeedChannel, totalFeedUnread],
   )
 
   return (

--- a/clients/web/src/context/inbox-notifications-context.ts
+++ b/clients/web/src/context/inbox-notifications-context.ts
@@ -1,0 +1,23 @@
+import { createContext } from 'react'
+
+export interface InboxNotification {
+  id: string
+  userId: string
+  eventType: string
+  title: string
+  body: string
+  actionUrl: string
+  isRead: boolean
+  createdAt: string
+}
+
+export type InboxNotificationsValue = {
+  notifications: InboxNotification[]
+  unreadCount: number
+  loading: boolean
+  refresh: () => Promise<void>
+  markRead: (id: string) => Promise<void>
+  markAllRead: () => Promise<void>
+}
+
+export const InboxNotificationsContext = createContext<InboxNotificationsValue | null>(null)

--- a/clients/web/src/context/inbox-notifications-provider.tsx
+++ b/clients/web/src/context/inbox-notifications-provider.tsx
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import { authorizedFetch, apiUrl } from '../lib/api'
+import { getAccessToken } from '../lib/auth'
+import { InboxNotificationsContext, type InboxNotification } from './inbox-notifications-context'
+
+export function InboxNotificationsProvider({ children }: { children: ReactNode }) {
+  const [notifications, setNotifications] = useState<InboxNotification[]>([])
+  const [unreadCount, setUnreadCount] = useState(0)
+  const [loading, setLoading] = useState(false)
+  const sseRef = useRef<EventSource | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await authorizedFetch('/api/v1/me/notifications')
+      if (!res.ok) return
+      const data = (await res.json()) as { notifications: InboxNotification[]; unreadCount: number }
+      setNotifications(data.notifications ?? [])
+      setUnreadCount(data.unreadCount ?? 0)
+    } catch {
+      /* ignore */
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const markRead = useCallback(async (id: string) => {
+    try {
+      await authorizedFetch(`/api/v1/me/notifications/${id}/read`, { method: 'POST' })
+      setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, isRead: true } : n)))
+      setUnreadCount((c) => Math.max(0, c - 1))
+    } catch {
+      /* ignore */
+    }
+  }, [])
+
+  const markAllRead = useCallback(async () => {
+    try {
+      await authorizedFetch('/api/v1/me/notifications/read-all', { method: 'POST' })
+      setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })))
+      setUnreadCount(0)
+    } catch {
+      /* ignore */
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+
+    if (typeof EventSource === 'undefined') return
+
+    const token = getAccessToken()
+    if (!token) return
+
+    const url = apiUrl(`/api/v1/me/notifications/sse?token=${encodeURIComponent(token)}`)
+    const es = new EventSource(url)
+    sseRef.current = es
+
+    es.addEventListener('notification', () => {
+      void refresh()
+    })
+
+    es.onerror = () => {
+      es.close()
+    }
+
+    return () => {
+      es.close()
+      sseRef.current = null
+    }
+  }, [refresh])
+
+  const value = { notifications, unreadCount, loading, refresh, markRead, markAllRead }
+
+  return (
+    <InboxNotificationsContext.Provider value={value}>{children}</InboxNotificationsContext.Provider>
+  )
+}

--- a/clients/web/src/context/use-course-feed-unread.ts
+++ b/clients/web/src/context/use-course-feed-unread.ts
@@ -9,6 +9,7 @@ export function useCourseFeedUnread() {
     return {
       feedUnreadForChannel: () => 0,
       clearFeedChannelUnread: noop,
+      clearAllFeedUnread: noop,
       setViewedFeedChannel: noop,
       totalFeedUnread: 0,
     } as const

--- a/clients/web/src/context/use-inbox-unread.ts
+++ b/clients/web/src/context/use-inbox-unread.ts
@@ -9,6 +9,11 @@ export function useMailboxRevision() {
   return useContext(InboxUnreadContext)?.mailboxRevision ?? 0
 }
 
+export function useRefreshInboxUnread() {
+  const refresh = useContext(InboxUnreadContext)?.refreshUnread
+  return refresh ?? (async () => {})
+}
+
 export function useCoursesRevision() {
   return useContext(InboxUnreadContext)?.coursesRevision ?? 0
 }

--- a/clients/web/src/context/use-push-notifications.ts
+++ b/clients/web/src/context/use-push-notifications.ts
@@ -1,85 +1,21 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { authorizedFetch, apiUrl } from '../lib/api'
-import { getAccessToken } from '../lib/auth'
+import { useContext } from 'react'
+import { InboxNotificationsContext } from './inbox-notifications-context'
 
-export interface InboxNotification {
-  id: string
-  userId: string
-  eventType: string
-  title: string
-  body: string
-  actionUrl: string
-  isRead: boolean
-  createdAt: string
-}
+export type { InboxNotification } from './inbox-notifications-context'
+
+const noopAsync = async () => {}
 
 export function useInboxNotifications() {
-  const [notifications, setNotifications] = useState<InboxNotification[]>([])
-  const [unreadCount, setUnreadCount] = useState(0)
-  const [loading, setLoading] = useState(false)
-  const sseRef = useRef<EventSource | null>(null)
-
-  const refresh = useCallback(async () => {
-    setLoading(true)
-    try {
-      const res = await authorizedFetch('/api/v1/me/notifications')
-      if (!res.ok) return
-      const data = (await res.json()) as { notifications: InboxNotification[]; unreadCount: number }
-      setNotifications(data.notifications ?? [])
-      setUnreadCount(data.unreadCount ?? 0)
-    } catch {
-      /* ignore */
-    } finally {
-      setLoading(false)
+  const ctx = useContext(InboxNotificationsContext)
+  if (!ctx) {
+    return {
+      notifications: [],
+      unreadCount: 0,
+      loading: false,
+      refresh: noopAsync,
+      markRead: noopAsync,
+      markAllRead: noopAsync,
     }
-  }, [])
-
-  const markRead = useCallback(async (id: string) => {
-    try {
-      await authorizedFetch(`/api/v1/me/notifications/${id}/read`, { method: 'POST' })
-      setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, isRead: true } : n)))
-      setUnreadCount((c) => Math.max(0, c - 1))
-    } catch {
-      /* ignore */
-    }
-  }, [])
-
-  const markAllRead = useCallback(async () => {
-    try {
-      await authorizedFetch('/api/v1/me/notifications/read-all', { method: 'POST' })
-      setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })))
-      setUnreadCount(0)
-    } catch {
-      /* ignore */
-    }
-  }, [])
-
-  // Connect SSE for real-time updates
-  useEffect(() => {
-    void refresh()
-
-    if (typeof EventSource === 'undefined') return
-
-    const token = getAccessToken()
-    if (!token) return
-
-    const url = apiUrl(`/api/v1/me/notifications/sse?token=${encodeURIComponent(token)}`)
-    const es = new EventSource(url)
-    sseRef.current = es
-
-    es.addEventListener('notification', () => {
-      void refresh()
-    })
-
-    es.onerror = () => {
-      es.close()
-    }
-
-    return () => {
-      es.close()
-      sseRef.current = null
-    }
-  }, [refresh])
-
-  return { notifications, unreadCount, loading, refresh, markRead, markAllRead }
+  }
+  return ctx
 }

--- a/clients/web/src/lib/__tests__/unified-notifications-alerts.test.ts
+++ b/clients/web/src/lib/__tests__/unified-notifications-alerts.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { inboxAlertsToUnified, notificationActionHref } from '../unified-notifications'
+import {
+  inboxAlertsToUnified,
+  notificationActionHref,
+  parseFeedNotificationChannel,
+  parseInboxNotificationMessageId,
+} from '../unified-notifications'
 
 describe('notificationActionHref', () => {
   it('keeps app-relative paths', () => {
@@ -33,5 +38,31 @@ describe('inboxAlertsToUnified', () => {
     expect(rows[0]?.kind).toBe('alert')
     expect(rows[0]?.alertId).toBe('n1')
     expect(rows[0]?.href).toBe('/courses/C-TEST01')
+  })
+})
+
+describe('parseInboxNotificationMessageId', () => {
+  it('extracts mailbox message id', () => {
+    expect(parseInboxNotificationMessageId('inbox:msg-123')).toBe('msg-123')
+  })
+
+  it('returns null for other kinds', () => {
+    expect(parseInboxNotificationMessageId('alert:abc')).toBeNull()
+  })
+})
+
+describe('parseFeedNotificationChannel', () => {
+  it('extracts course and channel from mention ids', () => {
+    expect(parseFeedNotificationChannel('feed:mention:C-ABC:ch-1:msg-9')).toEqual({
+      courseCode: 'C-ABC',
+      channelId: 'ch-1',
+    })
+  })
+
+  it('extracts course and channel from announcement ids', () => {
+    expect(parseFeedNotificationChannel('feed:announce:C-ABC:ch-1:msg-9')).toEqual({
+      courseCode: 'C-ABC',
+      channelId: 'ch-1',
+    })
   })
 })

--- a/clients/web/src/lib/communication-api.ts
+++ b/clients/web/src/lib/communication-api.ts
@@ -70,6 +70,12 @@ export async function patchMailbox(
   }
 }
 
+export async function markAllInboxMessagesRead(): Promise<void> {
+  const messages = await fetchMailboxMessages('inbox', '')
+  const unread = messages.filter((m) => m.folder === 'inbox' && !m.read)
+  await Promise.all(unread.map((m) => patchMailbox(m.id, { read: true })))
+}
+
 export async function sendMessage(
   body: { to_email?: string; subject: string; body: string; draft?: boolean },
 ): Promise<string> {

--- a/clients/web/src/lib/course-files-api.ts
+++ b/clients/web/src/lib/course-files-api.ts
@@ -225,15 +225,3 @@ export function formatBytes(bytes: number): string {
   const i = Math.floor(Math.log(bytes) / Math.log(k))
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`
 }
-
-export function fileIconForMime(mimeType: string): string {
-  if (mimeType.startsWith('image/')) return '🖼'
-  if (mimeType === 'application/pdf') return '📄'
-  if (mimeType.includes('spreadsheet') || mimeType.includes('excel') || mimeType.includes('csv')) return '📊'
-  if (mimeType.includes('presentation') || mimeType.includes('powerpoint')) return '📋'
-  if (mimeType.includes('word') || mimeType.includes('document')) return '📝'
-  if (mimeType.startsWith('video/')) return '🎬'
-  if (mimeType.startsWith('audio/')) return '🎵'
-  if (mimeType.includes('zip') || mimeType.includes('archive') || mimeType.includes('compressed')) return '📦'
-  return '📎'
-}

--- a/clients/web/src/lib/courses-api.ts
+++ b/clients/web/src/lib/courses-api.ts
@@ -4967,6 +4967,7 @@ export type CanvasImportInclude = {
   enrollments: boolean
   grades: boolean
   settings: boolean
+  files: boolean
 }
 
 export const CANVAS_IMPORT_INCLUDE_ALL: CanvasImportInclude = {
@@ -4976,6 +4977,7 @@ export const CANVAS_IMPORT_INCLUDE_ALL: CanvasImportInclude = {
   enrollments: true,
   grades: true,
   settings: true,
+  files: true,
 }
 
 export type PostCourseImportCanvasBody = {

--- a/clients/web/src/lib/quiz-analytics-api.ts
+++ b/clients/web/src/lib/quiz-analytics-api.ts
@@ -1,0 +1,44 @@
+import { authorizedFetch } from './api'
+import { readApiErrorMessage } from './errors'
+
+export type QuizScoreBucket = {
+  label: string
+  min: number
+  max: number
+  count: number
+}
+
+export type QuizQuestionStat = {
+  questionIndex: number
+  questionText: string
+  nResponses: number
+  pctCorrect: number
+}
+
+export type QuizAnalyticsReport = {
+  quizId: string
+  nAttempts: number
+  meanScore: number | null
+  scoreBuckets: QuizScoreBucket[]
+  questionStats: QuizQuestionStat[]
+}
+
+/** GET `/api/v1/courses/:code/quizzes/:id/analytics` — instructor only. */
+export async function fetchQuizAnalytics(
+  courseCode: string,
+  itemId: string,
+): Promise<QuizAnalyticsReport> {
+  const res = await authorizedFetch(
+    `/api/v1/courses/${encodeURIComponent(courseCode)}/quizzes/${encodeURIComponent(itemId)}/analytics`,
+  )
+  const raw = (await res.json().catch(() => ({}))) as Record<string, unknown>
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+
+  return {
+    quizId: raw.quizId as string,
+    nAttempts: raw.nAttempts as number,
+    meanScore: (raw.meanScore as number | null | undefined) ?? null,
+    scoreBuckets: (raw.scoreBuckets as QuizScoreBucket[]) ?? [],
+    questionStats: (raw.questionStats as QuizQuestionStat[]) ?? [],
+  }
+}

--- a/clients/web/src/lib/ui-density.ts
+++ b/clients/web/src/lib/ui-density.ts
@@ -33,6 +33,10 @@ export function gradebookStickyNameWidthClass(density: UiDensity): string {
     : 'w-[12rem] min-w-[12rem] max-w-[12rem]'
 }
 
+export function gradebookStickyNameWidthPx(density: UiDensity): number {
+  return density === 'compact' ? 160 : 192
+}
+
 /** `left` offset for the sticky Final column (matches name column width). */
 export function gradebookStickyFinalLeftClass(density: UiDensity): string {
   return density === 'compact' ? 'start-[10rem]' : 'start-[12rem]'

--- a/clients/web/src/lib/unified-notifications.ts
+++ b/clients/web/src/lib/unified-notifications.ts
@@ -71,6 +71,24 @@ export function inboxAlertsToUnified(alerts: InboxAlertNotification[]): UnifiedN
   }))
 }
 
+export function parseInboxNotificationMessageId(id: string): string | null {
+  if (!id.startsWith('inbox:')) return null
+  const messageId = id.slice('inbox:'.length).trim()
+  return messageId || null
+}
+
+export function parseFeedNotificationChannel(
+  id: string,
+): { courseCode: string; channelId: string } | null {
+  const parts = id.split(':')
+  if (parts.length < 5 || parts[0] !== 'feed') return null
+  if (parts[1] !== 'announce' && parts[1] !== 'mention') return null
+  const courseCode = parts[2]?.trim()
+  const channelId = parts[3]?.trim()
+  if (!courseCode || !channelId) return null
+  return { courseCode, channelId }
+}
+
 const FEED_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000
 const MAX_CHANNELS_PER_COURSE = 6
 const MAX_FEED_NODES_PER_COURSE = 200

--- a/clients/web/src/pages/lms/course-export-import-section.tsx
+++ b/clients/web/src/pages/lms/course-export-import-section.tsx
@@ -284,6 +284,11 @@ export function CourseExportImportSection({ courseCode }: { courseCode: string }
                     'Per-learner scores on imported assignments and quizzes (max points + gradebook cells). Learners need an email in Canvas; accounts are created when missing.',
                   ] as const,
                   ['settings', 'Settings', 'Course title, overview, dates, visibility, and syllabus sections.'] as const,
+                  [
+                    'files',
+                    'Files',
+                    'Course file folders and attachments from Canvas Files (shown on the course Files page).',
+                  ] as const,
                 ] as const
               ).map(([key, label, hint]) => (
                 <label

--- a/clients/web/src/pages/lms/course-files-page.tsx
+++ b/clients/web/src/pages/lms/course-files-page.tsx
@@ -1,4 +1,20 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import {
+  Archive,
+  ChevronDown,
+  FileText,
+  Film,
+  FolderOpen,
+  FolderPlus,
+  Image,
+  Music,
+  Paperclip,
+  Presentation,
+  Search,
+  Sheet,
+  Trash2,
+  Upload,
+} from 'lucide-react'
 import { useParams, useSearchParams } from 'react-router-dom'
 import { formatAbsoluteShort } from '../../lib/format-datetime'
 import { courseItemCreatePermission } from '../../lib/courses-api'
@@ -16,7 +32,6 @@ import {
   deleteFile,
   getFileContentUrl,
   formatBytes,
-  fileIconForMime,
   type FileFolder,
   type FileItem,
   type FolderContents,
@@ -26,6 +41,20 @@ import { LmsPage } from './lms-page'
 type ContextMenu =
   | { kind: 'folder'; item: FileFolder; x: number; y: number }
   | { kind: 'file'; item: FileItem; x: number; y: number }
+
+type SelectedItemKey = `folder:${string}` | `file:${string}`
+
+function selectedItemKey(kind: 'folder' | 'file', id: string): SelectedItemKey {
+  return `${kind}:${id}`
+}
+
+function matchesSearchQuery(name: string, query: string): boolean {
+  return name.toLowerCase().includes(query.trim().toLowerCase())
+}
+
+const CHECKBOX_COLUMN_CLASS = 'w-11 px-4 py-2.5 align-middle text-left'
+const CHECKBOX_INPUT_CLASS =
+  'block h-4 w-4 shrink-0 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-neutral-600 dark:bg-neutral-900'
 
 export default function CourseFilesPage() {
   const { courseCode: rawCode } = useParams<{ courseCode: string }>()
@@ -54,6 +83,8 @@ export default function CourseFilesPage() {
 
   const [contextMenu, setContextMenu] = useState<ContextMenu | null>(null)
   const [movingFile, setMovingFile] = useState<FileItem | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedItems, setSelectedItems] = useState<Set<SelectedItemKey>>(new Set())
 
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -72,6 +103,119 @@ export default function CourseFilesPage() {
   }, [courseCode, folderId])
 
   useEffect(() => { void load() }, [load])
+
+  useEffect(() => {
+    setSelectedItems(new Set())
+    setSearchQuery('')
+  }, [folderId])
+
+  const filteredFolders = useMemo(() => {
+    if (!contents) return []
+    const q = searchQuery.trim()
+    if (!q) return contents.folders
+    return contents.folders.filter(folder => matchesSearchQuery(folder.name, q))
+  }, [contents, searchQuery])
+
+  const filteredFiles = useMemo(() => {
+    if (!contents) return []
+    const q = searchQuery.trim()
+    if (!q) return contents.files
+    return contents.files.filter(file => matchesSearchQuery(file.displayName, q))
+  }, [contents, searchQuery])
+
+  const visibleItemKeys = useMemo(() => {
+    const keys: SelectedItemKey[] = []
+    for (const folder of filteredFolders) keys.push(selectedItemKey('folder', folder.id))
+    for (const file of filteredFiles) keys.push(selectedItemKey('file', file.id))
+    return keys
+  }, [filteredFolders, filteredFiles])
+
+  const allVisibleSelected =
+    visibleItemKeys.length > 0 && visibleItemKeys.every(key => selectedItems.has(key))
+
+  const someVisibleSelected =
+    visibleItemKeys.some(key => selectedItems.has(key)) && !allVisibleSelected
+
+  function toggleItemSelection(key: SelectedItemKey) {
+    setSelectedItems(prev => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  function toggleSelectAllVisible() {
+    setSelectedItems(prev => {
+      if (allVisibleSelected) {
+        const next = new Set(prev)
+        for (const key of visibleItemKeys) next.delete(key)
+        return next
+      }
+      const next = new Set(prev)
+      for (const key of visibleItemKeys) next.add(key)
+      return next
+    })
+  }
+
+  function clearSelection() {
+    setSelectedItems(new Set())
+  }
+
+  function getSelectedFolderAndFile() {
+    if (!contents || selectedItems.size !== 1) return null
+    const key = [...selectedItems][0]
+    const [kind, id] = key.split(':') as ['folder' | 'file', string]
+    if (kind === 'folder') {
+      const folder = contents.folders.find(f => f.id === id)
+      return folder ? { kind: 'folder' as const, folder } : null
+    }
+    const file = contents.files.find(f => f.id === id)
+    return file ? { kind: 'file' as const, file } : null
+  }
+
+  async function handleDeleteSelected() {
+    if (!contents || selectedItems.size === 0) return
+    const foldersToDelete = contents.folders.filter(f =>
+      selectedItems.has(selectedItemKey('folder', f.id)),
+    )
+    const filesToDelete = contents.files.filter(f =>
+      selectedItems.has(selectedItemKey('file', f.id)),
+    )
+    const total = foldersToDelete.length + filesToDelete.length
+    const message =
+      total === 1
+        ? foldersToDelete.length === 1
+          ? `Delete folder "${foldersToDelete[0].name}" and all its contents? This cannot be undone.`
+          : `Delete "${filesToDelete[0].displayName}"? This cannot be undone.`
+        : `Delete ${total} selected items? Folders and their contents will be removed. This cannot be undone.`
+    if (!confirm(message)) return
+
+    try {
+      for (const folder of foldersToDelete) {
+        await deleteFolder(courseCode, folder.id)
+      }
+      for (const file of filesToDelete) {
+        await deleteFile(courseCode, file.id)
+      }
+      clearSelection()
+      void load()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Could not delete selected items.')
+    }
+  }
+
+  function handleRenameSelected() {
+    const selected = getSelectedFolderAndFile()
+    if (!selected) return
+    if (selected.kind === 'folder') {
+      setRenamingFolder(selected.folder)
+      setRenameValue(selected.folder.name)
+      return
+    }
+    setRenamingFile(selected.file)
+    setRenameValue(selected.file.displayName)
+  }
 
   // Keep breadcrumb trail in sync when folderId changes
   useEffect(() => {
@@ -247,7 +391,8 @@ export default function CourseFilesPage() {
               onClick={() => setShowNewFolder(v => !v)}
               className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
             >
-              📁 New folder
+              <FolderPlus className="h-4 w-4" aria-hidden />
+              New folder
             </button>
             <button
               type="button"
@@ -255,7 +400,14 @@ export default function CourseFilesPage() {
               onClick={() => fileInputRef.current?.click()}
               className="inline-flex items-center gap-1.5 rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 disabled:opacity-60"
             >
-              {uploading ? (uploadProgress ?? 'Uploading…') : '⬆ Upload'}
+              {uploading ? (
+                uploadProgress ?? 'Uploading…'
+              ) : (
+                <>
+                  <Upload className="h-4 w-4" aria-hidden />
+                  Upload
+                </>
+              )}
             </button>
             <input
               ref={fileInputRef}
@@ -297,6 +449,42 @@ export default function CourseFilesPage() {
         </div>
       )}
 
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <div className="relative min-w-[12rem] flex-1 sm:max-w-md">
+          <Search
+            className="pointer-events-none absolute start-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400 dark:text-neutral-500"
+            aria-hidden
+          />
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            placeholder="Search files and folders…"
+            aria-label="Search files and folders"
+            className="w-full rounded-lg border border-slate-200 bg-white py-2 ps-9 pe-3 text-sm text-slate-900 outline-none placeholder:text-slate-500 focus:border-indigo-300 focus:ring-2 focus:ring-indigo-500/20 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500"
+          />
+        </div>
+        {canManage && selectedItems.size > 0 && (
+          <div className="flex shrink-0 items-center gap-2">
+            <span className="text-sm text-slate-600 dark:text-neutral-300">
+              {selectedItems.size} selected
+            </span>
+            <SelectionActionsMenu
+              canRename={selectedItems.size === 1}
+              onRename={handleRenameSelected}
+              onDelete={() => void handleDeleteSelected()}
+            />
+            <button
+              type="button"
+              onClick={clearSelection}
+              className="text-sm text-slate-500 hover:text-slate-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+            >
+              Clear
+            </button>
+          </div>
+        )}
+      </div>
+
       {/* Content */}
       {loading ? (
         <div className="flex items-center justify-center py-16">
@@ -308,23 +496,51 @@ export default function CourseFilesPage() {
         </div>
       ) : !contents || (contents.folders.length === 0 && contents.files.length === 0) ? (
         <EmptyState canManage={canManage} onUpload={() => fileInputRef.current?.click()} />
+      ) : filteredFolders.length === 0 && filteredFiles.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-center dark:border-neutral-800 dark:bg-neutral-950">
+          <Search className="mb-3 h-10 w-10 text-slate-300 dark:text-neutral-600" aria-hidden />
+          <p className="text-sm font-medium text-slate-700 dark:text-neutral-200">No matching files or folders</p>
+          <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+            Try a different search term.
+          </p>
+        </div>
       ) : (
         <div className="overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-950">
-          <table className="min-w-full divide-y divide-slate-100 text-sm dark:divide-neutral-800">
+          <table className="min-w-full table-fixed divide-y divide-slate-100 text-sm dark:divide-neutral-800">
+            {canManage && (
+              <colgroup>
+                <col className="w-11" />
+                <col />
+                <col className="w-28" />
+                <col className="w-36" />
+                <col className="w-36" />
+              </colgroup>
+            )}
             <thead>
               <tr className="bg-slate-50 dark:bg-neutral-900">
-                <th className="py-2.5 pl-4 pr-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">Name</th>
+                {canManage && (
+                  <th className={CHECKBOX_COLUMN_CLASS}>
+                    <SelectAllCheckbox
+                      checked={allVisibleSelected}
+                      indeterminate={someVisibleSelected}
+                      onChange={toggleSelectAllVisible}
+                    />
+                  </th>
+                )}
+                <th className={`py-2.5 pr-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400 ${canManage ? 'pl-2' : 'pl-4'}`}>Name</th>
                 <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">Size</th>
                 <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">Modified</th>
                 {canManage && <th className="py-2.5 pl-3 pr-4 text-right text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">Actions</th>}
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-50 dark:divide-neutral-800/60">
-              {contents.folders.map(folder => (
+              {filteredFolders.map(folder => (
                 <FolderRow
                   key={folder.id}
                   folder={folder}
                   canManage={canManage}
+                  selected={selectedItems.has(selectedItemKey('folder', folder.id))}
+                  onToggleSelect={() => toggleItemSelection(selectedItemKey('folder', folder.id))}
                   renamingFolder={renamingFolder}
                   renameValue={renameValue}
                   setRenameValue={setRenameValue}
@@ -336,12 +552,14 @@ export default function CourseFilesPage() {
                   onContextMenu={e => openContextMenu(e, folder, 'folder')}
                 />
               ))}
-              {contents.files.map(file => (
+              {filteredFiles.map(file => (
                 <FileRow
                   key={file.id}
                   file={file}
                   courseCode={courseCode}
                   canManage={canManage}
+                  selected={selectedItems.has(selectedItemKey('file', file.id))}
+                  onToggleSelect={() => toggleItemSelection(selectedItemKey('file', file.id))}
                   renamingFile={renamingFile}
                   renameValue={renameValue}
                   setRenameValue={setRenameValue}
@@ -445,10 +663,134 @@ export default function CourseFilesPage() {
   )
 }
 
+function FileMimeIcon({ mimeType }: { mimeType: string }) {
+  const className = 'h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500'
+  if (mimeType.startsWith('image/')) return <Image className={className} aria-hidden />
+  if (mimeType === 'application/pdf') return <FileText className={className} aria-hidden />
+  if (mimeType.includes('spreadsheet') || mimeType.includes('excel') || mimeType.includes('csv')) {
+    return <Sheet className={className} aria-hidden />
+  }
+  if (mimeType.includes('presentation') || mimeType.includes('powerpoint')) {
+    return <Presentation className={className} aria-hidden />
+  }
+  if (mimeType.includes('word') || mimeType.includes('document')) {
+    return <FileText className={className} aria-hidden />
+  }
+  if (mimeType.startsWith('video/')) return <Film className={className} aria-hidden />
+  if (mimeType.startsWith('audio/')) return <Music className={className} aria-hidden />
+  if (mimeType.includes('zip') || mimeType.includes('archive') || mimeType.includes('compressed')) {
+    return <Archive className={className} aria-hidden />
+  }
+  return <Paperclip className={className} aria-hidden />
+}
+
+function SelectAllCheckbox({
+  checked,
+  indeterminate,
+  onChange,
+}: {
+  checked: boolean
+  indeterminate: boolean
+  onChange: () => void
+}) {
+  const ref = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (ref.current) ref.current.indeterminate = indeterminate
+  }, [indeterminate])
+
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      checked={checked}
+      onChange={onChange}
+      aria-label="Select all visible items"
+      className={CHECKBOX_INPUT_CLASS}
+    />
+  )
+}
+
+function SelectionActionsMenu({
+  canRename,
+  onRename,
+  onDelete,
+}: {
+  canRename: boolean
+  onRename: () => void
+  onDelete: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const menuId = useId()
+
+  useEffect(() => {
+    if (!open) return
+    function onDoc(e: MouseEvent) {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [open])
+
+  return (
+    <div ref={rootRef} className="relative inline-block">
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        onClick={() => setOpen(o => !o)}
+        className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+      >
+        Actions
+        <ChevronDown
+          className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`}
+          aria-hidden
+        />
+      </button>
+      {open && (
+        <div
+          id={menuId}
+          role="menu"
+          aria-label="Selected file actions"
+          className="absolute start-0 z-50 mt-1 min-w-[10rem] overflow-hidden rounded-lg border border-slate-200 bg-white py-1 shadow-lg dark:border-neutral-700 dark:bg-neutral-900"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            disabled={!canRename}
+            onClick={() => {
+              onRename()
+              setOpen(false)
+            }}
+            className="flex w-full items-center px-4 py-2 text-start text-sm hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-neutral-800"
+          >
+            Rename
+          </button>
+          <hr className="my-1 border-slate-100 dark:border-neutral-700" />
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              onDelete()
+              setOpen(false)
+            }}
+            className="flex w-full items-center gap-2 px-4 py-2 text-start text-sm text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30"
+          >
+            <Trash2 className="h-4 w-4 shrink-0" aria-hidden />
+            Delete
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
 function EmptyState({ canManage, onUpload }: { canManage: boolean; onUpload: () => void }) {
   return (
     <div className="flex flex-col items-center justify-center rounded-xl border-2 border-dashed border-slate-200 py-16 text-center dark:border-neutral-700">
-      <span className="mb-3 text-4xl">📁</span>
+      <FolderOpen className="mb-3 h-12 w-12 text-slate-300 dark:text-neutral-600" aria-hidden />
       <p className="text-sm font-medium text-slate-700 dark:text-neutral-200">No files yet</p>
       <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
         {canManage ? 'Upload files or create folders to organize course materials.' : 'No files have been uploaded to this course yet.'}
@@ -469,6 +811,8 @@ function EmptyState({ canManage, onUpload }: { canManage: boolean; onUpload: () 
 type FolderRowProps = {
   folder: FileFolder
   canManage: boolean
+  selected: boolean
+  onToggleSelect: () => void
   renamingFolder: FileFolder | null
   renameValue: string
   setRenameValue: (v: string) => void
@@ -481,7 +825,7 @@ type FolderRowProps = {
 }
 
 function FolderRow({
-  folder, canManage, renamingFolder, renameValue, setRenameValue,
+  folder, canManage, selected, onToggleSelect, renamingFolder, renameValue, setRenameValue,
   onNavigate, onRenameStart, onRenameSubmit, onRenameCancel, onDelete, onContextMenu,
 }: FolderRowProps) {
   const isRenaming = renamingFolder?.id === folder.id
@@ -490,13 +834,25 @@ function FolderRow({
       className="group cursor-pointer hover:bg-slate-50 dark:hover:bg-neutral-900/50"
       onContextMenu={onContextMenu}
     >
-      <td className="py-2.5 pl-4 pr-3">
+      {canManage && (
+        <td className={CHECKBOX_COLUMN_CLASS}>
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={onToggleSelect}
+            onClick={e => e.stopPropagation()}
+            aria-label={`Select folder ${folder.name}`}
+            className={CHECKBOX_INPUT_CLASS}
+          />
+        </td>
+      )}
+      <td className={`py-2.5 pr-3 ${canManage ? 'pl-2' : 'pl-4'}`}>
         {isRenaming ? (
           <form
             className="flex items-center gap-2"
             onSubmit={e => { e.preventDefault(); onRenameSubmit() }}
           >
-            <span className="text-base">📁</span>
+            <FolderOpen className="h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500" aria-hidden />
             <input
               autoFocus
               value={renameValue}
@@ -512,7 +868,7 @@ function FolderRow({
             className="flex items-center gap-2 text-left text-sm font-medium text-slate-800 hover:text-indigo-600 dark:text-neutral-100 dark:hover:text-indigo-400"
             onClick={onNavigate}
           >
-            <span className="text-base">📁</span>
+            <FolderOpen className="h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500" aria-hidden />
             {folder.name}
           </button>
         )}
@@ -537,6 +893,8 @@ type FileRowProps = {
   file: FileItem
   courseCode: string
   canManage: boolean
+  selected: boolean
+  onToggleSelect: () => void
   renamingFile: FileItem | null
   renameValue: string
   setRenameValue: (v: string) => void
@@ -549,7 +907,7 @@ type FileRowProps = {
 }
 
 function FileRow({
-  file, courseCode, canManage, renamingFile, renameValue, setRenameValue,
+  file, courseCode, canManage, selected, onToggleSelect, renamingFile, renameValue, setRenameValue,
   onRenameStart, onRenameSubmit, onRenameCancel, onDelete, onMove, onContextMenu,
 }: FileRowProps) {
   const isRenaming = renamingFile?.id === file.id
@@ -558,13 +916,25 @@ function FileRow({
       className="group cursor-default hover:bg-slate-50 dark:hover:bg-neutral-900/50"
       onContextMenu={onContextMenu}
     >
-      <td className="py-2.5 pl-4 pr-3">
+      {canManage && (
+        <td className={CHECKBOX_COLUMN_CLASS}>
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={onToggleSelect}
+            onClick={e => e.stopPropagation()}
+            aria-label={`Select file ${file.displayName}`}
+            className={CHECKBOX_INPUT_CLASS}
+          />
+        </td>
+      )}
+      <td className={`py-2.5 pr-3 ${canManage ? 'pl-2' : 'pl-4'}`}>
         {isRenaming ? (
           <form
             className="flex items-center gap-2"
             onSubmit={e => { e.preventDefault(); onRenameSubmit() }}
           >
-            <span className="text-base">{fileIconForMime(file.mimeType)}</span>
+            <FileMimeIcon mimeType={file.mimeType} />
             <input
               autoFocus
               value={renameValue}
@@ -582,7 +952,7 @@ function FileRow({
             rel="noreferrer"
             className="flex items-center gap-2 text-sm font-medium text-slate-800 hover:text-indigo-600 dark:text-neutral-100 dark:hover:text-indigo-400"
           >
-            <span className="text-base">{fileIconForMime(file.mimeType)}</span>
+            <FileMimeIcon mimeType={file.mimeType} />
             {file.displayName}
           </a>
         )}
@@ -629,7 +999,8 @@ function MovePicker({
               className={`flex w-full items-center gap-2 px-4 py-2.5 text-sm hover:bg-slate-50 dark:hover:bg-neutral-800 ${currentFolderId === null ? 'font-semibold text-indigo-600' : ''}`}
               onClick={() => onMove(null)}
             >
-              📁 Root (top level)
+              <FolderOpen className="h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500" aria-hidden />
+              Root (top level)
             </button>
           </li>
           {folders.map(f => (
@@ -638,7 +1009,8 @@ function MovePicker({
                 className={`flex w-full items-center gap-2 px-4 py-2.5 text-sm hover:bg-slate-50 dark:hover:bg-neutral-800 ${currentFolderId === f.id ? 'font-semibold text-indigo-600' : ''}`}
                 onClick={() => onMove(f.id)}
               >
-                📁 {f.name}
+                <FolderOpen className="h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500" aria-hidden />
+                {f.name}
               </button>
             </li>
           ))}

--- a/clients/web/src/pages/lms/course-module-quiz-page.tsx
+++ b/clients/web/src/pages/lms/course-module-quiz-page.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { formatDateTime } from '../../lib/format'
 import { Link, useParams } from 'react-router-dom'
-import { Check, CheckCircle, ChevronDown, Download, Eye, Loader2, Pencil, Plus, Sparkles, Trash2, WifiOff, X } from 'lucide-react'
+import { Check, CheckCircle, ChevronDown, Download, Eye, Loader2, BarChart3, Pencil, Plus, Sparkles, Trash2, WifiOff, X } from 'lucide-react'
 import { useOnlineStatus } from '../../hooks/use-online-status'
 import { useOfflineContent } from '../../hooks/use-offline-content'
 import { ContentPageReader } from '../../components/content-page/content-page-reader'
@@ -60,7 +60,7 @@ import {
 } from './course-module-quiz-utils'
 import { recordLastVisitedModuleItem } from '../../lib/last-visited-module-item'
 import { LmsPage } from './lms-page'
-import { QuizItemAnalysisPanel } from '../../components/quiz/quiz-item-analysis-panel'
+import { QuizAnalyticsModal } from '../../components/quiz/quiz-analytics-modal'
 
 function QuestionTypeDropdown({
   value,
@@ -131,11 +131,13 @@ function QuizEditorMoreMenu({
   onPreview,
   onEditIntro,
   onGenerate,
+  onAnalytics,
 }: {
   disabled: boolean
   onPreview: () => void
   onEditIntro: () => void
   onGenerate: () => void
+  onAnalytics: () => void
 }) {
   const [open, setOpen] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
@@ -201,6 +203,18 @@ function QuizEditorMoreMenu({
           >
             <Sparkles className="h-4 w-4 shrink-0 text-slate-500 dark:text-neutral-400" aria-hidden />
             Generate questions
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              onAnalytics()
+              setOpen(false)
+            }}
+            className="flex w-full items-center gap-2 px-3 py-2.5 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
+          >
+            <BarChart3 className="h-4 w-4 shrink-0 text-slate-500 dark:text-neutral-400" aria-hidden />
+            Analytics
           </button>
           <div
             role="separator"
@@ -314,6 +328,7 @@ export default function CourseModuleQuizPage() {
   const [generateBusy, setGenerateBusy] = useState(false)
   const [generateError, setGenerateError] = useState<string | null>(null)
   const [previewOpen, setPreviewOpen] = useState(false)
+  const [analyticsOpen, setAnalyticsOpen] = useState(false)
   const [studentQuizPayload, setStudentQuizPayload] = useState<ModuleQuizPayload | null>(null)
   const [studentTakeOpen, setStudentTakeOpen] = useState(false)
   const [studentQuizBanner, setStudentQuizBanner] = useState<{ kind: 'success' | 'error'; text: string } | null>(null)
@@ -1050,6 +1065,7 @@ export default function CourseModuleQuizPage() {
                     onPreview={() => setPreviewOpen(true)}
                     onEditIntro={beginEditContent}
                     onGenerate={openGenerateModal}
+                    onAnalytics={() => setAnalyticsOpen(true)}
                   />
                   <button
                     type="button"
@@ -1386,10 +1402,6 @@ export default function CourseModuleQuizPage() {
             </aside>
           </div>
         )}
-
-        {canEdit && !loading && !loadError && !editingContent && courseCode && itemId && (
-          <QuizItemAnalysisPanel courseCode={courseCode} itemId={itemId} />
-        )}
       </div>
 
       {!loading && !loadError && editingContent && (
@@ -1548,6 +1560,14 @@ export default function CourseModuleQuizPage() {
           </div>
         </div>
       )}
+
+      <QuizAnalyticsModal
+        open={analyticsOpen}
+        onClose={() => setAnalyticsOpen(false)}
+        courseCode={courseCode ?? ''}
+        itemId={itemId ?? ''}
+        quizTitle={title || 'Quiz'}
+      />
 
       <QuizStudentPreviewModal
         open={previewOpen}

--- a/clients/web/src/pages/lms/gradebook/__tests__/gradebook-grid.test.tsx
+++ b/clients/web/src/pages/lms/gradebook/__tests__/gradebook-grid.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
 import { UiDensityProvider } from '../../../../context/ui-density-context'
@@ -105,5 +106,18 @@ describe('GradebookGrid — accessibility', () => {
     const cells = screen.getAllByRole('gridcell')
     // (1 final + 2 assignment) × 2 students = 6 cells
     expect(cells.length).toBeGreaterThanOrEqual(students.length * (1 + columns.length))
+  })
+
+  it('toggles transposed layout when Transpose is clicked', async () => {
+    const user = userEvent.setup()
+    renderGrid()
+    expect(screen.getByRole('grid', { name: /grades by student and assignment/i })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /^transpose$/i }))
+
+    expect(screen.getByRole('grid', { name: /grades by assignment and student/i })).toBeInTheDocument()
+    expect(screen.queryByRole('grid', { name: /grades by student and assignment/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^transpose$/i })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: /resize assignment column/i })).toBeInTheDocument()
   })
 })

--- a/clients/web/src/pages/lms/gradebook/gradebook-grid-transposed.tsx
+++ b/clients/web/src/pages/lms/gradebook/gradebook-grid-transposed.tsx
@@ -1,0 +1,509 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Lock } from 'lucide-react'
+import { studentProgressFeatureEnabled } from '../../../lib/student-progress'
+import { formatFinalPercent } from './compute-course-final-percent'
+import type { GradebookColumn, GradebookStudent } from './gradebook-grid-types'
+
+function parseGradeNumber(raw: string): number | null {
+  const s = raw.trim().replace(/,/g, '')
+  if (s === '') return null
+  const n = Number.parseFloat(s)
+  return Number.isFinite(n) ? n : null
+}
+
+function formatStat(n: number): string {
+  if (!Number.isFinite(n)) return '—'
+  if (Math.abs(n - Math.round(n)) < 1e-6) return String(Math.round(n))
+  let s = n.toFixed(2)
+  while (s.includes('.') && (s.endsWith('0') || s.endsWith('.'))) {
+    s = s.slice(0, -1)
+  }
+  return s
+}
+
+function heatMapCellClass(t: number): string {
+  if (!Number.isFinite(t)) return ''
+  const u = Math.max(0, Math.min(1, t))
+  if (u <= 0.17) return 'bg-sky-100/90 dark:bg-sky-950/35'
+  if (u <= 0.33) return 'bg-sky-50/80 dark:bg-sky-950/20'
+  if (u <= 0.5) return 'bg-slate-50 dark:bg-neutral-800/70'
+  if (u <= 0.67) return 'bg-amber-50/90 dark:bg-amber-950/25'
+  if (u <= 0.83) return 'bg-amber-100/85 dark:bg-amber-950/40'
+  return 'bg-orange-100/80 dark:bg-orange-950/45'
+}
+
+function gradingSelectOptions(
+  col: GradebookColumn,
+  scheme: { type: string; scaleJson: unknown } | null | undefined,
+): string[] {
+  const eff = col.effectiveDisplayType ?? 'points'
+  if (col.rubric) return []
+  if (eff === 'pass_fail') return ['Pass', 'Fail']
+  if (eff === 'complete_incomplete') return ['Complete', 'Incomplete']
+  if (eff === 'letter' || eff === 'gpa') {
+    const raw = scheme?.scaleJson
+    if (!Array.isArray(raw)) return []
+    const labels = raw
+      .map((x) =>
+        x && typeof x === 'object' && 'label' in x ? String((x as { label: unknown }).label).trim() : '',
+      )
+      .filter(Boolean)
+    return [...new Set(labels)]
+  }
+  return []
+}
+
+type AssignmentColumnStats = { avg: number | null; med: number | null }
+
+const MIN_ASSIGNMENT_COL_WIDTH_PX = 128
+const MAX_ASSIGNMENT_COL_WIDTH_PX = 480
+const TRANSPOSED_ASSIGNMENT_COL_WIDTH_KEY = 'lextures.gradebook.transposedAssignmentColWidth'
+
+function clampAssignmentColWidth(px: number): number {
+  return Math.round(Math.max(MIN_ASSIGNMENT_COL_WIDTH_PX, Math.min(MAX_ASSIGNMENT_COL_WIDTH_PX, px)))
+}
+
+function readStoredAssignmentColWidth(defaultPx: number): number {
+  if (typeof window === 'undefined') return defaultPx
+  try {
+    const raw = window.localStorage.getItem(TRANSPOSED_ASSIGNMENT_COL_WIDTH_KEY)
+    if (!raw) return defaultPx
+    const n = Number.parseInt(raw, 10)
+    if (!Number.isFinite(n)) return defaultPx
+    return clampAssignmentColWidth(n)
+  } catch {
+    return defaultPx
+  }
+}
+
+function assignmentColSurfaceClass(extra = ''): string {
+  return [
+    'sticky start-0 border-e border-slate-200 dark:border-neutral-700',
+    extra,
+  ].join(' ')
+}
+
+export type GradebookTransposedTableProps = {
+  columns: GradebookColumn[]
+  students: GradebookStudent[]
+  grades: Record<string, Record<string, string>>
+  onGradeChange: (studentId: string, columnId: string, value: string) => void
+  readOnly: boolean
+  gradingScheme?: { type: string; scaleJson: unknown } | null
+  gradeExcused?: Record<string, Record<string, boolean>>
+  gradeHeld?: Record<string, Record<string, boolean>>
+  droppedGrades?: Record<string, Record<string, boolean>>
+  finalPercentByStudentId: Record<string, number | null>
+  assignmentStats: AssignmentColumnStats[]
+  colorScaleEnabled: boolean
+  courseCode?: string
+  highlightStudentId?: string | null
+  onRubricClick?: (studentId: string, columnId: string) => void
+  onOpenGradeHistory?: (studentId: string, columnId: string) => void
+  onToggleExcused?: (studentId: string, columnId: string, excused: boolean) => void | Promise<void>
+  onPostAssignmentGrades?: (itemId: string) => void
+  postGradesPending?: string | null
+  pad: string
+  defaultAssignmentColWidthPx: number
+  studentColMin: string
+}
+
+type EditingCell = { studentId: string; columnId: string }
+
+function displayCellValue(
+  grades: Record<string, Record<string, string>>,
+  gradeExcused: Record<string, Record<string, boolean>> | undefined,
+  studentId: string,
+  columnId: string,
+): string {
+  if (gradeExcused?.[studentId]?.[columnId] === true) return 'EX'
+  return grades[studentId]?.[columnId] ?? ''
+}
+
+export function GradebookTransposedTable({
+  columns,
+  students,
+  grades,
+  onGradeChange,
+  readOnly,
+  gradingScheme = null,
+  gradeExcused,
+  gradeHeld,
+  droppedGrades,
+  finalPercentByStudentId,
+  assignmentStats,
+  colorScaleEnabled,
+  courseCode,
+  highlightStudentId,
+  onRubricClick,
+  onOpenGradeHistory,
+  onToggleExcused,
+  onPostAssignmentGrades,
+  postGradesPending,
+  pad,
+  defaultAssignmentColWidthPx,
+  studentColMin,
+}: GradebookTransposedTableProps) {
+  const [editing, setEditing] = useState<EditingCell | null>(null)
+  const [draft, setDraft] = useState('')
+  const [assignmentColWidthPx, setAssignmentColWidthPx] = useState(() =>
+    readStoredAssignmentColWidth(defaultAssignmentColWidthPx),
+  )
+  const [resizing, setResizing] = useState(false)
+  const resizeRef = useRef<{ startX: number; startWidth: number } | null>(null)
+
+  useEffect(() => {
+    setAssignmentColWidthPx(readStoredAssignmentColWidth(defaultAssignmentColWidthPx))
+  }, [defaultAssignmentColWidthPx])
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(TRANSPOSED_ASSIGNMENT_COL_WIDTH_KEY, String(assignmentColWidthPx))
+    } catch {
+      /* ignore */
+    }
+  }, [assignmentColWidthPx])
+
+  const assignmentColStyle = {
+    width: assignmentColWidthPx,
+    minWidth: assignmentColWidthPx,
+    maxWidth: assignmentColWidthPx,
+  } as const
+
+  const onResizePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>) => {
+      e.preventDefault()
+      e.stopPropagation()
+      resizeRef.current = { startX: e.clientX, startWidth: assignmentColWidthPx }
+      setResizing(true)
+      e.currentTarget.setPointerCapture(e.pointerId)
+    },
+    [assignmentColWidthPx],
+  )
+
+  const onResizePointerMove = useCallback((e: React.PointerEvent<HTMLButtonElement>) => {
+    const drag = resizeRef.current
+    if (!drag) return
+    const next = clampAssignmentColWidth(drag.startWidth + (e.clientX - drag.startX))
+    setAssignmentColWidthPx(next)
+  }, [])
+
+  const finishResize = useCallback((e: React.PointerEvent<HTMLButtonElement>) => {
+    if (!resizeRef.current) return
+    resizeRef.current = null
+    setResizing(false)
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    }
+  }, [])
+
+  const heatPercentForCell = useCallback(
+    (col: GradebookColumn, valStr: string): number | null => {
+      const n = parseGradeNumber(valStr)
+      if (n == null) return null
+      if (col.maxPoints != null && col.maxPoints > 0) {
+        return Math.max(0, Math.min(1, n / col.maxPoints))
+      }
+      const nums: number[] = []
+      for (const s of students) {
+        if (gradeExcused?.[s.id]?.[col.id] === true) continue
+        const v = parseGradeNumber(grades[s.id]?.[col.id] ?? '')
+        if (v != null) nums.push(v)
+      }
+      if (nums.length === 0) return 0.5
+      const min = Math.min(...nums)
+      const max = Math.max(...nums)
+      if (max <= min) return 0.5
+      return Math.max(0, Math.min(1, (n - min) / (max - min)))
+    },
+    [students, grades, gradeExcused],
+  )
+
+  const beginEdit = useCallback(
+    (studentId: string, columnId: string) => {
+      if (readOnly) return
+      setEditing({ studentId, columnId })
+      setDraft(displayCellValue(grades, gradeExcused, studentId, columnId))
+    },
+    [readOnly, grades, gradeExcused],
+  )
+
+  const commitEdit = useCallback(() => {
+    if (!editing) return
+    const raw = draft.trim()
+    const value = raw === 'EX' ? '' : raw
+    onGradeChange(editing.studentId, editing.columnId, value)
+    setEditing(null)
+    setDraft('')
+  }, [editing, draft, onGradeChange])
+
+  const cancelEdit = useCallback(() => {
+    setEditing(null)
+    setDraft('')
+  }, [])
+
+  return (
+    <div
+      className={`overflow-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-900 ${resizing ? 'cursor-col-resize select-none' : ''}`}
+    >
+      <table
+        role="grid"
+        aria-label="Grades by assignment and student"
+        aria-rowcount={columns.length + 2}
+        aria-colcount={1 + students.length}
+        className="w-full min-w-max table-fixed border-collapse text-start"
+      >
+        <colgroup>
+          <col style={{ width: assignmentColWidthPx }} />
+          {students.map((student) => (
+            <col key={student.id} />
+          ))}
+        </colgroup>
+        <thead>
+          <tr
+            aria-rowindex={1}
+            className="border-b border-slate-200 bg-slate-50 dark:border-neutral-700 dark:bg-neutral-800"
+          >
+            <th
+              scope="col"
+              style={assignmentColStyle}
+              className={`relative ${assignmentColSurfaceClass('top-0 z-30 border-b bg-slate-50 align-bottom dark:bg-neutral-800')} ${pad}`}
+            >
+              <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+                Assignment
+              </span>
+              <button
+                type="button"
+                aria-label="Resize assignment column"
+                aria-orientation="vertical"
+                title="Drag to resize assignment column"
+                className="absolute inset-y-0 end-0 z-40 w-2 translate-x-1/2 cursor-col-resize touch-none border-0 bg-transparent p-0 after:absolute after:inset-y-0 after:start-1/2 after:w-px after:-translate-x-1/2 after:bg-slate-300 after:transition-colors hover:after:bg-indigo-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 dark:after:bg-neutral-600 dark:hover:after:bg-indigo-400"
+                onPointerDown={onResizePointerDown}
+                onPointerMove={onResizePointerMove}
+                onPointerUp={finishResize}
+                onPointerCancel={finishResize}
+              />
+            </th>
+            {students.map((student) => (
+              <th
+                key={student.id}
+                scope="col"
+                title={student.name}
+                className={`sticky top-0 z-20 ${pad} ${studentColMin} border-b border-slate-200 bg-slate-50 align-bottom dark:border-neutral-700 dark:bg-neutral-800 ${
+                  highlightStudentId === student.id
+                    ? 'bg-amber-50/90 ring-2 ring-inset ring-amber-300/90 dark:bg-amber-950/25 dark:ring-amber-500/50'
+                    : ''
+                }`}
+              >
+                <span className="block max-w-[9rem] truncate text-xs font-semibold text-slate-800 dark:text-neutral-200">
+                  {studentProgressFeatureEnabled() && courseCode && student.enrollmentId ? (
+                    <Link
+                      to={`/courses/${encodeURIComponent(courseCode)}/students/${encodeURIComponent(student.enrollmentId)}/progress`}
+                      className="text-indigo-700 hover:underline dark:text-indigo-300"
+                    >
+                      {student.name}
+                    </Link>
+                  ) : (
+                    student.name
+                  )}
+                </span>
+              </th>
+            ))}
+          </tr>
+          <tr
+            aria-rowindex={2}
+            className="border-b border-slate-200 bg-slate-100 text-slate-800 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200"
+          >
+            <th
+              scope="row"
+              style={assignmentColStyle}
+              className={`${assignmentColSurfaceClass('z-[28] border-b bg-slate-100 text-start font-medium dark:bg-neutral-800')} ${pad}`}
+            >
+              <span className="text-[10px] font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+                Final
+              </span>
+            </th>
+            {students.map((student) => (
+              <th
+                key={`final-${student.id}`}
+                scope="col"
+                className={`${pad} ${studentColMin} border-b border-slate-200 bg-slate-100 text-end font-normal tabular-nums dark:border-neutral-700 dark:bg-neutral-800`}
+              >
+                {formatFinalPercent(finalPercentByStudentId[student.id] ?? null)}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {columns.map((col, rowIndex) => {
+            const stats = assignmentStats[rowIndex]
+            return (
+              <tr
+                key={col.id}
+                aria-rowindex={rowIndex + 3}
+                className="border-b border-slate-100 last:border-b-0 dark:border-neutral-700/80"
+              >
+                <th
+                  scope="row"
+                  title={col.title}
+                  style={assignmentColStyle}
+                  className={`${assignmentColSurfaceClass('z-10 bg-slate-100 text-start font-medium text-slate-950 dark:bg-neutral-800 dark:text-neutral-100')} ${pad}`}
+                >
+                  <span className="block truncate text-sm">{col.title}</span>
+                  <span className="mt-0.5 block text-[0.65rem] font-normal text-slate-500 dark:text-neutral-400">
+                    {col.maxPoints != null ? `Out of ${col.maxPoints}` : 'Max points not set'}
+                  </span>
+                  {stats ? (
+                    <span className="mt-1 block text-[11px] tabular-nums leading-snug text-slate-600 dark:text-neutral-300">
+                      Avg {stats.avg != null ? formatStat(stats.avg) : '—'} · Med{' '}
+                      {stats.med != null ? formatStat(stats.med) : '—'}
+                    </span>
+                  ) : null}
+                  {col.kind === 'assignment' &&
+                  col.postingPolicy === 'manual' &&
+                  onPostAssignmentGrades &&
+                  !readOnly ? (
+                    <button
+                      type="button"
+                      className="mt-1 inline-flex max-w-full items-center justify-center rounded-md border border-slate-200 bg-white px-1.5 py-0.5 text-[0.65rem] font-medium text-slate-700 shadow-sm hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                      aria-label={`Post grades for ${col.title}`}
+                      disabled={postGradesPending === col.id}
+                      onClick={() => onPostAssignmentGrades(col.id)}
+                    >
+                      {postGradesPending === col.id ? 'Posting…' : 'Post grades'}
+                    </button>
+                  ) : null}
+                </th>
+                {students.map((student) => {
+                  const val = displayCellValue(grades, gradeExcused, student.id, col.id)
+                  const isEditing =
+                    editing?.studentId === student.id && editing.columnId === col.id
+                  const isExcused = Boolean(gradeExcused?.[student.id]?.[col.id])
+                  const cellHeld = Boolean(gradeHeld?.[student.id]?.[col.id])
+                  const cellDropped = Boolean(droppedGrades?.[student.id]?.[col.id])
+                  const selectOpts = isEditing ? gradingSelectOptions(col, gradingScheme) : []
+                  const heatT =
+                    colorScaleEnabled && !isExcused
+                      ? heatPercentForCell(col, val === 'EX' ? '' : val)
+                      : null
+                  const heatSurface =
+                    heatT != null && !isEditing ? heatMapCellClass(heatT) : 'bg-white dark:bg-neutral-900/80'
+
+                  return (
+                    <td
+                      key={`${col.id}-${student.id}`}
+                      role="gridcell"
+                      className={`relative ${pad} ${studentColMin} border-s border-slate-100 text-end tabular-nums dark:border-neutral-700/80 ${heatSurface} ${
+                        cellDropped ? 'opacity-65 dark:opacity-70' : ''
+                      }`}
+                      onDoubleClick={() => beginEdit(student.id, col.id)}
+                    >
+                      {isEditing ? (
+                        selectOpts.length > 0 ? (
+                          <select
+                            autoFocus
+                            aria-label={`Grade for ${student.name}, ${col.title}`}
+                            className="m-0 w-full min-w-0 border-0 bg-transparent p-0 text-end text-sm text-slate-950 shadow-none outline-none ring-0 focus:ring-0 dark:text-neutral-100"
+                            value={draft}
+                            onChange={(e) => setDraft(e.target.value)}
+                            onBlur={commitEdit}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') commitEdit()
+                              if (e.key === 'Escape') cancelEdit()
+                            }}
+                          >
+                            <option value="">—</option>
+                            {selectOpts.map((opt) => (
+                              <option key={opt} value={opt}>
+                                {opt}
+                              </option>
+                            ))}
+                          </select>
+                        ) : (
+                          <input
+                            autoFocus
+                            type="text"
+                            inputMode="decimal"
+                            autoComplete="off"
+                            aria-label={`Grade for ${student.name}, ${col.title}`}
+                            className="m-0 w-full min-w-0 border-0 bg-transparent p-0 text-end text-sm tabular-nums text-slate-950 shadow-none outline-none ring-0 focus:ring-0 dark:text-neutral-100"
+                            value={draft}
+                            onChange={(e) => setDraft(e.target.value)}
+                            onBlur={commitEdit}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') commitEdit()
+                              if (e.key === 'Escape') cancelEdit()
+                            }}
+                          />
+                        )
+                      ) : (
+                        <div className="flex flex-col items-end gap-0.5">
+                          <span className="inline-flex max-w-full items-center justify-end gap-1">
+                            {cellHeld ? (
+                              <Lock
+                                className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400"
+                                aria-hidden
+                              />
+                            ) : null}
+                            <span
+                              className={
+                                val
+                                  ? isExcused
+                                    ? 'font-semibold text-slate-700 dark:text-neutral-200'
+                                    : 'text-slate-950 dark:text-neutral-100'
+                                  : 'text-neutral-400 dark:text-neutral-500'
+                              }
+                            >
+                              {val || '—'}
+                            </span>
+                          </span>
+                          <span className="inline-flex flex-wrap items-center justify-end gap-x-2 gap-y-0.5">
+                            {!readOnly && col.rubric && onRubricClick ? (
+                              <button
+                                type="button"
+                                className="text-[11px] font-medium text-indigo-600 hover:underline dark:text-indigo-400"
+                                onClick={() => onRubricClick(student.id, col.id)}
+                              >
+                                Rubric
+                              </button>
+                            ) : null}
+                            {onOpenGradeHistory &&
+                            (col.kind === 'assignment' ||
+                              col.kind === 'quiz' ||
+                              col.kind === 'quiz_comprehensive') ? (
+                              <button
+                                type="button"
+                                className="text-[11px] font-medium text-slate-600 hover:underline dark:text-neutral-400"
+                                onClick={() => onOpenGradeHistory(student.id, col.id)}
+                              >
+                                History
+                              </button>
+                            ) : null}
+                            {!readOnly &&
+                            onToggleExcused &&
+                            (col.kind === 'assignment' ||
+                              col.kind === 'quiz' ||
+                              col.kind === 'quiz_comprehensive') ? (
+                              <button
+                                type="button"
+                                className="text-[11px] font-medium text-slate-600 hover:underline dark:text-neutral-400"
+                                onClick={() => void onToggleExcused(student.id, col.id, !isExcused)}
+                              >
+                                {isExcused ? 'Unexcuse' : 'Excuse'}
+                              </button>
+                            ) : null}
+                          </span>
+                        </div>
+                      )}
+                    </td>
+                  )
+                })}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/clients/web/src/pages/lms/gradebook/gradebook-grid-types.ts
+++ b/clients/web/src/pages/lms/gradebook/gradebook-grid-types.ts
@@ -1,0 +1,24 @@
+import type { RubricDefinition } from '../../../lib/courses-api'
+
+export type GradebookColumn = {
+  id: string
+  title: string
+  maxPoints: number | null
+  kind?: string
+  assignmentGroupId?: string | null
+  rubric?: RubricDefinition | null
+  /** Plan 3.6 — resolved display mode for this column. */
+  effectiveDisplayType?: string
+  /** Plan 3.8 */
+  postingPolicy?: string | null
+  releaseAt?: string | null
+  dueAt?: string | null
+  neverDrop?: boolean
+  replaceWithFinal?: boolean
+}
+
+export type GradebookStudent = {
+  id: string
+  name: string
+  enrollmentId?: string
+}

--- a/clients/web/src/pages/lms/gradebook/gradebook-grid.tsx
+++ b/clients/web/src/pages/lms/gradebook/gradebook-grid.tsx
@@ -12,13 +12,14 @@ import {
 import { Link } from 'react-router-dom'
 import { createPortal } from 'react-dom'
 import { studentProgressFeatureEnabled } from '../../../lib/student-progress'
-import { ChevronDown, LayoutGrid, Lock, Thermometer, Users } from 'lucide-react'
+import { ChevronDown, ArrowLeftRight, LayoutGrid, Lock, Thermometer, Users } from 'lucide-react'
 import { useUiDensity } from '../../../context/ui-density-context'
 import {
   gradebookAssignmentColMinWidthClass,
   gradebookCellPad,
   gradebookStickyFinalLeftClass,
   gradebookStickyNameWidthClass,
+  gradebookStickyNameWidthPx,
 } from '../../../lib/ui-density'
 import { EmptyState } from '../../../components/ui/empty-state'
 import {
@@ -33,30 +34,11 @@ import {
   formatFinalPercent,
   type AssignmentGroupWeight,
 } from './compute-course-final-percent'
-import type { AssignmentGroup, RubricDefinition } from '../../../lib/courses-api'
+import { GradebookTransposedTable } from './gradebook-grid-transposed'
+import type { AssignmentGroup } from '../../../lib/courses-api'
+import type { GradebookColumn, GradebookStudent } from './gradebook-grid-types'
 
-export type GradebookColumn = {
-  id: string
-  title: string
-  maxPoints: number | null
-  kind?: string
-  assignmentGroupId?: string | null
-  rubric?: RubricDefinition | null
-  /** Plan 3.6 — resolved display mode for this column. */
-  effectiveDisplayType?: string
-  /** Plan 3.8 */
-  postingPolicy?: string | null
-  releaseAt?: string | null
-  dueAt?: string | null
-  neverDrop?: boolean
-  replaceWithFinal?: boolean
-}
-
-export type GradebookStudent = {
-  id: string
-  name: string
-  enrollmentId?: string
-}
+export type { GradebookColumn, GradebookStudent } from './gradebook-grid-types'
 
 type GradebookGridProps = {
   columns: GradebookColumn[]
@@ -316,6 +298,7 @@ export function GradebookGrid({
   const headerRowRef = useRef<HTMLTableRowElement>(null)
   const [headerStickyPx, setHeaderStickyPx] = useState(0)
   const [colorScaleEnabled, setColorScaleEnabled] = useState(false)
+  const [transposed, setTransposed] = useState(false)
 
   const baseRowCount = students.length
   const baseColCount = columns.length
@@ -1078,6 +1061,17 @@ export function GradebookGrid({
     setAssignmentFilter('')
   }, [])
 
+  const handleTransposedGradeChange = useCallback(
+    (studentId: string, columnId: string, value: string) => {
+      setGrades((prev) => {
+        const next = structuredClone(prev)
+        next[studentId] = { ...next[studentId], [columnId]: value }
+        return next
+      })
+    },
+    [],
+  )
+
   const modulesHref =
     courseCode != null && courseCode !== ''
       ? `/courses/${encodeURIComponent(courseCode)}/modules`
@@ -1179,8 +1173,40 @@ export function GradebookGrid({
         {rowCount > 0 && colCount > 0 && (
           <button
             type="button"
+            aria-pressed={transposed}
+            title={
+              transposed
+                ? 'Show students as rows and assignments as columns'
+                : 'Show assignments as rows and students as columns'
+            }
+            className={[
+              'inline-flex shrink-0 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition',
+              transposed
+                ? 'border-indigo-300 bg-indigo-50 text-indigo-950 dark:border-indigo-600 dark:bg-indigo-950/50 dark:text-indigo-100'
+                : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700/80',
+            ].join(' ')}
+            onClick={() => {
+              setTransposed((v) => !v)
+              setHeaderMenu(null)
+              setEditing(null)
+              setSelectionAnchor(null)
+              setFillDrag(null)
+              fillDragRef.current = null
+            }}
+          >
+            <ArrowLeftRight className="size-4 shrink-0 opacity-80" aria-hidden />
+            Transpose
+          </button>
+        )}
+        {rowCount > 0 && colCount > 0 && (
+          <button
+            type="button"
             aria-pressed={colorScaleEnabled}
-            title="Color each score cell from cool (low) to warm (high) within its column"
+            title={
+              transposed
+                ? 'Color each score cell from cool (low) to warm (high) within its row'
+                : 'Color each score cell from cool (low) to warm (high) within its column'
+            }
             className={[
               'inline-flex shrink-0 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition',
               colorScaleEnabled
@@ -1208,7 +1234,34 @@ export function GradebookGrid({
         </p>
       )}
 
-      {rowCount > 0 && baseColCount > 0 && (
+      {rowCount > 0 && baseColCount > 0 && transposed && (
+        <GradebookTransposedTable
+          columns={visibleColumns}
+          students={filteredStudents}
+          grades={grades}
+          onGradeChange={handleTransposedGradeChange}
+          readOnly={readOnly}
+          gradingScheme={gradingScheme}
+          gradeExcused={gradeExcused}
+          gradeHeld={gradeHeld}
+          droppedGrades={droppedGrades}
+          finalPercentByStudentId={finalPercentByStudentId}
+          assignmentStats={classSummaryStats.columns}
+          colorScaleEnabled={colorScaleEnabled}
+          courseCode={courseCode}
+          highlightStudentId={highlightStudentId}
+          onRubricClick={onRubricClick}
+          onOpenGradeHistory={onOpenGradeHistory}
+          onToggleExcused={onToggleExcused}
+          onPostAssignmentGrades={onPostAssignmentGrades}
+          postGradesPending={postGradesPending}
+          pad={pad}
+          defaultAssignmentColWidthPx={gradebookStickyNameWidthPx(density)}
+          studentColMin={assignmentColMin}
+        />
+      )}
+
+      {rowCount > 0 && baseColCount > 0 && !transposed && (
         <div className="overflow-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
           <table
             role="grid"

--- a/docs/CLOUD.md
+++ b/docs/CLOUD.md
@@ -1,0 +1,435 @@
+# Lextures Cloud Deployment Guide
+
+This document describes recommended cloud architectures for self-hosting or operating Lextures across the three major cloud providers — **AWS**, **Google Cloud Platform (GCP)**, and **Microsoft Azure**. It covers small, medium, and large deployment tiers, gives ballpark monthly cost estimates, and outlines a scaling scenario targeting **100,000 concurrent users**.
+
+## 1. Architecture inputs
+
+Lextures consists of:
+
+| Layer       | Technology                                                                 | Cloud considerations                                                                     |
+| ----------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Web (SPA)   | React 19 + Vite static bundle, served by nginx (`clients/web`, `www`)      | Static assets — CDN-friendly, no server runtime needed.                                  |
+| API         | Go 1.25 + Chi (`server/`), stateless HTTP, JWT auth, pgx Postgres driver   | Horizontally scalable behind an L7 load balancer. Container-native (`server/Dockerfile`). |
+| Database    | PostgreSQL 16                                                              | Single primary with read replicas at scale. Heavy use of relational features.            |
+| Object data | User uploads, exports, backups                                             | S3-class object storage.                                                                 |
+| AI (opt.)   | OpenRouter API egress                                                      | Outbound HTTPS only; no inbound infra needed.                                            |
+| Cache/queue | Optional Redis for sessions, rate limits, background jobs                  | Managed Redis recommended from medium tier upward.                                       |
+
+Deployment tiers used throughout this document:
+
+- **Small** — pilot / single school / < 1,000 MAU, < 100 concurrent.
+- **Medium** — district or multi-school / 1k–25k MAU, ~500–2,000 concurrent.
+- **Large** — multi-district SaaS / 25k–250k MAU, ~5,000–20,000 concurrent.
+
+All cost estimates are **USD/month, on-demand, single region, list price**. Reserved/committed-use discounts (1–3 yr) typically cut compute and database costs by 30–55%. Egress and OpenRouter usage are excluded unless noted.
+
+---
+
+## 2. AWS
+
+### 2.1 Small (AWS)
+
+| Component       | Service                                                      | Sizing                          |
+| --------------- | ------------------------------------------------------------ | ------------------------------- |
+| Web (SPA)       | S3 + CloudFront                                              | Standard tier                   |
+| API             | ECS Fargate behind ALB                                       | 1 task, 0.5 vCPU / 1 GB         |
+| Database        | RDS for PostgreSQL 16, Single-AZ                             | db.t4g.small, 50 GB gp3         |
+| Object storage  | S3                                                           | 50 GB                           |
+| Secrets / logs  | Secrets Manager, CloudWatch Logs                             | Minimal                         |
+| DNS / TLS       | Route 53 + ACM                                               | 1 hosted zone                   |
+
+**Estimated cost:** **~$130–180/mo**
+
+### 2.2 Medium (AWS)
+
+| Component       | Service                                                      | Sizing                                  |
+| --------------- | ------------------------------------------------------------ | --------------------------------------- |
+| Web (SPA)       | S3 + CloudFront                                              | + WAF                                   |
+| API             | ECS Fargate behind ALB, autoscaling 2–6                      | 1 vCPU / 2 GB tasks                     |
+| Database        | RDS PostgreSQL 16, **Multi-AZ**, 1 read replica              | db.m7g.large, 200 GB gp3, PITR on       |
+| Cache           | ElastiCache Redis (cluster mode off)                         | cache.t4g.small × 2 (replica)           |
+| Object storage  | S3 + lifecycle to IA                                         | 500 GB                                  |
+| Observability   | CloudWatch + AWS X-Ray, OpenSearch (small)                   |                                         |
+| Secrets         | Secrets Manager, KMS                                         |                                         |
+
+**Estimated cost:** **~$900–1,300/mo**
+
+### 2.3 Large (AWS)
+
+| Component       | Service                                                                              | Sizing                                  |
+| --------------- | ------------------------------------------------------------------------------------ | --------------------------------------- |
+| Web (SPA)       | S3 + CloudFront (multi-region), AWS WAF, Shield Standard                             |                                         |
+| API             | EKS (or Fargate) behind ALB, HPA + Cluster Autoscaler, 10–40 pods                    | 2 vCPU / 4 GB per pod                   |
+| Database        | Aurora PostgreSQL-Compatible, writer + 2–3 readers, Performance Insights             | db.r7g.2xlarge writer, r7g.xlarge readers |
+| Cache           | ElastiCache Redis cluster mode on, 3 shards × 2 replicas                             | cache.r7g.large                         |
+| Async jobs      | SQS + a worker service on Fargate/EKS                                                 |                                         |
+| Object storage  | S3 + CloudFront origin + Intelligent-Tiering                                         | Multi-TB                                |
+| Observability   | CloudWatch, X-Ray, managed Prometheus + Grafana                                       |                                         |
+| Network         | Multi-AZ VPC, PrivateLink for RDS, NAT GW pair, Transit Gateway if multi-account     |                                         |
+
+**Estimated cost:** **~$6,500–10,000/mo**
+
+---
+
+## 3. Google Cloud Platform (GCP)
+
+### 3.1 Small (GCP)
+
+| Component       | Service                                                      | Sizing                          |
+| --------------- | ------------------------------------------------------------ | ------------------------------- |
+| Web (SPA)       | Cloud Storage + Cloud CDN (with HTTPS LB)                    | Standard                        |
+| API             | Cloud Run                                                    | 1 vCPU / 512 MB, min 1 instance |
+| Database        | Cloud SQL for PostgreSQL 16, zonal                           | db-custom-1-3840, 50 GB SSD     |
+| Object storage  | Cloud Storage                                                | 50 GB                           |
+| Secrets / logs  | Secret Manager, Cloud Logging                                | Minimal                         |
+| DNS / TLS       | Cloud DNS + managed certs                                    |                                 |
+
+**Estimated cost:** **~$110–160/mo**
+
+### 3.2 Medium (GCP)
+
+| Component       | Service                                                                  | Sizing                                  |
+| --------------- | ------------------------------------------------------------------------ | --------------------------------------- |
+| Web (SPA)       | GCS + Cloud CDN behind external HTTPS LB, Cloud Armor                    |                                         |
+| API             | Cloud Run (or GKE Autopilot), min 2 / max 20 instances                   | 1 vCPU / 2 GB                           |
+| Database        | Cloud SQL PostgreSQL 16, **HA (regional)**, 1 read replica               | db-custom-2-7680, 200 GB SSD, PITR      |
+| Cache           | Memorystore for Redis (Standard tier)                                    | 1–5 GB                                  |
+| Object storage  | GCS + lifecycle to Nearline                                              | 500 GB                                  |
+| Observability   | Cloud Monitoring, Cloud Trace, Cloud Logging                             |                                         |
+
+**Estimated cost:** **~$800–1,200/mo**
+
+### 3.3 Large (GCP)
+
+| Component       | Service                                                                                | Sizing                                  |
+| --------------- | -------------------------------------------------------------------------------------- | --------------------------------------- |
+| Web (SPA)       | GCS + Cloud CDN, Cloud Armor (WAF + DDoS), global HTTPS LB                             |                                         |
+| API             | GKE Standard regional cluster, HPA + node autoscaling, 10–40 pods                      | 2 vCPU / 4 GB per pod                   |
+| Database        | **AlloyDB for PostgreSQL** (or Cloud SQL Enterprise Plus), 1 primary + 2 read pool nodes | 16 vCPU primary, 8 vCPU readers         |
+| Cache           | Memorystore for Redis Cluster                                                          | 30–60 GB                                |
+| Async jobs      | Pub/Sub + Cloud Run workers (or GKE worker deployment)                                 |                                         |
+| Object storage  | GCS Multi-Region + CDN + Autoclass                                                     | Multi-TB                                |
+| Observability   | Cloud Ops suite, Managed Service for Prometheus                                        |                                         |
+| Network         | VPC with Private Service Connect to AlloyDB, Cloud NAT pair                            |                                         |
+
+**Estimated cost:** **~$6,000–9,500/mo**
+
+---
+
+## 4. Microsoft Azure
+
+### 4.1 Small (Azure)
+
+| Component       | Service                                                      | Sizing                          |
+| --------------- | ------------------------------------------------------------ | ------------------------------- |
+| Web (SPA)       | Azure Static Web Apps (or Blob Storage + Azure Front Door)   | Standard                        |
+| API             | Azure Container Apps                                         | 0.5 vCPU / 1 GB, 1 replica min  |
+| Database        | Azure Database for PostgreSQL Flexible Server, Burstable     | B2s, 64 GB                      |
+| Object storage  | Blob Storage (Hot)                                           | 50 GB                           |
+| Secrets / logs  | Key Vault, Log Analytics                                     |                                 |
+| DNS / TLS       | Azure DNS + managed certs                                    |                                 |
+
+**Estimated cost:** **~$140–200/mo**
+
+### 4.2 Medium (Azure)
+
+| Component       | Service                                                              | Sizing                                  |
+| --------------- | -------------------------------------------------------------------- | --------------------------------------- |
+| Web (SPA)       | Static Web Apps + Front Door Standard (WAF)                          |                                         |
+| API             | Container Apps with autoscaling 2–10 replicas                        | 1 vCPU / 2 GB                           |
+| Database        | PostgreSQL Flexible Server **Zone-Redundant HA**, 1 read replica     | General Purpose D2ds_v5, 256 GB         |
+| Cache           | Azure Cache for Redis Standard                                       | C1                                      |
+| Object storage  | Blob + lifecycle to Cool                                             | 500 GB                                  |
+| Observability   | Application Insights, Log Analytics                                  |                                         |
+
+**Estimated cost:** **~$1,000–1,400/mo**
+
+### 4.3 Large (Azure)
+
+| Component       | Service                                                                              | Sizing                                  |
+| --------------- | ------------------------------------------------------------------------------------ | --------------------------------------- |
+| Web (SPA)       | Static Web Apps + Front Door Premium (WAF + DDoS Standard)                           |                                         |
+| API             | AKS (or Container Apps Environment), HPA + cluster autoscaler, 10–40 pods            | 2 vCPU / 4 GB per pod                   |
+| Database        | PostgreSQL Flexible Server **Business Critical** or Cosmos DB for PostgreSQL cluster | 8–16 vCPU primary + 2 read replicas     |
+| Cache           | Azure Cache for Redis Enterprise                                                     | E10                                     |
+| Async jobs      | Service Bus + worker container app                                                   |                                         |
+| Object storage  | Blob Premium + Azure CDN                                                             | Multi-TB                                |
+| Observability   | Azure Monitor, App Insights, Managed Grafana                                         |                                         |
+| Network         | Hub-spoke VNet, Private Endpoints for DB/Redis/Blob, NAT GW pair                     |                                         |
+
+**Estimated cost:** **~$7,000–10,500/mo**
+
+---
+
+## 5. Cross-provider cost summary
+
+| Tier   | AWS               | GCP               | Azure              |
+| ------ | ----------------- | ----------------- | ------------------ |
+| Small  | $130–180          | $110–160          | $140–200           |
+| Medium | $900–1,300        | $800–1,200        | $1,000–1,400       |
+| Large  | $6,500–10,000     | $6,000–9,500      | $7,000–10,500      |
+
+**Notes:**
+
+- All prices are list-price on-demand. Apply 30–55% off for 1–3 year reservations / Savings Plans / CUDs.
+- Egress is the biggest unpredictable line item; budget separately based on expected media delivery.
+- OpenRouter / LLM spend is fully variable and excluded.
+
+---
+
+## 6. Scaling to 100,000 concurrent users
+
+"Concurrent users" here means **100k simultaneous active sessions** with typical Lextures behavior: reading course content, taking quizzes (with IRT scoring), submitting assignments. Empirically this maps to roughly:
+
+- **~20,000–35,000 API requests per second** at peak (assuming ~0.25 RPS per user, mix of cached SPA navigation and dynamic API calls).
+- **~3,000–5,000 PostgreSQL transactions per second**, read-heavy (~85% reads).
+- **~50–150 Gbps of egress** if assets are not aggressively cached at the edge.
+
+### 6.1 Required architectural changes
+
+The "Large" tier above is sized for ~20k concurrent. To reach 100k concurrent comfortably:
+
+1. **Edge & static delivery**
+   - All SPA assets must be served from a global CDN (CloudFront / Cloud CDN / Front Door) with long TTLs and immutable hashed asset filenames (already produced by Vite).
+   - Enable HTTP/3, Brotli, and stale-while-revalidate.
+   - Cache LTI tool launches and public catalog endpoints at the edge with short TTLs where safe.
+
+2. **API layer**
+   - Run **80–200 API pods** (2 vCPU / 4 GB) across at least 3 AZ/zones.
+   - Use HPA based on **RPS or p95 latency**, not just CPU.
+   - Move the API to **Kubernetes** (EKS / GKE / AKS) for finer-grained scheduling, PodDisruptionBudgets, and topology spread; Cloud Run / Container Apps work but cold-start and per-instance concurrency limits become harder to tune at this scale.
+   - Add a **regional API gateway / WAF** with rate limiting per JWT subject and per IP.
+
+3. **Database**
+   - The single-writer Postgres becomes the hardest bottleneck. Options:
+     - **AWS**: Aurora PostgreSQL with **6–15 read replicas** (or **Aurora Limitless** for write sharding), writer on `db.r7g.8xlarge`+.
+     - **GCP**: **AlloyDB** with a read pool of 4–8 nodes, columnar engine on for analytics.
+     - **Azure**: **Cosmos DB for PostgreSQL** (Citus) with **distributed tables** for high-volume tables (`quiz_responses`, `attendance_records`, `grade_entries`), or PostgreSQL Flexible Server Business Critical + read replicas if write volume permits.
+   - Application changes required:
+     - **Read/write splitting** in the Go API (`server/internal/db`): route safe SELECTs to a replica pool via a separate `*pgxpool.Pool`.
+     - **Connection pooling** via **PgBouncer** (transaction mode) or **RDS Proxy / AlloyDB connection pooling**; otherwise 100+ pods × pool size will exhaust Postgres `max_connections`.
+     - Add **partitioning** on the largest time-series tables (responses, events, audit logs) by month.
+
+4. **Cache & sessions**
+   - Promote Redis to a **clustered, multi-shard deployment** (≥ 6 shards × 2 replicas, 100+ GB RAM total).
+   - Cache:
+     - JWT public keys / introspection results.
+     - Course structure trees, gradebook headers, standards taxonomies.
+     - IRT item parameters (read-mostly, frequently joined).
+   - Add a per-request **cache-aside** layer for hot quiz items.
+
+5. **Asynchronous work**
+   - Move heavy operations off the request path onto a queue (SQS / Pub/Sub / Service Bus):
+     - AI-assisted quiz generation and misconception detection (OpenRouter calls).
+     - Standards rollups, gradebook recalculation, report card generation, SCIM sync.
+     - Email / push notification fan-out.
+   - Run a dedicated worker deployment with its own HPA.
+
+6. **Object storage & media**
+   - Serve all user-uploaded content through the CDN with signed URLs.
+   - Enable multipart uploads directly from the browser to object storage (presigned PUTs) instead of streaming through the API.
+
+7. **Observability & SRE**
+   - SLOs: API p95 < 300 ms, availability ≥ 99.9%.
+   - **Distributed tracing** (OpenTelemetry → X-Ray / Cloud Trace / App Insights) is no longer optional.
+   - Synthetic probes per region, real-user monitoring on the SPA.
+   - **Load testing** with k6 / Locust at 1.5× peak before each major release.
+   - Incident runbooks (`docs/runbooks/`) extended for: replica lag, Redis failover, hot-shard mitigation, edge cache poisoning.
+
+8. **Multi-region (optional, > 100k or strict RPO/RTO)**
+   - Active/passive: async DB replication + DNS failover (Route 53 / Cloud DNS / Traffic Manager).
+   - Active/active is only justified for global latency requirements — it forces conflict resolution work on writable tables and significantly raises cost.
+
+### 6.2 Indicative cost at 100k concurrent
+
+| Provider | Compute (API + workers) | Database                  | Cache / queue | CDN + egress | **Total / mo**     |
+| -------- | ----------------------- | ------------------------- | ------------- | ------------ | ------------------ |
+| AWS      | ~$18k (EKS, 150 pods)   | ~$22k (Aurora + replicas) | ~$4k          | ~$15k        | **~$60k–80k**      |
+| GCP      | ~$16k (GKE, 150 pods)   | ~$20k (AlloyDB pool)      | ~$3.5k        | ~$13k        | **~$55k–75k**      |
+| Azure    | ~$19k (AKS, 150 pods)   | ~$24k (Cosmos PG / BC)    | ~$4.5k        | ~$15k        | **~$65k–85k**      |
+
+With 3-year reserved capacity and committed-use discounts, expect **30–45% reduction**. Egress is the most volatile component — aggressive CDN caching can cut it by half or more.
+
+### 6.3 Application-side prerequisites (independent of cloud)
+
+These are the changes to the codebase that must precede a 100k-user rollout, regardless of provider:
+
+- Read/write Postgres pool split in `server/internal/db`.
+- PgBouncer (transaction pooling) in front of every Postgres endpoint.
+- Time-based partitioning on high-volume tables; verify all queries use the partition key.
+- Redis-backed caching layer with explicit invalidation hooks on writes.
+- Background job runner with idempotent handlers (e.g. for OpenRouter retries).
+- Per-tenant rate limits and quotas, surfaced in the API and gateway.
+- Structured logs with tenant + request IDs; tracing spans on every external call (DB, Redis, OpenRouter, object storage).
+- Load-test harness checked into `e2e/` or `scripts/` that can hit a staging environment at ≥ 50k virtual users.
+
+---
+
+## 7. Choosing between providers
+
+| Criterion                          | AWS                            | GCP                              | Azure                                       |
+| ---------------------------------- | ------------------------------ | -------------------------------- | ------------------------------------------- |
+| Best managed Postgres for scale    | Aurora / Aurora Limitless      | **AlloyDB** (strongest read-pool ergonomics) | Cosmos DB for PostgreSQL (Citus sharding)   |
+| Easiest small-tier path            | ECS Fargate + RDS              | **Cloud Run + Cloud SQL**        | Container Apps + PG Flexible Server         |
+| Education-sector procurement       | Strong (GovCloud, FedRAMP)     | Good (Workspace tie-in)          | **Strongest** (EDU agreements, EntraID/SSO) |
+| Identity tie-in for K-12 districts | Cognito / IAM Identity Center  | Identity Platform                | **Entra ID / SCIM**, often already in use   |
+| CDN + edge                         | CloudFront + Lambda@Edge       | Cloud CDN + Cloud Armor          | Front Door Premium                          |
+| Typical lowest list price          | —                              | **Slightly cheapest** at scale   | —                                           |
+
+**Recommendation:**
+
+- Pilot / small district → **GCP (Cloud Run + Cloud SQL)** for the lowest operational overhead, or **AWS (ECS Fargate + RDS)** if the customer is already on AWS.
+- Mid-market SaaS → **AWS** for breadth of managed services and education-vertical familiarity.
+- K-12 / higher-ed already standardized on Microsoft 365 → **Azure**, primarily for Entra ID / SCIM alignment.
+- Hyper-scale (> 50k concurrent) → **GCP AlloyDB** or **AWS Aurora** are the two strongest data-tier options; pick based on existing platform expertise.
+
+---
+
+## 8. Kubernetes-native deployments
+
+This section describes what Lextures looks like if you commit to **Kubernetes as the primary runtime** on each provider — instead of the serverless-leaning options (Cloud Run, Container Apps, ECS Fargate) used in §2–4. Kubernetes is the right choice when you want a single deployment model across providers, you already operate clusters, or you expect to grow into the Large / 100k tier where K8s pays off.
+
+### 8.1 What stays the same regardless of provider
+
+- **Workloads**
+  - `api` Deployment (Go), 2 vCPU / 4 GB requests, HPA on RPS or p95 latency.
+  - `worker` Deployment for async jobs (AI generation, gradebook rollups, notifications).
+  - `web` is **not** in-cluster — the SPA ships to object storage + CDN. Running nginx pods is wasteful at scale.
+  - `migrate` Job that runs `server/migrations` on deploy; gated by a Helm/Argo hook.
+- **Cluster add-ons (same on every provider)**
+  - **Ingress**: NGINX Ingress or the provider's gateway controller.
+  - **TLS**: cert-manager + Let's Encrypt (or provider-managed certs).
+  - **Autoscaling**: HPA (workload) + Cluster Autoscaler / Karpenter-equivalent (nodes) + KEDA for queue-driven worker scaling.
+  - **Observability**: OpenTelemetry Collector → provider backend; Prometheus + Grafana (managed where available); Loki or provider logs.
+  - **Policy / supply chain**: OPA Gatekeeper or Kyverno, image signing (cosign), Trivy scanning in CI.
+  - **Secrets**: External Secrets Operator pulling from the provider's secret manager.
+  - **GitOps**: Argo CD or Flux, one app per environment.
+- **What stays outside the cluster**
+  - **PostgreSQL** — always use the managed service (RDS / Cloud SQL / AlloyDB / Azure PG). Running Postgres in-cluster is not recommended for Lextures' workload.
+  - **Redis** — managed (ElastiCache / Memorystore / Azure Cache) unless cost-constrained at the small tier.
+  - **Object storage** and **CDN** — managed.
+
+### 8.2 AWS — EKS
+
+| Concern              | Choice                                                                                       |
+| -------------------- | -------------------------------------------------------------------------------------------- |
+| Cluster              | **EKS** (control plane $73/mo) in a private VPC, 3 AZs                                       |
+| Nodes                | **Karpenter** with mixed Graviton (`m7g`, `c7g`) on-demand + spot for workers                |
+| Ingress              | AWS Load Balancer Controller → ALB (or NLB for gRPC)                                         |
+| DB / cache           | RDS / Aurora PostgreSQL + ElastiCache Redis, accessed via VPC endpoints                      |
+| Identity for pods    | **IRSA** (IAM Roles for Service Accounts) — no static creds                                  |
+| Storage              | EBS CSI (gp3) for any stateful add-ons; EFS CSI only if shared RW needed                     |
+| Secrets              | AWS Secrets Manager via External Secrets Operator                                            |
+| Observability        | CloudWatch Container Insights, AMP (Prometheus), AMG (Grafana), ADOT collector               |
+| Image registry       | ECR with image scanning + lifecycle policies                                                 |
+| Network policy       | VPC CNI + Network Policies (or Cilium for L7)                                                |
+
+**Indicative monthly costs**
+
+| Tier   | EKS + nodes                      | RDS / Aurora     | Redis / LB / misc | **Total**        |
+| ------ | -------------------------------- | ---------------- | ----------------- | ---------------- |
+| Small  | $73 CP + ~$120 (2× t4g.medium)   | ~$80             | ~$60              | **~$330–400**    |
+| Medium | $73 + ~$700 (6–10 nodes)         | ~$500            | ~$250             | **~$1.5k–1.9k**  |
+| Large  | $73 + ~$5k (Karpenter pool)      | ~$3.5k           | ~$1.5k            | **~$10k–13k**    |
+
+Small-tier EKS is meaningfully more expensive than ECS Fargate ($330+ vs ~$150) because of the control-plane fee and minimum node count. EKS only "wins" from medium upward.
+
+### 8.3 GCP — GKE
+
+| Concern              | Choice                                                                                       |
+| -------------------- | -------------------------------------------------------------------------------------------- |
+| Cluster              | **GKE Autopilot** for small/medium (no node mgmt), **GKE Standard regional** for large       |
+| Nodes (Standard)     | `e2`/`n2d` for general, `t2d` (AMD) or `c3` for API; node auto-provisioning on               |
+| Ingress              | GKE Gateway API → Global External HTTPS LB, Cloud Armor (WAF)                                |
+| DB / cache           | Cloud SQL or **AlloyDB** + Memorystore Redis, via Private Service Connect                    |
+| Identity for pods    | **Workload Identity** federating KSA → GSA                                                   |
+| Storage              | PD-Balanced / PD-SSD CSI; Filestore if shared RW needed                                      |
+| Secrets              | Secret Manager via External Secrets Operator (or GCP CSI Secret Store driver)                |
+| Observability        | **Managed Service for Prometheus** + Cloud Monitoring + Cloud Trace; GMP is essentially free for moderate volume |
+| Image registry       | Artifact Registry with vulnerability scanning                                                |
+| Network policy       | Dataplane V2 (Cilium-based) — enable on cluster creation                                     |
+
+**Indicative monthly costs**
+
+| Tier   | GKE + nodes                              | DB (Cloud SQL / AlloyDB) | Redis / LB / misc | **Total**        |
+| ------ | ---------------------------------------- | ------------------------ | ----------------- | ---------------- |
+| Small  | ~$75 (Autopilot, low usage)              | ~$70                     | ~$50              | **~$220–280**    |
+| Medium | ~$600 (Autopilot or 3 e2-standard-4)     | ~$450                    | ~$220             | **~$1.3k–1.7k**  |
+| Large  | ~$4.5k (Standard regional + autoprov.)   | ~$3.2k (AlloyDB)         | ~$1.3k            | **~$9k–12k**     |
+
+GKE Autopilot is usually the **cheapest Kubernetes path** at small/medium tier because there is no control-plane fee for the first zonal cluster ($0.10/hr per cluster after the free one) and you only pay for pod resources requested. AlloyDB on GKE Standard is the strongest large-tier story across all three providers.
+
+### 8.4 Azure — AKS
+
+| Concern              | Choice                                                                                       |
+| -------------------- | -------------------------------------------------------------------------------------------- |
+| Cluster              | **AKS** (free tier control plane for non-prod; **Standard tier $73/mo** for prod SLA)        |
+| Nodes                | `Dasv5` / `Dadsv5` (AMD) general; spot node pool for workers                                 |
+| Ingress              | **Application Gateway for Containers** (AGC) or AKS-managed NGINX; Front Door in front       |
+| DB / cache           | PostgreSQL Flexible Server (or Cosmos DB for PostgreSQL) + Azure Cache for Redis, Private Endpoints |
+| Identity for pods    | **Workload Identity** (federated) → Entra ID; replaces AAD Pod Identity                      |
+| Storage              | Azure Disk CSI (Premium SSD v2); Azure Files for shared RW                                   |
+| Secrets              | Key Vault via Secrets Store CSI driver or External Secrets Operator                          |
+| Observability        | **Azure Monitor managed Prometheus** + Container Insights + Managed Grafana                  |
+| Image registry       | Azure Container Registry (Premium for geo-replication) with Defender for Containers          |
+| Network policy       | Azure CNI Overlay + Cilium (preview/GA varies by region) for L7 policy                       |
+
+**Indicative monthly costs**
+
+| Tier   | AKS + nodes                            | PostgreSQL FS      | Redis / LB / misc | **Total**         |
+| ------ | -------------------------------------- | ------------------ | ----------------- | ----------------- |
+| Small  | ~$130 (free CP + 2 D2s_v5)             | ~$80               | ~$70              | **~$320–400**     |
+| Medium | $73 + ~$700                            | ~$550              | ~$250             | **~$1.6k–2.0k**   |
+| Large  | $73 + ~$5.2k                           | ~$4k (BC or Cosmos)| ~$1.6k            | **~$11k–14k**     |
+
+Azure's AKS pricing is broadly similar to EKS. Choose Azure when you specifically want Entra ID + SCIM tie-in for K-12 districts already on Microsoft 365.
+
+### 8.5 100k concurrent on Kubernetes — what changes vs §6
+
+Most of §6's recommendations are inherently Kubernetes-shaped. The K8s-specific adjustments are:
+
+1. **Cluster topology**
+   - Run a **regional** cluster (3 zones). 3+ node pools: `api` (compute-optimized), `worker` (general, spot-friendly), `system` (ingress, observability, no spot).
+   - Enable **PodTopologySpreadConstraints** across zones for `api` and `worker` Deployments.
+   - PDBs with `maxUnavailable: 10%` on `api`.
+2. **Autoscaling**
+   - HPA on **custom metrics** — RPS via Prometheus Adapter, or p95 latency. CPU alone underscales Go services.
+   - **KEDA** for `worker`, scaling on SQS / Pub/Sub / Service Bus queue depth.
+   - Cluster autoscaler / Karpenter / GKE node auto-provisioning sized to add nodes in < 60s — use pre-warmed capacity headroom (e.g. 10–20% overprovision via low-priority pause pods).
+3. **Connection management**
+   - Run **PgBouncer as a Deployment** (transaction pooling, ~10 replicas, behind a Service) between `api`/`worker` pods and the managed Postgres endpoint. Without this, 150+ pods × pool size will exhaust DB connections.
+   - Alternatively use the provider's pooler: RDS Proxy (AWS), AlloyDB built-in pooling (GCP), PgBouncer integrated in Azure PG Flexible Server.
+4. **Traffic management**
+   - Gateway API > Ingress for north-south at this scale.
+   - Add a **service mesh** (Istio Ambient, Linkerd, or Cilium Service Mesh) only if you need mTLS between services or per-tenant traffic policy — otherwise it is overhead.
+5. **Resource governance**
+   - Set **requests = limits** for `api` to get Guaranteed QoS and predictable latency.
+   - Namespace-level ResourceQuotas + LimitRanges to prevent noisy-neighbor pods from starving the cluster.
+6. **Rollouts**
+   - **Argo Rollouts** (or Flagger) for progressive delivery — canary on `api`, blue/green on schema-coupled releases that need to coordinate with `migrate` Jobs.
+7. **Disaster recovery**
+   - **Velero** for cluster state backup (manifests, PVs).
+   - Managed DB handles its own PITR; rehearse restore quarterly.
+
+### 8.6 Kubernetes vs serverless — when to pick which
+
+| Situation                                                                 | Recommendation                                                  |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Single small/medium tenant, no platform team                              | **Serverless** (Cloud Run / Container Apps / Fargate). Cheaper, less ops. |
+| Multi-tenant SaaS, multiple environments, need per-tenant isolation knobs | **Kubernetes**. Namespaces + network policy + quotas pay off.   |
+| Already running other workloads on K8s                                    | **Kubernetes**. Single platform.                                |
+| Strict cold-start / latency floor                                         | **Kubernetes** (always-on pods).                                |
+| Need portability across AWS / GCP / Azure                                 | **Kubernetes** with the per-provider mappings above.            |
+| Bursty, idle most of the day                                              | **Serverless** — Lextures scales to near-zero between class periods. |
+| Targeting 100k concurrent                                                 | **Kubernetes** — at this scale K8s controls and observability tooling are unmatched. |
+
+---
+
+## 9. References
+
+- Architecture overview: [docs/ARCH.md](ARCH.md)
+- Infrastructure-as-code skeletons: [iac/modules/aws](../iac/modules/aws), [iac/modules/gcp](../iac/modules/gcp), [iac/modules/azure](../iac/modules/azure)
+- Production Terraform composition: [iac/production](../iac/production)
+- Self-hosting guide: [www/src/docs/self-hosting.md](../www/src/docs/self-hosting.md)
+- Runbooks: [docs/runbooks](runbooks)
+- Kubernetes-native deployments: see §8 above

--- a/e2e/tests/item-analysis.spec.ts
+++ b/e2e/tests/item-analysis.spec.ts
@@ -46,6 +46,9 @@ test.describe('Item Analysis — UI', () => {
       seededCourse.moduleId,
     )
     await page.goto(`/courses/${seededCourse.courseCode}/modules/quiz/${itemId}`)
+    await page.getByRole('button', { name: 'More' }).click()
+    await page.getByRole('menuitem', { name: 'Analytics' }).click()
+    await expect(page.getByRole('dialog', { name: /quiz analytics/i })).toBeVisible({ timeout: 10000 })
     await expect(page.getByRole('heading', { name: 'Item Analysis', exact: true })).toBeVisible({ timeout: 10000 })
   })
 
@@ -59,7 +62,10 @@ test.describe('Item Analysis — UI', () => {
       seededCourse.moduleId,
     )
     await page.goto(`/courses/${seededCourse.courseCode}/modules/quiz/${itemId}`)
-    // Wait for the panel to load
+    await page.getByRole('button', { name: 'More' }).click()
+    await page.getByRole('menuitem', { name: 'Analytics' }).click()
+    await expect(page.getByRole('dialog', { name: /quiz analytics/i })).toBeVisible({ timeout: 10000 })
+    // Wait for the panel to load inside the analytics modal
     await expect(page.getByRole('heading', { name: 'Item Analysis', exact: true })).toBeVisible({ timeout: 10000 })
     // Expect the insufficient-data message (no responses yet)
     await expect(

--- a/e2e/tests/push-notifications.spec.ts
+++ b/e2e/tests/push-notifications.spec.ts
@@ -198,8 +198,9 @@ test.describe('Push Notifications UI', () => {
 
     const bell = page.getByRole('button', { name: /notifications/i })
     await bell.click()
+    await expect(page.getByRole('dialog', { name: /notifications/i })).toBeVisible()
 
-    // Alerts tab should be visible
-    await expect(page.getByRole('button', { name: /alerts/i })).toBeVisible()
+    // Alerts filter tab should be visible
+    await expect(page.getByRole('tab', { name: /alerts/i })).toBeVisible()
   })
 })

--- a/server/internal/httpserver/canvas_grade_import.go
+++ b/server/internal/httpserver/canvas_grade_import.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/lextures/lextures/server/internal/models/coursemodulequiz"
 	"github.com/lextures/lextures/server/internal/repos/user"
 )
 
@@ -543,6 +544,7 @@ func canvasImportAllCanvasGrades(
 	courseID uuid.UUID,
 	canvasAssignToItem map[int64]uuid.UUID,
 	canvasQuizToItem map[int64]uuid.UUID,
+	canvasQuizToQuestions map[int64][]coursemodulequiz.QuizQuestion,
 	canvasUserToLocal map[int64]uuid.UUID,
 ) error {
 	// #region agent log
@@ -562,6 +564,9 @@ func canvasImportAllCanvasGrades(
 		return err
 	}
 	if err := canvasImportQuizGrades(ctx, tx, client, canvasBase, accessToken, canvasCourseID, courseID, canvasQuizToItem, canvasUserToLocal); err != nil {
+		return err
+	}
+	if err := canvasImportQuizAttempts(ctx, tx, client, canvasBase, accessToken, canvasCourseID, courseID, canvasQuizToItem, canvasQuizToQuestions, canvasUserToLocal); err != nil {
 		return err
 	}
 	return nil

--- a/server/internal/httpserver/canvas_import_ws.go
+++ b/server/internal/httpserver/canvas_import_ws.go
@@ -133,6 +133,10 @@ func (i canvasImportInclude) withDefaults() canvasImportInclude {
 	if !i.Modules && !i.Assignments && !i.Quizzes && !i.Enrollments && !i.Grades && !i.Settings && !i.Files {
 		return canvasImportInclude{Modules: true, Assignments: true, Quizzes: true, Enrollments: true, Grades: true, Settings: true, Files: true}
 	}
+	// Legacy clients send every category except files; treat that as "import everything".
+	if i.Modules && i.Assignments && i.Quizzes && i.Enrollments && i.Grades && i.Settings && !i.Files {
+		i.Files = true
+	}
 	return i
 }
 
@@ -267,6 +271,7 @@ func (d Deps) runCanvasImport(
 	_ = tx.QueryRow(ctx, `SELECT COALESCE(MAX(sort_order), -1) + 1 FROM course.course_structure_items WHERE course_id = $1`, courseID).Scan(&nextSort)
 	canvasAssignToItem := make(map[int64]uuid.UUID)
 	canvasQuizToItem := make(map[int64]uuid.UUID)
+	canvasQuizToQuestions := make(map[int64][]coursemodulequiz.QuizQuestion)
 	if include.Modules {
 		if !progress("Importing modules and items...") {
 			return context.Canceled
@@ -354,6 +359,7 @@ func (d Deps) runCanvasImport(
 							return fmt.Errorf("Failed to load quiz questions from Canvas (quiz id %d): %w", cid, qe)
 						}
 						questions = qq
+						canvasQuizToQuestions[cid] = questions
 					}
 					qJSON, mj := json.Marshal(questions)
 					if mj != nil {
@@ -430,6 +436,9 @@ func (d Deps) runCanvasImport(
 		if !progress("Importing assignment and quiz grades from Canvas...") {
 			return context.Canceled
 		}
+		if !progress("Importing quiz attempt responses from Canvas...") {
+			return context.Canceled
+		}
 		// #region agent log
 		canvasAgentDebugLog("canvas-import", "H2", "canvas_import_ws.go:runCanvasImport", "invoking aggregated grade import (post-module maps)", map[string]any{
 			"includeModules":     include.Modules,
@@ -440,7 +449,7 @@ func (d Deps) runCanvasImport(
 			"userMapLen":         len(canvasUserToLocal),
 		})
 		// #endregion agent log
-		if err := canvasImportAllCanvasGrades(ctx, tx, client, canvasBase, accessToken, canvasCourseID, courseID, canvasAssignToItem, canvasQuizToItem, canvasUserToLocal); err != nil {
+		if err := canvasImportAllCanvasGrades(ctx, tx, client, canvasBase, accessToken, canvasCourseID, courseID, canvasAssignToItem, canvasQuizToItem, canvasQuizToQuestions, canvasUserToLocal); err != nil {
 			return err
 		}
 	}

--- a/server/internal/httpserver/canvas_import_ws_test.go
+++ b/server/internal/httpserver/canvas_import_ws_test.go
@@ -36,6 +36,14 @@ func TestCanvasImportInclude_WithDefaults_PartialUnchanged(t *testing.T) {
 	}
 }
 
+func TestCanvasImportInclude_WithDefaults_LegacyAllExceptFiles(t *testing.T) {
+	legacy := canvasImportInclude{Modules: true, Assignments: true, Quizzes: true, Enrollments: true, Grades: true, Settings: true}
+	got := legacy.withDefaults()
+	if !got.Files {
+		t.Fatalf("legacy all-true include should default Files=true, got %+v", got)
+	}
+}
+
 func TestMarkdownFromHTML_ConvertsBasicFormatting(t *testing.T) {
 	md := markdownFromHTML("<h2>Title</h2><p>Hello <strong>world</strong> and <a href=\"https://example.com\">link</a>.</p>")
 	if !strings.Contains(md, "## Title") {

--- a/server/internal/httpserver/canvas_quiz_import_test.go
+++ b/server/internal/httpserver/canvas_quiz_import_test.go
@@ -3,6 +3,8 @@ package httpserver
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/lextures/lextures/server/internal/models/coursemodulequiz"
 )
 
 func TestCanvasQuestionToQuizQuestion_MultipleChoice(t *testing.T) {
@@ -76,5 +78,90 @@ func TestCanvasMatchingPairsJSON(t *testing.T) {
 	}
 	if len(wrap.Pairs) != 1 || wrap.Pairs[0].LeftID != "l0" || wrap.Pairs[0].RightID != "r0" {
 		t.Fatalf("%+v", wrap)
+	}
+}
+
+func TestCanvasQuestionIDFromLocalID(t *testing.T) {
+	id, ok := canvasQuestionIDFromLocalID("canvas-42")
+	if !ok || id != 42 {
+		t.Fatalf("got %d ok=%v", id, ok)
+	}
+	if _, ok := canvasQuestionIDFromLocalID("local-1"); ok {
+		t.Fatal("expected false for non-canvas id")
+	}
+}
+
+func TestCanvasParseSubmissionData(t *testing.T) {
+	raw := []any{
+		map[string]any{
+			"question_id": float64(10),
+			"answer":      float64(55),
+			"points":      float64(1),
+			"correct":     "true",
+		},
+	}
+	answers := canvasParseSubmissionData(raw)
+	if len(answers) != 1 || answers[0].CanvasQuestionID != 10 {
+		t.Fatalf("unexpected: %+v", answers)
+	}
+	if answers[0].Points == nil || *answers[0].Points != 1 {
+		t.Fatalf("points: %+v", answers[0].Points)
+	}
+}
+
+func TestCanvasUnwrapQuizSubmission(t *testing.T) {
+	wrapped := map[string]any{
+		"quiz_submissions": []any{
+			map[string]any{
+				"id": float64(99),
+				"submission_data": []any{
+					map[string]any{
+						"question_id": float64(5),
+						"points":      float64(2),
+						"correct":     true,
+					},
+				},
+			},
+		},
+	}
+	unwrapped := canvasUnwrapQuizSubmission(wrapped)
+	if int64At(unwrapped, "id") != 99 {
+		t.Fatalf("expected id 99, got %+v", unwrapped)
+	}
+	answers := canvasParseSubmissionData(unwrapped["submission_data"])
+	if len(answers) != 1 || answers[0].CanvasQuestionID != 5 || answers[0].Points == nil || *answers[0].Points != 2 {
+		t.Fatalf("unexpected answers: %+v", answers)
+	}
+}
+
+func TestCanvasParseSubmissionDataMap(t *testing.T) {
+	raw := map[string]any{
+		"101": map[string]any{"score": float64(1), "correct": "true"},
+	}
+	answers := canvasParseSubmissionData(raw)
+	if len(answers) != 1 || answers[0].CanvasQuestionID != 101 {
+		t.Fatalf("unexpected: %+v", answers)
+	}
+}
+
+func TestCanvasGradeImportedMultipleChoice(t *testing.T) {
+	correct := uint(1)
+	q := coursemodulequiz.QuizQuestion{
+		ID:                 "canvas-7",
+		QuestionType:       "multiple_choice",
+		CorrectChoiceIndex: &correct,
+		Points:             2,
+	}
+	choiceMaps := map[int64]int{100: 0, 200: 1}
+	answer := canvasQuizSubmissionAnswer{
+		CanvasQuestionID: 7,
+		Answer:           float64(200),
+	}
+	_, isCorrect, pts, max := canvasGradeImportedQuestion(q, answer, choiceMaps, nil)
+	if isCorrect == nil || !*isCorrect {
+		t.Fatalf("expected correct, got %v", isCorrect)
+	}
+	if pts != 2 || max != 2 {
+		t.Fatalf("points earned=%v max=%v", pts, max)
 	}
 }

--- a/server/internal/httpserver/canvas_quiz_submissions_import.go
+++ b/server/internal/httpserver/canvas_quiz_submissions_import.go
@@ -1,0 +1,796 @@
+package httpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/lextures/lextures/server/internal/models/coursemodulequiz"
+)
+
+type canvasQuizSubmissionAnswer struct {
+	CanvasQuestionID int64
+	Answer           any
+	Points           *float64
+	Correct          *bool
+}
+
+func canvasQuizSubmissionImportable(m map[string]any) bool {
+	if m == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(strAt(m, "workflow_state", ""))) {
+	case "complete", "pending_review":
+		return true
+	default:
+		return false
+	}
+}
+
+func canvasQuestionIDFromLocalID(id string) (int64, bool) {
+	const prefix = "canvas-"
+	if !strings.HasPrefix(id, prefix) {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(strings.TrimPrefix(id, prefix), 10, 64)
+	return n, err == nil && n > 0
+}
+
+func canvasQuestionIndexByCanvasID(questions []coursemodulequiz.QuizQuestion) map[int64]int {
+	out := make(map[int64]int, len(questions))
+	for i, q := range questions {
+		if cid, ok := canvasQuestionIDFromLocalID(q.ID); ok {
+			out[cid] = i
+		}
+	}
+	return out
+}
+
+func canvasUnwrapQuizSubmission(raw map[string]any) map[string]any {
+	if raw == nil {
+		return nil
+	}
+	if _, ok := raw["submission_data"]; ok {
+		return raw
+	}
+	if _, ok := raw["workflow_state"]; ok {
+		return raw
+	}
+	if subs, ok := raw["quiz_submissions"].([]any); ok && len(subs) > 0 {
+		if m, ok := subs[0].(map[string]any); ok {
+			return m
+		}
+	}
+	return raw
+}
+
+func canvasLoadQuizAnswerMetadata(
+	ctx context.Context,
+	client *http.Client,
+	canvasBase, accessToken string,
+	canvasCourseID, canvasQuizID int64,
+) (choiceMaps map[int64]map[int64]int, correctAnswerIDs map[int64]map[int64]struct{}, err error) {
+	path := fmt.Sprintf("courses/%d/quizzes/%d/questions", canvasCourseID, canvasQuizID)
+	rows, err := canvasGetArrayPaginated(ctx, client, canvasBase, accessToken, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	choiceMaps = make(map[int64]map[int64]int, len(rows))
+	correctAnswerIDs = make(map[int64]map[int64]struct{}, len(rows))
+	for _, row := range rows {
+		qid := int64At(row, "id")
+		if qid <= 0 {
+			continue
+		}
+		choiceByAnswerID := make(map[int64]int)
+		correctIDs := make(map[int64]struct{})
+		choiceIdx := 0
+		for _, a := range canvasAnswerMaps(row) {
+			aid := int64At(a, "id")
+			if aid <= 0 {
+				continue
+			}
+			choiceByAnswerID[aid] = choiceIdx
+			choiceIdx++
+			if canvasAnswerWeight(a) > 0 {
+				correctIDs[aid] = struct{}{}
+			}
+		}
+		if len(choiceByAnswerID) > 0 {
+			choiceMaps[qid] = choiceByAnswerID
+		}
+		if len(correctIDs) > 0 {
+			correctAnswerIDs[qid] = correctIDs
+		}
+	}
+	return choiceMaps, correctAnswerIDs, nil
+}
+
+func canvasLoadQuizAnswerChoiceMaps(
+	ctx context.Context,
+	client *http.Client,
+	canvasBase, accessToken string,
+	canvasCourseID, canvasQuizID int64,
+) (map[int64]map[int64]int, error) {
+	choiceMaps, _, err := canvasLoadQuizAnswerMetadata(ctx, client, canvasBase, accessToken, canvasCourseID, canvasQuizID)
+	return choiceMaps, err
+}
+
+func canvasGetQuizSubmissionDetail(
+	ctx context.Context,
+	client *http.Client,
+	canvasBase, accessToken string,
+	canvasCourseID, canvasQuizID, quizSubmissionID int64,
+) (map[string]any, error) {
+	path := fmt.Sprintf("courses/%d/quizzes/%d/submissions/%d", canvasCourseID, canvasQuizID, quizSubmissionID)
+	raw, err := canvasGetObject(ctx, client, canvasBase, accessToken, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return canvasUnwrapQuizSubmission(raw), nil
+}
+
+func canvasGetQuizSubmissionQuestions(
+	ctx context.Context,
+	client *http.Client,
+	canvasBase, accessToken string,
+	quizSubmissionID int64,
+) ([]map[string]any, error) {
+	path := fmt.Sprintf("quiz_submissions/%d/questions", quizSubmissionID)
+	v, err := canvasGetJSON(ctx, client, canvasBase, accessToken, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	switch t := v.(type) {
+	case map[string]any:
+		raw, ok := t["quiz_submission_questions"].([]any)
+		if !ok {
+			return nil, nil
+		}
+		out := make([]map[string]any, 0, len(raw))
+		for _, it := range raw {
+			if m, ok := it.(map[string]any); ok && m != nil {
+				out = append(out, m)
+			}
+		}
+		return out, nil
+	case []any:
+		out := make([]map[string]any, 0, len(t))
+		for _, it := range t {
+			if m, ok := it.(map[string]any); ok && m != nil {
+				out = append(out, m)
+			}
+		}
+		return out, nil
+	default:
+		return nil, nil
+	}
+}
+
+func canvasParseSubmissionData(raw any) []canvasQuizSubmissionAnswer {
+	switch t := raw.(type) {
+	case []any:
+		return canvasParseSubmissionDataSlice(t)
+	case map[string]any:
+		return canvasParseSubmissionDataMap(t)
+	case string:
+		if strings.TrimSpace(t) == "" {
+			return nil
+		}
+		var parsed any
+		if err := json.Unmarshal([]byte(t), &parsed); err != nil {
+			return nil
+		}
+		return canvasParseSubmissionData(parsed)
+	default:
+		return nil
+	}
+}
+
+func canvasParseSubmissionDataMap(items map[string]any) []canvasQuizSubmissionAnswer {
+	out := make([]canvasQuizSubmissionAnswer, 0, len(items))
+	for key, value := range items {
+		qid, err := strconv.ParseInt(strings.TrimSpace(key), 10, 64)
+		if err != nil || qid <= 0 {
+			continue
+		}
+		entry, ok := value.(map[string]any)
+		if !ok || entry == nil {
+			continue
+		}
+		entry = cloneStringKeyMap(entry)
+		if entry["question_id"] == nil {
+			entry["question_id"] = float64(qid)
+		}
+		out = append(out, canvasParseSubmissionDataEntry(entry)...)
+	}
+	return out
+}
+
+func cloneStringKeyMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func canvasParseSubmissionDataSlice(items []any) []canvasQuizSubmissionAnswer {
+	out := make([]canvasQuizSubmissionAnswer, 0, len(items))
+	for _, it := range items {
+		m, ok := it.(map[string]any)
+		if !ok || m == nil {
+			continue
+		}
+		out = append(out, canvasParseSubmissionDataEntry(m)...)
+	}
+	return out
+}
+
+func canvasParseSubmissionDataEntry(m map[string]any) []canvasQuizSubmissionAnswer {
+	qid := int64At(m, "question_id")
+	if qid <= 0 {
+		qid = int64At(m, "id")
+	}
+	if qid <= 0 {
+		return nil
+	}
+	var pts *float64
+	for _, key := range []string{"points", "score", "points_awarded"} {
+		if v, ok := coerceCanvasJSONNumber(m[key]); ok {
+			pts = &v
+			break
+		}
+	}
+	var correct *bool
+	switch c := m["correct"].(type) {
+	case bool:
+		correct = &c
+	case string:
+		s := strings.ToLower(strings.TrimSpace(c))
+		if s == "true" || s == "1" {
+			b := true
+			correct = &b
+		} else if s == "false" || s == "0" {
+			b := false
+			correct = &b
+		}
+	}
+	answer := m["answer"]
+	if answer == nil {
+		answer = m["answer_id"]
+	}
+	if answer == nil {
+		answer = m["answers"]
+	}
+	if answer == nil {
+		answer = m["text"]
+	}
+	return []canvasQuizSubmissionAnswer{{
+		CanvasQuestionID: qid,
+		Answer:           answer,
+		Points:           pts,
+		Correct:          correct,
+	}}
+}
+
+func canvasMergeSubmissionAnswers(detail, listItem map[string]any, questionRows []map[string]any) map[int64]canvasQuizSubmissionAnswer {
+	out := make(map[int64]canvasQuizSubmissionAnswer)
+	for _, src := range []map[string]any{detail, listItem} {
+		if src == nil {
+			continue
+		}
+		for _, a := range canvasParseSubmissionData(src["submission_data"]) {
+			out[a.CanvasQuestionID] = canvasMergeQuizSubmissionAnswer(out[a.CanvasQuestionID], a)
+		}
+	}
+	for _, row := range questionRows {
+		qid := int64At(row, "id")
+		if qid <= 0 {
+			continue
+		}
+		prev := out[qid]
+		if prev.Answer == nil {
+			prev.Answer = row["answer"]
+		}
+		if prev.Points == nil {
+			if v, ok := coerceCanvasJSONNumber(row["points"]); ok {
+				prev.Points = &v
+			}
+		}
+		prev.CanvasQuestionID = qid
+		out[qid] = prev
+	}
+	return out
+}
+
+func canvasMergeQuizSubmissionAnswer(existing, incoming canvasQuizSubmissionAnswer) canvasQuizSubmissionAnswer {
+	if existing.CanvasQuestionID == 0 {
+		existing = incoming
+	} else {
+		if incoming.Answer != nil {
+			existing.Answer = incoming.Answer
+		}
+		if incoming.Points != nil {
+			existing.Points = incoming.Points
+		}
+		if incoming.Correct != nil {
+			existing.Correct = incoming.Correct
+		}
+	}
+	return existing
+}
+
+func canvasQuizSubmissionScore(raw map[string]any) (score float64, hasScore bool) {
+	if raw == nil {
+		return 0, false
+	}
+	for _, key := range []string{"kept_score", "score", "score_before_regrade"} {
+		if v, ok := coerceCanvasJSONNumber(raw[key]); ok {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+func canvasQuizPointsPossible(questions []coursemodulequiz.QuizQuestion, quizPointsWorth *int) float64 {
+	var sum float64
+	for _, q := range questions {
+		if q.Points > 0 {
+			sum += float64(q.Points)
+		} else {
+			sum += 1
+		}
+	}
+	if sum > 0 {
+		return sum
+	}
+	if quizPointsWorth != nil && *quizPointsWorth > 0 {
+		return float64(*quizPointsWorth)
+	}
+	return 0
+}
+
+func canvasAnswerIDs(answer any) []int64 {
+	switch v := answer.(type) {
+	case float64:
+		return []int64{int64(v)}
+	case int64:
+		return []int64{v}
+	case string:
+		if n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64); err == nil {
+			return []int64{n}
+		}
+	case []any:
+		out := make([]int64, 0, len(v))
+		for _, item := range v {
+			out = append(out, canvasAnswerIDs(item)...)
+		}
+		return out
+	}
+	return nil
+}
+
+func canvasAnswerIDSet(answer any) map[int64]struct{} {
+	ids := canvasAnswerIDs(answer)
+	out := make(map[int64]struct{}, len(ids))
+	for _, id := range ids {
+		out[id] = struct{}{}
+	}
+	return out
+}
+
+func canvasResponseJSONForAnswer(q coursemodulequiz.QuizQuestion, answer any, choiceByAnswerID map[int64]int) json.RawMessage {
+	switch q.QuestionType {
+	case "multiple_choice", "true_false":
+		if q.MultipleAnswer {
+			if ids := canvasAnswerIDs(answer); len(ids) > 0 {
+				indices := make([]uint, 0, len(ids))
+				for _, id := range ids {
+					if idx, ok := canvasAnswerToChoiceIndex(float64(id), choiceByAnswerID); ok {
+						indices = append(indices, idx)
+					}
+				}
+				if len(indices) > 0 {
+					b, _ := json.Marshal(map[string]any{"selectedChoiceIndices": indices})
+					return b
+				}
+			}
+		}
+		if idx, ok := canvasAnswerToChoiceIndex(answer, choiceByAnswerID); ok {
+			b, _ := json.Marshal(map[string]any{"selectedChoiceIndex": idx})
+			return b
+		}
+		if idx, ok := canvasAnswerAsChoiceIndex(answer, len(q.Choices)); ok {
+			b, _ := json.Marshal(map[string]any{"selectedChoiceIndex": idx})
+			return b
+		}
+	case "short_answer", "essay":
+		if text := canvasAnswerAsString(answer); text != "" {
+			b, _ := json.Marshal(map[string]any{"textAnswer": text})
+			return b
+		}
+	case "fill_in_blank":
+		switch v := answer.(type) {
+		case map[string]any:
+			b, _ := json.Marshal(map[string]any{"blanks": v})
+			return b
+		case string:
+			if strings.TrimSpace(v) != "" {
+				b, _ := json.Marshal(map[string]any{"textAnswer": strings.TrimSpace(v)})
+				return b
+			}
+		default:
+			if text := canvasAnswerAsString(answer); text != "" {
+				b, _ := json.Marshal(map[string]any{"textAnswer": text})
+				return b
+			}
+		}
+	case "numeric":
+		if v, ok := coerceCanvasJSONNumber(answer); ok {
+			b, _ := json.Marshal(map[string]any{"numericValue": v})
+			return b
+		}
+	}
+	if answer != nil {
+		b, _ := json.Marshal(map[string]any{"canvasAnswer": answer})
+		return b
+	}
+	return json.RawMessage(`{}`)
+}
+
+func canvasAnswerAsChoiceIndex(answer any, choiceCount int) (uint, bool) {
+	if choiceCount <= 0 {
+		return 0, false
+	}
+	switch v := answer.(type) {
+	case float64:
+		idx := int(v)
+		if idx >= 0 && idx < choiceCount {
+			return uint(idx), true
+		}
+	case int64:
+		if v >= 0 && int(v) < choiceCount {
+			return uint(v), true
+		}
+	}
+	return 0, false
+}
+
+func canvasAnswerAsString(answer any) string {
+	switch v := answer.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	default:
+		return ""
+	}
+}
+
+func canvasAnswerToChoiceIndex(answer any, choiceByAnswerID map[int64]int) (uint, bool) {
+	switch v := answer.(type) {
+	case float64:
+		if idx, ok := choiceByAnswerID[int64(v)]; ok {
+			return uint(idx), true
+		}
+	case int64:
+		if idx, ok := choiceByAnswerID[v]; ok {
+			return uint(idx), true
+		}
+	case string:
+		if n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64); err == nil {
+			if idx, ok := choiceByAnswerID[n]; ok {
+				return uint(idx), true
+			}
+		}
+	}
+	return 0, false
+}
+
+func canvasGradeImportedQuestion(
+	q coursemodulequiz.QuizQuestion,
+	answer canvasQuizSubmissionAnswer,
+	choiceByAnswerID map[int64]int,
+	correctIDs map[int64]struct{},
+) (responseJSON json.RawMessage, isCorrect *bool, pointsAwarded, maxPoints float64) {
+	maxPoints = float64(q.Points)
+	if maxPoints <= 0 {
+		maxPoints = 1
+	}
+	responseJSON = canvasResponseJSONForAnswer(q, answer.Answer, choiceByAnswerID)
+
+	if answer.Points != nil {
+		pointsAwarded = *answer.Points
+		if pointsAwarded < 0 {
+			pointsAwarded = 0
+		}
+		if pointsAwarded > maxPoints {
+			pointsAwarded = maxPoints
+		}
+		if answer.Correct != nil {
+			isCorrect = answer.Correct
+		} else if maxPoints > 0 {
+			c := pointsAwarded >= maxPoints-0.0001
+			isCorrect = &c
+		}
+		return responseJSON, isCorrect, pointsAwarded, maxPoints
+	}
+
+	if answer.Correct != nil {
+		isCorrect = answer.Correct
+		if *answer.Correct {
+			pointsAwarded = maxPoints
+		}
+		return responseJSON, isCorrect, pointsAwarded, maxPoints
+	}
+
+	switch q.QuestionType {
+	case "multiple_choice", "true_false":
+		if q.MultipleAnswer && len(correctIDs) > 0 {
+			selected := canvasAnswerIDSet(answer.Answer)
+			c := canvasAnswerSetsEqual(selected, correctIDs)
+			isCorrect = &c
+			if c {
+				pointsAwarded = maxPoints
+			}
+			break
+		}
+		if idx, ok := canvasAnswerToChoiceIndex(answer.Answer, choiceByAnswerID); ok && q.CorrectChoiceIndex != nil {
+			c := idx == *q.CorrectChoiceIndex
+			isCorrect = &c
+			if c {
+				pointsAwarded = maxPoints
+			}
+			break
+		}
+		if idx, ok := canvasAnswerAsChoiceIndex(answer.Answer, len(q.Choices)); ok && q.CorrectChoiceIndex != nil {
+			c := idx == *q.CorrectChoiceIndex
+			isCorrect = &c
+			if c {
+				pointsAwarded = maxPoints
+			}
+		}
+	case "numeric":
+		if v, ok := coerceCanvasJSONNumber(answer.Answer); ok {
+			c := canvasNumericAnswerCorrect(q.TypeConfig, v)
+			isCorrect = &c
+			if c {
+				pointsAwarded = maxPoints
+			}
+		}
+	}
+
+	return responseJSON, isCorrect, pointsAwarded, maxPoints
+}
+
+func canvasAnswerSetsEqual(selected, correct map[int64]struct{}) bool {
+	if len(selected) != len(correct) {
+		return false
+	}
+	for id := range correct {
+		if _, ok := selected[id]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func canvasNumericAnswerCorrect(typeConfig json.RawMessage, value float64) bool {
+	var cfg struct {
+		Correct      *float64 `json:"correct"`
+		ToleranceAbs *float64 `json:"toleranceAbs"`
+		TolerancePct *float64 `json:"tolerancePct"`
+	}
+	if len(typeConfig) == 0 || json.Unmarshal(typeConfig, &cfg) != nil || cfg.Correct == nil {
+		return false
+	}
+	target := *cfg.Correct
+	if cfg.ToleranceAbs != nil {
+		return math.Abs(value-target) <= *cfg.ToleranceAbs+0.000001
+	}
+	if cfg.TolerancePct != nil && *cfg.TolerancePct > 0 {
+		return math.Abs(value-target) <= math.Abs(target)*(*cfg.TolerancePct)/100.0+0.000001
+	}
+	return math.Abs(value-target) <= 0.000001
+}
+
+func canvasParseCanvasTime(raw any) *time.Time {
+	s, _ := raw.(string)
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return nil
+	}
+	utc := t.UTC()
+	return &utc
+}
+
+func canvasUpsertImportedQuizAttempt(
+	ctx context.Context,
+	tx pgx.Tx,
+	courseID, itemID, studentID uuid.UUID,
+	attemptNumber int32,
+	startedAt, submittedAt *time.Time,
+	pointsEarned, pointsPossible float64,
+) (uuid.UUID, error) {
+	var scorePercent *float32
+	if pointsPossible > 0 {
+		pct := float32((pointsEarned / pointsPossible) * 100)
+		if pct < 0 {
+			pct = 0
+		}
+		if pct > 100 {
+			pct = 100
+		}
+		scorePercent = &pct
+	}
+	start := time.Now().UTC()
+	if startedAt != nil {
+		start = *startedAt
+	}
+	submitted := start
+	if submittedAt != nil {
+		submitted = *submittedAt
+	}
+	var attemptID uuid.UUID
+	err := tx.QueryRow(ctx, `
+INSERT INTO course.quiz_attempts (
+  course_id, structure_item_id, student_user_id, attempt_number, status,
+  is_adaptive, started_at, submitted_at, points_earned, points_possible, score_percent
+) VALUES ($1, $2, $3, $4, 'submitted', false, $5, $6, $7, $8, $9)
+ON CONFLICT (structure_item_id, student_user_id, attempt_number) DO UPDATE SET
+  status = 'submitted',
+  started_at = EXCLUDED.started_at,
+  submitted_at = EXCLUDED.submitted_at,
+  points_earned = EXCLUDED.points_earned,
+  points_possible = EXCLUDED.points_possible,
+  score_percent = EXCLUDED.score_percent
+RETURNING id
+`, courseID, itemID, studentID, attemptNumber, start, submitted, pointsEarned, pointsPossible, scorePercent).Scan(&attemptID)
+	return attemptID, err
+}
+
+func canvasReplaceImportedQuizResponses(
+	ctx context.Context,
+	tx pgx.Tx,
+	attemptID uuid.UUID,
+	questions []coursemodulequiz.QuizQuestion,
+	answers map[int64]canvasQuizSubmissionAnswer,
+	choiceMaps map[int64]map[int64]int,
+	correctAnswerIDs map[int64]map[int64]struct{},
+) error {
+	if _, err := tx.Exec(ctx, `DELETE FROM course.quiz_responses WHERE attempt_id = $1`, attemptID); err != nil {
+		return err
+	}
+	indexByCanvasID := canvasQuestionIndexByCanvasID(questions)
+	for canvasQID, answer := range answers {
+		qi, ok := indexByCanvasID[canvasQID]
+		if !ok || qi < 0 || qi >= len(questions) {
+			continue
+		}
+		q := questions[qi]
+		responseJSON, isCorrect, pointsAwarded, maxPoints := canvasGradeImportedQuestion(
+			q, answer, choiceMaps[canvasQID], correctAnswerIDs[canvasQID],
+		)
+		_, err := tx.Exec(ctx, `
+INSERT INTO course.quiz_responses (
+  attempt_id, question_index, question_id, question_type, prompt_snapshot,
+  response_json, is_correct, points_awarded, max_points
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+`, attemptID, qi, q.ID, q.QuestionType, q.Prompt, responseJSON, isCorrect, pointsAwarded, maxPoints)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func canvasImportQuizAttempts(
+	ctx context.Context,
+	tx pgx.Tx,
+	client *http.Client,
+	canvasBase, accessToken string,
+	canvasCourseID int64,
+	courseID uuid.UUID,
+	canvasQuizToItem map[int64]uuid.UUID,
+	canvasQuizToQuestions map[int64][]coursemodulequiz.QuizQuestion,
+	canvasUserToLocal map[int64]uuid.UUID,
+) error {
+	for canvasQID, itemID := range canvasQuizToItem {
+		questions := canvasQuizToQuestions[canvasQID]
+		if len(questions) == 0 {
+			continue
+		}
+		choiceMaps, correctAnswerIDs, err := canvasLoadQuizAnswerMetadata(ctx, client, canvasBase, accessToken, canvasCourseID, canvasQID)
+		if err != nil {
+			return fmt.Errorf("Canvas quiz %d answer map: %w", canvasQID, err)
+		}
+		subs, err := canvasGetQuizSubmissionsPaginated(ctx, client, canvasBase, accessToken, canvasCourseID, canvasQID, nil)
+		if err != nil {
+			return fmt.Errorf("Canvas quiz %d submissions for attempts: %w", canvasQID, err)
+		}
+		pointsPossibleQuiz := canvasQuizPointsPossible(questions, nil)
+		for _, raw := range subs {
+			if !canvasQuizSubmissionImportable(raw) {
+				continue
+			}
+			canvasUserID := int64At(raw, "user_id")
+			studentID, ok := canvasUserToLocal[canvasUserID]
+			if !ok {
+				continue
+			}
+			submissionID := int64At(raw, "id")
+			if submissionID <= 0 {
+				continue
+			}
+			attemptNum := int32(int64At(raw, "attempt"))
+			if attemptNum < 1 {
+				attemptNum = 1
+			}
+
+			detail, err := canvasGetQuizSubmissionDetail(ctx, client, canvasBase, accessToken, canvasCourseID, canvasQID, submissionID)
+			if err != nil {
+				return fmt.Errorf("Canvas quiz submission %d detail: %w", submissionID, err)
+			}
+			questionRows, err := canvasGetQuizSubmissionQuestions(ctx, client, canvasBase, accessToken, submissionID)
+			if err != nil {
+				return fmt.Errorf("Canvas quiz submission %d questions: %w", submissionID, err)
+			}
+			answers := canvasMergeSubmissionAnswers(detail, raw, questionRows)
+			score, hasScore := canvasQuizSubmissionScore(raw)
+			if len(answers) == 0 && !hasScore {
+				continue
+			}
+
+			var earned float64
+			indexByCanvasID := canvasQuestionIndexByCanvasID(questions)
+			for canvasQuestionID, ans := range answers {
+				qi, ok := indexByCanvasID[canvasQuestionID]
+				if !ok || qi >= len(questions) {
+					continue
+				}
+				_, _, pts, _ := canvasGradeImportedQuestion(questions[qi], ans, choiceMaps[canvasQuestionID], correctAnswerIDs[canvasQuestionID])
+				earned += pts
+			}
+			possible := pointsPossibleQuiz
+			if possible <= 0 {
+				possible = earned
+			}
+			if hasScore {
+				earned = score
+				if possible <= 0 {
+					possible = score
+				}
+			}
+
+			startedAt := canvasParseCanvasTime(raw["started_at"])
+			submittedAt := canvasParseCanvasTime(raw["finished_at"])
+			if submittedAt == nil {
+				submittedAt = canvasParseCanvasTime(raw["submitted_at"])
+			}
+
+			attemptID, err := canvasUpsertImportedQuizAttempt(ctx, tx, courseID, itemID, studentID, attemptNum, startedAt, submittedAt, earned, possible)
+			if err != nil {
+				return fmt.Errorf("save quiz attempt canvas submission %d: %w", submissionID, err)
+			}
+			if err := canvasReplaceImportedQuizResponses(ctx, tx, attemptID, questions, answers, choiceMaps, correctAnswerIDs); err != nil {
+				return fmt.Errorf("save quiz responses canvas submission %d: %w", submissionID, err)
+			}
+		}
+	}
+	return nil
+}

--- a/server/internal/httpserver/canvas_quiz_submissions_import.go
+++ b/server/internal/httpserver/canvas_quiz_submissions_import.go
@@ -114,16 +114,6 @@ func canvasLoadQuizAnswerMetadata(
 	return choiceMaps, correctAnswerIDs, nil
 }
 
-func canvasLoadQuizAnswerChoiceMaps(
-	ctx context.Context,
-	client *http.Client,
-	canvasBase, accessToken string,
-	canvasCourseID, canvasQuizID int64,
-) (map[int64]map[int64]int, error) {
-	choiceMaps, _, err := canvasLoadQuizAnswerMetadata(ctx, client, canvasBase, accessToken, canvasCourseID, canvasQuizID)
-	return choiceMaps, err
-}
-
 func canvasGetQuizSubmissionDetail(
 	ctx context.Context,
 	client *http.Client,
@@ -255,11 +245,11 @@ func canvasParseSubmissionDataEntry(m map[string]any) []canvasQuizSubmissionAnsw
 	case bool:
 		correct = &c
 	case string:
-		s := strings.ToLower(strings.TrimSpace(c))
-		if s == "true" || s == "1" {
+		switch strings.ToLower(strings.TrimSpace(c)) {
+		case "true", "1":
 			b := true
 			correct = &b
-		} else if s == "false" || s == "0" {
+		case "false", "0":
 			b := false
 			correct = &b
 		}

--- a/server/internal/httpserver/course_factory_reset.go
+++ b/server/internal/httpserver/course_factory_reset.go
@@ -1,14 +1,16 @@
 package httpserver
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/courseroles"
 	"github.com/lextures/lextures/server/internal/repos/course"
 	"github.com/lextures/lextures/server/internal/repos/coursefiles"
-	"github.com/lextures/lextures/server/internal/courseroles"
 )
 
 // handlePostFactoryResetCourse is POST /api/v1/courses/{course_code}/factory-reset.
@@ -48,15 +50,41 @@ func (d Deps) handlePostFactoryResetCourse() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
 			return
 		}
-		coursefiles.RemoveStoredBlobs(d.effectiveConfig().CourseFilesRoot, courseCode, outcome.RemovedCourseFileStorageKeys)
+		cfg := d.effectiveConfig()
+		coursefiles.RemoveStoredBlobs(cfg.CourseFilesRoot, courseCode, outcome.RemovedCourseFileStorageKeys)
+		d.removeFileManagerBlobs(r.Context(), courseCode, cfg.CourseFilesRoot, outcome.RemovedFileManagerStorageKeys)
 		log.Printf(
-			"factory-reset: success course=%q viewer=%s removed_file_blobs=%d",
+			"factory-reset: success course=%q viewer=%s removed_legacy_file_blobs=%d removed_file_manager_blobs=%d",
 			courseCode,
 			viewer.String(),
 			len(outcome.RemovedCourseFileStorageKeys),
+			len(outcome.RemovedFileManagerStorageKeys),
 		)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(outcome.Course)
+	}
+}
+
+// removeFileManagerBlobs deletes on-disk or object-store blobs for course.file_items rows.
+func (d Deps) removeFileManagerBlobs(ctx context.Context, courseCode, filesRoot string, storageKeys []string) {
+	if len(storageKeys) == 0 {
+		return
+	}
+	root := strings.TrimSpace(filesRoot)
+	if root == "" {
+		root = "data/course-files"
+	}
+	storage := d.Storage
+	for _, key := range storageKeys {
+		if storage != nil {
+			if err := storage.DeleteObject(ctx, key); err != nil {
+				log.Printf("factory-reset: file manager blob delete key=%q err=%v", key, err)
+			}
+			continue
+		}
+		if err := deleteLocalFile(root + "/" + courseCode + "/" + key); err != nil {
+			log.Printf("factory-reset: file manager local delete key=%q err=%v", key, err)
+		}
 	}
 }
 

--- a/server/internal/httpserver/courses_routes.go
+++ b/server/internal/httpserver/courses_routes.go
@@ -51,6 +51,7 @@ func (d Deps) registerCourseRoutes(r chi.Router) {
 	r.Get("/api/v1/courses/{course_code}/quizzes/{item_id}", d.handleGetModuleQuiz())
 	r.Patch("/api/v1/courses/{course_code}/quizzes/{item_id}", d.handlePatchModuleQuiz())
 	d.registerQuizDeliveryRoutes(r)
+	r.Get("/api/v1/courses/{course_code}/quizzes/{item_id}/analytics", d.handleGetQuizAnalytics())
 	r.Get("/api/v1/courses/{course_code}/quizzes/{item_id}/item-analysis", d.handleGetItemAnalysis())
 	r.Post("/api/v1/courses/{course_code}/quizzes/{item_id}/item-analysis/compute", d.handleComputeItemAnalysis())
 	r.Get("/api/v1/courses/{course_code}/quizzes/{item_id}/item-analysis/export.csv", d.handleExportItemAnalysisCSV())

--- a/server/internal/httpserver/quiz_analytics.go
+++ b/server/internal/httpserver/quiz_analytics.go
@@ -1,0 +1,54 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	repoitemanalysis "github.com/lextures/lextures/server/internal/repos/itemanalysis"
+	"github.com/lextures/lextures/server/internal/apierr"
+	svcquizanalytics "github.com/lextures/lextures/server/internal/service/quizanalytics"
+)
+
+type quizAnalyticsJSON struct {
+	QuizID         string                      `json:"quizId"`
+	NAttempts      int                         `json:"nAttempts"`
+	MeanScore      *float64                    `json:"meanScore"`
+	ScoreBuckets   []svcquizanalytics.ScoreBucket  `json:"scoreBuckets"`
+	QuestionStats  []svcquizanalytics.QuestionStat `json:"questionStats"`
+}
+
+func (d Deps) handleGetQuizAnalytics() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet+","+http.MethodOptions)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+
+		_, _, itemID, ok := d.requireItemAnalysisAccess(w, r)
+		if !ok {
+			return
+		}
+
+		ctx := r.Context()
+		rows, err := repoitemanalysis.FetchAttemptResponses(ctx, d.Pool, itemID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load quiz analytics.")
+			return
+		}
+
+		report := svcquizanalytics.BuildReport(itemID, rows)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(quizAnalyticsJSON{
+			QuizID:        report.QuizID.String(),
+			NAttempts:     report.NAttempts,
+			MeanScore:     report.MeanScore,
+			ScoreBuckets:  report.ScoreBuckets,
+			QuestionStats: report.QuestionStats,
+		})
+	}
+}

--- a/server/internal/httpserver/quiz_analytics_nodb_test.go
+++ b/server/internal/httpserver/quiz_analytics_nodb_test.go
@@ -1,0 +1,37 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleGetQuizAnalytics_Unauthorized(t *testing.T) {
+	h := NewHandler(Deps{})
+	r := httptest.NewRequest(http.MethodGet, baseItemPath+"/analytics", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, r)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestHandleGetQuizAnalytics_Options(t *testing.T) {
+	h := NewHandler(Deps{})
+	r := httptest.NewRequest(http.MethodOptions, baseItemPath+"/analytics", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, r)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rr.Code)
+	}
+}
+
+func TestHandleGetQuizAnalytics_MethodNotAllowed(t *testing.T) {
+	h := NewHandler(Deps{})
+	r := httptest.NewRequest(http.MethodPost, baseItemPath+"/analytics", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, r)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rr.Code)
+	}
+}

--- a/server/internal/repos/course/factory_reset.go
+++ b/server/internal/repos/course/factory_reset.go
@@ -11,8 +11,9 @@ import (
 )
 
 type FactoryResetCourseOutcome struct {
-	Course                       *CoursePublic
-	RemovedCourseFileStorageKeys []string
+	Course                          *CoursePublic
+	RemovedCourseFileStorageKeys    []string
+	RemovedFileManagerStorageKeys   []string
 }
 
 // FactoryResetCourse matches Rust `course::factory_reset_course` behavior.
@@ -63,7 +64,19 @@ func FactoryResetCourse(ctx context.Context, pool *pgxpool.Pool, courseCode stri
 		return nil, err
 	}
 
+	fileManagerKeys, err := listStorageKeysForFileManager(ctx, tx, *courseID)
+	if err != nil {
+		log.Printf("factory-reset: list file manager keys failed course=%q err=%v", courseCode, err)
+		return nil, err
+	}
+
 	if err = execResetStep(ctx, tx, courseCode, "delete course_files", `DELETE FROM course.course_files WHERE course_id = $1`, *courseID); err != nil {
+		return nil, err
+	}
+	if err = execResetStep(ctx, tx, courseCode, "delete file_items", `DELETE FROM course.file_items WHERE course_id = $1`, *courseID); err != nil {
+		return nil, err
+	}
+	if err = execResetStep(ctx, tx, courseCode, "delete file_folders", `DELETE FROM course.file_folders WHERE course_id = $1`, *courseID); err != nil {
 		return nil, err
 	}
 	if err = execResetStep(ctx, tx, courseCode, "delete syllabus_acceptances", `DELETE FROM course.syllabus_acceptances WHERE course_id = $1`, *courseID); err != nil {
@@ -141,10 +154,16 @@ func FactoryResetCourse(ctx context.Context, pool *pgxpool.Pool, courseCode stri
 		log.Printf("factory-reset: course missing after reset course=%q", courseCode)
 		return nil, nil
 	}
-	log.Printf("factory-reset: committed course=%q file_keys=%d", courseCode, len(fileKeys))
+	log.Printf(
+		"factory-reset: committed course=%q legacy_file_keys=%d file_manager_keys=%d",
+		courseCode,
+		len(fileKeys),
+		len(fileManagerKeys),
+	)
 	return &FactoryResetCourseOutcome{
-		Course:                       resetCourse,
-		RemovedCourseFileStorageKeys: fileKeys,
+		Course:                        resetCourse,
+		RemovedCourseFileStorageKeys:  fileKeys,
+		RemovedFileManagerStorageKeys: fileManagerKeys,
 	}, nil
 }
 
@@ -159,6 +178,23 @@ func execResetStep(ctx context.Context, tx pgx.Tx, courseCode, step, sql string,
 
 func listStorageKeysForCourseFiles(ctx context.Context, tx pgx.Tx, courseID uuid.UUID) ([]string, error) {
 	rows, err := tx.Query(ctx, `SELECT storage_key FROM course.course_files WHERE course_id = $1`, courseID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	keys := make([]string, 0)
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return keys, rows.Err()
+}
+
+func listStorageKeysForFileManager(ctx context.Context, tx pgx.Tx, courseID uuid.UUID) ([]string, error) {
+	rows, err := tx.Query(ctx, `SELECT storage_key FROM course.file_items WHERE course_id = $1`, courseID)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/repos/studentaccommodations/studentaccommodations.go
+++ b/server/internal/repos/studentaccommodations/studentaccommodations.go
@@ -69,10 +69,20 @@ const rowSelectCols = `
        alternative_format, effective_from, effective_until,
        created_by, updated_by, created_at, updated_at`
 
+// rowSelectColsSA qualifies columns for queries that JOIN course.courses (both have created_at).
+const rowSelectColsSA = `
+       (sa.time_multiplier)::double precision,
+       sa.extra_attempts, sa.hints_always_enabled, sa.reduced_distraction_mode,
+       sa.speech_to_text_enabled,
+       sa.tts_enabled, sa.dyslexia_display_enabled, sa.high_contrast_enabled,
+       sa.reduced_motion_enabled, sa.separate_setting, sa.active,
+       sa.alternative_format, sa.effective_from, sa.effective_until,
+       sa.created_by, sa.updated_by, sa.created_at, sa.updated_at`
+
 // ListForUserWithCourse returns active rows for a user with optional course code.
 func ListForUserWithCourse(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) ([]ListRow, error) {
 	const q = `
-SELECT sa.id, sa.user_id, sa.course_id,` + rowSelectCols + `,
+SELECT sa.id, sa.user_id, sa.course_id,` + rowSelectColsSA + `,
        c.course_code AS course_code
 FROM course.student_accommodations sa
 LEFT JOIN course.courses c ON c.id = sa.course_id

--- a/server/internal/service/itemanalysis/service.go
+++ b/server/internal/service/itemanalysis/service.go
@@ -166,14 +166,12 @@ func computeStats(quizID uuid.UUID, rows []repoitemanalysis.AttemptResponseRow, 
 			continue
 		}
 
-		// p-value
-		correctCount := 0
+		// p-value: average proportion of max points earned on this item.
+		var sumFrac float64
 		for _, o := range observations {
-			if o.isCorrect {
-				correctCount++
-			}
+			sumFrac += o.itemFrac
 		}
-		pval := float64(correctCount) / float64(len(observations))
+		pval := sumFrac / float64(len(observations))
 
 		// point-biserial r_pb
 		var rpbPtr *float64

--- a/server/internal/service/quizanalytics/service.go
+++ b/server/internal/service/quizanalytics/service.go
@@ -1,0 +1,186 @@
+// Package quizanalytics builds instructor-facing quiz performance reports.
+package quizanalytics
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/google/uuid"
+	repoitemanalysis "github.com/lextures/lextures/server/internal/repos/itemanalysis"
+)
+
+const bucketCount = 10
+
+// ScoreBucket is one histogram bin for overall quiz scores (0–100%).
+type ScoreBucket struct {
+	Label string `json:"label"`
+	Min   int    `json:"min"`
+	Max   int    `json:"max"`
+	Count int    `json:"count"`
+}
+
+// QuestionStat summarizes performance on one quiz question.
+type QuestionStat struct {
+	QuestionIndex int     `json:"questionIndex"`
+	QuestionText  string  `json:"questionText"`
+	NResponses    int     `json:"nResponses"`
+	PctCorrect    float64 `json:"pctCorrect"`
+}
+
+// Report is the analytics payload for a quiz.
+type Report struct {
+	QuizID        uuid.UUID      `json:"quizId"`
+	NAttempts     int            `json:"nAttempts"`
+	MeanScore     *float64       `json:"meanScore"`
+	ScoreBuckets  []ScoreBucket  `json:"scoreBuckets"`
+	QuestionStats []QuestionStat `json:"questionStats"`
+}
+
+// BuildReport aggregates submitted attempt data into score and question distributions.
+func BuildReport(quizID uuid.UUID, rows []repoitemanalysis.AttemptResponseRow) Report {
+	buckets := defaultScoreBuckets()
+	report := Report{
+		QuizID:       quizID,
+		ScoreBuckets: buckets,
+	}
+
+	type attemptAgg struct {
+		scorePct  *float64
+		responses map[int]repoitemanalysis.AttemptResponseRow
+	}
+
+	attempts := map[uuid.UUID]*attemptAgg{}
+	for _, r := range rows {
+		agg, ok := attempts[r.AttemptID]
+		if !ok {
+			agg = &attemptAgg{responses: map[int]repoitemanalysis.AttemptResponseRow{}}
+			attempts[r.AttemptID] = agg
+		}
+		if agg.scorePct == nil && r.ScorePercent != nil {
+			agg.scorePct = r.ScorePercent
+		}
+		agg.responses[r.QuestionIndex] = r
+	}
+
+	report.NAttempts = len(attempts)
+	if report.NAttempts == 0 {
+		return report
+	}
+
+	var scoreSum float64
+	var scoredAttempts int
+	for _, agg := range attempts {
+		if agg.scorePct == nil {
+			continue
+		}
+		scoredAttempts++
+		scoreSum += *agg.scorePct
+		bucketIdx := scoreBucketIndex(*agg.scorePct)
+		if bucketIdx >= 0 && bucketIdx < len(buckets) {
+			buckets[bucketIdx].Count++
+		}
+	}
+	if scoredAttempts > 0 {
+		mean := scoreSum / float64(scoredAttempts)
+		report.MeanScore = &mean
+	}
+
+	type questionAgg struct {
+		text     string
+		sumFrac  float64
+		count    int
+	}
+	questions := map[int]*questionAgg{}
+	for _, agg := range attempts {
+		for qi, r := range agg.responses {
+			q, ok := questions[qi]
+			if !ok {
+				q = &questionAgg{}
+				questions[qi] = q
+			}
+			if r.PromptText != nil && q.text == "" {
+				q.text = *r.PromptText
+			}
+			q.sumFrac += itemPerformanceFraction(r)
+			q.count++
+		}
+	}
+
+	indices := make([]int, 0, len(questions))
+	for qi := range questions {
+		indices = append(indices, qi)
+	}
+	sort.Ints(indices)
+
+	report.QuestionStats = make([]QuestionStat, 0, len(indices))
+	for _, qi := range indices {
+		q := questions[qi]
+		if q.count == 0 {
+			continue
+		}
+		report.QuestionStats = append(report.QuestionStats, QuestionStat{
+			QuestionIndex: qi,
+			QuestionText:  q.text,
+			NResponses:    q.count,
+			PctCorrect:    round1(q.sumFrac / float64(q.count) * 100),
+		})
+	}
+
+	return report
+}
+
+func defaultScoreBuckets() []ScoreBucket {
+	buckets := make([]ScoreBucket, bucketCount)
+	for i := range buckets {
+		min := i * 10
+		max := min + 9
+		if i == bucketCount-1 {
+			max = 100
+		}
+		buckets[i] = ScoreBucket{
+			Label: bucketLabel(min, max),
+			Min:   min,
+			Max:   max,
+		}
+	}
+	return buckets
+}
+
+func bucketLabel(min, max int) string {
+	if min == max {
+		return fmt.Sprintf("%d%%", min)
+	}
+	return fmt.Sprintf("%d–%d%%", min, max)
+}
+
+func scoreBucketIndex(scorePct float64) int {
+	if scorePct < 0 {
+		return 0
+	}
+	if scorePct >= 100 {
+		return bucketCount - 1
+	}
+	return int(math.Floor(scorePct / 10))
+}
+
+func itemPerformanceFraction(r repoitemanalysis.AttemptResponseRow) float64 {
+	if r.MaxPoints > 0 {
+		frac := r.PointsAwarded / r.MaxPoints
+		if frac < 0 {
+			return 0
+		}
+		if frac > 1 {
+			return 1
+		}
+		return frac
+	}
+	if r.IsCorrect != nil && *r.IsCorrect {
+		return 1
+	}
+	return 0
+}
+
+func round1(v float64) float64 {
+	return math.Round(v*10) / 10
+}

--- a/server/internal/service/quizanalytics/service_test.go
+++ b/server/internal/service/quizanalytics/service_test.go
@@ -1,0 +1,55 @@
+package quizanalytics
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	repoitemanalysis "github.com/lextures/lextures/server/internal/repos/itemanalysis"
+)
+
+func scorePtr(v float64) *float64 { return &v }
+
+func TestBuildReportScoreHistogram(t *testing.T) {
+	quizID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	rows := []repoitemanalysis.AttemptResponseRow{
+		{AttemptID: uuid.MustParse("00000000-0000-0000-0000-000000000001"), ScorePercent: scorePtr(15), QuestionIndex: 0, MaxPoints: 1, PointsAwarded: 1},
+		{AttemptID: uuid.MustParse("00000000-0000-0000-0000-000000000002"), ScorePercent: scorePtr(55), QuestionIndex: 0, MaxPoints: 1, PointsAwarded: 0},
+		{AttemptID: uuid.MustParse("00000000-0000-0000-0000-000000000003"), ScorePercent: scorePtr(95), QuestionIndex: 0, MaxPoints: 1, PointsAwarded: 1},
+		{AttemptID: uuid.MustParse("00000000-0000-0000-0000-000000000004"), ScorePercent: scorePtr(100), QuestionIndex: 0, MaxPoints: 1, PointsAwarded: 1},
+	}
+
+	report := BuildReport(quizID, rows)
+	if report.NAttempts != 4 {
+		t.Fatalf("expected 4 attempts, got %d", report.NAttempts)
+	}
+	if report.MeanScore == nil || *report.MeanScore != 66.25 {
+		t.Fatalf("expected mean 66.25, got %v", report.MeanScore)
+	}
+	if report.ScoreBuckets[1].Count != 1 || report.ScoreBuckets[5].Count != 1 ||
+		report.ScoreBuckets[9].Count != 2 {
+		t.Fatalf("unexpected bucket counts: %+v", report.ScoreBuckets)
+	}
+}
+
+func TestBuildReportQuestionStats(t *testing.T) {
+	quizID := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	text := "What is 2+2?"
+	correct := true
+	rows := []repoitemanalysis.AttemptResponseRow{
+		{AttemptID: uuid.MustParse("00000000-0000-0000-0000-000000000010"), ScorePercent: scorePtr(100), QuestionIndex: 0, PromptText: &text, MaxPoints: 2, PointsAwarded: 2},
+		{AttemptID: uuid.MustParse("00000000-0000-0000-0000-000000000011"), ScorePercent: scorePtr(50), QuestionIndex: 0, PromptText: &text, MaxPoints: 2, PointsAwarded: 1},
+		{AttemptID: uuid.MustParse("00000000-0000-0000-0000-000000000012"), ScorePercent: scorePtr(0), QuestionIndex: 0, PromptText: &text, IsCorrect: &correct, MaxPoints: 1, PointsAwarded: 0},
+	}
+
+	report := BuildReport(quizID, rows)
+	if len(report.QuestionStats) != 1 {
+		t.Fatalf("expected 1 question stat, got %d", len(report.QuestionStats))
+	}
+	stat := report.QuestionStats[0]
+	if stat.NResponses != 3 {
+		t.Fatalf("expected 3 responses, got %d", stat.NResponses)
+	}
+	if stat.PctCorrect != 50 {
+		t.Fatalf("expected 50%% correct, got %v", stat.PctCorrect)
+	}
+}

--- a/www/src/app.tsx
+++ b/www/src/app.tsx
@@ -575,12 +575,21 @@ function HomePage() {
 /* ─────────────────────────────────────────────────────────
    ROUTER
    ───────────────────────────────────────────────────────── */
+function resolveRoute(pathname: string, hash: string): string {
+  if (hash.startsWith('#/')) {
+    const hashRoute = hash.slice(1)
+    // e.g. /blog + #/blog/my-post — pathname wins today and breaks post links
+    if (pathname !== '/' && hashRoute.startsWith(`${pathname}/`)) {
+      return hashRoute
+    }
+    if (pathname === '/') return hashRoute
+  }
+  return pathname !== '/' ? pathname : '/'
+}
+
 export default function App() {
   const hash = useHashRoute()
-  const path = window.location.pathname
-  const route = path !== '/'
-    ? path
-    : (hash.startsWith('#/') ? hash.slice(1) : '/')
+  const route = resolveRoute(window.location.pathname, hash)
 
   if (route === '/get-started') return <GetStartedPage />
   if (route === '/higher-ed') return <HigherEdPage />

--- a/www/src/pages/blog-index.tsx
+++ b/www/src/pages/blog-index.tsx
@@ -105,7 +105,7 @@ export function BlogIndex() {
                           </time>
                           <h2 className="mt-2 text-xl font-semibold leading-snug text-slate-900 sm:text-2xl">
                             <a
-                              href={`#/blog/${post.slug}`}
+                              href={`/blog/${post.slug}`}
                               className="no-underline transition-colors hover:text-accent"
                             >
                               {post.title}
@@ -117,7 +117,7 @@ export function BlogIndex() {
                           <p className="mt-2 text-sm text-slate-400">By {post.author}</p>
                         </div>
                         <a
-                          href={`#/blog/${post.slug}`}
+                          href={`/blog/${post.slug}`}
                           className="btn-primary shrink-0 gap-2 self-start"
                           aria-label={`Read ${post.title}`}
                         >

--- a/www/src/pages/blog-post.tsx
+++ b/www/src/pages/blog-post.tsx
@@ -14,7 +14,7 @@ export function BlogPost({ slug }: { slug: string }) {
         <Header />
         <main className="mx-auto max-w-3xl px-4 py-24 sm:px-6 lg:px-8">
           <p className="text-slate-500">Post not found.</p>
-          <a href="#/blog" className="btn-secondary mt-6 inline-flex gap-2">
+          <a href="/blog" className="btn-secondary mt-6 inline-flex gap-2">
             <ArrowLeft className="h-4 w-4" aria-hidden />
             Back to blog
           </a>
@@ -32,7 +32,7 @@ export function BlogPost({ slug }: { slug: string }) {
         <div className="border-b border-slate-200 bg-white py-12 sm:py-16">
           <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
             <a
-              href="#/blog"
+              href="/blog"
               className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 no-underline transition-colors hover:text-slate-900"
             >
               <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
@@ -62,7 +62,7 @@ export function BlogPost({ slug }: { slug: string }) {
             </div>
 
             <div className="mt-16 border-t border-slate-200/80 pt-10">
-              <a href="#/blog" className="btn-secondary inline-flex gap-2">
+              <a href="/blog" className="btn-secondary inline-flex gap-2">
                 <ArrowLeft className="h-4 w-4" aria-hidden />
                 Back to all posts
               </a>


### PR DESCRIPTION
## Summary

- Add an inbox notifications context and refactor the notifications drawer and push-notification hooks so unread state is unified across feed, inbox, and alerts.
- Add quiz analytics (API, service, modal on the quiz page) and a transposed gradebook grid view with shared grid types.
- Extend course files UI, factory reset, and Canvas import to load quiz questions, import quiz submission attempts/grades, and keep page-slug link rewriting from main.

## Test plan

- [ ] Open notifications drawer: verify inbox/feed unread counts and mark-read behavior
- [ ] Open a course quiz as instructor: open quiz analytics modal and confirm data loads
- [ ] Gradebook: switch to transposed view; edit cells and confirm existing grid tests pass (`npm run test` in `clients/web/`)
- [ ] Course Files: list, upload, rename, move files
- [ ] Canvas import with grades/quizzes enabled: confirm quiz questions and submission grades import without errors
- [ ] `cd server && go test ./internal/httpserver/... ./internal/service/quizanalytics/... -count=1 -short`