### PR TITLE
feat: folder drag-and-drop in course files and PPTX rendering improvements

### DIFF
--- a/clients/web/src/lib/course-files-api.ts
+++ b/clients/web/src/lib/course-files-api.ts
@@ -203,6 +203,26 @@ export async function moveFile(
   return raw as FileItem
 }
 
+/** Move a folder to a different folder. Pass null/empty to move to root. */
+export async function moveFolder(
+  courseCode: string,
+  folderId: string,
+  parentId: string | null,
+): Promise<FileFolder> {
+  const res = await authorizedFetch(
+    `/api/v1/courses/${encodeURIComponent(courseCode)}/files/folders/${encodeURIComponent(folderId)}`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ parentId: parentId ?? '' }),
+    },
+  )
+  const raw = await parseJson(res)
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  return raw as FileFolder
+}
+
+
 export async function deleteFile(courseCode: string, itemId: string): Promise<void> {
   const res = await authorizedFetch(
     `/api/v1/courses/${encodeURIComponent(courseCode)}/files/items/${encodeURIComponent(itemId)}`,

--- a/clients/web/src/pages/lms/course-files-page.tsx
+++ b/clients/web/src/pages/lms/course-files-page.tsx
@@ -29,6 +29,7 @@ import {
   confirmFileUpload,
   renameFile,
   moveFile,
+  moveFolder,
   deleteFile,
   getFileContentUrl,
   formatBytes,
@@ -84,7 +85,9 @@ export default function CourseFilesPage() {
   const [showNewFolder, setShowNewFolder] = useState(false)
 
   const [contextMenu, setContextMenu] = useState<ContextMenu | null>(null)
-  const [movingFile, setMovingFile] = useState<FileItem | null>(null)
+  const [draggingItem, setDraggingItem] = useState<{ kind: 'folder' | 'file'; id: string } | null>(null)
+  const [dragOverFolderId, setDragOverFolderId] = useState<string | null>(null)
+  const [dragOverBreadcrumbId, setDragOverBreadcrumbId] = useState<string | 'root' | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedItems, setSelectedItems] = useState<Set<SelectedItemKey>>(new Set())
   const [previewFile, setPreviewFile] = useState<FileItem | null>(null)
@@ -175,6 +178,25 @@ export default function CourseFilesPage() {
     }
     const file = contents.files.find(f => f.id === id)
     return file ? { kind: 'file' as const, file } : null
+  }
+
+  async function handleMoveSelectedUp() {
+    if (!folderId || selectedItems.size === 0) return
+    const parentFolderId = breadcrumbs.length >= 2 ? breadcrumbs[breadcrumbs.length - 2].id : null
+    const foldersToMove = contents?.folders.filter(f => selectedItems.has(selectedItemKey('folder', f.id))) ?? []
+    const filesToMove = contents?.files.filter(f => selectedItems.has(selectedItemKey('file', f.id))) ?? []
+    try {
+      for (const folder of foldersToMove) {
+        await moveFolder(courseCode, folder.id, parentFolderId)
+      }
+      for (const file of filesToMove) {
+        await moveFile(courseCode, file.id, parentFolderId)
+      }
+      clearSelection()
+      void load()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Could not move items.')
+    }
   }
 
   async function handleDeleteSelected() {
@@ -305,14 +327,16 @@ export default function CourseFilesPage() {
     }
   }
 
-  async function handleMoveFile(targetFolderId: string | null) {
-    if (!movingFile) return
+  async function handleMoveItem(kind: 'folder' | 'file', id: string, targetFolderId: string | null) {
     try {
-      await moveFile(courseCode, movingFile.id, targetFolderId)
-      setMovingFile(null)
+      if (kind === 'file') {
+        await moveFile(courseCode, id, targetFolderId)
+      } else {
+        await moveFolder(courseCode, id, targetFolderId)
+      }
       void load()
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Could not move file.')
+      alert(err instanceof Error ? err.message : `Could not move ${kind}.`)
     }
   }
 
@@ -382,27 +406,95 @@ export default function CourseFilesPage() {
       <div className="mb-4 flex flex-wrap items-center gap-2">
         {/* Breadcrumbs */}
         <nav className="flex min-w-0 flex-1 items-center gap-1 text-sm">
-          <button
-            onClick={() => navigateToFolder(null)}
-            className="text-indigo-600 hover:underline dark:text-indigo-400"
+          <span
+            onDragOver={(e) => {
+              if (draggingItem && folderId !== undefined) {
+                e.preventDefault()
+                e.dataTransfer.dropEffect = 'move'
+              }
+            }}
+            onDragEnter={() => {
+              if (draggingItem && folderId !== undefined) {
+                setDragOverBreadcrumbId('root')
+              }
+            }}
+            onDragLeave={(e) => {
+              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                setDragOverBreadcrumbId(null)
+              }
+            }}
+            onDrop={() => {
+              if (draggingItem && folderId !== undefined) {
+                void handleMoveItem(draggingItem.kind, draggingItem.id, null)
+              }
+              setDragOverBreadcrumbId(null)
+            }}
+            className={`px-1.5 py-0.5 rounded transition-all duration-150 ${
+              draggingItem && folderId !== undefined
+                ? dragOverBreadcrumbId === 'root'
+                  ? 'bg-indigo-100 dark:bg-indigo-900/60 ring-2 ring-indigo-500 text-indigo-700 dark:text-indigo-300 font-semibold'
+                  : 'bg-indigo-50/50 dark:bg-indigo-950/20 border border-dashed border-indigo-300 dark:border-indigo-700'
+                : ''
+            }`}
           >
-            Files
-          </button>
-          {breadcrumbs.map((b, i) => (
-            <span key={b.id} className="flex items-center gap-1">
-              <span className="text-slate-400">/</span>
-              {i < breadcrumbs.length - 1 ? (
-                <button
-                  onClick={() => navigateToFolder(b.id, b.name)}
-                  className="text-indigo-600 hover:underline dark:text-indigo-400"
+            <button
+              onClick={() => navigateToFolder(null)}
+              className="text-indigo-600 hover:underline dark:text-indigo-400"
+            >
+              Files
+            </button>
+          </span>
+          {breadcrumbs.map((b, i) => {
+            const isLast = i === breadcrumbs.length - 1
+            const canDropOnCrumb = draggingItem && folderId !== b.id && draggingItem.id !== b.id
+            return (
+              <span key={b.id} className="flex items-center gap-1">
+                <span className="text-slate-400">/</span>
+                <span
+                  onDragOver={(e) => {
+                    if (canDropOnCrumb) {
+                      e.preventDefault()
+                      e.dataTransfer.dropEffect = 'move'
+                    }
+                  }}
+                  onDragEnter={() => {
+                    if (canDropOnCrumb) {
+                      setDragOverBreadcrumbId(b.id)
+                    }
+                  }}
+                  onDragLeave={(e) => {
+                    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                      setDragOverBreadcrumbId(null)
+                    }
+                  }}
+                  onDrop={() => {
+                    if (canDropOnCrumb) {
+                      void handleMoveItem(draggingItem!.kind, draggingItem!.id, b.id)
+                    }
+                    setDragOverBreadcrumbId(null)
+                  }}
+                  className={`px-1.5 py-0.5 rounded transition-all duration-150 ${
+                    canDropOnCrumb
+                      ? dragOverBreadcrumbId === b.id
+                        ? 'bg-indigo-100 dark:bg-indigo-900/60 ring-2 ring-indigo-500 text-indigo-700 dark:text-indigo-300 font-semibold'
+                        : 'bg-indigo-50/50 dark:bg-indigo-950/20 border border-dashed border-indigo-300 dark:border-indigo-700'
+                      : ''
+                  }`}
                 >
-                  {b.name}
-                </button>
-              ) : (
-                <span className="truncate font-medium text-slate-800 dark:text-neutral-200">{b.name}</span>
-              )}
-            </span>
-          ))}
+                  {!isLast ? (
+                    <button
+                      onClick={() => navigateToFolder(b.id, b.name)}
+                      className="text-indigo-600 hover:underline dark:text-indigo-400"
+                    >
+                      {b.name}
+                    </button>
+                  ) : (
+                    <span className="truncate font-medium text-slate-800 dark:text-neutral-200">{b.name}</span>
+                  )}
+                </span>
+              </span>
+            )
+          })}
         </nav>
 
         {canManage && (
@@ -493,6 +585,8 @@ export default function CourseFilesPage() {
             <SelectionActionsMenu
               canRename={selectedItems.size === 1}
               onRename={handleRenameSelected}
+              canMoveUp={!!folderId}
+              onMoveUp={() => void handleMoveSelectedUp()}
               onDelete={() => void handleDeleteSelected()}
             />
             <button
@@ -571,6 +665,13 @@ export default function CourseFilesPage() {
                   onRenameCancel={() => setRenamingFolder(null)}
                   onDelete={() => void handleDeleteFolder(folder)}
                   onContextMenu={e => openContextMenu(e, folder, 'folder')}
+                  draggingItem={draggingItem}
+                  dragOverFolderId={dragOverFolderId}
+                  onDragStart={(kind, id) => setDraggingItem({ kind, id })}
+                  onDragEnd={() => { setDraggingItem(null); setDragOverFolderId(null); setDragOverBreadcrumbId(null); }}
+                  onDragEnter={(id) => setDragOverFolderId(id)}
+                  onDragLeave={() => setDragOverFolderId(null)}
+                  onDrop={(kind, dragId, targetId) => void handleMoveItem(kind, dragId, targetId)}
                 />
               ))}
               {filteredFiles.map(file => (
@@ -587,9 +688,11 @@ export default function CourseFilesPage() {
                   onRenameSubmit={() => void handleRenameFile()}
                   onRenameCancel={() => setRenamingFile(null)}
                   onDelete={() => void handleDeleteFile(file)}
-                  onMove={() => setMovingFile(file)}
                   onPreview={() => setPreviewFile(file)}
                   onContextMenu={e => openContextMenu(e, file, 'file')}
+                  draggingItem={draggingItem}
+                  onDragStart={(kind, id) => setDraggingItem({ kind, id })}
+                  onDragEnd={() => { setDraggingItem(null); setDragOverFolderId(null); setDragOverBreadcrumbId(null); }}
                 />
               ))}
             </tbody>
@@ -598,6 +701,12 @@ export default function CourseFilesPage() {
       )}
 
       {/* Context menu */}
+      {contextMenu && (
+        <div
+          className="fixed inset-0 z-10"
+          onClick={() => setContextMenu(null)}
+        />
+      )}
       {contextMenu && (
         <div
           className="fixed z-20 min-w-[160px] rounded-lg border border-slate-200 bg-white py-1 shadow-lg dark:border-neutral-700 dark:bg-neutral-900"
@@ -653,12 +762,6 @@ export default function CourseFilesPage() {
                   >
                     Rename
                   </button>
-                  <button
-                    className="flex w-full items-center gap-2 px-4 py-2 text-sm hover:bg-slate-50 dark:hover:bg-neutral-800"
-                    onClick={() => { setMovingFile(contextMenu.item as FileItem); setContextMenu(null) }}
-                  >
-                    Move to…
-                  </button>
                   <hr className="my-1 border-slate-100 dark:border-neutral-700" />
                   <button
                     className="flex w-full items-center gap-2 px-4 py-2 text-sm text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30"
@@ -671,17 +774,6 @@ export default function CourseFilesPage() {
             </>
           )}
         </div>
-      )}
-
-      {/* Move to folder picker */}
-      {movingFile && contents && (
-        <MovePicker
-          file={movingFile}
-          folders={contents.folders}
-          currentFolderId={folderId ?? null}
-          onMove={handleMoveFile}
-          onCancel={() => setMovingFile(null)}
-        />
       )}
 
       <FilePreview
@@ -746,10 +838,14 @@ function SelectAllCheckbox({
 function SelectionActionsMenu({
   canRename,
   onRename,
+  canMoveUp,
+  onMoveUp,
   onDelete,
 }: {
   canRename: boolean
   onRename: () => void
+  canMoveUp: boolean
+  onMoveUp: () => void
   onDelete: () => void
 }) {
   const [open, setOpen] = useState(false)
@@ -800,6 +896,19 @@ function SelectionActionsMenu({
           >
             Rename
           </button>
+          {canMoveUp && (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                onMoveUp()
+                setOpen(false)
+              }}
+              className="flex w-full items-center px-2.5 py-2 text-start text-sm hover:bg-slate-50 dark:hover:bg-neutral-800"
+            >
+              Move up a folder
+            </button>
+          )}
           <hr className="my-1 border-slate-100 dark:border-neutral-700" />
           <button
             type="button"
@@ -854,17 +963,74 @@ type FolderRowProps = {
   onRenameCancel: () => void
   onDelete: () => void
   onContextMenu: (e: React.MouseEvent) => void
+  draggingItem: { kind: 'folder' | 'file'; id: string } | null
+  dragOverFolderId: string | null
+  onDragStart: (kind: 'folder' | 'file', id: string) => void
+  onDragEnd: () => void
+  onDragEnter: (id: string) => void
+  onDragLeave: () => void
+  onDrop: (kind: 'folder' | 'file', dragId: string, targetId: string) => void
 }
 
 function FolderRow({
   folder, canManage, selected, onToggleSelect, renamingFolder, renameValue, setRenameValue,
   onNavigate, onRenameStart, onRenameSubmit, onRenameCancel, onDelete, onContextMenu,
+  draggingItem, dragOverFolderId, onDragStart, onDragEnd, onDragEnter, onDragLeave, onDrop,
 }: FolderRowProps) {
   const isRenaming = renamingFolder?.id === folder.id
+  const isDraggingActive = draggingItem !== null
+  const isSelf = draggingItem?.id === folder.id && draggingItem?.kind === 'folder'
+  const isDragOver = dragOverFolderId === folder.id
+
+  let dragClass = 'group cursor-pointer hover:bg-slate-50 dark:hover:bg-neutral-900/50 transition-colors'
+  if (isDraggingActive) {
+    if (isSelf) {
+      dragClass = 'opacity-40 select-none pointer-events-none'
+    } else {
+      if (isDragOver) {
+        dragClass = 'bg-indigo-100/90 dark:bg-indigo-900/60 text-indigo-700 dark:text-indigo-300 ring-2 ring-indigo-500 ring-inset font-semibold shadow-sm'
+      } else {
+        dragClass = 'bg-indigo-50/60 dark:bg-indigo-950/30 text-indigo-600 dark:text-indigo-400 border border-dashed border-indigo-300 dark:border-indigo-700'
+      }
+    }
+  }
+
   return (
     <tr
-      className="group cursor-pointer hover:bg-slate-50 dark:hover:bg-neutral-900/50"
+      className={dragClass}
       onContextMenu={onContextMenu}
+      draggable={canManage && !isRenaming}
+      onDragStart={(e) => {
+        if (canManage && !isRenaming) {
+          e.dataTransfer.effectAllowed = 'move'
+          // Defer state update so the browser captures the drag ghost before re-render
+          setTimeout(() => onDragStart('folder', folder.id), 0)
+        }
+      }}
+      onDragEnd={onDragEnd}
+      onDragOver={(e) => {
+        if (isDraggingActive && !isSelf) {
+          e.preventDefault()
+          e.dataTransfer.dropEffect = 'move'
+        }
+      }}
+      onDragEnter={() => {
+        if (isDraggingActive && !isSelf) {
+          onDragEnter(folder.id)
+        }
+      }}
+      onDragLeave={(e) => {
+        // Only clear highlight when truly leaving the row, not when crossing into a child cell
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+          onDragLeave()
+        }
+      }}
+      onDrop={(e) => {
+        if (isDraggingActive && !isSelf) {
+          e.preventDefault()
+          onDrop(draggingItem.kind, draggingItem.id, folder.id)
+        }
+      }}
     >
       {canManage && (
         <td className={CHECKBOX_COLUMN_CLASS}>
@@ -892,7 +1058,7 @@ function FolderRow({
               onKeyDown={e => e.key === 'Escape' && onRenameCancel()}
               className="min-w-0 flex-1 rounded border border-indigo-400 px-1.5 py-0.5 text-sm dark:bg-neutral-800"
             />
-            <button type="submit" className="text-xs text-indigo-600 hover:underline">Save</button>
+            <button type="submit" className="text-xs text-indigo-600 hover:underline font-medium">Save</button>
             <button type="button" onClick={onRenameCancel} className="text-xs text-slate-400 hover:underline">Cancel</button>
           </form>
         ) : (
@@ -912,8 +1078,8 @@ function FolderRow({
       {canManage && (
         <td className="py-2.5 pl-3 pr-4 text-right">
           <div className="invisible flex items-center justify-end gap-2 group-hover:visible">
-            <button onClick={onRenameStart} className="text-xs text-slate-500 hover:text-indigo-600 dark:text-neutral-400">Rename</button>
-            <button onClick={onDelete} className="text-xs text-red-500 hover:text-red-700">Delete</button>
+            <button onClick={onRenameStart} className="text-xs text-slate-500 hover:text-indigo-600 dark:text-neutral-400 font-medium">Rename</button>
+            <button onClick={onDelete} className="text-xs text-red-500 hover:text-red-700 font-medium">Delete</button>
           </div>
         </td>
       )}
@@ -933,20 +1099,43 @@ type FileRowProps = {
   onRenameSubmit: () => void
   onRenameCancel: () => void
   onDelete: () => void
-  onMove: () => void
   onPreview: () => void
   onContextMenu: (e: React.MouseEvent) => void
+  draggingItem: { kind: 'folder' | 'file'; id: string } | null
+  onDragStart: (kind: 'folder' | 'file', id: string) => void
+  onDragEnd: () => void
 }
 
 function FileRow({
   file, canManage, selected, onToggleSelect, renamingFile, renameValue, setRenameValue,
-  onRenameStart, onRenameSubmit, onRenameCancel, onDelete, onMove, onPreview, onContextMenu,
+  onRenameStart, onRenameSubmit, onRenameCancel, onDelete, onPreview, onContextMenu,
+  draggingItem, onDragStart, onDragEnd,
 }: FileRowProps) {
   const isRenaming = renamingFile?.id === file.id
+  const isDraggingActive = draggingItem !== null
+  const isSelf = draggingItem?.id === file.id && draggingItem?.kind === 'file'
+
+  let dragClass = 'group cursor-default hover:bg-slate-50 dark:hover:bg-neutral-900/50 transition-colors'
+  if (isDraggingActive) {
+    if (isSelf) {
+      dragClass = 'opacity-40 select-none pointer-events-none'
+    } else {
+      dragClass = 'opacity-30 pointer-events-none select-none grayscale'
+    }
+  }
+
   return (
     <tr
-      className="group cursor-default hover:bg-slate-50 dark:hover:bg-neutral-900/50"
+      className={dragClass}
       onContextMenu={onContextMenu}
+      draggable={canManage && !isRenaming}
+      onDragStart={(e) => {
+        if (canManage && !isRenaming) {
+          e.dataTransfer.effectAllowed = 'move'
+          setTimeout(() => onDragStart('file', file.id), 0)
+        }
+      }}
+      onDragEnd={onDragEnd}
     >
       {canManage && (
         <td className={CHECKBOX_COLUMN_CLASS}>
@@ -974,7 +1163,7 @@ function FileRow({
               onKeyDown={e => e.key === 'Escape' && onRenameCancel()}
               className="min-w-0 flex-1 rounded border border-indigo-400 px-1.5 py-0.5 text-sm dark:bg-neutral-800"
             />
-            <button type="submit" className="text-xs text-indigo-600 hover:underline">Save</button>
+            <button type="submit" className="text-xs text-indigo-600 hover:underline font-medium">Save</button>
             <button type="button" onClick={onRenameCancel} className="text-xs text-slate-400 hover:underline">Cancel</button>
           </form>
         ) : (
@@ -995,67 +1184,11 @@ function FileRow({
       {canManage && (
         <td className="py-2.5 pl-3 pr-4 text-right">
           <div className="invisible flex items-center justify-end gap-2 group-hover:visible">
-            <button onClick={onRenameStart} className="text-xs text-slate-500 hover:text-indigo-600 dark:text-neutral-400">Rename</button>
-            <button onClick={onMove} className="text-xs text-slate-500 hover:text-indigo-600 dark:text-neutral-400">Move</button>
-            <button onClick={onDelete} className="text-xs text-red-500 hover:text-red-700">Delete</button>
+            <button onClick={onRenameStart} className="text-xs text-slate-500 hover:text-indigo-600 dark:text-neutral-400 font-medium">Rename</button>
+            <button onClick={onDelete} className="text-xs text-red-500 hover:text-red-700 font-medium">Delete</button>
           </div>
         </td>
       )}
     </tr>
-  )
-}
-
-function MovePicker({
-  file,
-  folders,
-  currentFolderId,
-  onMove,
-  onCancel,
-}: {
-  file: FileItem
-  folders: FileFolder[]
-  currentFolderId: string | null
-  onMove: (folderId: string | null) => void
-  onCancel: () => void
-}) {
-  return (
-    <div className="fixed inset-0 z-30 flex items-center justify-center bg-black/40">
-      <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl dark:bg-neutral-900">
-        <h2 className="mb-4 text-base font-semibold text-slate-900 dark:text-neutral-100">
-          Move "{file.displayName}"
-        </h2>
-        <ul className="mb-4 max-h-56 overflow-y-auto rounded-lg border border-slate-200 dark:border-neutral-700">
-          <li>
-            <button
-              className={`flex w-full items-center gap-2 px-4 py-2.5 text-sm hover:bg-slate-50 dark:hover:bg-neutral-800 ${currentFolderId === null ? 'font-semibold text-indigo-600' : ''}`}
-              onClick={() => onMove(null)}
-            >
-              <FolderOpen className="h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500" aria-hidden />
-              Root (top level)
-            </button>
-          </li>
-          {folders.map(f => (
-            <li key={f.id}>
-              <button
-                className={`flex w-full items-center gap-2 px-4 py-2.5 text-sm hover:bg-slate-50 dark:hover:bg-neutral-800 ${currentFolderId === f.id ? 'font-semibold text-indigo-600' : ''}`}
-                onClick={() => onMove(f.id)}
-              >
-                <FolderOpen className="h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500" aria-hidden />
-                {f.name}
-              </button>
-            </li>
-          ))}
-        </ul>
-        <div className="flex justify-end gap-2">
-          <button
-            type="button"
-            onClick={onCancel}
-            className="rounded px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-100 dark:hover:bg-neutral-800"
-          >
-            Cancel
-          </button>
-        </div>
-      </div>
-    </div>
   )
 }

--- a/server/internal/httpserver/course_file_manager.go
+++ b/server/internal/httpserver/course_file_manager.go
@@ -181,7 +181,8 @@ func (d Deps) handlePatchCourseFilesFolder() http.HandlerFunc {
 			return
 		}
 		var body struct {
-			Name *string `json:"name"`
+			Name     *string `json:"name"`
+			ParentID *string `json:"parentId"` // empty string = move to root
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
@@ -211,7 +212,30 @@ func (d Deps) handlePatchCourseFilesFolder() http.HandlerFunc {
 			_ = json.NewEncoder(w).Encode(folder)
 			return
 		}
-		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Provide name to update.")
+		if body.ParentID != nil {
+			var parentID *uuid.UUID
+			if *body.ParentID != "" {
+				fid, parseErr := uuid.Parse(*body.ParentID)
+				if parseErr != nil {
+					apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid parentId.")
+					return
+				}
+				parentID = &fid
+			}
+			folder, moveErr := filemanager.MoveFolder(r.Context(), d.Pool, courseID, folderID, parentID)
+			if moveErr != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, moveErr.Error())
+				return
+			}
+			if folder == nil {
+				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Folder not found.")
+				return
+			}
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			_ = json.NewEncoder(w).Encode(folder)
+			return
+		}
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Provide name or parentId to update.")
 	}
 }
 

--- a/server/internal/repos/filemanager/folders.go
+++ b/server/internal/repos/filemanager/folders.go
@@ -138,6 +138,51 @@ func RenameFolder(ctx context.Context, db *pgxpool.Pool, courseID, folderID uuid
 	return GetFolder(ctx, db, courseID, folderID)
 }
 
+func MoveFolder(ctx context.Context, db *pgxpool.Pool, courseID, folderID uuid.UUID, parentID *uuid.UUID) (*Folder, error) {
+	if parentID != nil {
+		if *parentID == folderID {
+			return nil, errors.New("cannot move a folder into itself")
+		}
+		var parentExists bool
+		err := db.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM course.file_folders WHERE id = $1 AND course_id = $2)`, *parentID, courseID).Scan(&parentExists)
+		if err != nil {
+			return nil, err
+		}
+		if !parentExists {
+			return nil, errors.New("target folder not found")
+		}
+
+		var isDescendant bool
+		err = db.QueryRow(ctx, `
+			WITH RECURSIVE tree AS (
+				SELECT id FROM course.file_folders WHERE id = $1 AND course_id = $2
+				UNION ALL
+				SELECT f.id FROM course.file_folders f JOIN tree t ON f.parent_id = t.id
+			)
+			SELECT EXISTS(SELECT 1 FROM tree WHERE id = $3)
+		`, folderID, courseID, *parentID).Scan(&isDescendant)
+		if err != nil {
+			return nil, err
+		}
+		if isDescendant {
+			return nil, errors.New("cannot move a folder into one of its subfolders")
+		}
+	}
+
+	tag, err := db.Exec(ctx, `
+		UPDATE course.file_folders SET parent_id = $1, updated_at = $2
+		WHERE id = $3 AND course_id = $4
+	`, parentID, time.Now(), folderID, courseID)
+	if err != nil {
+		return nil, err
+	}
+	if tag.RowsAffected() == 0 {
+		return nil, nil
+	}
+	return GetFolder(ctx, db, courseID, folderID)
+}
+
+
 func DeleteFolder(ctx context.Context, db *pgxpool.Pool, courseID, folderID uuid.UUID) (bool, error) {
 	tag, err := db.Exec(ctx, `
 		DELETE FROM course.file_folders WHERE id = $1 AND course_id = $2

--- a/server/internal/service/officepreview/pptx_visual.go
+++ b/server/internal/service/officepreview/pptx_visual.go
@@ -38,6 +38,44 @@ type pptxVisualLayer struct {
 	// image layers
 	dataURI string
 	alt     string
+	// shape geometry
+	borderRadiusPx float64
+}
+
+// readShapeBorderRadiusPx extracts a CSS border-radius for known preset geometries.
+// Returns 0 if the shape is not a rounded rectangle.
+func readShapeBorderRadiusPx(n *pptxXMLNode, cx, cy int64) float64 {
+	spPr := n.child("spPr")
+	if spPr == nil {
+		return 0
+	}
+	prstGeom := spPr.child("prstGeom")
+	if prstGeom == nil {
+		return 0
+	}
+	prst := prstGeom.attr("prst")
+	if prst != "roundRect" && prst != "round1Rect" && prst != "round2SameRect" && prst != "round2DiagRect" {
+		return 0
+	}
+	// adj is a fraction of the shorter side, scaled by 100000. Default 16667 (~1/6).
+	adj := int64(16667)
+	if avLst := prstGeom.child("avLst"); avLst != nil {
+		if gd := avLst.child("gd"); gd != nil {
+			if fmla := gd.attr("fmla"); strings.HasPrefix(fmla, "val ") {
+				if v := parseEMU(strings.TrimPrefix(fmla, "val ")); v > 0 {
+					adj = v
+				}
+			}
+		}
+	}
+	minSide := cx
+	if cy < minSide {
+		minSide = cy
+	}
+	if minSide <= 0 {
+		return 0
+	}
+	return emuToPx(minSide) * float64(adj) / 100000
 }
 
 func convertPptxToVisualHTML(data []byte, filename, mimeType string) (string, error) {
@@ -421,6 +459,7 @@ func extractSpLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partP
 			left: left, top: top, cx: cx, cy: cy,
 			rotDeg: xfrm.rotDeg, flipH: xfrm.flipH,
 			kind: "text", background: bg, border: border,
+			borderRadiusPx: readShapeBorderRadiusPx(n, cx, cy),
 		}, true
 	}
 
@@ -443,7 +482,13 @@ func extractSpLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partP
 		fontPt = 14
 	}
 	if color == "" {
-		color = "#1e3a5f"
+		// Fall back to the theme's body text color (tx1, mapped via clrMap).
+		// Use inherit if even that's missing so the document CSS can take over.
+		if hex := theme.resolveScheme("tx1"); hex != "" {
+			color = "#" + hex
+		} else {
+			color = "inherit"
+		}
 	}
 	title := shapeIsTitle(n)
 	if title && fontPt < 20 {
@@ -481,6 +526,7 @@ func extractSpLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partP
 		fontPx: ptToPx(fontPt), color: color, bold: bold, isTitle: title,
 		background: bg, border: border, vertAlign: vertAlign,
 		vert: vert, noWrap: noWrap,
+		borderRadiusPx: readShapeBorderRadiusPx(n, cx, cy),
 	}, true
 }
 
@@ -538,6 +584,9 @@ func renderPptxVisualLayer(layer pptxVisualLayer) string {
 	}
 
 	posCSS := fmt.Sprintf("left:%.2fpx;top:%.2fpx;width:%.2fpx;height:%.2fpx;z-index:%d;", left, top, width, height, z)
+	if layer.borderRadiusPx > 0 {
+		posCSS += fmt.Sprintf("border-radius:%.2fpx;", layer.borderRadiusPx)
+	}
 
 	if layer.kind == "image" {
 		return fmt.Sprintf(

--- a/server/internal/service/officepreview/pptx_xml_tree.go
+++ b/server/internal/service/officepreview/pptx_xml_tree.go
@@ -347,6 +347,7 @@ func resolveColorNodeDirect(node *pptxXMLNode, theme *pptxTheme) string {
 
 // shapeStyleFill reads the shape's fill color from p:style/a:fillRef,
 // which is how layout/master background shapes get their theme color.
+// idx=1 → first fillStyleLst entry (solidFill), idx>=2 → gradients, idx>=1001 → bgFillStyleLst.
 func shapeStyleFill(sp *pptxXMLNode, theme *pptxTheme) string {
 	styleEl := sp.child("style")
 	if styleEl == nil {
@@ -356,13 +357,40 @@ func shapeStyleFill(sp *pptxXMLNode, theme *pptxTheme) string {
 	if fillRef == nil {
 		return ""
 	}
-	// idx=0 means no fill
-	if fillRef.attr("idx") == "0" {
+	idxStr := fillRef.attr("idx")
+	if idxStr == "" || idxStr == "0" {
 		return ""
 	}
-	clr := resolveColorNode(fillRef, theme)
-	if clr != "" {
-		return "background-color:" + clr + ";"
+	idx := parseEMU(idxStr)
+
+	// Resolve the placeholder color (the schemeClr/srgbClr inside fillRef itself).
+	phClrHex := ""
+	if clr := resolveColorNode(fillRef, theme); clr != "" {
+		phClrHex = strings.TrimPrefix(clr, "#")
+	}
+
+	// Pick the fill style list entry: idx 1..N → fillStyleLst, idx 1001+ → bgFillStyleLst.
+	var fillNode *pptxXMLNode
+	if idx >= 1001 {
+		i := int(idx - 1001)
+		if i < len(theme.bgFillStyles) {
+			fillNode = theme.bgFillStyles[i]
+		}
+	} else {
+		i := int(idx - 1)
+		if i >= 0 && i < len(theme.fillStyles) {
+			fillNode = theme.fillStyles[i]
+		}
+	}
+
+	if fillNode != nil && phClrHex != "" {
+		if css := renderThemeFillCSS(fillNode, phClrHex, theme); css != "" {
+			return "background:" + css + ";"
+		}
+	}
+	// Fall back to flat color when the fill style isn't gradient-renderable.
+	if phClrHex != "" {
+		return "background-color:#" + phClrHex + ";"
 	}
 	return ""
 }
@@ -739,10 +767,14 @@ func parseSlideBgCSS(cSld *pptxXMLNode, theme *pptxTheme) string {
 // ----- Theme color resolution -----
 
 type pptxTheme struct {
-	colors map[string]string // scheme name → RRGGBB hex (no #)
+	colors        map[string]string // scheme name → RRGGBB hex (no #)
+	clrMap        map[string]string // bg1/tx1/bg2/tx2/etc → dk1/lt1/... per slide master clrMap
+	fillStyles    []*pptxXMLNode    // fmtScheme/fillStyleLst entries (1-indexed by fillRef idx)
+	bgFillStyles  []*pptxXMLNode    // fmtScheme/bgFillStyleLst entries (1001+ idx)
 }
 
-var schemeClrAlias = map[string]string{
+// defaultClrMap is the standard mapping used when a master doesn't define its own.
+var defaultClrMap = map[string]string{
 	"bg1": "lt1",
 	"bg2": "lt2",
 	"tx1": "dk1",
@@ -750,6 +782,7 @@ var schemeClrAlias = map[string]string{
 }
 
 func loadPptxTheme(zr *zip.Reader) *pptxTheme {
+	theme := &pptxTheme{colors: make(map[string]string), clrMap: defaultClrMap}
 	for _, name := range []string{"ppt/theme/theme1.xml", "ppt/theme/theme2.xml", "ppt/theme/theme3.xml"} {
 		data, err := readZipFile(zr, name)
 		if err != nil {
@@ -771,9 +804,42 @@ func loadPptxTheme(zr *zip.Reader) *pptxTheme {
 				colors[schemeName] = hex
 			}
 		}
-		return &pptxTheme{colors: colors}
+		theme.colors = colors
+		// Also cache fillStyleLst / bgFillStyleLst entries for fillRef idx resolution.
+		if fmtScheme := root.findDeep("fmtScheme"); fmtScheme != nil {
+			if fsl := fmtScheme.child("fillStyleLst"); fsl != nil {
+				for i := range fsl.Children {
+					c := &fsl.Children[i]
+					theme.fillStyles = append(theme.fillStyles, c)
+				}
+			}
+			if bfsl := fmtScheme.child("bgFillStyleLst"); bfsl != nil {
+				for i := range bfsl.Children {
+					c := &bfsl.Children[i]
+					theme.bgFillStyles = append(theme.bgFillStyles, c)
+				}
+			}
+		}
+		break
 	}
-	return &pptxTheme{colors: make(map[string]string)}
+	// Read the first slide master's clrMap, if present. Most decks have one master,
+	// and its clrMap can swap the standard bg/tx mappings (e.g., dark-themed templates).
+	if data, err := readZipFile(zr, "ppt/slideMasters/slideMaster1.xml"); err == nil {
+		if root, err := parsePptxXML(data); err == nil {
+			if cm := root.findDeep("clrMap"); cm != nil {
+				m := make(map[string]string, len(cm.Attrs))
+				for _, a := range cm.Attrs {
+					if a.Value != "" {
+						m[a.Name.Local] = a.Value
+					}
+				}
+				if len(m) > 0 {
+					theme.clrMap = m
+				}
+			}
+		}
+	}
+	return theme
 }
 
 func extractSingleColorHex(node *pptxXMLNode) string {
@@ -791,8 +857,10 @@ func extractSingleColorHex(node *pptxXMLNode) string {
 }
 
 func (t *pptxTheme) resolveScheme(name string) string {
-	if alias, ok := schemeClrAlias[name]; ok {
-		name = alias
+	if t.clrMap != nil {
+		if alias, ok := t.clrMap[name]; ok && alias != "" {
+			name = alias
+		}
 	}
 	return t.colors[name]
 }
@@ -853,12 +921,20 @@ func prstColorHex(name string) string {
 }
 
 func applyColorTransforms(hex string, node *pptxXMLNode) string {
+	rgba := applyColorTransformsRGBA(hex, node)
+	return fmt.Sprintf("%02X%02X%02X", rgba[0], rgba[1], rgba[2])
+}
+
+// applyColorTransformsRGBA applies OOXML color transforms and returns RGBA with
+// alpha in [0,255]. Alpha defaults to 255 unless an <a:alpha> transform is present.
+func applyColorTransformsRGBA(hex string, node *pptxXMLNode) [4]uint8 {
 	if len(hex) != 6 {
-		return hex
+		return [4]uint8{0, 0, 0, 255}
 	}
 	r := hexByteU8(hex, 0)
 	g := hexByteU8(hex, 2)
 	b := hexByteU8(hex, 4)
+	alpha := uint8(255)
 
 	for _, child := range node.Children {
 		val := parseEMU(child.attr("val"))
@@ -881,9 +957,99 @@ func applyColorTransforms(hex string, node *pptxXMLNode) string {
 			h, l, s := rgbToHLS(r, g, b)
 			l = clampF(l + float64(val)/100000)
 			r, g, b = hlsToRGB(h, l, s)
+		case "satMod":
+			h, l, s := rgbToHLS(r, g, b)
+			s = clampF(s * float64(val) / 100000)
+			r, g, b = hlsToRGB(h, l, s)
+		case "satOff":
+			h, l, s := rgbToHLS(r, g, b)
+			s = clampF(s + float64(val)/100000)
+			r, g, b = hlsToRGB(h, l, s)
+		case "alpha":
+			f := float64(val) / 100000
+			alpha = uint8(clampF(f) * 255)
 		}
 	}
-	return fmt.Sprintf("%02X%02X%02X", r, g, b)
+	return [4]uint8{r, g, b, alpha}
+}
+
+// renderThemeFillCSS renders a theme fillStyleLst entry (solidFill or gradFill)
+// as a CSS `background:` declaration value (without trailing semicolon), with
+// `phClr` substituted by the supplied placeholder color (hex without `#`).
+// Returns "" if the fill kind isn't supported.
+func renderThemeFillCSS(fillNode *pptxXMLNode, phClrHex string, theme *pptxTheme) string {
+	if fillNode == nil || phClrHex == "" {
+		return ""
+	}
+	switch fillNode.XMLName.Local {
+	case "solidFill":
+		clr := fillNode.child("schemeClr")
+		if clr == nil {
+			return ""
+		}
+		rgba := applyColorTransformsRGBA(phClrHex, clr)
+		return formatColorCSS(rgba)
+	case "gradFill":
+		gsLst := fillNode.child("gsLst")
+		if gsLst == nil {
+			return ""
+		}
+		type stop struct {
+			pos  float64 // 0..100
+			rgba [4]uint8
+		}
+		var stops []stop
+		for i := range gsLst.Children {
+			gs := &gsLst.Children[i]
+			if gs.XMLName.Local != "gs" {
+				continue
+			}
+			pos := float64(parseEMU(gs.attr("pos"))) / 1000
+			var clrNode *pptxXMLNode
+			if c := gs.child("schemeClr"); c != nil {
+				clrNode = c
+			} else if c := gs.child("srgbClr"); c != nil {
+				clrNode = c
+			}
+			if clrNode == nil {
+				continue
+			}
+			base := phClrHex
+			if clrNode.XMLName.Local == "srgbClr" {
+				if v := clrNode.attr("val"); v != "" {
+					base = strings.ToUpper(v)
+				}
+			}
+			stops = append(stops, stop{pos: pos, rgba: applyColorTransformsRGBA(base, clrNode)})
+		}
+		if len(stops) < 2 {
+			if len(stops) == 1 {
+				return formatColorCSS(stops[0].rgba)
+			}
+			return ""
+		}
+		// Angle: OOXML lin ang is in 60000ths of a degree, 0 = pointing right, CW.
+		// CSS linear-gradient angle: 0deg = pointing up, CW. So CSS = ang/60000 + 90.
+		cssAngle := 90.0
+		if lin := fillNode.child("lin"); lin != nil {
+			cssAngle = float64(parseEMU(lin.attr("ang")))/60000 + 90
+		}
+		var b strings.Builder
+		fmt.Fprintf(&b, "linear-gradient(%.2fdeg", cssAngle)
+		for _, s := range stops {
+			fmt.Fprintf(&b, ", %s %.2f%%", formatColorCSS(s.rgba), s.pos)
+		}
+		b.WriteString(")")
+		return b.String()
+	}
+	return ""
+}
+
+func formatColorCSS(rgba [4]uint8) string {
+	if rgba[3] == 255 {
+		return fmt.Sprintf("#%02X%02X%02X", rgba[0], rgba[1], rgba[2])
+	}
+	return fmt.Sprintf("rgba(%d,%d,%d,%.3f)", rgba[0], rgba[1], rgba[2], float64(rgba[3])/255)
 }
 
 func hexByteU8(hex string, offset int) uint8 {


### PR DESCRIPTION
## Summary

- **Course files — folder drag-and-drop**: Files and folders can now be dragged onto other folders (and breadcrumb entries) to move them. A \"move up\" bulk-action button is shown when items are selected inside a subfolder. The old move-file modal is replaced by native HTML5 drag-and-drop for both files and folders.
- **Backend `MoveFolder`**: New `filemanager.MoveFolder` repo function with a recursive-CTE guard that prevents moving a folder into itself or any of its descendants. The existing `PATCH /courses/:code/files/folders/:id` endpoint now accepts `parentId` in addition to `name`.
- **PPTX — theme fill resolution**: `shapeStyleFill` now resolves the correct `fillStyleLst`/`bgFillStyleLst` entry from `fmtScheme` so gradient-backed shapes render with the right background instead of a flat fallback.
- **PPTX — `clrMap` support**: The slide master's `clrMap` is loaded so dark-themed templates correctly map `tx1`/`bg1` to the intended scheme colors.
- **PPTX — text color fallback**: Hardcoded `#1e3a5f` replaced by the document's `tx1` scheme color (with `inherit` as a last resort).
- **PPTX — rounded rectangles**: `readShapeBorderRadiusPx` reads the `adj` value from `prstGeom` (`roundRect`, `round1Rect`, etc.) and emits a CSS `border-radius`.

## Test plan

- [x] TypeScript typecheck passes (`tsc -b`)
- [x] Go build passes (`go build ./...`)
- [x] ESLint passes (0 errors, pre-existing warnings only)
- [x] `go vet ./internal/...` clean
- [x] Web unit tests: 558/558 passed (`vitest run`)
- [x] Go short tests: all packages pass (`make testshort`)
- [x] E2e suite: 617 passed, 37 skipped, 1 pre-existing failure (`backup-restore` authorization — unrelated to these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)