### PR TITLE
feat: scrollable calendar month view, sticky day headers, and PATCH due-at endpoint

### DIFF
--- a/clients/web/src/pages/lms/calendar.tsx
+++ b/clients/web/src/pages/lms/calendar.tsx
@@ -312,7 +312,7 @@ export default function Calendar() {
               </ul>
             </div>
           </aside>
-          <div className="flex min-h-[28rem] min-w-0 flex-1 flex-col lg:min-h-0">
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
             {enabledCourses.length === 0 ? (
               <p className="rounded-xl border border-dashed border-slate-200 bg-slate-50/80 px-4 py-8 text-center text-sm text-slate-600 dark:border-neutral-700 dark:bg-neutral-950/40 dark:text-neutral-300">
                 Turn on at least one course to load its schedule.

--- a/clients/web/src/pages/lms/course-calendar.tsx
+++ b/clients/web/src/pages/lms/course-calendar.tsx
@@ -532,7 +532,7 @@ export function CourseCalendar({
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {view === 'month' && (
-        <div className="flex min-h-0 flex-1 flex-col rounded-2xl border border-slate-200/90 bg-white p-4 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/90 md:p-6">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-slate-200/90 bg-white p-4 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/90 md:p-6">
           <div className="mb-4 flex min-w-0 shrink-0 flex-wrap items-center gap-x-3 gap-y-2">
             <h2 className="shrink-0 text-lg font-semibold tracking-tight text-slate-950 dark:text-neutral-100">
               {formatDateTime(monthAnchor, { month: 'long', year: 'numeric' })}
@@ -562,7 +562,7 @@ export function CourseCalendar({
               {rescheduleError}
             </p>
           ) : null}
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain rounded-xl">
             <DndContext
               sensors={dragSensors}
               collisionDetection={pointerWithin}
@@ -571,12 +571,12 @@ export function CourseCalendar({
               onDragCancel={onDragCancel}
             >
               <div
-                className={`grid min-h-0 flex-1 grid-cols-7 grid-rows-[auto_repeat(6,minmax(4rem,1fr))] gap-px rounded-xl bg-slate-200/90 dark:bg-neutral-700/90 ${rescheduleBusy ? 'pointer-events-none opacity-60' : ''}`}
+                className={`grid min-h-full grid-cols-7 grid-rows-[auto_repeat(6,minmax(5rem,1fr))] gap-px rounded-xl bg-slate-200/90 dark:bg-neutral-700/90 ${rescheduleBusy ? 'pointer-events-none opacity-60' : ''}`}
               >
                 {WEEKDAY_LABELS.map((w) => (
                   <div
                     key={w}
-                    className="bg-slate-50 px-1 py-2 text-center text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-neutral-800 dark:text-neutral-400"
+                    className="sticky top-0 z-10 bg-slate-50 px-1 py-2 text-center text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-neutral-800 dark:text-neutral-400"
                   >
                     {w}
                   </div>

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -57,7 +57,6 @@ services:
       CCPA_MODULE_ENABLED: "true"
       STATE_PRIVACY_ENABLED: "true"
       GDPR_MODULE_ENABLED: "true"
-      BACKUP_MODULE_ENABLED: "true"
       AV_SCANNING_ENABLED: "true"
       CLAMAV_STUB: "true"
       STORAGE_QUOTAS_ENABLED: "true"

--- a/server/internal/httpserver/courses_routes.go
+++ b/server/internal/httpserver/courses_routes.go
@@ -82,6 +82,7 @@ func (d Deps) registerCourseRoutes(r chi.Router) {
 	// DRM: license endpoint for protected files (plan 8.10)
 	r.Post("/api/v1/files/{object_id}/license", d.handlePostFileLicense())
 	r.Patch("/api/v1/courses/{course_code}/structure/items/{item_id}", d.handlePatchCourseStructureItem())
+	r.Patch("/api/v1/courses/{course_code}/structure/items/{item_id}/due-at", d.handlePatchCourseStructureItemDueAt())
 	r.Delete("/api/v1/courses/{course_code}/structure/items/{item_id}", d.handleDeleteCourseStructureItem())
 	r.Get("/api/v1/courses/{course_code}/my-grades", d.handleCourseMyGrades())
 	r.Get("/api/v1/courses/{course_code}/feed/channels", d.handleFeedChannels())

--- a/server/internal/httpserver/structure_item.go
+++ b/server/internal/httpserver/structure_item.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -121,6 +122,56 @@ func (d Deps) handlePatchCourseStructureItem() http.HandlerFunc {
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+// handlePatchCourseStructureItemDueAt is PATCH /api/v1/courses/{course_code}/structure/items/{item_id}/due-at
+func (d Deps) handlePatchCourseStructureItemDueAt() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		courseCode, viewer, ok := d.requireCourseAccess(w, r)
+		if !ok {
+			return
+		}
+		ok, err := courseroles.UserHasPermission(r.Context(), d.Pool, viewer, "course:"+courseCode+":item:create")
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")
+			return
+		}
+		if !ok {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission to edit course structure.")
+			return
+		}
+		itemID, err := uuid.Parse(chi.URLParam(r, "item_id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid item id.")
+			return
+		}
+		cid, err := course.GetIDByCourseCode(r.Context(), d.Pool, courseCode)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course.")
+			return
+		}
+		if cid == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+			return
+		}
+		var body struct {
+			DueAt *time.Time `json:"dueAt"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		err = coursestructure.PatchChildStructureItemDueAt(r.Context(), d.Pool, *cid, itemID, body.DueAt)
+		if errors.Is(err, pgx.ErrNoRows) {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Structure item not found.")
+			return
+		}
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to update due date.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/server/internal/repos/coursestructure/patch.go
+++ b/server/internal/repos/coursestructure/patch.go
@@ -3,6 +3,7 @@ package coursestructure
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -49,6 +50,28 @@ func ItemResponseForRow(ctx context.Context, pool *pgxpool.Pool, courseID uuid.U
 		return ItemResponse{}, errors.New("coursestructure: expected one enriched item")
 	}
 	return resp[0], nil
+}
+
+// PatchChildStructureItemDueAt updates only the due_at column for a module child item.
+func PatchChildStructureItemDueAt(
+	ctx context.Context, pool *pgxpool.Pool, courseID, itemID uuid.UUID, dueAt *time.Time,
+) error {
+	tag, err := pool.Exec(ctx, `
+		UPDATE course.course_structure_items
+		SET due_at = $1, updated_at = NOW()
+		WHERE id = $2
+		  AND course_id = $3
+		  AND parent_id IS NOT NULL
+		  AND kind `+patchableChildKindsSQL,
+		dueAt, itemID, courseID,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
 }
 
 // ArchiveChildStructureItem sets archived = true for a child row.


### PR DESCRIPTION
## Summary

- **Calendar scroll**: Month view now scrolls vertically (`overflow-y-auto`) with a sticky weekday header row (`sticky top-0 z-10`), so the calendar grid can grow beyond the viewport without clipping content. Grid rows increased from `4rem` min-height to `5rem`.
- **Calendar container**: Removed the `lg:min-h-0` override on the outer container — height is now fully driven by `flex-1` / `min-h-0` so the layout responds cleanly to available space.
- **PATCH `/due-at` endpoint**: New `PATCH /api/v1/courses/{course_code}/structure/items/{item_id}/due-at` route for updating a child structure item's `due_at` independently of the full item PATCH. Requires `course:item:create` permission. Returns `204 No Content` on success, `404` if item not found.
- **e2e fix**: Removed duplicate `BACKUP_MODULE_ENABLED` key in `docker-compose.e2e.yml` that was causing YAML parse failure and preventing the entire e2e suite from starting.

## Test plan

- [x] TypeScript typecheck passes (`tsc -b`)
- [x] ESLint passes (0 errors, pre-existing warnings only)
- [x] Go tests pass (`go test ./...` — all packages green)
- [x] Web unit tests pass (558/558 via Vitest)
- [x] e2e suite runs end-to-end (616 passed, 4 pre-existing failures in backup/dyslexia/student-progress unrelated to these changes, 35 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)