### PR TITLE
feat: org-type setting (higher-ed / K-12) with grade-level filter gating

### DIFF
--- a/clients/web/src/components/settings/org-units-panel.tsx
+++ b/clients/web/src/components/settings/org-units-panel.tsx
@@ -8,6 +8,8 @@ import { readApiErrorMessage } from '../../lib/errors'
 import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
 import { usePermissions } from '../../context/use-permissions'
 
+export type OrgType = 'higher-ed' | 'k-12'
+
 type OrgRow = {
   id: string
   name: string
@@ -109,6 +111,9 @@ export function OrgUnitsPanel() {
   const [childType, setChildType] = useState<string>('department')
   const [creatingChild, setCreatingChild] = useState(false)
 
+  const [orgType, setOrgType] = useState<OrgType>('higher-ed')
+  const [orgTypeSaving, setOrgTypeSaving] = useState(false)
+
   const loadOrgs = useCallback(async () => {
     if (!canRbac) return
     try {
@@ -155,6 +160,16 @@ export function OrgUnitsPanel() {
   useEffect(() => {
     if (orgId && canUnits) void loadTree()
   }, [orgId, canUnits, loadTree])
+
+  useEffect(() => {
+    if (!orgId) return
+    void authorizedFetch(`/api/v1/orgs/${encodeURIComponent(orgId)}/settings/org-type`)
+      .then((r) => r.json())
+      .then((data: { orgType?: OrgType }) => {
+        if (data.orgType === 'k-12' || data.orgType === 'higher-ed') setOrgType(data.orgType)
+      })
+      .catch(() => {})
+  }, [orgId])
 
   async function createRoot(e: FormEvent) {
     e.preventDefault()
@@ -206,6 +221,26 @@ export function OrgUnitsPanel() {
     }
   }
 
+  async function saveOrgType(newType: OrgType) {
+    if (!orgId) return
+    setOrgTypeSaving(true)
+    try {
+      const res = await authorizedFetch(`/api/v1/orgs/${encodeURIComponent(orgId)}/settings/org-type`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgType: newType }),
+      })
+      const raw: unknown = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(readApiErrorMessage(raw))
+      setOrgType(newType)
+      toastSaveOk('Institution type saved.')
+    } catch (err) {
+      toastMutationError(err instanceof Error ? err.message : 'Request failed.')
+    } finally {
+      setOrgTypeSaving(false)
+    }
+  }
+
   if (!canUnits) {
     return (
       <p className="mt-2 text-sm text-slate-600 dark:text-neutral-400">
@@ -216,6 +251,30 @@ export function OrgUnitsPanel() {
 
   return (
     <div className="mt-6 space-y-6">
+      <div className="rounded-xl border border-slate-200 bg-slate-50/80 p-4 dark:border-neutral-600 dark:bg-neutral-800/40">
+        <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Institution type</h3>
+        <p className="mt-1 text-xs text-slate-500 dark:text-neutral-400">
+          Determines which features are available. K-12 enables grade-level filtering on the course catalog.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-3">
+          {(['higher-ed', 'k-12'] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              disabled={orgTypeSaving}
+              onClick={() => void saveOrgType(t)}
+              className={`rounded-xl border px-4 py-2 text-sm font-medium transition disabled:opacity-50 ${
+                orgType === t
+                  ? 'border-indigo-600 bg-indigo-600 text-white'
+                  : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800'
+              }`}
+            >
+              {t === 'higher-ed' ? 'Higher Education' : 'K-12'}
+            </button>
+          ))}
+        </div>
+      </div>
+
       <div className="flex flex-wrap items-center justify-between gap-3">
         <p className="text-sm text-slate-600 dark:text-neutral-400">
           Structure your tenant with nested schools and departments. Course catalog visibility can be limited to a unit

--- a/clients/web/src/pages/lms/AttendanceCheckin.tsx
+++ b/clients/web/src/pages/lms/AttendanceCheckin.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { getAttendanceSession, selfReportAttendance, type AttendanceSessionDetail } from '../../lib/course-attendance-api'
+import { LmsPage } from './lms-page'
+
+type CheckinState = 'loading' | 'submitting' | 'done' | 'already_recorded' | 'window_closed' | 'error'
+
+export default function AttendanceCheckin() {
+  const { courseCode, sessionId } = useParams<{ courseCode: string; sessionId: string }>()
+  const [session, setSession] = useState<AttendanceSessionDetail | null>(null)
+  const [state, setState] = useState<CheckinState>('loading')
+  const [recordedStatus, setRecordedStatus] = useState<'present' | 'tardy'>('present')
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!courseCode || !sessionId) return
+    void (async () => {
+      try {
+        const detail = await getAttendanceSession(courseCode, sessionId)
+        setSession(detail)
+        if (detail.myRecord && detail.myRecord.status !== 'not_recorded') {
+          setRecordedStatus(detail.myRecord.status as 'present' | 'tardy')
+          setState('already_recorded')
+          return
+        }
+        if (!detail.canSelfReport) {
+          setState('window_closed')
+          return
+        }
+        setState('submitting')
+        await selfReportAttendance(courseCode, sessionId, 'present')
+        setRecordedStatus('present')
+        setState('done')
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : 'Check-in failed.'
+        if (msg.toLowerCase().includes('window') || msg.toLowerCase().includes('closed')) {
+          setState('window_closed')
+        } else if (msg.toLowerCase().includes('already')) {
+          setState('already_recorded')
+        } else {
+          setErrorMsg(msg)
+          setState('error')
+        }
+      }
+    })()
+  }, [courseCode, sessionId])
+
+  const handleMarkTardy = async () => {
+    if (!courseCode || !sessionId) return
+    setState('submitting')
+    try {
+      await selfReportAttendance(courseCode, sessionId, 'tardy')
+      setRecordedStatus('tardy')
+      setState('done')
+    } catch (e) {
+      setErrorMsg(e instanceof Error ? e.message : 'Check-in failed.')
+      setState('error')
+    }
+  }
+
+  const sessionTitle = session?.title ?? 'Attendance session'
+
+  return (
+    <LmsPage title="Check in">
+      <div className="flex flex-col items-center justify-center py-12">
+        {state === 'loading' || state === 'submitting' ? (
+          <p className="text-sm text-slate-500" aria-busy="true">
+            {state === 'submitting' ? 'Recording your attendance…' : 'Loading…'}
+          </p>
+        ) : state === 'done' ? (
+          <div className="w-full max-w-sm rounded-2xl border border-emerald-200 bg-emerald-50 p-8 text-center shadow-sm dark:border-emerald-900 dark:bg-emerald-950/30">
+            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/40">
+              <svg className="h-7 w-7 text-emerald-600 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <h2 className="text-lg font-semibold text-emerald-900 dark:text-emerald-100">
+              {recordedStatus === 'tardy' ? 'Marked tardy' : 'Checked in!'}
+            </h2>
+            <p className="mt-1 text-sm text-emerald-700 dark:text-emerald-300">{sessionTitle}</p>
+            {recordedStatus === 'present' && (
+              <button
+                type="button"
+                onClick={() => void handleMarkTardy()}
+                className="mt-4 text-xs text-emerald-600 underline hover:text-emerald-800 dark:text-emerald-400 dark:hover:text-emerald-200"
+              >
+                Actually, I&apos;m late — mark tardy
+              </button>
+            )}
+          </div>
+        ) : state === 'already_recorded' ? (
+          <div className="w-full max-w-sm rounded-2xl border border-slate-200 bg-white p-8 text-center shadow-sm dark:border-neutral-800 dark:bg-neutral-950">
+            <h2 className="text-base font-semibold text-slate-900 dark:text-neutral-100">Already recorded</h2>
+            <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+              Your attendance for <span className="font-medium">{sessionTitle}</span> has already been recorded
+              {recordedStatus ? ` as ${recordedStatus}` : ''}.
+            </p>
+          </div>
+        ) : state === 'window_closed' ? (
+          <div className="w-full max-w-sm rounded-2xl border border-amber-200 bg-amber-50 p-8 text-center shadow-sm dark:border-amber-900 dark:bg-amber-950/30">
+            <h2 className="text-base font-semibold text-amber-900 dark:text-amber-100">Session closed</h2>
+            <p className="mt-1 text-sm text-amber-700 dark:text-amber-300">
+              The check-in window for <span className="font-medium">{sessionTitle}</span> is no longer open.
+            </p>
+          </div>
+        ) : (
+          <div className="w-full max-w-sm rounded-2xl border border-red-200 bg-red-50 p-8 text-center shadow-sm dark:border-red-900 dark:bg-red-950/30">
+            <h2 className="text-base font-semibold text-red-900 dark:text-red-100">Check-in failed</h2>
+            <p className="mt-1 text-sm text-red-700 dark:text-red-300">{errorMsg ?? 'Something went wrong. Please try again.'}</p>
+          </div>
+        )}
+      </div>
+    </LmsPage>
+  )
+}

--- a/clients/web/src/pages/lms/course-catalog-import-menu.tsx
+++ b/clients/web/src/pages/lms/course-catalog-import-menu.tsx
@@ -27,7 +27,7 @@ export function CourseCatalogImportMenu({ onImportCanvas }: Props) {
         aria-expanded={open}
         aria-controls={open ? menuId : undefined}
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-2 py-1.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800 sm:w-auto"
+        className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800 sm:w-auto"
       >
         <Download className="h-4 w-4 shrink-0" aria-hidden />
         <span>Import</span>

--- a/clients/web/src/pages/lms/courses.tsx
+++ b/clients/web/src/pages/lms/courses.tsx
@@ -28,6 +28,7 @@ import { usePermissions } from '../../context/use-permissions'
 import { useCoursesRevision } from '../../context/use-inbox-unread'
 import { authorizedFetch } from '../../lib/api'
 import { putCourseCatalogOrder, type CoursePublic, fetchOrgTerms, type OrgTerm } from '../../lib/courses-api'
+import { type OrgType } from '../../components/settings/org-units-panel'
 import { decodeJwtPayload } from '../../lib/jwt-payload'
 import { getAccessToken } from '../../lib/auth'
 import { readApiErrorMessage } from '../../lib/errors'
@@ -205,6 +206,8 @@ export default function Courses() {
   const [termFilter, setTermFilter] = useState<string>('')
   const [termList, setTermList] = useState<OrgTerm[]>([])
   const [gradeLevelFilter, setGradeLevelFilter] = useState<string>('')
+  const [orgType, setOrgType] = useState<OrgType>('higher-ed')
+  void orgType
   const orgId = decodeJwtPayload(getAccessToken())?.org_id ?? ''
 
   useEffect(() => {
@@ -217,6 +220,22 @@ export default function Courses() {
       .catch(() => {
         if (!cancelled) setTermList([])
       })
+    return () => {
+      cancelled = true
+    }
+  }, [orgId])
+
+  useEffect(() => {
+    if (!orgId) return
+    let cancelled = false
+    void authorizedFetch(`/api/v1/orgs/${encodeURIComponent(orgId)}/settings/org-type`)
+      .then((r) => r.json())
+      .then((data: { orgType?: OrgType }) => {
+        if (!cancelled && (data.orgType === 'k-12' || data.orgType === 'higher-ed')) {
+          setOrgType(data.orgType)
+        }
+      })
+      .catch(() => {})
     return () => {
       cancelled = true
     }
@@ -373,38 +392,40 @@ export default function Courses() {
             </select>
           </div>
         )}
-        <div className="min-w-48 max-w-sm flex-1">
-          <label htmlFor="course-catalog-grade-filter" className="text-sm font-medium text-slate-700 dark:text-neutral-200">
-            Grade level
-          </label>
-          <select
-            id="course-catalog-grade-filter"
-            value={gradeLevelFilter}
-            onChange={(e) => setGradeLevelFilter(e.target.value)}
-            className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 shadow-sm outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/30 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100"
-            aria-label="Filter courses by grade level"
-          >
-            <option value="">All grade levels</option>
-            <option value="K">Kindergarten</option>
-            <option value="1">Grade 1</option>
-            <option value="2">Grade 2</option>
-            <option value="3">Grade 3</option>
-            <option value="4">Grade 4</option>
-            <option value="5">Grade 5</option>
-            <option value="6">Grade 6</option>
-            <option value="7">Grade 7</option>
-            <option value="8">Grade 8</option>
-            <option value="9">Grade 9</option>
-            <option value="10">Grade 10</option>
-            <option value="11">Grade 11</option>
-            <option value="12">Grade 12</option>
-            <option value="K-2">K–2 (multi-grade)</option>
-            <option value="3-5">3–5 (multi-grade)</option>
-            <option value="6-8">6–8 (multi-grade)</option>
-            <option value="9-12">9–12 (multi-grade)</option>
-            <option value="K-12">K–12 (all grades)</option>
-          </select>
-        </div>
+        {orgType === 'k-12' && (
+          <div className="min-w-48 max-w-sm flex-1">
+            <label htmlFor="course-catalog-grade-filter" className="text-sm font-medium text-slate-700 dark:text-neutral-200">
+              Grade level
+            </label>
+            <select
+              id="course-catalog-grade-filter"
+              value={gradeLevelFilter}
+              onChange={(e) => setGradeLevelFilter(e.target.value)}
+              className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 shadow-sm outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/30 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100"
+              aria-label="Filter courses by grade level"
+            >
+              <option value="">All grade levels</option>
+              <option value="K">Kindergarten</option>
+              <option value="1">Grade 1</option>
+              <option value="2">Grade 2</option>
+              <option value="3">Grade 3</option>
+              <option value="4">Grade 4</option>
+              <option value="5">Grade 5</option>
+              <option value="6">Grade 6</option>
+              <option value="7">Grade 7</option>
+              <option value="8">Grade 8</option>
+              <option value="9">Grade 9</option>
+              <option value="10">Grade 10</option>
+              <option value="11">Grade 11</option>
+              <option value="12">Grade 12</option>
+              <option value="K-2">K–2 (multi-grade)</option>
+              <option value="3-5">3–5 (multi-grade)</option>
+              <option value="6-8">6–8 (multi-grade)</option>
+              <option value="9-12">9–12 (multi-grade)</option>
+              <option value="K-12">K–12 (all grades)</option>
+            </select>
+          </div>
+        )}
       </div>
 
       {courses === null && !error && <CoursesCatalogSkeleton />}

--- a/clients/web/src/pages/lms/dashboard.tsx
+++ b/clients/web/src/pages/lms/dashboard.tsx
@@ -10,7 +10,6 @@ import {
   Megaphone,
   MessageCircle,
   Sparkles,
-  Users,
   Flame,
   ChevronDown,
   ChevronUp,
@@ -22,7 +21,6 @@ import { fetchFeedChannels, fetchFeedMessages } from '../../lib/course-feed-api'
 import { getCourseViewAs } from '../../lib/course-view-as'
 import { getAccountType, getJwtSubject } from '../../lib/auth'
 import {
-  courseEnrollmentsReadPermission,
   courseGradebookViewPermission,
   fetchCourse,
   fetchCourseGradebookGrid,
@@ -42,7 +40,6 @@ import {
 } from '../../lib/courses-api'
 import { getMostRecentLastVisited, hrefForLastVisited } from '../../lib/last-visited-module-item'
 import { hrefForRecommendationItem, surfaceLabel } from '../../lib/recommendation-nav'
-import { formatTimeAgoFromIso } from '../../lib/format-time-ago'
 import { DeadlineDateTime } from '../../components/timezone/deadline-datetime'
 import { useInboxUnreadCount, useCoursesRevision } from '../../context/use-inbox-unread'
 import { useCourseFeedUnread } from '../../context/use-course-feed-unread'
@@ -56,13 +53,6 @@ import {
 import { DashboardLoadingSkeleton } from '../../components/ui/lms-content-skeletons'
 import { StudyStatsCard } from '../../components/study-stats/study-stats-card'
 import { LmsPage } from './lms-page'
-
-type CourseEnrollmentRow = {
-  userId: string
-  displayName: string | null
-  role: string
-  lastCourseAccessAt?: string | null
-}
 
 function startOfWeekMonday(now = new Date()): Date {
   const d = new Date(now)
@@ -234,7 +224,6 @@ export default function Dashboard() {
     {
       course: CoursePublic
       emptyGradeCells: number | null
-      recentLearners: { name: string; lastAt: string | null }[] | null
     }[]
   >([])
 
@@ -390,53 +379,7 @@ export default function Dashboard() {
               emptyGradeCells = null
             }
           }
-          let recentLearners: { name: string; lastAt: string | null }[] | null = null
-          if (allows(courseEnrollmentsReadPermission(code))) {
-            try {
-              const res = await authorizedFetch(`/api/v1/courses/${encodeURIComponent(code)}/enrollments`)
-              const raw: unknown = await res.json().catch(() => ({}))
-              if (res.ok) {
-                const data = raw as { enrollments?: unknown[] }
-                const rows = Array.isArray(data.enrollments) ? data.enrollments : []
-                const mapped: CourseEnrollmentRow[] = rows.map((row) => {
-                  const o = row as Record<string, unknown>
-                  const userId =
-                    typeof o.userId === 'string'
-                      ? o.userId
-                      : typeof o.user_id === 'string'
-                        ? o.user_id
-                        : ''
-                  const displayName =
-                    typeof o.displayName === 'string'
-                      ? o.displayName
-                      : typeof o.display_name === 'string'
-                        ? o.display_name
-                        : null
-                  const role = typeof o.role === 'string' ? o.role : 'Student'
-                  const lastCourseAccessAt =
-                    typeof o.lastCourseAccessAt === 'string'
-                      ? o.lastCourseAccessAt
-                      : typeof o.last_course_access_at === 'string'
-                        ? o.last_course_access_at
-                        : null
-                  return { userId, displayName, role, lastCourseAccessAt }
-                })
-                const studentsOnly = mapped.filter((e) => e.role.toLowerCase() === 'student')
-                const sorted = [...studentsOnly].sort((a, b) => {
-                  const ta = a.lastCourseAccessAt ? new Date(a.lastCourseAccessAt).getTime() : 0
-                  const tb = b.lastCourseAccessAt ? new Date(b.lastCourseAccessAt).getTime() : 0
-                  return tb - ta
-                })
-                recentLearners = sorted.slice(0, 5).map((e) => ({
-                  name: e.displayName?.trim() || 'Student',
-                  lastAt: e.lastCourseAccessAt ?? null,
-                }))
-              }
-            } catch {
-              recentLearners = null
-            }
-          }
-          return { course, emptyGradeCells, recentLearners }
+          return { course, emptyGradeCells }
         })
 
         if (detailGenRef.current !== gen) return
@@ -1028,35 +971,6 @@ export default function Dashboard() {
                             Modules
                           </Link>
                         </div>
-                        {row.recentLearners && row.recentLearners.length > 0 && (
-                          <div className="mt-5 border-t border-slate-100 pt-4 dark:border-neutral-800">
-                            <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-neutral-500">
-                              <Users className="h-3.5 w-3.5" aria-hidden />
-                              Recent roster activity
-                            </p>
-                            <ul className="mt-2 space-y-1.5">
-                              {row.recentLearners.map((p, i) => (
-                                <li
-                                  key={`${p.name}-${i}`}
-                                  className="flex justify-between gap-2 text-xs text-slate-600 dark:text-neutral-300"
-                                >
-                                  <span className="truncate font-medium text-slate-800 dark:text-neutral-100">
-                                    {p.name}
-                                  </span>
-                                  <span className="shrink-0 text-slate-400 dark:text-neutral-500">
-                                    {formatTimeAgoFromIso(p.lastAt)}
-                                  </span>
-                                </li>
-                              ))}
-                            </ul>
-                            <Link
-                              to={`${base}/enrollments`}
-                              className="mt-3 inline-block text-xs font-medium text-indigo-600 hover:underline dark:text-indigo-400"
-                            >
-                              Full roster
-                            </Link>
-                          </div>
-                        )}
                       </div>
                     )
                   })}

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -1,0 +1,405 @@
+# Lextures — Architecture & Stack Blueprint
+
+Use this as a reference to start a new project with a similar shape to [Lextures](https://github.com/StudyDrift/lextures): a **monorepo** with a **Go API**, **React SPA**, and **PostgreSQL**, optimized for local Docker dev and self-hosting.
+
+---
+
+## 1. What Lextures Is
+
+**Lextures** is an open-source LMS (Learning Management System): courses, modules, grading, enrollments, integrations (LTI, SAML, OIDC, SCIM), optional AI via OpenRouter. License: **AGPL-3.0**.
+
+For a **greenfield** project you typically keep the **platform shape** (repo layout, layers, tooling) and drop domain-specific pieces (quizzes, LTI, 220+ migrations, compliance modules).
+
+---
+
+## 2. Monorepo Layout
+
+```
+lextures/
+├── server/                 # Go API (module: github.com/lextures/lextures/server)
+│   ├── cmd/
+│   │   ├── server/         # Main HTTP entry
+│   │   └── bootstrap-admin/  # One-off CLI tools
+│   ├── migrations/         # Numbered SQL (001_*.sql … 225_*.sql)
+│   ├── internal/
+│   │   ├── app/            # Wiring: config, DB, migrations, HTTP server
+│   │   ├── httpserver/     # Chi routes + HTTP handlers (large surface)
+│   │   ├── service/        # Business logic
+│   │   ├── repos/          # pgx data access
+│   │   ├── models/         # Domain types
+│   │   ├── auth/           # JWT, passwords (Argon2id)
+│   │   ├── authz/          # RBAC permission matching
+│   │   ├── apierr/         # JSON error envelope
+│   │   ├── config/         # Env-based config
+│   │   ├── migrate/        # Migration runner
+│   │   └── background/     # Periodic jobs (goroutines today)
+│   ├── Dockerfile
+│   └── .env.example
+├── clients/
+│   ├── web/                # Primary React SPA
+│   ├── cli/                # Go admin CLI
+│   ├── android/            # Native mobile (optional)
+│   └── ios/
+├── www/                    # Marketing/docs site (separate Vite app)
+├── e2e/                    # Playwright tests
+├── iac/                    # Terraform modules (AWS/GCP/Azure)
+├── docs/                   # ARCH.md, getting-started, ADRs
+├── data/                   # Local file storage mount (course-files)
+├── docker-compose.yml      # Base: postgres, server, web
+├── docker-compose.dev.yml  # Dev: Vite HMR :5173
+├── docker-compose.prod.yml # Prod: nginx static :3000
+├── Makefile                # e2e orchestration
+├── AGENTS.md               # Agent/dev environment notes
+└── package.json            # Root (minimal; Playwright at repo root for e2e)
+```
+
+**Pattern:** one repo, multiple deployable artifacts; API and SPA versioned together; shared contracts evolving toward OpenAPI.
+
+---
+
+## 3. Tech Stack (Copy This Table)
+
+| Layer | Choices |
+|--------|---------|
+| **API** | Go **1.25**, [chi v5](https://github.com/go-chi/chi), [pgx v5](https://github.com/jackc/pgx), `log/slog` |
+| **Auth** | JWT access tokens (`golang-jwt/jwt/v5`), refresh tokens, Argon2id passwords, optional WebAuthn/TOTP/MFA |
+| **DB** | PostgreSQL **16** (Docker Alpine image locally) |
+| **Web app** | React **19**, Vite **8**, TypeScript **6**, Tailwind CSS **v4** (`@tailwindcss/vite`) |
+| **Routing (web)** | React Router **v7** (`BrowserRouter` + `Routes`) |
+| **Validation (web)** | Zod schemas + `parseApiResponse` helpers |
+| **Rich text** | TipTap (domain-specific; optional for new apps) |
+| **i18n** | i18next + react-i18next |
+| **Tests (web)** | Vitest, Testing Library, MSW for mocks |
+| **Tests (API)** | `go test` with Postgres service in CI |
+| **E2E** | Playwright (`e2e/`, `make e2e`) |
+| **Containers** | Docker Compose (dev/prod/e2e overlays) |
+| **CI** | GitHub Actions: golangci-lint, go test + coverage floor, govulncheck, web lint/typecheck/test |
+| **Pre-commit** | Husky + lint-staged (ESLint on `*.ts/tsx`) + `tsc -b` from `clients/web` |
+
+**Ports (local dev):**
+
+- Web (Vite): `5173`
+- API: `8080`
+- Postgres: `5432` (user/pass/db: `studydrift` / `studydrift` / `studydrift`)
+
+---
+
+## 4. Backend Architecture
+
+### 4.1 Four-layer split
+
+Documented in `docs/ARCH.md` as the intended mental model:
+
+1. **`httpserver`** — HTTP: decode JSON, call services, write JSON/errors. Split by domain (`auth.go`, `course_*.go`, …). Chi router in `server.go`.
+2. **`service`** — Business rules, orchestration, transactions.
+3. **`repos`** — SQL via pgx; one package per aggregate/table group.
+4. **`models`** — Structs and domain constants (often with `doc.go`).
+
+**Entry flow:**
+
+```
+cmd/server/main.go
+  → app.Run(ctx, embedded migrations FS)
+    → config.Load()
+    → db.NewPool(DATABASE_URL)
+    → migrate.RunWithFS (if RUN_MIGRATIONS=true)
+    → merge env + DB platform settings
+    → filestorage.New(local or S3-compatible)
+    → background.StartWithStorage(...)
+    → httpserver.NewHandler(Deps) on http.Server
+```
+
+### 4.2 HTTP conventions
+
+- **API prefix:** `/api/v1/...`
+- **Health:** `GET /health`, `GET /health/ready` (DB ping)
+- **OpenAPI:** `GET /api/openapi.json`, `GET /api/docs` (skeleton today; roadmap is OpenAPI-first)
+- **Errors:** stable JSON shape via `apierr`:
+
+  ```json
+  { "error": { "code": "FORBIDDEN", "message": "Human-readable text." } }
+  ```
+
+- **Middleware (chi):** CORS, RequestID, RealIP, Recoverer, access logging
+- **404:** explicit handler when no route matches (distinct from handler-level NOT_FOUND)
+
+### 4.3 Auth & authorization
+
+- **Signup/login:** `authservice` → Argon2id hash → JWT via `JWTSigner` (claims: `sub`, `email`, `org_id`, session version for revocation)
+- **Password policy:** HIBP breach check on signup/password change
+- **Bootstrap admin:** `BOOTSTRAP_ADMIN_EMAIL` — first human signup with matching email gets **Global Admin** (advisory lock + role assign in transaction)
+- **RBAC:** permissions are four segments: `scope:area:function:action` with `*` wildcards (`authz.PermissionMatches`)
+- **Handlers today:** often call `require_permission()` manually (ARCH.md recommends moving to chi middleware)
+
+### 4.4 Configuration
+
+- **Secrets & infra:** env vars (`server/.env` from `.env.example`)
+  - Required: `DATABASE_URL`, `JWT_SECRET` (≥32 chars prod), `PORT`, `PUBLIC_WEB_ORIGIN`, `RUN_MIGRATIONS`
+  - Files: `COURSE_FILES_ROOT` or S3-compatible storage vars
+- **Feature flags:** stored in DB (`settings.platform_app_settings`), not `VITE_*` build flags. Web loads `GET /api/v1/platform/features` at runtime.
+
+### 4.5 Migrations
+
+- **~223** sequential SQL files in `server/migrations/`
+- Embedded in Go module root, applied on startup when `RUN_MIGRATIONS=true`
+- PostgreSQL-specific: schemas (`"user".users`), JSONB, advisory locks, `uuid`, etc. — **not portable to SQLite**
+- Dev repair: `MIGRATE_REPAIR_CHECKSUMS` for idempotent migration edits
+
+### 4.6 Background work
+
+- `internal/background/` — periodic goroutines (e.g. quiz auto-submit, grade release every ~30s)
+- Roadmap: Postgres-backed job queue (`FOR UPDATE SKIP LOCKED`)
+
+---
+
+## 5. Frontend Architecture
+
+### 5.1 Bootstrap (`clients/web/src/main.tsx`)
+
+Provider tree (simplified):
+
+```
+StrictMode
+  BrowserRouter
+    I18nProvider
+      LocaleFormatProvider
+        OrgBrandingProvider
+          PermissionsProvider
+            App + LmsToaster
+```
+
+PWA: `vite-plugin-pwa` with custom service worker `src/sw.ts`.
+
+### 5.2 Routing
+
+- Central `app.tsx` with many `<Route>` entries
+- Pages under `src/pages/` (LMS under `pages/lms/`, admin, auth)
+- Shared UI: `src/components/`, hooks in `src/hooks/`, contexts in `src/context/`
+
+### 5.3 API client pattern (current)
+
+- **`src/lib/api.ts`:** `apiBaseUrl()` from `VITE_API_URL`, `authorizedFetch` with JWT + refresh retry + 401 → clear session + `studydrift-auth-required` event
+- **Per-domain modules:** `*-api.ts` (e.g. `courses-api.ts`) — hand-written fetch + **Zod** parse
+- **Codegen (optional):** `npm run openapi:types` → `src/lib/generated/openapi-types.ts` from running server
+- **No React Query yet** — many `fetch` + `useEffect` + `useState`; ARCH recommends TanStack Query for new work
+
+### 5.4 Auth on the client
+
+- Access token in `localStorage` (`studydrift_access_token`)
+- Refresh token flow via `/api/v1/auth/refresh`
+- Permissions context loaded after login for UI gating
+
+### 5.5 Styling & a11y
+
+- Tailwind v4 via Vite plugin
+- ESLint: `eslint-plugin-jsx-a11y`, i18n key checks
+- Scripts: contrast check, bundle size budget, locale parity
+
+### 5.6 Testing
+
+- Unit/component: Vitest + jsdom + Testing Library
+- MSW handlers in `src/test/mocks/`
+- E2E: separate `e2e/` package, `make e2e` spins ephemeral Postgres + stack
+
+---
+
+## 6. Docker & Local Dev
+
+**Recommended dev:**
+
+```bash
+# .env at repo root
+BOOTSTRAP_ADMIN_EMAIL=you@yourdomain.com
+
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build -d
+# Web: http://localhost:5173  API: http://localhost:8080
+```
+
+**Without full Docker:**
+
+```bash
+docker compose -f docker-compose.yml up -d postgres
+cp server/.env.example server/.env   # set DATABASE_URL, JWT_SECRET, BOOTSTRAP_ADMIN_EMAIL
+cd server && go run ./cmd/server
+cd clients/web && npm install && VITE_API_URL=http://localhost:8080 npm run dev
+```
+
+**Prod-style static web:**
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build
+# Web nginx :3000, API :8080
+```
+
+---
+
+## 7. CI & Quality Gates
+
+From `.github/workflows/ci.yml` (on PRs to `main`):
+
+| Job | What it does |
+|-----|----------------|
+| **server-go** | Postgres 16 service, golangci-lint v2.x (Go 1.25+), `go test ./internal/...` with coverage ≥ ~10.5%, govulncheck, build `cmd/server` |
+| **client-cli** | Lint/test Go CLI |
+| **web** | ESLint, `tsc -b`, Vitest, bundle checks |
+| **e2e** | Playwright against compose/local Postgres |
+
+**Local commands:**
+
+| Task | Command | CWD |
+|------|---------|-----|
+| Go build | `go build -o bin/server ./cmd/server` | `server/` |
+| Go test (short) | `go test ./... -short` | `server/` |
+| Go lint | `golangci-lint run ./...` | `server/` |
+| Web typecheck | `npm run typecheck` | `clients/web/` |
+| Web test | `npm run test` | `clients/web/` |
+| E2E | `make e2e` | repo root |
+
+---
+
+## 8. Cross-Cutting Concerns (Present in Lextures)
+
+Worth knowing before copying — many are **optional** for a smaller greenfield app:
+
+| Concern | Implementation |
+|---------|----------------|
+| **Multi-tenant / orgs** | Org branding, org units, terms, sections (schema evolving) |
+| **SSO** | SAML 2.0, OIDC, Clever/ClassLink |
+| **LTI 1.3** | Provider/consumer |
+| **SCIM** | User provisioning |
+| **File uploads** | TUS resumable uploads, local or MinIO/S3 |
+| **Real-time** | WebSockets (`coder/websocket`), comm/notification hubs (partial) |
+| **AI** | OpenRouter behind platform settings |
+| **Compliance** | FERPA, GDPR, COPPA, CCPA routes and audit logs |
+| **Mobile** | Android/iOS clients + shared API |
+| **Marketing site** | `www/` separate Vite app |
+| **IaC** | `iac/` Terraform for demo/production clouds |
+
+---
+
+## 9. Greenfield Starter Checklist
+
+Use this to bootstrap a **new** project with Lextures-like architecture (minimal viable platform):
+
+### Repo skeleton
+
+- [ ] `server/` Go module with `cmd/server`, `internal/{app,httpserver,service,repos,models,auth,apierr,config,migrate,db}`
+- [ ] `clients/web/` Vite + React + TS + Tailwind v4
+- [ ] `docker-compose.yml` (postgres + server + web)
+- [ ] `docker-compose.dev.yml` (Vite port 5173, hot reload)
+- [ ] Root `AGENTS.md` or `README` with start commands
+- [ ] `.github/workflows/ci.yml` (postgres service + go test + web lint/test)
+- [ ] `.env.example` files (never commit real `.env`)
+
+### Backend (day one)
+
+- [ ] Chi router: `/health`, `/api/v1/auth/signup`, `/api/v1/auth/login`, `/api/v1/me`
+- [ ] pgx pool + migrations `001_users.sql` (users table + roles)
+- [ ] Argon2id + JWT + refresh tokens
+- [ ] `apierr` JSON envelope
+- [ ] CORS for `PUBLIC_WEB_ORIGIN`
+- [ ] `RUN_MIGRATIONS=true` on boot
+
+### Frontend (day one)
+
+- [ ] `VITE_API_URL` → `lib/api.ts` + `authorizedFetch`
+- [ ] Login/signup pages + token storage
+- [ ] React Router + one protected dashboard route
+- [ ] Zod for API responses (even before OpenAPI codegen)
+
+### Defer until needed
+
+- OpenAPI codegen + CI drift check (P0.1 in ARCH.md)
+- TanStack Query (replace fetch/useEffect pattern)
+- Auth middleware on router (vs per-handler checks)
+- S3 file storage abstraction
+- Job queue, Redis cache, WebSockets
+- Husky (add when team grows)
+
+### Conventions to adopt from Lextures
+
+- TypeScript **exhaustive switch** with `never` in default case (`.cursor/rules`)
+- **Imports at top of file** only (no inline imports)
+- Permission strings `scope:area:function:action` if you need RBAC early
+- Feature flags in **DB**, not build-time env (for operability)
+- Separate **platform secrets** (env) from **product toggles** (DB)
+
+---
+
+## 10. Architecture Roadmap (From `docs/ARCH.md`)
+
+Lextures’ own engineers prioritize these **before** scaling features — good guidance for what **not** to replicate blindly:
+
+| Priority | Item |
+|----------|------|
+| **P0** | OpenAPI-first API contract + generated TS types |
+| **P0** | Break up monolithic handler/page files (>500 LOC) |
+| **P0** | Auth as chi middleware, not manual checks in every handler |
+| **P0** | TanStack Query for server state |
+| **P0** | DB query audit (N+1, indexes) |
+| **P1** | Postgres job queue, structured JSON logs + metrics, S3 file store, Playwright E2E on PRs |
+
+**Current snapshot (ARCH.md):** ~67K LOC Go, ~265 TSX files, hand-maintained API clients, seven React contexts, local filesystem storage, limited integration tests on backend.
+
+---
+
+## 11. Minimal `go.mod` Dependencies (Starter Set)
+
+From Lextures’ core (trim the rest for a new app):
+
+```go
+require (
+    github.com/go-chi/chi/v5
+    github.com/jackc/pgx/v5
+    github.com/golang-jwt/jwt/v5
+    github.com/alexedwards/argon2id
+    github.com/google/uuid
+    golang.org/x/crypto
+)
+```
+
+---
+
+## 12. Minimal Web `package.json` Dependencies (Starter Set)
+
+```json
+{
+  "dependencies": {
+    "react": "^19",
+    "react-dom": "^19",
+    "react-router-dom": "^7",
+    "zod": "^4"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^6",
+    "@tailwindcss/vite": "^4",
+    "tailwindcss": "^4",
+    "typescript": "~6",
+    "vite": "^8",
+    "vitest": "^4",
+    "@testing-library/react": "^16",
+    "eslint": "^9",
+    "typescript-eslint": "^8"
+  }
+}
+```
+
+---
+
+## 13. Key Docs in the Repo
+
+| Doc | Purpose |
+|-----|---------|
+| `README.md` | Product + stack summary |
+| `docs/getting-started.md` | Docker, bootstrap admin, local dev |
+| `docs/ARCH.md` | Deep architecture recommendations |
+| `AGENTS.md` | Commands, env vars, gotchas for agents/CI VMs |
+| `server/.env.example` | API configuration template |
+
+---
+
+## 14. One-Paragraph Summary
+
+**Lextures** is a **monorepo LMS** built as a **stateless Go API** (chi + pgx + JWT + layered `httpserver → service → repos → models`) and a **React 19 SPA** (Vite + TS + Tailwind v4 + Zod-validated fetch clients), backed by **PostgreSQL 16** and **Docker Compose** for dev/prod. Configuration splits **secrets in env** and **feature toggles in the database**. The project is mature in domain features but intentionally documents gaps (OpenAPI coverage, React Query, auth middleware, job queue) so new work can improve the platform shape without copying 220 migrations or compliance modules wholesale.
+
+For a new project: **copy the repo layout, stack versions, error/auth patterns, and Compose-based dev loop**; start with **one migration, a handful of API routes, and a thin React shell**; adopt ARCH.md **P0 items early** if you expect multiple clients or a growing team.

--- a/server/internal/httpserver/org_routes.go
+++ b/server/internal/httpserver/org_routes.go
@@ -26,4 +26,6 @@ func (d Deps) registerOrgRoutes(r chi.Router) {
 	r.Get("/api/v1/orgs/{orgId}/users", d.handleOrgUsersSearch())
 	r.Get("/api/v1/orgs/{orgId}/settings/support-widget", d.handleOrgSupportWidgetItem())
 	r.Put("/api/v1/orgs/{orgId}/settings/support-widget", d.handleOrgSupportWidgetItem())
+	r.Get("/api/v1/orgs/{orgId}/settings/org-type", d.handleOrgTypeItem())
+	r.Put("/api/v1/orgs/{orgId}/settings/org-type", d.handleOrgTypeItem())
 }

--- a/server/internal/httpserver/org_type_http.go
+++ b/server/internal/httpserver/org_type_http.go
@@ -1,0 +1,63 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/lextures/lextures/server/internal/apierr"
+)
+
+// GET /api/v1/orgs/{orgId}/settings/org-type
+// PUT /api/v1/orgs/{orgId}/settings/org-type
+func (d Deps) handleOrgTypeItem() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		orgStr := strings.TrimSpace(chi.URLParam(r, "orgId"))
+		orgID, err := uuid.Parse(orgStr)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid organization id.")
+			return
+		}
+		if _, _, ok := d.adminOrgOrUnitAccess(w, r, orgID); !ok {
+			return
+		}
+		ctx := r.Context()
+
+		switch r.Method {
+		case http.MethodGet:
+			var orgType string
+			err := d.Pool.QueryRow(ctx, `SELECT org_type FROM tenant.organizations WHERE id = $1 AND status <> 'deleted'`, orgID).Scan(&orgType)
+			if err != nil {
+				orgType = "higher-ed"
+			}
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			_ = json.NewEncoder(w).Encode(map[string]any{"orgId": orgID.String(), "orgType": orgType})
+
+		case http.MethodPut:
+			var body struct {
+				OrgType string `json:"orgType"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+				return
+			}
+			if body.OrgType != "higher-ed" && body.OrgType != "k-12" {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, `orgType must be "higher-ed" or "k-12".`)
+				return
+			}
+			_, err := d.Pool.Exec(ctx, `UPDATE tenant.organizations SET org_type = $1, updated_at = NOW() WHERE id = $2`, body.OrgType, orgID)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to update organization type.")
+				return
+			}
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			_ = json.NewEncoder(w).Encode(map[string]any{"orgId": orgID.String(), "orgType": body.OrgType})
+
+		default:
+			w.Header().Set("Allow", strings.Join([]string{http.MethodGet, http.MethodPut}, ", "))
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		}
+	}
+}

--- a/server/migrations/227_org_type.sql
+++ b/server/migrations/227_org_type.sql
@@ -1,0 +1,4 @@
+-- 227: Organization type for K-12 vs higher education feature flag
+-- Defaults to 'higher-ed'; set to 'k-12' to enable grade-level features.
+ALTER TABLE tenant.organizations ADD COLUMN IF NOT EXISTS org_type TEXT NOT NULL DEFAULT 'higher-ed';
+ALTER TABLE tenant.organizations ADD CONSTRAINT organizations_org_type_check CHECK (org_type IN ('higher-ed', 'k-12'));


### PR DESCRIPTION
## Summary

- **Migration 227**: adds `org_type TEXT NOT NULL DEFAULT 'higher-ed'` column to `tenant.organizations` with a check constraint (`'higher-ed'` or `'k-12'`)
- **New API**: `GET/PUT /api/v1/orgs/{orgId}/settings/org-type` — reads and persists the institution type; guarded by existing `adminOrgOrUnitAccess` middleware
- **Settings UI**: the Org Units panel now shows an "Institution type" card with Higher Education / K-12 toggle buttons; selection is persisted immediately via PUT
- **Course Catalog**: grade-level filter is only rendered when the org is `k-12`, avoiding irrelevant UI noise for higher-ed institutions
- **Dashboard**: removed "Recent Roster Activity" section from instructor course cards (was making extra enrollment API calls per card)
- **AttendanceCheckin page**: new student self-report check-in page (`/courses/:courseCode/attendance/:sessionId/checkin`) — auto-records present on load, lets student switch to tardy, handles already-recorded / window-closed states

## Test plan

- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] ESLint passes — 0 errors, warnings are pre-existing project-wide (`npm run lint`)
- [x] 558 unit tests pass (`npm run test`)
- [x] Go build passes (`go build ./...`, `go vet ./...`)
- [x] E2e suite: 632 passed, 3 pre-existing failures (backup-restore drill, dyslexia reading preferences — last modified in PRs #179/#193, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)