### PR TITLE
feat: Canvas import progress log and broader link rewrite on import

### DIFF
--- a/clients/web/src/components/canvas/canvas-import-progress-log.tsx
+++ b/clients/web/src/components/canvas/canvas-import-progress-log.tsx
@@ -1,0 +1,98 @@
+import { ChevronDown, Loader2 } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import type { CanvasImportProgressEntry } from '../../hooks/use-canvas-import-progress-log'
+
+type CanvasImportProgressLogProps = {
+  entries: CanvasImportProgressEntry[]
+  title?: string
+  defaultExpanded?: boolean
+  className?: string
+  maxHeightClassName?: string
+  active?: boolean
+}
+
+export function CanvasImportProgressLog({
+  entries,
+  title = 'Import progress',
+  defaultExpanded = true,
+  className = '',
+  maxHeightClassName = 'max-h-48',
+  active = false,
+}: CanvasImportProgressLogProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!expanded || entries.length === 0) return
+    bottomRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [entries, expanded])
+
+  if (entries.length === 0) return null
+
+  return (
+    <div
+      className={[
+        'rounded-xl border border-slate-200 bg-slate-50/80 dark:border-neutral-700 dark:bg-neutral-900/60',
+        className,
+      ].join(' ')}
+    >
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 px-3 py-2.5 text-start text-sm font-medium text-slate-800 dark:text-neutral-100"
+        onClick={() => setExpanded((open) => !open)}
+        aria-expanded={expanded}
+      >
+        {active ? (
+          <Loader2
+            className="h-4 w-4 shrink-0 motion-safe:animate-spin text-indigo-600 dark:text-indigo-400"
+            aria-hidden
+          />
+        ) : (
+          <span
+            className="h-4 w-4 shrink-0 rounded-full bg-indigo-600/15 ring-2 ring-indigo-600/30 dark:bg-indigo-400/15 dark:ring-indigo-400/30"
+            aria-hidden
+          />
+        )}
+        <span className="min-w-0 flex-1 truncate">{title}</span>
+        <span className="shrink-0 text-xs tabular-nums text-slate-500 dark:text-neutral-500">
+          {entries.length}
+        </span>
+        <ChevronDown
+          className={[
+            'h-4 w-4 shrink-0 text-slate-500 transition dark:text-neutral-400',
+            expanded ? 'rotate-180' : '',
+          ].join(' ')}
+          aria-hidden
+        />
+      </button>
+      {expanded ? (
+        <div
+          role="log"
+          aria-live="polite"
+          aria-relevant="additions"
+          className={['overflow-y-auto border-t border-slate-200 px-3 py-3 dark:border-neutral-700', maxHeightClassName].join(
+            ' ',
+          )}
+        >
+          <div className="relative ps-4">
+            <div
+              className="absolute top-0 bottom-0 start-[5px] w-px bg-slate-300 dark:bg-neutral-600"
+              aria-hidden
+            />
+            <ul className="space-y-2">
+              {entries.map((entry) => (
+                <li
+                  key={entry.id}
+                  className="canvas-import-status-in text-sm leading-snug text-slate-600 dark:text-neutral-400"
+                >
+                  {entry.text}
+                </li>
+              ))}
+            </ul>
+            <div ref={bottomRef} aria-hidden />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/clients/web/src/hooks/use-canvas-import-progress-log.ts
+++ b/clients/web/src/hooks/use-canvas-import-progress-log.ts
@@ -1,0 +1,24 @@
+import { useCallback, useRef, useState } from 'react'
+
+export type CanvasImportProgressEntry = {
+  id: number
+  text: string
+}
+
+export function useCanvasImportProgressLog() {
+  const idRef = useRef(0)
+  const [entries, setEntries] = useState<CanvasImportProgressEntry[]>([])
+
+  const append = useCallback((text: string) => {
+    const trimmed = text.trim()
+    if (!trimmed) return
+    setEntries((prev) => [...prev, { id: ++idRef.current, text: trimmed }])
+  }, [])
+
+  const clear = useCallback(() => {
+    idRef.current = 0
+    setEntries([])
+  }, [])
+
+  return { entries, append, clear }
+}

--- a/clients/web/src/pages/lms/canvas-import-courses-modal.tsx
+++ b/clients/web/src/pages/lms/canvas-import-courses-modal.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { Search, X } from 'lucide-react'
+import { CanvasImportProgressLog } from '../../components/canvas/canvas-import-progress-log'
+import { useCanvasImportProgressLog } from '../../hooks/use-canvas-import-progress-log'
 import { CanvasReadOnlyNotice } from '../../components/canvas/canvas-read-only-notice'
 import { BookLoader } from '../../components/quiz/book-loader'
 import {
@@ -48,12 +50,8 @@ export function CanvasImportCoursesModal({ open, onClose, onImported }: Props) {
   const [selected, setSelected] = useState<Set<number>>(new Set())
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [importStatus, setImportStatus] = useState<string | null>(null)
-  const [importDone, setImportDone] = useState<{
-    ok: number
-    failed: string[]
-    cancelled: boolean
-  } | null>(null)
+  const { entries: importLog, append: appendImportLog, clear: clearImportLog } =
+    useCanvasImportProgressLog()
   const importCancelledRef = useRef(false)
   const activeCourseImportAbortRef = useRef<AbortController | null>(null)
   const [nameFilter, setNameFilter] = useState('')
@@ -85,14 +83,13 @@ export function CanvasImportCoursesModal({ open, onClose, onImported }: Props) {
     setSelected(new Set())
     setBusy(false)
     setError(null)
-    setImportStatus(null)
-    setImportDone(null)
+    clearImportLog()
     setNameFilter('')
     setHideUnpublished(false)
     importCancelledRef.current = false
     activeCourseImportAbortRef.current?.abort()
     activeCourseImportAbortRef.current = null
-  }, [])
+  }, [clearImportLog])
 
   useEffect(() => {
     if (!open) return
@@ -179,13 +176,13 @@ export function CanvasImportCoursesModal({ open, onClose, onImported }: Props) {
   function requestCancelImport() {
     importCancelledRef.current = true
     activeCourseImportAbortRef.current?.abort()
-    setImportStatus('Stopping import…')
+    appendImportLog('Stopping import…')
   }
 
   async function onImport() {
     if (coursesToImport.length === 0) return
     setError(null)
-    setImportDone(null)
+    clearImportLog()
     importCancelledRef.current = false
     activeCourseImportAbortRef.current = null
     setStep('importing')
@@ -194,12 +191,11 @@ export function CanvasImportCoursesModal({ open, onClose, onImported }: Props) {
     const token = canvasToken.trim()
     const toImport = coursesToImport
     let ok = 0
-    const failed: string[] = []
 
     for (let i = 0; i < toImport.length; i++) {
       if (importCancelledRef.current) break
       const canvasCourse = toImport[i]!
-      setImportStatus(`Importing ${i + 1} of ${toImport.length}: ${canvasCourse.name}`)
+      appendImportLog(`Importing ${i + 1} of ${toImport.length}: ${canvasCourse.name}`)
       try {
         const created = await createCourse({
           title: canvasCourse.name,
@@ -217,7 +213,7 @@ export function CanvasImportCoursesModal({ open, onClose, onImported }: Props) {
             accessToken: token,
             include: CANVAS_IMPORT_INCLUDE_ALL,
           },
-          (message) => setImportStatus(`${canvasCourse.name}: ${message}`),
+          (message) => appendImportLog(`${canvasCourse.name}: ${message}`),
           { signal: courseAbort.signal },
         )
         ok++
@@ -226,18 +222,16 @@ export function CanvasImportCoursesModal({ open, onClose, onImported }: Props) {
         if (msg === CANVAS_IMPORT_CANCELLED_MESSAGE || importCancelledRef.current) {
           break
         }
-        failed.push(`${canvasCourse.name}: ${msg}`)
+        appendImportLog(`${canvasCourse.name}: ${msg}`)
       } finally {
         activeCourseImportAbortRef.current = null
       }
     }
 
-    const cancelled = importCancelledRef.current
-    setImportDone({ ok, failed, cancelled })
-    setImportStatus(null)
     setBusy(false)
     if (ok > 0) onImported?.()
     if (!rememberCredentials) setCanvasToken('')
+    onClose()
   }
 
   if (!open) return null
@@ -482,51 +476,20 @@ export function CanvasImportCoursesModal({ open, onClose, onImported }: Props) {
           )}
 
           {step === 'importing' && (
-            <div className="flex min-h-[280px] flex-col items-center justify-center gap-6 overflow-visible py-10">
-              {busy && !importDone && (
-                <>
-                  <div className="overflow-visible px-6 pt-8" aria-hidden>
-                    <span className="inline-flex origin-center scale-[0.65] sm:scale-[0.75]">
-                      <BookLoader className="![--quiz-book-loader-color:rgb(79,70,229)] dark:![--quiz-book-loader-color:rgb(129,140,248)]" />
-                    </span>
-                  </div>
-                  {importStatus && (
-                    <p
-                      className="canvas-import-status-in max-w-sm text-center text-sm text-slate-600 dark:text-neutral-400"
-                      role="status"
-                      aria-live="polite"
-                    >
-                      {importStatus}
-                    </p>
-                  )}
-                </>
-              )}
-              {importDone && (
-                <div className="w-full space-y-3 text-sm">
-                  {importDone.cancelled ? (
-                    <p className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-slate-800 dark:border-neutral-600 dark:bg-neutral-800/60 dark:text-neutral-200">
-                      Import stopped.
-                      {importDone.ok > 0
-                        ? ` ${importDone.ok} course${importDone.ok === 1 ? ' was' : 's were'} imported before you cancelled.`
-                        : ' No courses were fully imported.'}
-                    </p>
-                  ) : importDone.ok > 0 ? (
-                    <p className="rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-emerald-900 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-200">
-                      Imported {importDone.ok} course{importDone.ok === 1 ? '' : 's'} successfully.
-                    </p>
-                  ) : null}
-                  {importDone.failed.length > 0 && (
-                    <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-amber-950 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
-                      <p className="font-medium">Some imports failed:</p>
-                      <ul className="mt-2 list-inside list-disc space-y-1 text-xs">
-                        {importDone.failed.map((line) => (
-                          <li key={line}>{line}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
+            <div className="flex min-h-[280px] flex-col gap-4 py-2">
+              {busy && (
+                <div className="flex shrink-0 justify-center overflow-visible px-6 pt-4" aria-hidden>
+                  <span className="inline-flex origin-center scale-[0.65] sm:scale-[0.75]">
+                    <BookLoader className="![--quiz-book-loader-color:rgb(79,70,229)] dark:![--quiz-book-loader-color:rgb(129,140,248)]" />
+                  </span>
                 </div>
               )}
+              <CanvasImportProgressLog
+                entries={importLog}
+                active={busy}
+                maxHeightClassName="max-h-72"
+                className="min-h-0 w-full"
+              />
             </div>
           )}
         </div>
@@ -577,22 +540,13 @@ export function CanvasImportCoursesModal({ open, onClose, onImported }: Props) {
               </button>
             </>
           )}
-          {step === 'importing' && busy && !importDone && (
+          {step === 'importing' && busy && (
             <button
               type="button"
               onClick={requestCancelImport}
               className="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
             >
               Cancel import
-            </button>
-          )}
-          {step === 'importing' && importDone && (
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500"
-            >
-              Done
             </button>
           )}
         </div>

--- a/clients/web/src/pages/lms/course-export-import-section.tsx
+++ b/clients/web/src/pages/lms/course-export-import-section.tsx
@@ -1,6 +1,8 @@
 import { type ChangeEvent, useEffect, useRef, useState } from 'react'
 import { Download, GraduationCap, Upload } from 'lucide-react'
 import { CanvasReadOnlyNotice } from '../../components/canvas/canvas-read-only-notice'
+import { CanvasImportProgressLog } from '../../components/canvas/canvas-import-progress-log'
+import { useCanvasImportProgressLog } from '../../hooks/use-canvas-import-progress-log'
 import { BookLoader } from '../../components/quiz/book-loader'
 import { usePermissions } from '../../context/use-permissions'
 import {
@@ -30,10 +32,8 @@ export function CourseExportImportSection({ courseCode }: { courseCode: string }
   const [canvasCourseId, setCanvasCourseId] = useState('')
   const [canvasToken, setCanvasToken] = useState('')
   const [canvasInclude, setCanvasInclude] = useState<CanvasImportInclude>(CANVAS_IMPORT_INCLUDE_ALL)
-  const [canvasImportStatus, setCanvasImportStatus] = useState<{
-    key: number
-    text: string
-  } | null>(null)
+  const { entries: canvasImportLog, append: appendCanvasImportLog, clear: clearCanvasImportLog } =
+    useCanvasImportProgressLog()
   const [rememberCanvasCredentials, setRememberCanvasCredentials] = useState(false)
 
   useEffect(() => {
@@ -108,7 +108,7 @@ export function CourseExportImportSection({ courseCode }: { courseCode: string }
 
   async function onCanvasImport() {
     setFeedback(null)
-    setCanvasImportStatus(null)
+    clearCanvasImportLog()
     setBusy('importingCanvas')
     try {
       await postCourseImportCanvas(
@@ -120,12 +120,7 @@ export function CourseExportImportSection({ courseCode }: { courseCode: string }
           accessToken: canvasToken.trim(),
           include: canvasInclude,
         },
-        (message) => {
-          setCanvasImportStatus((prev) => ({
-            key: (prev?.key ?? 0) + 1,
-            text: message,
-          }))
-        },
+        (message) => appendCanvasImportLog(message),
       )
       setFeedback({
         kind: 'ok',
@@ -141,7 +136,6 @@ export function CourseExportImportSection({ courseCode }: { courseCode: string }
       })
     } finally {
       setBusy('idle')
-      setCanvasImportStatus(null)
     }
   }
 
@@ -413,16 +407,11 @@ export function CourseExportImportSection({ courseCode }: { courseCode: string }
               {busy === 'importingCanvas' ? 'Importing from Canvas…' : 'Import from Canvas'}
             </button>
           </div>
-          {canvasImportStatus && (
-            <p
-              key={canvasImportStatus.key}
-              className="canvas-import-status-in mt-3 text-sm text-slate-600 dark:text-neutral-400"
-              role="status"
-              aria-live="polite"
-            >
-              {canvasImportStatus.text}
-            </p>
-          )}
+          <CanvasImportProgressLog
+            entries={canvasImportLog}
+            active={busy === 'importingCanvas'}
+            className="mt-3"
+          />
         </div>
 
         <div className="mt-8 border-t border-slate-200 pt-8 dark:border-neutral-600">

--- a/server/internal/httpserver/canvas_import_ws.go
+++ b/server/internal/httpserver/canvas_import_ws.go
@@ -317,7 +317,7 @@ func (d Deps) runCanvasImport(
 					if kind == "content_page" {
 						pageURL := strAt(it, "page_url", "")
 						if pageURL != "" {
-							canvasPageSlugToItem[pageURL] = itemID
+							canvasPageSlugToItem[strings.ToLower(strings.TrimSpace(pageURL))] = itemID
 							page, e := canvasGetObject(ctx, client, canvasBase, accessToken, fmt.Sprintf("courses/%d/pages/%s", canvasCourseID, url.PathEscape(pageURL)), nil)
 							if e == nil {
 								md = markdownFromHTML(strAt(page, "body", ""))
@@ -490,15 +490,18 @@ func (d Deps) runCanvasImport(
 		if !progress("Updating internal links…") {
 			return context.Canceled
 		}
+		enrichCanvasLinkMaps(ctx, client, canvasBase, accessToken, canvasCourseID, d.Pool, courseID,
+			canvasAssignToItem, canvasQuizToItem, canvasPageSlugToItem)
 		rc := &canvasLinkRewriteCtx{
-			CanvasBase:     canvasBase,
-			CanvasCourseID: canvasCourseID,
-			CourseCode:     courseCode,
-			Assignments:    canvasAssignToItem,
-			Quizzes:        canvasQuizToItem,
-			PageSlugs:      canvasPageSlugToItem,
-			FileIDs:        canvasFileIDs,
-			FileNames:      canvasFileNames,
+			CanvasBase:            canvasBase,
+			CanvasCourseID:        canvasCourseID,
+			CourseCode:            courseCode,
+			Assignments:           canvasAssignToItem,
+			Quizzes:               canvasQuizToItem,
+			PageSlugs:             canvasPageSlugToItem,
+			FileIDs:               canvasFileIDs,
+			FileNames:             canvasFileNames,
+			AllowedHostSuffixes:   d.effectiveConfig().CanvasAllowedHostSuffixes,
 		}
 		if err := rewriteCanvasLinksInCourseMarkdown(ctx, d.Pool, courseID, rc); err != nil {
 			log.Printf("canvas-import: link rewrite err=%v", err)
@@ -759,24 +762,162 @@ func htmlToPlainText(html string) string {
 // canvasLinkRewriteCtx holds ID mappings used to convert Canvas-internal URLs
 // embedded in imported content into their Lextures equivalents.
 type canvasLinkRewriteCtx struct {
-	CanvasBase     string
-	CanvasCourseID int64
-	CourseCode     string
-	Assignments    map[int64]uuid.UUID // canvas assignment ID → lextures item UUID
-	Quizzes        map[int64]uuid.UUID // canvas quiz ID → lextures item UUID
-	PageSlugs      map[string]uuid.UUID // canvas page_url slug → lextures item UUID
-	FileIDs        map[int64]uuid.UUID // canvas file ID → lextures file-item UUID
-	FileNames      map[int64]string   // canvas file ID → display name
+	CanvasBase            string
+	CanvasCourseID        int64
+	CourseCode            string
+	Assignments           map[int64]uuid.UUID // canvas assignment ID → lextures item UUID
+	Quizzes               map[int64]uuid.UUID // canvas quiz ID → lextures item UUID
+	PageSlugs             map[string]uuid.UUID // canvas page_url slug → lextures item UUID
+	FileIDs               map[int64]uuid.UUID // canvas file ID → lextures file-item UUID
+	FileNames             map[int64]string   // canvas file ID → display name
+	AllowedHostSuffixes   []string
 }
 
 var (
-	canvasFilePathRe   = regexp.MustCompile(`(?i)^/courses/(\d+)/files/(\d+)`)
-	canvasAssignPathRe = regexp.MustCompile(`(?i)^/courses/(\d+)/assignments/(\d+)`)
-	canvasQuizPathRe   = regexp.MustCompile(`(?i)^/courses/(\d+)/quizzes/(\d+)`)
-	canvasPagePathRe   = regexp.MustCompile(`(?i)^/courses/(\d+)/pages/([^/?#\s]+)`)
-	canvasModulePathRe = regexp.MustCompile(`(?i)^/courses/(\d+)/modules`)
-	markdownLinkRe     = regexp.MustCompile(`(!?)\[([^\]]*)\]\(([^)]+)\)`)
+	canvasFilePathRe    = regexp.MustCompile(`(?i)^/courses/(\d+)/files/(\d+)`)
+	canvasAssignPathRe  = regexp.MustCompile(`(?i)^/courses/(\d+)/assignments/(\d+)`)
+	canvasQuizPathRe    = regexp.MustCompile(`(?i)^/courses/(\d+)/quizzes/(\d+)`)
+	canvasPagePathRe    = regexp.MustCompile(`(?i)^/courses/(\d+)/pages/([^/?#\s]+)`)
+	canvasModulePathRe  = regexp.MustCompile(`(?i)^/courses/(\d+)/modules`)
+	markdownLinkRe      = regexp.MustCompile(`(!?)\[([^\]]*)\]\(([^)]+)\)`)
+	markdownAngleLinkRe = regexp.MustCompile(`<(https?://[^>\s]+)>`)
+	htmlAnchorTagRe     = regexp.MustCompile(`(?i)<a\s([^>]*?)>`)
+	htmlAnchorHrefRe    = regexp.MustCompile(`(?i)href\s*=\s*["']([^"']+)["']`)
 )
+
+func normalizeLinkMatchTitle(title string) string {
+	return strings.ToLower(strings.TrimSpace(title))
+}
+
+func canvasURLHostMatches(host, canvasBase string, allowedHostSuffixes []string) bool {
+	if host == "" {
+		return true
+	}
+	base, err := url.Parse(canvasBase)
+	if err == nil && strings.EqualFold(host, base.Host) {
+		return true
+	}
+	hostname := strings.ToLower(host)
+	if i := strings.Index(hostname, ":"); i >= 0 {
+		hostname = hostname[:i]
+	}
+	for _, suffix := range allowedHostSuffixes {
+		s := strings.ToLower(strings.TrimPrefix(strings.TrimPrefix(strings.TrimSpace(suffix), "*."), "."))
+		if s != "" && (hostname == s || strings.HasSuffix(hostname, "."+s)) {
+			return true
+		}
+	}
+	return false
+}
+
+// enrichCanvasLinkMaps fills Canvas→Lextures ID maps using the full Canvas course
+// catalog matched to existing module items by title (and page slug). Module import
+// only records content_id for module items; links often target other course resources.
+func enrichCanvasLinkMaps(
+	ctx context.Context,
+	client *http.Client,
+	canvasBase, accessToken string,
+	canvasCourseID int64,
+	pool *pgxpool.Pool,
+	courseID uuid.UUID,
+	assignments, quizzes map[int64]uuid.UUID,
+	pageSlugs map[string]uuid.UUID,
+) {
+	rows, err := pool.Query(ctx, `
+		SELECT id, kind, title FROM course.course_structure_items
+		WHERE course_id = $1 AND archived = false
+		  AND kind IN ('assignment', 'quiz', 'content_page')`,
+		courseID)
+	if err != nil {
+		log.Printf("canvas-link-rewrite: load local items: %v", err)
+		return
+	}
+	defer rows.Close()
+	byKindTitle := make(map[string]map[string][]uuid.UUID)
+	for rows.Next() {
+		var id uuid.UUID
+		var kind, title string
+		if err := rows.Scan(&id, &kind, &title); err != nil {
+			continue
+		}
+		t := normalizeLinkMatchTitle(title)
+		if t == "" {
+			continue
+		}
+		if byKindTitle[kind] == nil {
+			byKindTitle[kind] = make(map[string][]uuid.UUID)
+		}
+		byKindTitle[kind][t] = append(byKindTitle[kind][t], id)
+	}
+	uniqueByKindTitle := func(kind, title string) (uuid.UUID, bool) {
+		ids := byKindTitle[kind][normalizeLinkMatchTitle(title)]
+		if len(ids) != 1 {
+			return uuid.Nil, false
+		}
+		return ids[0], true
+	}
+
+	assignRows, err := canvasGetArrayPaginated(ctx, client, canvasBase, accessToken,
+		fmt.Sprintf("courses/%d/assignments", canvasCourseID), nil)
+	if err != nil {
+		log.Printf("canvas-link-rewrite: list assignments: %v", err)
+	} else {
+		for _, a := range assignRows {
+			cid := int64At(a, "id")
+			if cid <= 0 {
+				continue
+			}
+			if _, ok := assignments[cid]; ok {
+				continue
+			}
+			if id, ok := uniqueByKindTitle("assignment", strAt(a, "name", "")); ok {
+				assignments[cid] = id
+			}
+		}
+	}
+
+	quizRows, err := canvasGetArrayPaginated(ctx, client, canvasBase, accessToken,
+		fmt.Sprintf("courses/%d/quizzes", canvasCourseID), nil)
+	if err != nil {
+		log.Printf("canvas-link-rewrite: list quizzes: %v", err)
+	} else {
+		for _, q := range quizRows {
+			cid := int64At(q, "id")
+			if cid <= 0 {
+				continue
+			}
+			if _, ok := quizzes[cid]; ok {
+				continue
+			}
+			if id, ok := uniqueByKindTitle("quiz", strAt(q, "title", "")); ok {
+				quizzes[cid] = id
+			}
+		}
+	}
+
+	pageRows, err := canvasGetArrayPaginated(ctx, client, canvasBase, accessToken,
+		fmt.Sprintf("courses/%d/pages", canvasCourseID), nil)
+	if err != nil {
+		log.Printf("canvas-link-rewrite: list pages: %v", err)
+	} else {
+		for _, p := range pageRows {
+			slug := strings.ToLower(strings.TrimSpace(strAt(p, "url", "")))
+			if slug == "" {
+				continue
+			}
+			if _, ok := pageSlugs[slug]; ok {
+				continue
+			}
+			if id, ok := uniqueByKindTitle("content_page", strAt(p, "title", "")); ok {
+				pageSlugs[slug] = id
+				continue
+			}
+			if id, ok := uniqueByKindTitle("content_page", slug); ok {
+				pageSlugs[slug] = id
+			}
+		}
+	}
+}
 
 // rewriteURL returns the Lextures equivalent of a Canvas-internal URL, or the
 // original URL unchanged if it points to a different domain or resource type.
@@ -785,12 +926,9 @@ func (rc *canvasLinkRewriteCtx) rewriteURL(rawURL string) string {
 	if err != nil {
 		return rawURL
 	}
-	// For absolute URLs, only process those pointing at the Canvas host.
-	if u.Host != "" {
-		base, perr := url.Parse(rc.CanvasBase)
-		if perr != nil || !strings.EqualFold(u.Host, base.Host) {
-			return rawURL
-		}
+	// For absolute URLs, only process those pointing at an allowed Canvas host.
+	if u.Host != "" && !canvasURLHostMatches(u.Host, rc.CanvasBase, rc.AllowedHostSuffixes) {
+		return rawURL
 	}
 	path := u.Path
 
@@ -843,6 +981,7 @@ func (rc *canvasLinkRewriteCtx) rewriteURL(rawURL string) string {
 			return rawURL
 		}
 		slug, _ := url.PathUnescape(m[2])
+		slug = strings.ToLower(strings.TrimSpace(slug))
 		if localID, ok := rc.PageSlugs[slug]; ok {
 			return fmt.Sprintf("/courses/%s/modules/content/%s",
 				url.PathEscape(rc.CourseCode), localID)
@@ -860,10 +999,10 @@ func (rc *canvasLinkRewriteCtx) rewriteURL(rawURL string) string {
 	return rawURL
 }
 
-// rewriteMarkdown rewrites all Markdown link/image URLs that point into the
-// Canvas course to their Lextures equivalents.
+// rewriteMarkdown rewrites Markdown links, autolinks, and any leftover HTML
+// anchors that point into the Canvas course to their Lextures equivalents.
 func (rc *canvasLinkRewriteCtx) rewriteMarkdown(markdown string) string {
-	return markdownLinkRe.ReplaceAllStringFunc(markdown, func(match string) string {
+	s := markdownLinkRe.ReplaceAllStringFunc(markdown, func(match string) string {
 		subs := markdownLinkRe.FindStringSubmatch(match)
 		if len(subs) < 4 {
 			return match
@@ -874,6 +1013,30 @@ func (rc *canvasLinkRewriteCtx) rewriteMarkdown(markdown string) string {
 			return match
 		}
 		return fmt.Sprintf("%s[%s](%s)", bang, text, newURL)
+	})
+	s = markdownAngleLinkRe.ReplaceAllStringFunc(s, func(match string) string {
+		subs := markdownAngleLinkRe.FindStringSubmatch(match)
+		if len(subs) < 2 {
+			return match
+		}
+		newURL := rc.rewriteURL(subs[1])
+		if newURL == subs[1] {
+			return match
+		}
+		return "<" + newURL + ">"
+	})
+	return htmlAnchorTagRe.ReplaceAllStringFunc(s, func(tag string) string {
+		return htmlAnchorHrefRe.ReplaceAllStringFunc(tag, func(hrefPart string) string {
+			subs := htmlAnchorHrefRe.FindStringSubmatch(hrefPart)
+			if len(subs) < 2 {
+				return hrefPart
+			}
+			newURL := rc.rewriteURL(subs[1])
+			if newURL == subs[1] {
+				return hrefPart
+			}
+			return `href="` + newURL + `"`
+		})
 	})
 }
 

--- a/server/internal/httpserver/canvas_link_rewrite_test.go
+++ b/server/internal/httpserver/canvas_link_rewrite_test.go
@@ -1,0 +1,69 @@
+package httpserver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestCanvasURLHostMatches_AllowedSuffix(t *testing.T) {
+	base := "https://byui.instructure.com"
+	suffixes := []string{"instructure.com"}
+	if !canvasURLHostMatches("eu01.instructure.com", base, suffixes) {
+		t.Fatal("expected another instructure subdomain to match suffix policy")
+	}
+	if !canvasURLHostMatches("byui.instructure.com", base, suffixes) {
+		t.Fatal("expected exact canvas host match")
+	}
+	if canvasURLHostMatches("example.com", base, suffixes) {
+		t.Fatal("expected unrelated host to be rejected")
+	}
+}
+
+func TestCanvasLinkRewriteCtx_RewriteAssignmentURL(t *testing.T) {
+	localID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	rc := &canvasLinkRewriteCtx{
+		CanvasBase:          "https://school.instructure.com",
+		CanvasCourseID:      42,
+		CourseCode:          "C-TEST",
+		Assignments:         map[int64]uuid.UUID{99: localID},
+		AllowedHostSuffixes: []string{"instructure.com"},
+	}
+	raw := "https://other.instructure.com/courses/42/assignments/99"
+	got := rc.rewriteURL(raw)
+	want := "/courses/C-TEST/modules/assignment/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	if got != want {
+		t.Fatalf("rewriteURL() = %q, want %q", got, want)
+	}
+}
+
+func TestCanvasLinkRewriteCtx_RewriteMarkdownAndHTML(t *testing.T) {
+	localID := uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	rc := &canvasLinkRewriteCtx{
+		CanvasBase:          "https://school.instructure.com",
+		CanvasCourseID:      7,
+		CourseCode:          "C-XXZQQA",
+		Assignments:         map[int64]uuid.UUID{123: localID},
+		AllowedHostSuffixes: []string{"instructure.com"},
+	}
+	md := strings.Join([]string{
+		"Read the [syllabus](https://school.instructure.com/courses/7/assignments/123).",
+		`<a href="/courses/7/assignments/123">syllabus</a>`,
+		"<https://school.instructure.com/courses/7/assignments/123>",
+	}, "\n")
+	got := rc.rewriteMarkdown(md)
+	wantPath := "/courses/C-XXZQQA/modules/assignment/11111111-2222-3333-4444-555555555555"
+	if !strings.Contains(got, "[syllabus]("+wantPath+")") {
+		t.Fatalf("expected markdown link rewrite, got:\n%s", got)
+	}
+	if !strings.Contains(got, `href="`+wantPath+`"`) {
+		t.Fatalf("expected HTML anchor rewrite, got:\n%s", got)
+	}
+	if !strings.Contains(got, "<"+wantPath+">") {
+		t.Fatalf("expected angle autolink rewrite, got:\n%s", got)
+	}
+	if strings.Contains(got, "instructure.com") {
+		t.Fatalf("expected no Canvas hosts left, got:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a reusable scrollable Canvas import progress log (catalog modal and per-course import) so users see a full timeline of status messages instead of a single line that gets replaced.
- Improve Canvas link rewriting on import: enrich ID maps from the full course catalog by title, accept allowed Instructure host suffixes, normalize page slugs, and rewrite Markdown autolinks and leftover HTML anchors.
- Add server tests for host matching and markdown/HTML link rewrite behavior.

## Test plan
- [ ] Import one or more courses from the Canvas catalog modal and confirm progress entries accumulate in the log; cancel mid-import and verify the modal closes after completion.
- [ ] Import Canvas content into an existing course and confirm the progress log shows WebSocket status messages and persists after import finishes.
- [ ] Import a course with cross-links (assignments, pages, quizzes) on another Instructure subdomain and verify links point to Lextures module URLs.
- [ ] Run `go test ./internal/httpserver -run Canvas -count=1` in `server/`.