### PR TITLE
feat: command palette search hub with full-text API and query modifiers

### DIFF
--- a/clients/web/src/components/command-palette/command-palette-dialog.tsx
+++ b/clients/web/src/components/command-palette/command-palette-dialog.tsx
@@ -55,6 +55,7 @@ const GROUP_ICONS: Record<SearchGroup, typeof BookOpen> = {
 }
 
 const SEARCH_DEBOUNCE_MS = 200
+const EMPTY_SERVER_ITEMS: SearchListItem[] = []
 
 function currentCourseCodeFromPath(pathname: string): string | null {
   const m = /^\/courses\/([^/]+)/.exec(pathname)
@@ -155,6 +156,9 @@ export function CommandPaletteDialog() {
   const parsed = useMemo(() => parseSearchQuery(query), [query])
   const coursePicker = useMemo(() => parseCoursePickerState(query), [query])
   const isHubMode = parsed.raw === '' && !coursePicker.active
+  const serverSearchActive = parsed.text.length >= 2
+  const activeServerItems = serverSearchActive ? serverItems : EMPTY_SERVER_ITEMS
+  const activeServerLoading = serverSearchActive && serverLoading
 
   const pickerCourses = useMemo(() => {
     if (!coursePicker.active) return []
@@ -168,14 +172,13 @@ export function CommandPaletteDialog() {
   }, [coursePicker, coursesForSearch])
 
   useEffect(() => {
-    if (parsed.text.length < 2) {
-      setServerItems([])
-      setServerLoading(false)
+    if (!serverSearchActive) {
       return
     }
     let cancelled = false
-    setServerLoading(true)
     const timer = window.setTimeout(() => {
+      if (cancelled) return
+      setServerLoading(true)
       const types = parsed.types
       const typeParam = types
         ? [...types].filter((t) => t === 'course' || t === 'person' || t === 'content').join(',')
@@ -201,7 +204,7 @@ export function CommandPaletteDialog() {
       cancelled = true
       window.clearTimeout(timer)
     }
-  }, [parsed.text, parsed.scopeCourseCode, parsed.types])
+  }, [serverSearchActive, parsed.text, parsed.scopeCourseCode, parsed.types])
 
   const pinnedCourseCode = isHubMode ? currentCourseCode : parsed.scopeCourseCode
 
@@ -221,7 +224,7 @@ export function CommandPaletteDialog() {
 
     const seen = new Set<string>()
     const merged: SearchListItem[] = []
-    for (const it of [...go, ...serverItems, ...localFiltered]) {
+    for (const it of [...go, ...activeServerItems, ...localFiltered]) {
       if (seen.has(it.id)) continue
       seen.add(it.id)
       merged.push(it)
@@ -235,7 +238,7 @@ export function CommandPaletteDialog() {
     currentCourseCode,
     parsed,
     query,
-    serverItems,
+    activeServerItems,
     pinnedCourseCode,
   ])
 
@@ -337,7 +340,7 @@ export function CommandPaletteDialog() {
           ? 'No matching courses'
           : `${pickerCourses.length} ${pickerCourses.length === 1 ? 'course' : 'courses'}`
         : filtered.length === 0
-          ? serverLoading
+          ? activeServerLoading
             ? 'Searching'
             : 'No results'
           : `${filtered.length} ${filtered.length === 1 ? 'result' : 'results'}`
@@ -461,10 +464,10 @@ export function CommandPaletteDialog() {
               })}
             </>
           )}
-          {loadState === 'ready' && !coursePicker.active && serverLoading && filtered.length === 0 && !isHubMode && (
+          {loadState === 'ready' && !coursePicker.active && activeServerLoading && filtered.length === 0 && !isHubMode && (
             <p className="px-3 py-8 text-center text-sm text-slate-600 dark:text-neutral-400">Searching…</p>
           )}
-          {loadState === 'ready' && !coursePicker.active && !serverLoading && filtered.length === 0 && (
+          {loadState === 'ready' && !coursePicker.active && !activeServerLoading && filtered.length === 0 && (
             <p className="px-3 py-8 text-center text-sm text-slate-600 dark:text-neutral-400">No results.</p>
           )}
           {loadState === 'ready' && !coursePicker.active &&

--- a/clients/web/src/components/command-palette/command-palette-dialog.tsx
+++ b/clients/web/src/components/command-palette/command-palette-dialog.tsx
@@ -1,34 +1,77 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { useNavigate } from 'react-router-dom'
-import { ArrowDown, ArrowUp, BookOpen, FileText, Navigation, Search, Users, Zap, Stars } from 'lucide-react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import {
+  ArrowDown,
+  ArrowUp,
+  BookOpen,
+  Clock,
+  FileText,
+  Layers,
+  Navigation,
+  Search,
+  Users,
+  Zap,
+  Stars,
+} from 'lucide-react'
+import { useCourseNavFeatures } from '../../context/course-nav-features-context'
 import { usePermissions } from '../../context/use-permissions'
 import {
-  buildSearchItems,
+  capSearchResults,
   filterSearchItems,
   SEARCH_GROUP_LABEL,
   sortSearchItems,
+  buildLocalSearchCandidates,
   type SearchGroup,
   type SearchListItem,
 } from '../../lib/build-search-items'
 import { buildCommandPaletteGoToItems } from '../../lib/command-palette-go-to'
-import { fetchSearchIndex, type SearchCourseItem, type SearchPersonItem } from '../../lib/search-api'
+import { buildSearchHubItems } from '../../lib/search-hub'
+import {
+  applyCoursePickerSelection,
+  parseCoursePickerState,
+  parseSearchQuery,
+} from '../../lib/search-query-parse'
+import { listSearchRecents, recordSearchRecent } from '../../lib/search-recents'
+import {
+  fetchSearchIndex,
+  fetchSearchQuery,
+  queryResultsToSearchItems,
+  type SearchCourseItem,
+} from '../../lib/search-api'
+import { mergeCoursesWithNavFeatures } from '../../lib/search-course-features'
 import { LiveRegion } from '../a11y/live-region'
 import { useCommandPalette } from './use-command-palette'
 
 const GROUP_ICONS: Record<SearchGroup, typeof BookOpen> = {
+  recent: Clock,
   goto: Navigation,
   action: Zap,
   course: BookOpen,
   person: Users,
   page: FileText,
-  ai: Stars
+  content: Layers,
+  ai: Stars,
+}
+
+const SEARCH_DEBOUNCE_MS = 200
+
+function currentCourseCodeFromPath(pathname: string): string | null {
+  const m = /^\/courses\/([^/]+)/.exec(pathname)
+  if (!m?.[1]) return null
+  try {
+    return decodeURIComponent(m[1]).trim() || null
+  } catch {
+    return m[1].trim() || null
+  }
 }
 
 export function CommandPaletteDialog() {
   const { close } = useCommandPalette()
   const navigate = useNavigate()
+  const location = useLocation()
   const { allows } = usePermissions()
+  const navFeatures = useCourseNavFeatures()
   const inputRef = useRef<HTMLInputElement>(null)
   const dialogRef = useRef<HTMLDivElement>(null)
   const activeRowRef = useRef<HTMLButtonElement | null>(null)
@@ -36,8 +79,19 @@ export function CommandPaletteDialog() {
   const [query, setQuery] = useState('')
   const [cursor, setCursor] = useState(0)
   const [courses, setCourses] = useState<SearchCourseItem[]>([])
-  const [people, setPeople] = useState<SearchPersonItem[]>([])
   const [loadState, setLoadState] = useState<'loading' | 'error' | 'ready'>('loading')
+  const [serverItems, setServerItems] = useState<SearchListItem[]>([])
+  const [serverLoading, setServerLoading] = useState(false)
+
+  const currentCourseCode = useMemo(
+    () => currentCourseCodeFromPath(location.pathname),
+    [location.pathname],
+  )
+
+  const coursesForSearch = useMemo(
+    () => mergeCoursesWithNavFeatures(courses, currentCourseCode, navFeatures),
+    [courses, currentCourseCode, navFeatures],
+  )
 
   useEffect(() => {
     const prevOverflow = document.body.style.overflow
@@ -51,13 +105,11 @@ export function CommandPaletteDialog() {
     void fetchSearchIndex()
       .then((data) => {
         setCourses(Array.isArray(data.courses) ? data.courses : [])
-        setPeople(Array.isArray(data.people) ? data.people : [])
         setLoadState('ready')
       })
       .catch(() => {
         setLoadState('error')
         setCourses([])
-        setPeople([])
       })
   }, [])
 
@@ -66,7 +118,6 @@ export function CommandPaletteDialog() {
     return () => window.clearTimeout(t)
   }, [])
 
-  // Close on Escape; trap focus within the dialog on Tab/Shift+Tab.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -101,31 +152,105 @@ export function CommandPaletteDialog() {
     return () => window.removeEventListener('keydown', onKey, true)
   }, [close])
 
-  const allItems = useMemo(
-    () => buildSearchItems(courses, people, allows),
-    [courses, people, allows],
-  )
+  const parsed = useMemo(() => parseSearchQuery(query), [query])
+  const coursePicker = useMemo(() => parseCoursePickerState(query), [query])
+  const isHubMode = parsed.raw === '' && !coursePicker.active
+
+  const pickerCourses = useMemo(() => {
+    if (!coursePicker.active) return []
+    const f = coursePicker.filter
+    return coursesForSearch.filter((c) => {
+      if (!f) return true
+      const code = c.courseCode.toLowerCase()
+      const title = c.title.toLowerCase()
+      return code.includes(f) || title.includes(f)
+    })
+  }, [coursePicker, coursesForSearch])
+
+  useEffect(() => {
+    if (parsed.text.length < 2) {
+      setServerItems([])
+      setServerLoading(false)
+      return
+    }
+    let cancelled = false
+    setServerLoading(true)
+    const timer = window.setTimeout(() => {
+      const types = parsed.types
+      const typeParam = types
+        ? [...types].filter((t) => t === 'course' || t === 'person' || t === 'content').join(',')
+        : undefined
+      void fetchSearchQuery({
+        q: parsed.text,
+        scope: parsed.scopeCourseCode,
+        types: typeParam,
+      })
+        .then((data) => {
+          if (cancelled) return
+          setServerItems(queryResultsToSearchItems(data.groups))
+        })
+        .catch(() => {
+          if (cancelled) return
+          setServerItems([])
+        })
+        .finally(() => {
+          if (!cancelled) setServerLoading(false)
+        })
+    }, SEARCH_DEBOUNCE_MS)
+    return () => {
+      cancelled = true
+      window.clearTimeout(timer)
+    }
+  }, [parsed.text, parsed.scopeCourseCode, parsed.types])
+
+  const pinnedCourseCode = isHubMode ? currentCourseCode : parsed.scopeCourseCode
 
   const filtered = useMemo(() => {
-    const base = filterSearchItems(allItems, query)
-    const go = buildCommandPaletteGoToItems(query, courses, allows)
-    if (go.length === 0) return base
+    if (isHubMode) {
+      return capSearchResults(buildSearchHubItems(coursesForSearch, allows, currentCourseCode), {
+        hubMode: true,
+        pinnedCourseCode,
+      })
+    }
+
+    const localCandidates = buildLocalSearchCandidates(coursesForSearch, allows, parsed)
+    const localFiltered = filterSearchItems(localCandidates, query, {
+      currentCourseCode,
+    })
+    const go = buildCommandPaletteGoToItems(query, coursesForSearch, allows)
+
     const seen = new Set<string>()
     const merged: SearchListItem[] = []
-    for (const it of [...go, ...base]) {
+    for (const it of [...go, ...serverItems, ...localFiltered]) {
       if (seen.has(it.id)) continue
       seen.add(it.id)
       merged.push(it)
     }
-    return sortSearchItems(merged)
-  }, [allItems, query, courses, allows])
 
-  const safeIndex =
-    filtered.length === 0 ? 0 : Math.min(cursor, Math.max(0, filtered.length - 1))
+    return capSearchResults(sortSearchItems(merged), { pinnedCourseCode })
+  }, [
+    isHubMode,
+    coursesForSearch,
+    allows,
+    currentCourseCode,
+    parsed,
+    query,
+    serverItems,
+    pinnedCourseCode,
+  ])
+
+  const listLength = coursePicker.active ? pickerCourses.length : filtered.length
+  const safeIndex = listLength === 0 ? 0 : Math.min(cursor, Math.max(0, listLength - 1))
 
   useLayoutEffect(() => {
     activeRowRef.current?.scrollIntoView({ block: 'nearest' })
-  }, [safeIndex, filtered])
+  }, [safeIndex, filtered, pickerCourses, coursePicker.active])
+
+  const selectPickerCourse = (course: SearchCourseItem) => {
+    setQuery(applyCoursePickerSelection(query, coursePicker.atIndex, course.courseCode))
+    setCursor(0)
+    window.setTimeout(() => inputRef.current?.focus(), 0)
+  }
 
   const go = (item: SearchListItem) => {
     if (item.id === 'global:ask-ai') {
@@ -134,10 +259,52 @@ export function CommandPaletteDialog() {
     } else {
       navigate(item.path)
     }
+    if (item.group === 'recent') {
+      const stored = listSearchRecents().find((r) => `recent:${r.id}` === item.id)
+      if (stored) {
+        recordSearchRecent({
+          id: stored.id,
+          group: stored.group,
+          title: stored.title,
+          subtitle: stored.subtitle,
+          path: stored.path,
+          haystack: '',
+        })
+      }
+    } else {
+      recordSearchRecent(item)
+    }
     close()
   }
 
   const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (coursePicker.active) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        if (pickerCourses.length === 0) return
+        setCursor((c) => {
+          const at = Math.min(c, pickerCourses.length - 1)
+          return (at + 1) % pickerCourses.length
+        })
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        if (pickerCourses.length === 0) return
+        setCursor((c) => {
+          const at = Math.min(c, pickerCourses.length - 1)
+          return (at - 1 + pickerCourses.length) % pickerCourses.length
+        })
+        return
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        const course = pickerCourses[safeIndex]
+        if (course) selectPickerCourse(course)
+        return
+      }
+    }
+
     if (e.key === 'ArrowDown') {
       e.preventDefault()
       if (filtered.length === 0) return
@@ -165,9 +332,15 @@ export function CommandPaletteDialog() {
 
   const resultsAnnouncement =
     loadState === 'ready'
-      ? filtered.length === 0
-        ? 'No results'
-        : `${filtered.length} ${filtered.length === 1 ? 'result' : 'results'}`
+      ? coursePicker.active
+        ? pickerCourses.length === 0
+          ? 'No matching courses'
+          : `${pickerCourses.length} ${pickerCourses.length === 1 ? 'course' : 'courses'}`
+        : filtered.length === 0
+          ? serverLoading
+            ? 'Searching'
+            : 'No results'
+          : `${filtered.length} ${filtered.length === 1 ? 'result' : 'results'}`
       : ''
 
   const palette = (
@@ -197,15 +370,21 @@ export function CommandPaletteDialog() {
               setCursor(0)
             }}
             onKeyDown={onInputKeyDown}
-            placeholder="Search courses, people, pages, actions…"
+            placeholder="Search courses, content, people… (@course to scope)"
             aria-label="Search"
             className="min-w-0 flex-1 border-0 bg-transparent text-base text-slate-900 outline-none placeholder:text-slate-600 dark:text-neutral-100 dark:placeholder:text-neutral-400"
             autoComplete="off"
             autoCorrect="off"
             spellCheck={false}
-            aria-controls="command-palette-results"
+            aria-controls={coursePicker.active ? 'command-palette-course-picker' : 'command-palette-results'}
             aria-activedescendant={
-              filtered[safeIndex] ? `cmd-result-${filtered[safeIndex].id}` : undefined
+              coursePicker.active
+                ? pickerCourses[safeIndex]
+                  ? `cmd-course-${encodeURIComponent(pickerCourses[safeIndex]!.courseCode)}`
+                  : undefined
+                : filtered[safeIndex]
+                  ? `cmd-result-${filtered[safeIndex].id}`
+                  : undefined
             }
           />
           <kbd className="hidden shrink-0 rounded-md border border-slate-200 bg-slate-50 px-2 py-1 font-mono text-[11px] text-slate-600 sm:inline dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-300">
@@ -213,13 +392,12 @@ export function CommandPaletteDialog() {
           </kbd>
         </div>
 
-        {/* Polite live region: announces result count to screen readers after each query change. */}
         <LiveRegion>{resultsAnnouncement}</LiveRegion>
 
         <div
-          id="command-palette-results"
+          id={coursePicker.active ? 'command-palette-course-picker' : 'command-palette-results'}
           role="listbox"
-          aria-label="Search results"
+          aria-label={coursePicker.active ? 'Choose a course' : 'Search results'}
           className="max-h-[min(60vh,420px)] overflow-y-auto px-2 py-2"
         >
           {loadState === 'loading' && (
@@ -230,10 +408,66 @@ export function CommandPaletteDialog() {
               Could not load search.
             </p>
           )}
-          {loadState === 'ready' && filtered.length === 0 && (
+          {loadState === 'ready' && coursePicker.active && (
+            <>
+              <div
+                className="px-3 pb-1 pt-2 text-xs font-semibold uppercase tracking-wide text-slate-600 dark:text-neutral-400"
+                aria-hidden="true"
+              >
+                Scope to course
+              </div>
+              {pickerCourses.length === 0 && (
+                <p className="px-3 py-8 text-center text-sm text-slate-600 dark:text-neutral-400">
+                  No matching courses.
+                </p>
+              )}
+              {pickerCourses.map((course, idx) => {
+                const selected = idx === safeIndex
+                return (
+                  <button
+                    key={course.courseCode}
+                    id={`cmd-course-${encodeURIComponent(course.courseCode)}`}
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    ref={selected ? activeRowRef : undefined}
+                    className={`flex w-full items-start gap-3 rounded-xl px-3 py-2.5 text-start text-sm transition ${selected
+                      ? 'bg-indigo-50 text-slate-900 dark:bg-indigo-950/70 dark:text-neutral-100'
+                      : 'text-slate-700 hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800/80'
+                      }`}
+                    onMouseEnter={() => setCursor(idx)}
+                    onClick={() => selectPickerCourse(course)}
+                  >
+                    <BookOpen
+                      className={`mt-0.5 h-4 w-4 shrink-0 ${selected
+                        ? 'text-indigo-600 dark:text-indigo-400'
+                        : 'text-slate-400 dark:text-neutral-500'
+                        }`}
+                      aria-hidden
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block font-medium leading-snug">{course.title}</span>
+                      <span
+                        className={`block text-xs ${selected
+                          ? 'text-slate-600 dark:text-neutral-300'
+                          : 'text-slate-600 dark:text-neutral-400'
+                          }`}
+                      >
+                        {course.courseCode}
+                      </span>
+                    </span>
+                  </button>
+                )
+              })}
+            </>
+          )}
+          {loadState === 'ready' && !coursePicker.active && serverLoading && filtered.length === 0 && !isHubMode && (
+            <p className="px-3 py-8 text-center text-sm text-slate-600 dark:text-neutral-400">Searching…</p>
+          )}
+          {loadState === 'ready' && !coursePicker.active && !serverLoading && filtered.length === 0 && (
             <p className="px-3 py-8 text-center text-sm text-slate-600 dark:text-neutral-400">No results.</p>
           )}
-          {loadState === 'ready' &&
+          {loadState === 'ready' && !coursePicker.active &&
             filtered.map((item, idx) => {
               const showHeader = idx === 0 || filtered[idx - 1]!.group !== item.group
               const Icon = GROUP_ICONS[item.group]
@@ -271,11 +505,10 @@ export function CommandPaletteDialog() {
                     <span className="min-w-0 flex-1">
                       <span className="block font-medium leading-snug">{item.title}</span>
                       <span
-                        className={`block text-xs ${
-                          selected
-                            ? 'text-slate-600 dark:text-neutral-300'
-                            : 'text-slate-600 dark:text-neutral-400'
-                        }`}
+                        className={`block text-xs ${selected
+                          ? 'text-slate-600 dark:text-neutral-300'
+                          : 'text-slate-600 dark:text-neutral-400'
+                          }`}
                       >
                         {item.subtitle}
                       </span>

--- a/clients/web/src/lib/__tests__/build-search-items.test.ts
+++ b/clients/web/src/lib/__tests__/build-search-items.test.ts
@@ -3,10 +3,23 @@ import {
   courseEnrollmentsReadPermission,
   courseGradebookViewPermission,
   courseItemCreatePermission,
+  courseItemsCreatePermission,
 } from '../courses-api'
-import { buildSearchItems, filterSearchItems, SEARCH_GROUP_LABEL } from '../build-search-items'
+import {
+  buildCourseActionItems,
+  buildCourseListItems,
+  buildCoursePageItems,
+  buildGlobalSearchItems,
+  buildLocalSearchCandidates,
+  buildSearchItems,
+  capSearchResults,
+  filterSearchItems,
+  SEARCH_GROUP_LABEL,
+} from '../build-search-items'
+import { buildSearchHubItems } from '../search-hub'
+import { parseSearchQuery } from '../search-query-parse'
 import { PERM_COURSE_CREATE, PERM_RBAC_MANAGE } from '../rbac-api'
-import type { SearchCourseItem, SearchPersonItem } from '../search-api'
+import type { SearchCourseItem } from '../search-api'
 
 const allowsNone = () => false
 const allowsAll = (perm: string) =>
@@ -17,28 +30,9 @@ describe('buildSearchItems', () => {
     { courseCode: 'CS-101', title: 'Intro' },
     { courseCode: 'a/b', title: 'Encoded' },
   ]
-  const people: SearchPersonItem[] = [
-    {
-      userId: 'u1',
-      email: 'a@x.com',
-      displayName: 'Alice',
-      role: 'student',
-      courseCode: 'CS-101',
-      courseTitle: 'Intro',
-    },
-    {
-      userId: 'u2',
-      email: 'b@x.com',
-      displayName: null,
-      role: 'ta',
-      courseCode: 'CS-101',
-      courseTitle: 'Intro',
-    },
-  ]
 
-  it('includes course and person rows with expected paths and haystack', () => {
-    const allowsRoster = (p: string) => p === courseEnrollmentsReadPermission('CS-101')
-    const items = buildSearchItems(courses, people, allowsRoster)
+  it('includes course rows with expected paths and haystack', () => {
+    const items = buildSearchItems(courses, [], allowsNone)
     const course = items.find((i) => i.id === 'course:CS-101')
     expect(course).toMatchObject({
       group: 'course',
@@ -48,79 +42,6 @@ describe('buildSearchItems', () => {
     })
     expect(course?.haystack).toContain('intro')
     expect(course?.haystack).toContain('cs-101')
-
-    const e = encodeURIComponent
-    const person = items.find(
-      (i) => i.id === `person:${e('u1')}:${e('CS-101')}:${e('student')}`,
-    )
-    expect(person).toMatchObject({
-      group: 'person',
-      path: '/courses/CS-101/enrollments',
-      title: 'Alice',
-    })
-
-    const allowsGrade = (p: string) =>
-      p === courseEnrollmentsReadPermission('CS-101') || p === courseGradebookViewPermission('CS-101')
-    const itemsG = buildSearchItems(courses, people, allowsGrade)
-    const personG = itemsG.find(
-      (i) => i.id === `person:${e('u1')}:${e('CS-101')}:${e('student')}`,
-    )
-    expect(personG?.path).toBe('/courses/CS-101/gradebook?student=u1')
-
-    const emailOnly = items.find(
-      (i) => i.id === `person:${e('u2')}:${e('CS-101')}:${e('ta')}`,
-    )
-    expect(emailOnly?.title).toBe('b@x.com')
-    expect(person?.subtitle).toBe('Intro · CS-101 · student')
-  })
-
-  it('URL-encodes person item ids so colons in user id or course code cannot collide with id delimiters', () => {
-    const people: SearchPersonItem[] = [
-      {
-        userId: 'user:with:colons',
-        email: 'edge@x.com',
-        displayName: 'Edge',
-        role: 'ta',
-        courseCode: 'C/S',
-        courseTitle: 'Slash course',
-      },
-    ]
-    const allows = (p: string) => p === courseEnrollmentsReadPermission('C/S')
-    const items = buildSearchItems([], people, allows)
-    const p = items.find((i) => i.group === 'person' && i.title === 'Edge')
-    expect(p).toBeDefined()
-    const enc = encodeURIComponent
-    expect(p?.id).toBe(
-      `person:${enc('user:with:colons')}:${enc('C/S')}:${enc('ta')}`,
-    )
-  })
-
-  it('uses distinct ids when the same user has multiple roles in one course', () => {
-    const dualRole: SearchPersonItem[] = [
-      {
-        userId: 'same',
-        email: 'x@x.com',
-        displayName: 'Pat',
-        role: 'Student',
-        courseCode: 'C-1',
-        courseTitle: 'Course',
-      },
-      {
-        userId: 'same',
-        email: 'x@x.com',
-        displayName: 'Pat',
-        role: 'Teacher',
-        courseCode: 'C-1',
-        courseTitle: 'Course',
-      },
-    ]
-    const allows = (p: string) => p === courseEnrollmentsReadPermission('C-1')
-    const items = buildSearchItems([], dualRole, allows)
-    const e = encodeURIComponent
-    const ids = items.filter((i) => i.group === 'person').map((i) => i.id)
-    expect(new Set(ids).size).toBe(2)
-    expect(ids).toContain(`person:${e('same')}:${e('C-1')}:${e('Student')}`)
-    expect(ids).toContain(`person:${e('same')}:${e('C-1')}:${e('Teacher')}`)
   })
 
   it('URL-encodes course codes in paths', () => {
@@ -129,7 +50,7 @@ describe('buildSearchItems', () => {
     expect(enc?.path).toBe('/courses/a%2Fb')
   })
 
-  it('includes Ask AI as the first shortcut for every user', () => {
+  it('includes Ask AI as a global shortcut for every user', () => {
     const items = buildSearchItems([], [], allowsNone)
     const ask = items.find((i) => i.id === 'global:ask-ai')
     expect(ask).toMatchObject({
@@ -207,7 +128,7 @@ describe('buildSearchItems', () => {
     expect(items.some((i) => i.id === 'action:/courses/X/enrollments:add')).toBe(false)
   })
 
-  it('adds course settings general page when staff may edit course', () => {
+  it('includes course settings general page when staff may edit course', () => {
     const allowsItemsX = (p: string) => p === courseItemCreatePermission('X')
     const items = buildSearchItems([{ courseCode: 'X', title: 'Y' }], [], allowsItemsX)
     expect(items.some((i) => i.path === '/courses/X/settings/general')).toBe(true)
@@ -215,31 +136,64 @@ describe('buildSearchItems', () => {
     expect(noItems.some((i) => i.path === '/courses/X/settings/general')).toBe(false)
   })
 
-  it('includes grading settings page only when gradebook view is granted', () => {
-    const allowsGradeG = (p: string) => p === courseGradebookViewPermission('G')
-    const items = buildSearchItems([{ courseCode: 'G', title: 'H' }], [], allowsGradeG)
-    expect(items.some((i) => i.path === '/courses/G/settings/grading')).toBe(true)
-    const noGrade = buildSearchItems([{ courseCode: 'G', title: 'H' }], [], allowsNone)
-    expect(noGrade.some((i) => i.path === '/courses/G/settings/grading')).toBe(false)
+  it('includes enabled course apps that match side-nav feature gates', () => {
+    const allowsStaff = (p: string) =>
+      p === courseItemCreatePermission('X') ||
+      p === courseItemsCreatePermission('X') ||
+      p === courseGradebookViewPermission('X')
+    const pages = buildCoursePageItems(
+      [
+        {
+          courseCode: 'X',
+          title: 'Y',
+          discussionsEnabled: true,
+          collabDocsEnabled: true,
+          groupSpacesEnabled: true,
+          liveSessionsEnabled: true,
+          officeHoursEnabled: true,
+          attendanceEnabled: true,
+          whiteboardEnabled: true,
+          questionBankEnabled: true,
+          sbgEnabled: true,
+          standardsAlignmentEnabled: true,
+        },
+      ],
+      allowsStaff,
+    )
+    const paths = pages.map((p) => p.path)
+    expect(paths).toContain('/courses/X/discussions')
+    expect(paths).toContain('/courses/X/collab-docs')
+    expect(paths).toContain('/courses/X/groups')
+    expect(paths).toContain('/courses/X/files')
+    expect(paths).toContain('/courses/X/live')
+    expect(paths).toContain('/courses/X/office-hours')
+    expect(paths).toContain('/courses/X/attendance')
+    expect(paths).toContain('/courses/X/whiteboard')
+    expect(paths).toContain('/courses/X/questions')
+    expect(paths).toContain('/courses/X/standards-gradebook')
+    expect(paths).toContain('/courses/X/standards-coverage')
   })
 
-  it('includes import-export, outcomes, features, blueprint, and archive settings when item:create is granted', () => {
-    const allowsItems = (p: string) => p === courseItemCreatePermission('Z')
-    const items = buildSearchItems([{ courseCode: 'Z', title: 'W' }], [], allowsItems)
-    expect(items.some((i) => i.path === '/courses/Z/settings/outcomes')).toBe(true)
-    expect(items.some((i) => i.path === '/courses/Z/settings/features')).toBe(true)
-    expect(items.some((i) => i.path === '/courses/Z/settings/import-export')).toBe(true)
-    expect(items.some((i) => i.path === '/courses/Z/settings/blueprint')).toBe(true)
-    expect(items.some((i) => i.path === '/courses/Z/settings/archive')).toBe(true)
-  })
-
-  it('omits import-export, outcomes, features, blueprint, and archive settings without item:create', () => {
-    const items = buildSearchItems([{ courseCode: 'Z', title: 'W' }], [], allowsNone)
-    expect(items.some((i) => i.path === '/courses/Z/settings/outcomes')).toBe(false)
-    expect(items.some((i) => i.path === '/courses/Z/settings/features')).toBe(false)
-    expect(items.some((i) => i.path === '/courses/Z/settings/import-export')).toBe(false)
-    expect(items.some((i) => i.path === '/courses/Z/settings/blueprint')).toBe(false)
-    expect(items.some((i) => i.path === '/courses/Z/settings/archive')).toBe(false)
+  it('includes whiteboard when enabled and staff may edit the course', () => {
+    const allowsItems = (p: string) => p === courseItemCreatePermission('X')
+    const items = buildSearchItems(
+      [{ courseCode: 'X', title: 'Y', whiteboardEnabled: true }],
+      [],
+      allowsItems,
+    )
+    expect(items.some((i) => i.path === '/courses/X/whiteboard')).toBe(true)
+    const disabled = buildSearchItems(
+      [{ courseCode: 'X', title: 'Y', whiteboardEnabled: false }],
+      [],
+      allowsItems,
+    )
+    expect(disabled.some((i) => i.path === '/courses/X/whiteboard')).toBe(false)
+    const noPerm = buildSearchItems(
+      [{ courseCode: 'X', title: 'Y', whiteboardEnabled: true }],
+      [],
+      allowsNone,
+    )
+    expect(noPerm.some((i) => i.path === '/courses/X/whiteboard')).toBe(false)
   })
 
   it('omits feed, notebook, and calendar search targets when disabled on the course', () => {
@@ -262,16 +216,35 @@ describe('buildSearchItems', () => {
     expect(items.some((i) => i.path === '/courses/X/calendar')).toBe(false)
     expect(items.some((i) => i.path === '/courses/X/syllabus')).toBe(true)
   })
+})
 
-  it('includes gradebook page only for courses where gradebook view is granted', () => {
-    const courses: SearchCourseItem[] = [
-      { courseCode: 'C-ONE', title: 'First' },
-      { courseCode: 'C-TWO', title: 'Second' },
-    ]
-    const allowsGradebookOne = (p: string) => p === courseGradebookViewPermission('C-ONE')
-    const items = buildSearchItems(courses, [], allowsGradebookOne)
-    expect(items.some((i) => i.path === '/courses/C-ONE/gradebook')).toBe(true)
-    expect(items.some((i) => i.path === '/courses/C-TWO/gradebook')).toBe(false)
+describe('buildLocalSearchCandidates', () => {
+  it('omits per-course pages until there is query text or a scope', () => {
+    const courses = [{ courseCode: 'X', title: 'Y' }]
+    const parsed = parseSearchQuery('')
+    const items = buildLocalSearchCandidates(courses, allowsNone, parsed)
+    expect(items.some((i) => i.path === '/courses/X/syllabus')).toBe(false)
+    expect(items.some((i) => i.id === 'course:X')).toBe(true)
+  })
+
+  it('includes scoped course pages for @scope without extra text', () => {
+    const courses = [{ courseCode: 'X', title: 'Y' }]
+    const parsed = parseSearchQuery('@X')
+    const items = buildLocalSearchCandidates(courses, allowsNone, parsed)
+    expect(items.some((i) => i.path === '/courses/X/syllabus')).toBe(true)
+    expect(items.filter((i) => i.id === 'course:X').length).toBe(1)
+  })
+})
+
+describe('buildSearchHubItems', () => {
+  it('stays small for many courses (no page cartesian product)', () => {
+    const many = Array.from({ length: 20 }, (_, i) => ({
+      courseCode: `C-${i}`,
+      title: `Course ${i}`,
+    }))
+    const hub = buildSearchHubItems(many, allowsNone, null)
+    expect(hub.length).toBeLessThan(30)
+    expect(hub.filter((i) => i.group === 'page' && i.path.includes('/syllabus')).length).toBe(0)
   })
 })
 
@@ -329,9 +302,61 @@ describe('filterSearchItems', () => {
   })
 })
 
+describe('capSearchResults', () => {
+  it('limits total and per-group counts', () => {
+    const items = Array.from({ length: 40 }, (_, i) => ({
+      id: `page:${i}`,
+      group: 'page' as const,
+      title: `Page ${i}`,
+      subtitle: '',
+      path: `/p/${i}`,
+      haystack: `page ${i}`,
+    }))
+    const capped = capSearchResults(items)
+    expect(capped.length).toBeLessThanOrEqual(25)
+    expect(capped.filter((i) => i.group === 'page').length).toBeLessThanOrEqual(5)
+  })
+
+  it('keeps all pinned course pages when scope is set', () => {
+    const pinned = Array.from({ length: 12 }, (_, i) => ({
+      id: `page:c:${i}`,
+      group: 'page' as const,
+      title: `Tool ${i}`,
+      subtitle: '',
+      path: `/courses/X/tool-${i}`,
+      haystack: '',
+    }))
+    const other = Array.from({ length: 10 }, (_, i) => ({
+      id: `page:o:${i}`,
+      group: 'page' as const,
+      title: `Other ${i}`,
+      subtitle: '',
+      path: `/courses/Y/tool-${i}`,
+      haystack: '',
+    }))
+    const capped = capSearchResults([...pinned, ...other], { pinnedCourseCode: 'X' })
+    expect(capped.filter((i) => i.path.startsWith('/courses/X/')).length).toBe(12)
+  })
+})
+
+describe('parseSearchQuery', () => {
+  it('parses @scope and type: filters', () => {
+    expect(parseSearchQuery('@bio gradebook')).toMatchObject({
+      scopeCourseCode: 'bio',
+      text: 'gradebook',
+    })
+    expect(parseSearchQuery('type:person smith')).toMatchObject({
+      text: 'smith',
+    })
+    expect(parseSearchQuery('type:person smith').types).toEqual(new Set(['person']))
+  })
+})
+
 describe('SEARCH_GROUP_LABEL', () => {
   it('has a label for each group', () => {
     expect(SEARCH_GROUP_LABEL.ai).toBe('AI')
+    expect(SEARCH_GROUP_LABEL.recent).toBe('Recent')
+    expect(SEARCH_GROUP_LABEL.content).toBe('Content')
     expect(SEARCH_GROUP_LABEL.action).toBe('Actions')
     expect(SEARCH_GROUP_LABEL.course).toBe('Courses')
     expect(SEARCH_GROUP_LABEL.person).toBe('People')
@@ -339,12 +364,32 @@ describe('SEARCH_GROUP_LABEL', () => {
   })
 })
 
-describe('buildSearchItems with full permissions', () => {
+describe('granular builders', () => {
+  it('buildCourseListItems only returns course rows', () => {
+    const rows = buildCourseListItems([{ courseCode: 'A', title: 'Alpha' }])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.group).toBe('course')
+  })
+
+  it('buildCoursePageItems respects permissions', () => {
+    const allowsGrade = (p: string) => p === courseGradebookViewPermission('G')
+    const pages = buildCoursePageItems([{ courseCode: 'G', title: 'H' }], allowsGrade)
+    expect(pages.some((i) => i.path === '/courses/G/gradebook')).toBe(true)
+    expect(buildCoursePageItems([{ courseCode: 'G', title: 'H' }], allowsNone).some(
+      (i) => i.path === '/courses/G/gradebook',
+    )).toBe(false)
+  })
+
+  it('buildCourseActionItems requires roster permission', () => {
+    const allowsRoster = (p: string) => p === courseEnrollmentsReadPermission('Z')
+    expect(buildCourseActionItems([{ courseCode: 'Z', title: 'W' }], allowsRoster).length).toBe(1)
+    expect(buildCourseActionItems([{ courseCode: 'Z', title: 'W' }], allowsNone).length).toBe(0)
+  })
+
   it('includes rbac page and create course when allows returns true', () => {
-    const items = buildSearchItems([], [], allowsAll)
+    const items = buildGlobalSearchItems(allowsAll)
     expect(items.some((i) => i.path === '/settings/roles')).toBe(true)
     expect(items.some((i) => i.path === '/settings/platform')).toBe(true)
-    expect(items.some((i) => i.path === '/settings/ai/models')).toBe(true)
     expect(items.some((i) => i.id === 'action:/courses/create')).toBe(true)
   })
 })

--- a/clients/web/src/lib/__tests__/search-course-features.test.ts
+++ b/clients/web/src/lib/__tests__/search-course-features.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import {
+  featureDefaultOn,
+  mergeCoursesWithNavFeatures,
+  normalizeSearchCourseItem,
+} from '../search-course-features'
+
+describe('featureDefaultOn', () => {
+  it('treats undefined as enabled for opt-out features', () => {
+    expect(featureDefaultOn(undefined)).toBe(true)
+    expect(featureDefaultOn(true)).toBe(true)
+    expect(featureDefaultOn(false)).toBe(false)
+  })
+})
+
+describe('normalizeSearchCourseItem', () => {
+  it('defaults live sessions on when the search index omits the flag', () => {
+    expect(normalizeSearchCourseItem({ courseCode: 'X', title: 'Y' }).liveSessionsEnabled).toBe(
+      true,
+    )
+  })
+})
+
+describe('mergeCoursesWithNavFeatures', () => {
+  it('overlays nav flags for the active course', () => {
+    const merged = mergeCoursesWithNavFeatures(
+      [{ courseCode: 'BIO', title: 'Biology', liveSessionsEnabled: false }],
+      'BIO',
+      {
+        notebookEnabled: true,
+        feedEnabled: true,
+        calendarEnabled: true,
+        questionBankEnabled: false,
+        standardsAlignmentEnabled: false,
+        discussionsEnabled: false,
+        collabDocsEnabled: false,
+        sbgEnabled: false,
+        liveSessionsEnabled: true,
+        groupSpacesEnabled: false,
+        officeHoursEnabled: false,
+        filesEnabled: true,
+        attendanceEnabled: false,
+        whiteboardEnabled: false,
+      },
+    )
+    const bio = merged.find((c) => c.courseCode === 'BIO')
+    expect(bio?.liveSessionsEnabled).toBe(true)
+  })
+
+  it('adds a synthetic course row when the active course is missing from the index', () => {
+    const merged = mergeCoursesWithNavFeatures([], 'NEW', {
+      notebookEnabled: true,
+      feedEnabled: true,
+      calendarEnabled: true,
+      questionBankEnabled: false,
+      standardsAlignmentEnabled: false,
+      discussionsEnabled: false,
+      collabDocsEnabled: false,
+      sbgEnabled: false,
+      liveSessionsEnabled: true,
+      groupSpacesEnabled: false,
+      officeHoursEnabled: false,
+      filesEnabled: true,
+      attendanceEnabled: false,
+      whiteboardEnabled: false,
+    })
+    expect(merged).toHaveLength(1)
+    expect(merged[0]?.courseCode).toBe('NEW')
+    expect(merged[0]?.liveSessionsEnabled).toBe(true)
+  })
+})

--- a/clients/web/src/lib/__tests__/search-query-parse.test.ts
+++ b/clients/web/src/lib/__tests__/search-query-parse.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyCoursePickerSelection,
+  courseMatchesScope,
+  parseCoursePickerState,
+  parseSearchQuery,
+} from '../search-query-parse'
+
+describe('parseSearchQuery', () => {
+  it('returns empty text for blank input', () => {
+    expect(parseSearchQuery('')).toMatchObject({ text: '', scopeCourseCode: null, types: null })
+  })
+
+  it('extracts in: scope', () => {
+    expect(parseSearchQuery('in:BIOL-101 midterm')).toMatchObject({
+      scopeCourseCode: 'biol-101',
+      text: 'midterm',
+    })
+  })
+
+  it('supports multiple type: prefixes', () => {
+    const parsed = parseSearchQuery('type:course type:content essay')
+    expect(parsed.types).toEqual(new Set(['course', 'content']))
+    expect(parsed.text).toBe('essay')
+  })
+})
+
+describe('courseMatchesScope', () => {
+  it('matches case-insensitively', () => {
+    expect(courseMatchesScope('BIOL-101', 'biol-101')).toBe(true)
+    expect(courseMatchesScope('BIOL-101', 'chem-200')).toBe(false)
+  })
+})
+
+describe('parseCoursePickerState', () => {
+  it('activates on bare @', () => {
+    expect(parseCoursePickerState('@')).toMatchObject({ active: true, filter: '', atIndex: 0 })
+  })
+
+  it('activates while typing a partial course code', () => {
+    expect(parseCoursePickerState('@bio')).toMatchObject({ active: true, filter: 'bio', atIndex: 0 })
+  })
+
+  it('deactivates after scope is completed with a trailing space', () => {
+    expect(parseCoursePickerState('@bio ')).toMatchObject({ active: false })
+    expect(parseCoursePickerState('@bio gradebook')).toMatchObject({ active: false })
+  })
+
+  it('supports @ picker suffix after other text', () => {
+    expect(parseCoursePickerState('type:page @chem')).toMatchObject({
+      active: true,
+      filter: 'chem',
+    })
+  })
+})
+
+describe('applyCoursePickerSelection', () => {
+  it('inserts the course code and trailing space', () => {
+    expect(applyCoursePickerSelection('@bio', 0, 'BIOL-101')).toBe('@BIOL-101 ')
+    expect(applyCoursePickerSelection('hello @b', 6, 'CHEM-1')).toBe('hello @CHEM-1 ')
+  })
+})

--- a/clients/web/src/lib/build-search-items.ts
+++ b/clients/web/src/lib/build-search-items.ts
@@ -1,12 +1,34 @@
+import { atRiskI18n } from './at-risk-i18n'
 import {
   courseEnrollmentsReadPermission,
   courseGradebookViewPermission,
   courseItemCreatePermission,
+  courseItemsCreatePermission,
 } from './courses-api'
-import type { SearchCourseItem, SearchPersonItem } from './search-api'
+import {
+  atRiskFeatureEnabled,
+  outcomesReportFeatureEnabled,
+  xapiEmissionFeatureEnabled,
+} from './platform-features'
+import type { SearchCourseItem } from './search-api'
+import { featureDefaultOn } from './search-course-features'
 import { PERM_COURSE_CREATE, PERM_RBAC_MANAGE, PERM_REPORTS_VIEW } from './rbac-api'
+import {
+  courseMatchesScope,
+  parseSearchQuery,
+  type ParsedSearchQuery,
+  type SearchEntityType,
+} from './search-query-parse'
 
-export type SearchGroup = 'course' | 'person' | 'page' | 'action' | 'goto' | 'ai'
+export type SearchGroup =
+  | 'course'
+  | 'person'
+  | 'page'
+  | 'action'
+  | 'goto'
+  | 'ai'
+  | 'content'
+  | 'recent'
 
 export type SearchListItem = {
   id: string
@@ -16,6 +38,8 @@ export type SearchListItem = {
   path: string
   /** Lowercase text used for client-side filtering */
   haystack: string
+  /** Optional relevance boost from server or ranking */
+  score?: number
 }
 
 function enc(s: string): string {
@@ -28,18 +52,8 @@ function courseSearchBreadcrumb(c: SearchCourseItem): string {
   return t ? `${t} · ${c.courseCode}` : c.courseCode
 }
 
-function personLabel(p: SearchPersonItem): string {
-  const name = p.displayName?.trim()
-  return name || p.email
-}
-
-export function buildSearchItems(
-  courses: SearchCourseItem[],
-  people: SearchPersonItem[],
-  allows: (perm: string) => boolean,
-): SearchListItem[] {
+export function buildGlobalSearchItems(allows: (perm: string) => boolean): SearchListItem[] {
   const items: SearchListItem[] = [
-    // The first item will be Ask AI
     {
       id: 'global:ask-ai',
       group: 'ai',
@@ -49,40 +63,6 @@ export function buildSearchItems(
       haystack: 'ask ai assistant tutor help chat questions',
     },
   ]
-
-  for (const c of courses) {
-    const path = `/courses/${enc(c.courseCode)}`
-    const title = c.title
-    const subtitle = c.courseCode
-    items.push({
-      id: `course:${c.courseCode}`,
-      group: 'course',
-      title,
-      subtitle,
-      path,
-      haystack: `${title} ${subtitle} course`.toLowerCase(),
-    })
-  }
-
-  for (const p of people) {
-    if (!allows(courseEnrollmentsReadPermission(p.courseCode))) {
-      continue
-    }
-    const label = personLabel(p)
-    const subtitle = `${p.courseTitle} · ${p.courseCode} · ${p.role}`
-    const path = allows(courseGradebookViewPermission(p.courseCode))
-      ? `/courses/${enc(p.courseCode)}/gradebook?student=${enc(p.userId)}`
-      : `/courses/${enc(p.courseCode)}/enrollments`
-    // Encode segments so colons in ids/roles (or odd course codes) cannot collide with delimiters.
-    items.push({
-      id: `person:${enc(p.userId)}:${enc(p.courseCode)}:${enc(p.role)}`,
-      group: 'person',
-      title: label,
-      subtitle,
-      path,
-      haystack: `${label} ${p.email} ${p.role} ${p.courseTitle} ${p.courseCode} people enrollment gradebook`.toLowerCase(),
-    })
-  }
 
   const globalPages: { title: string; subtitle: string; path: string; hint: string }[] = [
     { title: 'Dashboard', subtitle: 'Home', path: '/', hint: 'dashboard home' },
@@ -180,72 +160,262 @@ export function buildSearchItems(
     })
   }
 
-  const coursePageDefs: {
-    suffix: string
-    title: string
-    hint: string
-    /** If set, the page is only searchable when `allows(permission(courseCode))` is true. */
-    requiredPermission?: (courseCode: string) => string
-    /** If set, omit when the course has turned off this tool. */
-    whenCourse?: (c: SearchCourseItem) => boolean
-  }[] = [
-      { suffix: '', title: 'Course dashboard', hint: 'dashboard overview' },
-      {
-        suffix: '/feed',
-        title: 'Feed',
-        hint: 'feed chat channels messages discussion',
-        whenCourse: (c) => c.feedEnabled !== false,
-      },
-      { suffix: '/syllabus', title: 'Syllabus', hint: 'syllabus outline' },
-      {
-        suffix: '/modules',
-        title: 'Modules',
-        hint: 'modules lessons content pages assignments quizzes external links',
-      },
-      {
-        suffix: '/notebook',
-        title: 'Notebook',
-        hint: 'notes journal thoughts',
-        whenCourse: (c) => c.notebookEnabled !== false,
-      },
-      {
-        suffix: '/calendar',
-        title: 'Course calendar',
-        hint: 'calendar schedule',
-        whenCourse: (c) => c.calendarEnabled !== false,
-      },
-      {
-        suffix: '/my-grades',
-        title: 'My grades',
-        hint: 'grades scores student your grades',
-      },
-      {
-        suffix: '/gradebook',
-        title: 'Gradebook',
-        hint: 'gradebook grades scores',
-        requiredPermission: courseGradebookViewPermission,
-      },
-      {
-        suffix: '/enrollments',
-        title: 'Enrollments',
-        hint: 'enrollments people roster students',
-        requiredPermission: courseEnrollmentsReadPermission,
-      },
-      {
-        suffix: '/settings/general',
-        title: 'Course settings',
-        hint: 'settings configuration title description dates schedule hero branding',
-        requiredPermission: courseItemCreatePermission,
-      },
-    ]
+  if (allows(PERM_COURSE_CREATE)) {
+    items.push({
+      id: 'action:/courses/create',
+      group: 'action',
+      title: 'Create new course',
+      subtitle: 'Add a course to the catalog',
+      path: '/courses/create',
+      haystack: 'create new course add action'.toLowerCase(),
+    })
+  }
 
+  return items
+}
+
+export function buildCourseListItems(courses: SearchCourseItem[]): SearchListItem[] {
+  return courses.map((c) => ({
+    id: `course:${c.courseCode}`,
+    group: 'course' as const,
+    title: c.title,
+    subtitle: c.courseCode,
+    path: `/courses/${enc(c.courseCode)}`,
+    haystack: `${c.title} ${c.courseCode} course`.toLowerCase(),
+  }))
+}
+
+type CoursePageDef = {
+  suffix: string
+  title: string
+  hint: string
+  whenCourse?: (c: SearchCourseItem) => boolean
+  whenPlatform?: () => boolean
+  requiredPermission?: (courseCode: string) => string
+  /** Visible when the user has any one of these course permissions. */
+  requiredAnyPermission?: ((courseCode: string) => string)[]
+}
+
+/** Mirrors course side-nav links (side-nav-course-links.tsx). */
+const coursePageDefs: CoursePageDef[] = [
+  { suffix: '', title: 'Course dashboard', hint: 'dashboard overview' },
+  {
+    suffix: '/feed',
+    title: 'Feed',
+    hint: 'feed chat channels messages discussion',
+    whenCourse: (c) => featureDefaultOn(c.feedEnabled),
+  },
+  {
+    suffix: '/discussions',
+    title: 'Discussions',
+    hint: 'discussions forums threads conversation',
+    whenCourse: (c) => c.discussionsEnabled === true,
+  },
+  {
+    suffix: '/collab-docs',
+    title: 'Collab docs',
+    hint: 'collab docs collaborative documents co-editing',
+    whenCourse: (c) => c.collabDocsEnabled === true,
+  },
+  {
+    suffix: '/groups',
+    title: 'Groups',
+    hint: 'groups group spaces enrollment teams',
+    whenCourse: (c) => c.groupSpacesEnabled === true,
+  },
+  { suffix: '/syllabus', title: 'Syllabus', hint: 'syllabus outline' },
+  {
+    suffix: '/files',
+    title: 'Files',
+    hint: 'files drive uploads course files documents',
+    whenCourse: (c) => featureDefaultOn(c.filesEnabled),
+  },
+  {
+    suffix: '/modules',
+    title: 'Modules',
+    hint: 'modules lessons content pages assignments quizzes external links',
+  },
+  {
+    suffix: '/live',
+    title: 'Live Sessions',
+    hint: 'live live sessions virtual classroom video meeting jitsi zoom bbb bigbluebutton',
+    whenCourse: (c) => featureDefaultOn(c.liveSessionsEnabled),
+  },
+  {
+    suffix: '/office-hours',
+    title: 'Office Hours',
+    hint: 'office hours appointments scheduling',
+    whenCourse: (c) => c.officeHoursEnabled === true,
+  },
+  {
+    suffix: '/attendance',
+    title: 'Attendance',
+    hint: 'attendance roll call sessions',
+    whenCourse: (c) => c.attendanceEnabled === true,
+  },
+  {
+    suffix: '/whiteboard',
+    title: 'Whiteboard',
+    hint: 'whiteboard canvas drawing brainstorm excalidraw sketch collaborative',
+    whenCourse: (c) => c.whiteboardEnabled === true,
+    requiredPermission: courseItemCreatePermission,
+  },
+  {
+    suffix: '/questions',
+    title: 'Question bank',
+    hint: 'question bank quiz questions assessment items',
+    whenCourse: (c) => c.questionBankEnabled === true,
+    requiredPermission: courseItemsCreatePermission,
+  },
+  {
+    suffix: '/misconception-report',
+    title: 'Misconceptions',
+    hint: 'misconceptions misconception report learning gaps',
+    whenCourse: (c) => c.questionBankEnabled === true,
+    requiredPermission: courseItemsCreatePermission,
+  },
+  {
+    suffix: '/notebook',
+    title: 'Notebook',
+    hint: 'notes journal thoughts',
+    whenCourse: (c) => featureDefaultOn(c.notebookEnabled),
+  },
+  {
+    suffix: '/calendar',
+    title: 'Course calendar',
+    hint: 'calendar schedule',
+    whenCourse: (c) => featureDefaultOn(c.calendarEnabled),
+  },
+  {
+    suffix: '/my-grades',
+    title: 'My grades',
+    hint: 'grades scores student your grades',
+  },
+  {
+    suffix: '/gradebook',
+    title: 'Gradebook',
+    hint: 'gradebook grades scores',
+    requiredPermission: courseGradebookViewPermission,
+  },
+  {
+    suffix: '/at-risk',
+    title: atRiskI18n.title,
+    hint: 'at risk students alerts early warning',
+    whenPlatform: atRiskFeatureEnabled,
+    requiredPermission: courseGradebookViewPermission,
+  },
+  {
+    suffix: '/outcomes-report',
+    title: 'Outcomes report',
+    hint: 'outcomes report learning objectives mastery',
+    whenPlatform: outcomesReportFeatureEnabled,
+    requiredPermission: courseGradebookViewPermission,
+  },
+  {
+    suffix: '/event-log',
+    title: 'Event log',
+    hint: 'event log xapi caliper learning activity',
+    whenPlatform: xapiEmissionFeatureEnabled,
+    requiredPermission: courseGradebookViewPermission,
+  },
+  {
+    suffix: '/standards-gradebook',
+    title: 'Standards gradebook',
+    hint: 'standards gradebook sbg proficiency mastery',
+    whenCourse: (c) => c.sbgEnabled === true,
+    requiredPermission: courseGradebookViewPermission,
+  },
+  {
+    suffix: '/standards-coverage',
+    title: 'Standards coverage',
+    hint: 'standards coverage alignment objectives',
+    whenCourse: (c) => c.standardsAlignmentEnabled === true,
+    requiredAnyPermission: [courseGradebookViewPermission, courseItemCreatePermission],
+  },
+  {
+    suffix: '/enrollments',
+    title: 'Enrollments',
+    hint: 'enrollments people roster students',
+    requiredPermission: courseEnrollmentsReadPermission,
+  },
+  {
+    suffix: '/settings/general',
+    title: 'Course settings',
+    hint: 'settings configuration title description dates schedule hero branding',
+    requiredPermission: courseItemCreatePermission,
+  },
+]
+
+function coursePageDefAllowed(
+  def: CoursePageDef,
+  courseCode: string,
+  allows: (perm: string) => boolean,
+): boolean {
+  if (def.whenPlatform && !def.whenPlatform()) return false
+  if (def.requiredPermission && !allows(def.requiredPermission(courseCode))) return false
+  if (def.requiredAnyPermission) {
+    const ok = def.requiredAnyPermission.some((perm) => allows(perm(courseCode)))
+    if (!ok) return false
+  }
+  return true
+}
+
+const courseSettingsSectionDefs: {
+  suffix: string
+  title: string
+  hint: string
+  requiredPermission?: (courseCode: string) => string
+}[] = [
+  {
+    suffix: '/settings/grading',
+    title: 'Grading settings',
+    hint: 'grading scale assignment groups weights categories',
+    requiredPermission: courseGradebookViewPermission,
+  },
+  {
+    suffix: '/settings/outcomes',
+    title: 'Course outcomes',
+    hint: 'learning outcomes objectives alignment evidence quiz questions progress',
+    requiredPermission: courseItemCreatePermission,
+  },
+  {
+    suffix: '/settings/features',
+    title: 'Course features',
+    hint: 'features tools notebook feed calendar enable disable toggles',
+    requiredPermission: courseItemCreatePermission,
+  },
+  {
+    suffix: '/settings/import-export',
+    title: 'Import / export',
+    hint: 'export import backup canvas migrate course package',
+    requiredPermission: courseItemCreatePermission,
+  },
+  {
+    suffix: '/settings/blueprint',
+    title: 'Course blueprint',
+    hint: 'district curriculum master child courses sync push template',
+    requiredPermission: courseItemCreatePermission,
+  },
+  {
+    suffix: '/settings/archive',
+    title: 'Archived modules',
+    hint: 'archived deleted restore trash unarchive structure',
+    requiredPermission: courseItemCreatePermission,
+  },
+]
+
+export function buildCoursePageItems(
+  courses: SearchCourseItem[],
+  allows: (perm: string) => boolean,
+): SearchListItem[] {
+  const items: SearchListItem[] = []
   for (const c of courses) {
     const base = `/courses/${enc(c.courseCode)}`
     for (const def of coursePageDefs) {
-      if (def.requiredPermission && !allows(def.requiredPermission(c.courseCode))) {
+      if (def.whenCourse && !def.whenCourse(c)) {
         continue
       }
-      if (def.whenCourse && !def.whenCourse(c)) {
+      if (!coursePageDefAllowed(def, c.courseCode, allows)) {
         continue
       }
       const path = `${base}${def.suffix}`
@@ -258,54 +428,6 @@ export function buildSearchItems(
         haystack: `${def.title} ${c.title} ${c.courseCode} ${def.hint} page`.toLowerCase(),
       })
     }
-  }
-
-  const courseSettingsSectionDefs: {
-    suffix: string
-    title: string
-    hint: string
-    requiredPermission?: (courseCode: string) => string
-  }[] = [
-      {
-        suffix: '/settings/grading',
-        title: 'Grading settings',
-        hint: 'grading scale assignment groups weights categories',
-        requiredPermission: courseGradebookViewPermission,
-      },
-      {
-        suffix: '/settings/outcomes',
-        title: 'Course outcomes',
-        hint: 'learning outcomes objectives alignment evidence quiz questions progress',
-        requiredPermission: courseItemCreatePermission,
-      },
-      {
-        suffix: '/settings/features',
-        title: 'Course features',
-        hint: 'features tools notebook feed calendar enable disable toggles',
-        requiredPermission: courseItemCreatePermission,
-      },
-      {
-        suffix: '/settings/import-export',
-        title: 'Import / export',
-        hint: 'export import backup canvas migrate course package',
-        requiredPermission: courseItemCreatePermission,
-      },
-      {
-        suffix: '/settings/blueprint',
-        title: 'Course blueprint',
-        hint: 'district curriculum master child courses sync push template',
-        requiredPermission: courseItemCreatePermission,
-      },
-      {
-        suffix: '/settings/archive',
-        title: 'Archived modules',
-        hint: 'archived deleted restore trash unarchive structure',
-        requiredPermission: courseItemCreatePermission,
-      },
-    ]
-
-  for (const c of courses) {
-    const base = `/courses/${enc(c.courseCode)}`
     for (const def of courseSettingsSectionDefs) {
       if (def.requiredPermission && !allows(def.requiredPermission(c.courseCode))) {
         continue
@@ -321,18 +443,14 @@ export function buildSearchItems(
       })
     }
   }
+  return items
+}
 
-  if (allows(PERM_COURSE_CREATE)) {
-    items.push({
-      id: 'action:/courses/create',
-      group: 'action',
-      title: 'Create new course',
-      subtitle: 'Add a course to the catalog',
-      path: '/courses/create',
-      haystack: 'create new course add action'.toLowerCase(),
-    })
-  }
-
+export function buildCourseActionItems(
+  courses: SearchCourseItem[],
+  allows: (perm: string) => boolean,
+): SearchListItem[] {
+  const items: SearchListItem[] = []
   for (const c of courses) {
     if (!allows(courseEnrollmentsReadPermission(c.courseCode))) {
       continue
@@ -347,12 +465,50 @@ export function buildSearchItems(
       haystack: `add enrollment enroll people invite students open enrollments learners ${c.title} ${c.courseCode} action`.toLowerCase(),
     })
   }
-
   return items
+}
+
+/** @deprecated Use granular builders; kept for tests and backward compatibility. */
+export function buildSearchItems(
+  courses: SearchCourseItem[],
+  _people: unknown[],
+  allows: (perm: string) => boolean,
+): SearchListItem[] {
+  return [
+    ...buildGlobalSearchItems(allows),
+    ...buildCourseListItems(courses),
+    ...buildCoursePageItems(courses, allows),
+    ...buildCourseActionItems(courses, allows),
+  ]
+}
+
+const GROUP_ORDER: SearchGroup[] = [
+  'recent',
+  'ai',
+  'goto',
+  'action',
+  'course',
+  'content',
+  'person',
+  'page',
+]
+
+export const SEARCH_GROUP_LABEL: Record<SearchGroup, string> = {
+  recent: 'Recent',
+  goto: 'Go to',
+  action: 'Actions',
+  course: 'Courses',
+  content: 'Content',
+  person: 'People',
+  page: 'Pages',
+  ai: 'AI',
 }
 
 export function sortSearchItems(items: SearchListItem[]): SearchListItem[] {
   return [...items].sort((a, b) => {
+    const scoreA = a.score ?? 0
+    const scoreB = b.score ?? 0
+    if (scoreB !== scoreA) return scoreB - scoreA
     const gi = GROUP_ORDER.indexOf(a.group)
     const gj = GROUP_ORDER.indexOf(b.group)
     if (gi !== gj) return gi - gj
@@ -364,22 +520,157 @@ export function sortSearchItems(items: SearchListItem[]): SearchListItem[] {
   })
 }
 
-export function filterSearchItems(items: SearchListItem[], query: string): SearchListItem[] {
-  const q = query.trim().toLowerCase()
-  const words = q.split(/\s+/).filter(Boolean)
-  const filtered = words.length
-    ? items.filter((it) => words.every((w) => it.haystack.includes(w)))
-    : items
-  return sortSearchItems(filtered)
+function itemMatchesWords(item: SearchListItem, words: string[]): boolean {
+  return words.every((w) => item.haystack.includes(w))
 }
 
-const GROUP_ORDER: SearchGroup[] = ['ai', 'goto', 'action', 'course', 'person', 'page']
+function boostForItem(
+  item: SearchListItem,
+  parsed: ParsedSearchQuery,
+  currentCourseCode: string | null,
+): number {
+  let score = item.score ?? 0
+  if (currentCourseCode && item.haystack.includes(currentCourseCode.toLowerCase())) {
+    score += 0.5
+  }
+  if (parsed.scopeCourseCode && item.haystack.includes(parsed.scopeCourseCode)) {
+    score += 0.75
+  }
+  if (parsed.text && item.title.toLowerCase().startsWith(parsed.text)) {
+    score += 0.25
+  }
+  return score
+}
 
-export const SEARCH_GROUP_LABEL: Record<SearchGroup, string> = {
-  goto: 'Go to',
-  action: 'Actions',
-  course: 'Courses',
-  person: 'People',
-  page: 'Pages',
-  ai: 'AI'
+function typeAllowed(group: SearchGroup, types: Set<SearchEntityType> | null): boolean {
+  if (!types) return true
+  if (group === 'recent') return true
+  if (group === 'ai' || group === 'goto') return true
+  return types.has(group)
+}
+
+export type FilterSearchOptions = {
+  currentCourseCode?: string | null
+  includePages?: boolean
+  includeActions?: boolean
+}
+
+export function filterSearchItems(
+  items: SearchListItem[],
+  query: string,
+  options: FilterSearchOptions = {},
+): SearchListItem[] {
+  const parsed = parseSearchQuery(query)
+  const currentCourseCode = options.currentCourseCode ?? null
+
+  if (!parsed.text && !parsed.scopeCourseCode && !parsed.types) {
+    return sortSearchItems(items)
+  }
+
+  const words = parsed.text.split(/\s+/).filter(Boolean)
+
+  let pool = items.filter((it) => {
+    if (!typeAllowed(it.group, parsed.types)) return false
+    if (parsed.scopeCourseCode) {
+      if (it.group === 'course') {
+        return courseMatchesScope(it.subtitle, parsed.scopeCourseCode)
+      }
+      if (it.group === 'page' || it.group === 'action') {
+        return it.haystack.includes(parsed.scopeCourseCode)
+      }
+    }
+    if (words.length === 0) return true
+    return itemMatchesWords(it, words)
+  })
+
+  pool = pool.map((it) => ({
+    ...it,
+    score: boostForItem(it, parsed, currentCourseCode),
+  }))
+
+  return sortSearchItems(pool)
+}
+
+export function buildLocalSearchCandidates(
+  courses: SearchCourseItem[],
+  allows: (perm: string) => boolean,
+  parsed: ParsedSearchQuery,
+): SearchListItem[] {
+  const scopedCourses = parsed.scopeCourseCode
+    ? courses.filter((c) => courseMatchesScope(c.courseCode, parsed.scopeCourseCode))
+    : courses
+
+  const items: SearchListItem[] = [...buildGlobalSearchItems(allows)]
+
+  const includeCourses = !parsed.types || parsed.types.has('course')
+  const includePages = !parsed.types || parsed.types.has('page')
+  const includeActions = !parsed.types || parsed.types.has('action')
+
+  if (includeCourses) {
+    items.push(...buildCourseListItems(scopedCourses))
+  }
+  if (includePages && (parsed.scopeCourseCode || parsed.text.length > 0)) {
+    items.push(...buildCoursePageItems(scopedCourses, allows))
+  }
+  if (includeActions && (parsed.scopeCourseCode || parsed.text.length > 0)) {
+    items.push(...buildCourseActionItems(scopedCourses, allows))
+  }
+
+  return items
+}
+
+export const SEARCH_RESULT_CAP = 25
+export const SEARCH_HUB_RESULT_CAP = 40
+export const SEARCH_GROUP_CAP = 5
+
+export type CapSearchOptions = {
+  /** Include every page row for this course (hub or @scope). */
+  pinnedCourseCode?: string | null
+  hubMode?: boolean
+}
+
+function coursePagePathPrefix(courseCode: string): string {
+  return `/courses/${encodeURIComponent(courseCode)}`
+}
+
+function isPageForCourse(item: SearchListItem, courseCode: string): boolean {
+  const prefix = coursePagePathPrefix(courseCode)
+  return item.group === 'page' && (item.path === prefix || item.path.startsWith(`${prefix}/`))
+}
+
+function capSearchResultsDefault(items: SearchListItem[], totalCap: number): SearchListItem[] {
+  const groupCounts = new Map<SearchGroup, number>()
+  const out: SearchListItem[] = []
+  for (const it of sortSearchItems(items)) {
+    const count = groupCounts.get(it.group) ?? 0
+    if (count >= SEARCH_GROUP_CAP) continue
+    groupCounts.set(it.group, count + 1)
+    out.push(it)
+    if (out.length >= totalCap) break
+  }
+  return out
+}
+
+export function capSearchResults(items: SearchListItem[], options: CapSearchOptions = {}): SearchListItem[] {
+  const pinned = options.pinnedCourseCode?.trim()
+  if (!pinned) {
+    return capSearchResultsDefault(items, options.hubMode ? SEARCH_HUB_RESULT_CAP : SEARCH_RESULT_CAP)
+  }
+
+  const pinnedPages = sortSearchItems(items.filter((it) => isPageForCourse(it, pinned)))
+  const pinnedIds = new Set(pinnedPages.map((it) => it.id))
+  const rest = items.filter((it) => !pinnedIds.has(it.id))
+  const cappedRest = capSearchResultsDefault(
+    rest,
+    options.hubMode ? SEARCH_HUB_RESULT_CAP : SEARCH_RESULT_CAP,
+  )
+
+  const seen = new Set<string>()
+  const out: SearchListItem[] = []
+  for (const it of [...pinnedPages, ...cappedRest]) {
+    if (seen.has(it.id)) continue
+    seen.add(it.id)
+    out.push(it)
+  }
+  return out
 }

--- a/clients/web/src/lib/search-api.ts
+++ b/clients/web/src/lib/search-api.ts
@@ -1,15 +1,24 @@
 import { authorizedFetch } from './api'
 import { readApiErrorMessage } from './errors'
+import type { SearchGroup, SearchListItem } from './build-search-items'
+import { normalizeSearchCourseItem } from './search-course-features'
 
 export type SearchCourseItem = {
   courseCode: string
   title: string
-  /** When false, course feed is hidden from search and nav. */
+  /** When false, hidden from search and nav (defaults on). */
   notebookEnabled?: boolean
   feedEnabled?: boolean
   calendarEnabled?: boolean
-  /** Plan 6.1 — discussion forums in the course menu. */
   discussionsEnabled?: boolean
+  collabDocsEnabled?: boolean
+  sbgEnabled?: boolean
+  liveSessionsEnabled?: boolean
+  groupSpacesEnabled?: boolean
+  officeHoursEnabled?: boolean
+  filesEnabled?: boolean
+  attendanceEnabled?: boolean
+  whiteboardEnabled?: boolean
   questionBankEnabled?: boolean
   standardsAlignmentEnabled?: boolean
 }
@@ -28,6 +37,27 @@ export type SearchIndexResponse = {
   people: SearchPersonItem[]
 }
 
+export type SearchQueryResultItem = {
+  id: string
+  type: string
+  title: string
+  subtitle: string
+  path: string
+  score?: number
+}
+
+export type SearchQueryGroup = {
+  type: string
+  label: string
+  total: number
+  items: SearchQueryResultItem[]
+}
+
+export type SearchQueryResponse = {
+  groups: SearchQueryGroup[]
+  tookMs: number
+}
+
 async function parseJson(res: Response): Promise<unknown> {
   return res.json().catch(() => ({}))
 }
@@ -38,8 +68,56 @@ export async function fetchSearchIndex(): Promise<SearchIndexResponse> {
   const raw = await parseJson(res)
   if (!res.ok) throw new Error(readApiErrorMessage(raw))
   const body = raw as Partial<SearchIndexResponse>
+  const rawCourses = Array.isArray(body.courses) ? body.courses : []
   return {
-    courses: Array.isArray(body.courses) ? body.courses : [],
+    courses: rawCourses.map((c) => normalizeSearchCourseItem(c as SearchCourseItem)),
     people: Array.isArray(body.people) ? body.people : [],
   }
+}
+
+export type FetchSearchQueryParams = {
+  q: string
+  scope?: string | null
+  types?: string
+}
+
+/** Server-side FTS for courses, people, and module content. */
+export async function fetchSearchQuery(params: FetchSearchQueryParams): Promise<SearchQueryResponse> {
+  const sp = new URLSearchParams()
+  sp.set('q', params.q)
+  if (params.scope) sp.set('scope', params.scope)
+  if (params.types) sp.set('types', params.types)
+  const res = await authorizedFetch(`/api/v1/search/query?${sp.toString()}`)
+  const raw = await parseJson(res)
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  const body = raw as Partial<SearchQueryResponse>
+  return {
+    groups: Array.isArray(body.groups) ? body.groups : [],
+    tookMs: typeof body.tookMs === 'number' ? body.tookMs : 0,
+  }
+}
+
+const SERVER_GROUP_MAP: Record<string, SearchGroup> = {
+  course: 'course',
+  person: 'person',
+  content: 'content',
+}
+
+export function queryResultsToSearchItems(groups: SearchQueryGroup[]): SearchListItem[] {
+  const out: SearchListItem[] = []
+  for (const group of groups) {
+    const mappedGroup = SERVER_GROUP_MAP[group.type] ?? 'page'
+    for (const item of group.items) {
+      out.push({
+        id: item.id,
+        group: mappedGroup,
+        title: item.title,
+        subtitle: item.subtitle,
+        path: item.path,
+        haystack: `${item.title} ${item.subtitle} ${item.type}`.toLowerCase(),
+        score: item.score,
+      })
+    }
+  }
+  return out
 }

--- a/clients/web/src/lib/search-course-features.ts
+++ b/clients/web/src/lib/search-course-features.ts
@@ -1,0 +1,94 @@
+import type { CourseNavFeatures } from '../context/course-nav-features-context'
+import type { SearchCourseItem } from './search-api'
+
+/** Opt-out course tools (enabled unless explicitly false). */
+export function featureDefaultOn(value: boolean | undefined): boolean {
+  return value !== false
+}
+
+export function courseCodesEqual(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase()
+}
+
+/** Align search-index rows with the same default-on semantics as course nav. */
+export function normalizeSearchCourseItem(c: SearchCourseItem): SearchCourseItem {
+  return {
+    ...c,
+    notebookEnabled: featureDefaultOn(c.notebookEnabled),
+    feedEnabled: featureDefaultOn(c.feedEnabled),
+    calendarEnabled: featureDefaultOn(c.calendarEnabled),
+    filesEnabled: featureDefaultOn(c.filesEnabled),
+    liveSessionsEnabled: featureDefaultOn(c.liveSessionsEnabled),
+  }
+}
+
+type NavFeatureFlags = Pick<
+  CourseNavFeatures,
+  | 'notebookEnabled'
+  | 'feedEnabled'
+  | 'calendarEnabled'
+  | 'questionBankEnabled'
+  | 'standardsAlignmentEnabled'
+  | 'discussionsEnabled'
+  | 'collabDocsEnabled'
+  | 'sbgEnabled'
+  | 'liveSessionsEnabled'
+  | 'groupSpacesEnabled'
+  | 'officeHoursEnabled'
+  | 'filesEnabled'
+  | 'attendanceEnabled'
+  | 'whiteboardEnabled'
+>
+
+export function navFeaturesToSearchCourse(
+  courseCode: string,
+  nav: NavFeatureFlags,
+  existing?: SearchCourseItem,
+): SearchCourseItem {
+  return normalizeSearchCourseItem({
+    courseCode,
+    title: existing?.title ?? courseCode,
+    notebookEnabled: nav.notebookEnabled,
+    feedEnabled: nav.feedEnabled,
+    calendarEnabled: nav.calendarEnabled,
+    questionBankEnabled: nav.questionBankEnabled,
+    standardsAlignmentEnabled: nav.standardsAlignmentEnabled,
+    discussionsEnabled: nav.discussionsEnabled,
+    collabDocsEnabled: nav.collabDocsEnabled,
+    sbgEnabled: nav.sbgEnabled,
+    liveSessionsEnabled: nav.liveSessionsEnabled,
+    groupSpacesEnabled: nav.groupSpacesEnabled,
+    officeHoursEnabled: nav.officeHoursEnabled,
+    filesEnabled: nav.filesEnabled,
+    attendanceEnabled: nav.attendanceEnabled,
+    whiteboardEnabled: nav.whiteboardEnabled,
+  })
+}
+
+/**
+ * Overlay live course nav flags onto the search index for the active course so
+ * command-palette results match the side nav (fetchCourse vs /api/v1/search).
+ */
+export function mergeCoursesWithNavFeatures(
+  courses: SearchCourseItem[],
+  currentCourseCode: string | null,
+  nav: NavFeatureFlags,
+): SearchCourseItem[] {
+  const normalized = courses.map(normalizeSearchCourseItem)
+  if (!currentCourseCode) return normalized
+
+  const idx = normalized.findIndex((c) => courseCodesEqual(c.courseCode, currentCourseCode))
+  const merged = navFeaturesToSearchCourse(
+    currentCourseCode,
+    nav,
+    idx >= 0 ? normalized[idx] : undefined,
+  )
+
+  if (idx >= 0) {
+    const out = [...normalized]
+    out[idx] = { ...normalized[idx], ...merged }
+    return out
+  }
+
+  return [...normalized, merged]
+}

--- a/clients/web/src/lib/search-hub.ts
+++ b/clients/web/src/lib/search-hub.ts
@@ -1,0 +1,64 @@
+import {
+  buildCourseListItems,
+  buildCoursePageItems,
+  buildGlobalSearchItems,
+  type SearchListItem,
+} from './build-search-items'
+import { recentsToSearchItems, listSearchRecents } from './search-recents'
+import type { SearchCourseItem } from './search-api'
+import { courseCodesEqual } from './search-course-features'
+import { PERM_COURSE_CREATE } from './rbac-api'
+
+const HUB_COURSE_LIMIT = 5
+
+/** Curated command-palette rows when the query is empty (no cartesian page explosion). */
+export function buildSearchHubItems(
+  courses: SearchCourseItem[],
+  allows: (perm: string) => boolean,
+  currentCourseCode: string | null,
+): SearchListItem[] {
+  const items: SearchListItem[] = []
+  const seen = new Set<string>()
+
+  const push = (it: SearchListItem) => {
+    if (seen.has(it.id)) return
+    seen.add(it.id)
+    items.push(it)
+  }
+
+  for (const it of recentsToSearchItems(listSearchRecents())) {
+    push(it)
+  }
+
+  if (currentCourseCode) {
+    const current = courses.find((c) => courseCodesEqual(c.courseCode, currentCourseCode))
+    if (current) {
+      push({
+        id: `hub:course:${current.courseCode}`,
+        group: 'course',
+        title: current.title,
+        subtitle: `${current.courseCode} · current course`,
+        path: `/courses/${encodeURIComponent(current.courseCode)}`,
+        haystack: `${current.title} ${current.courseCode} current course`.toLowerCase(),
+      })
+      for (const page of buildCoursePageItems([current], allows)) {
+        push(page)
+      }
+    }
+  }
+
+  for (const g of buildGlobalSearchItems(allows)) {
+    push(g)
+  }
+
+  for (const c of buildCourseListItems(courses).slice(0, HUB_COURSE_LIMIT)) {
+    push(c)
+  }
+
+  if (allows(PERM_COURSE_CREATE)) {
+    const create = buildGlobalSearchItems(allows).find((i) => i.id === 'action:/courses/create')
+    if (create) push(create)
+  }
+
+  return items
+}

--- a/clients/web/src/lib/search-query-parse.ts
+++ b/clients/web/src/lib/search-query-parse.ts
@@ -1,0 +1,110 @@
+export type SearchEntityType = 'course' | 'person' | 'page' | 'action' | 'content' | 'goto' | 'ai'
+
+export type ParsedSearchQuery = {
+  /** Free-text tokens after stripping scope/type prefixes. */
+  text: string
+  /** Lowercase course code from `@code` or `in:code`. */
+  scopeCourseCode: string | null
+  /** When set, only these entity types are included. */
+  types: Set<SearchEntityType> | null
+  /** Original trimmed query. */
+  raw: string
+}
+
+const TYPE_PREFIX_RE = /^type:(course|person|page|action|content)\s+/i
+const IN_SCOPE_RE = /^in:([^\s]+)\s+/i
+const AT_SCOPE_RE = /^@([^\s]+)\s+/i
+
+function normalizeScope(raw: string): string {
+  try {
+    return decodeURIComponent(raw.trim()).toLowerCase()
+  } catch {
+    return raw.trim().toLowerCase()
+  }
+}
+
+/** Parse command-palette query modifiers (`@bio`, `in:biol101`, `type:person`). */
+export function parseSearchQuery(query: string): ParsedSearchQuery {
+  let rest = query.trim()
+  const types = new Set<SearchEntityType>()
+  let scopeCourseCode: string | null = null
+
+  for (;;) {
+    const typeMatch = TYPE_PREFIX_RE.exec(rest)
+    if (typeMatch) {
+      types.add(typeMatch[1]!.toLowerCase() as SearchEntityType)
+      rest = rest.slice(typeMatch[0].length).trimStart()
+      continue
+    }
+    const inMatch = IN_SCOPE_RE.exec(rest)
+    if (inMatch) {
+      scopeCourseCode = normalizeScope(inMatch[1]!)
+      rest = rest.slice(inMatch[0].length).trimStart()
+      continue
+    }
+    const atMatch = AT_SCOPE_RE.exec(rest)
+    if (atMatch) {
+      scopeCourseCode = normalizeScope(atMatch[1]!)
+      rest = rest.slice(atMatch[0].length).trimStart()
+      continue
+    }
+    break
+  }
+
+  return {
+    text: rest.toLowerCase(),
+    scopeCourseCode,
+    types: types.size > 0 ? types : null,
+    raw: query.trim(),
+  }
+}
+
+export function courseMatchesScope(courseCode: string, scope: string | null): boolean {
+  if (!scope) return true
+  return courseCode.trim().toLowerCase() === scope
+}
+
+export type CoursePickerState = {
+  active: boolean
+  /** Lowercase filter typed after `@` (empty = show all courses). */
+  filter: string
+  /** Index of `@` in the raw query (for splicing on select). */
+  atIndex: number
+}
+
+const INCOMPLETE_AT_SUFFIX_RE = /(?:^|\s)@([^\s]*)$/
+
+/**
+ * True while the user is choosing a course scope (`@` or `@partial` without a trailing space).
+ * Completed scopes like `@bio ` or `@bio gradebook` are not picker mode.
+ */
+export function parseCoursePickerState(query: string): CoursePickerState {
+  const inactive: CoursePickerState = { active: false, filter: '', atIndex: -1 }
+  const trimmed = query
+  if (!trimmed.includes('@')) return inactive
+
+  const parsed = parseSearchQuery(query)
+  if (parsed.scopeCourseCode !== null) return inactive
+
+  const suffix = INCOMPLETE_AT_SUFFIX_RE.exec(query)
+  if (!suffix) return inactive
+
+  const atIndex = query.lastIndexOf('@')
+  if (atIndex < 0) return inactive
+
+  return {
+    active: true,
+    filter: suffix[1]!.toLowerCase(),
+    atIndex,
+  }
+}
+
+/** Replace an in-progress `@filter` suffix with a completed `@courseCode ` scope. */
+export function applyCoursePickerSelection(
+  query: string,
+  atIndex: number,
+  courseCode: string,
+): string {
+  const prefix = query.slice(0, atIndex)
+  return `${prefix}@${courseCode} `
+}

--- a/clients/web/src/lib/search-recents.ts
+++ b/clients/web/src/lib/search-recents.ts
@@ -1,0 +1,69 @@
+import type { SearchGroup, SearchListItem } from './build-search-items'
+
+const STORAGE_KEY = 'lextures:search-recents:v1'
+const MAX_RECENTS = 10
+
+export type SearchRecentEntry = {
+  id: string
+  group: SearchGroup
+  title: string
+  subtitle: string
+  path: string
+  visitedAt: string
+}
+
+function readStore(): SearchRecentEntry[] {
+  if (typeof localStorage === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (row): row is SearchRecentEntry =>
+        !!row &&
+        typeof row === 'object' &&
+        typeof (row as SearchRecentEntry).id === 'string' &&
+        typeof (row as SearchRecentEntry).path === 'string',
+    )
+  } catch {
+    return []
+  }
+}
+
+function writeStore(entries: SearchRecentEntry[]) {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
+  } catch {
+    /* quota / private mode */
+  }
+}
+
+export function listSearchRecents(): SearchRecentEntry[] {
+  return readStore().sort((a, b) => Date.parse(b.visitedAt) - Date.parse(a.visitedAt))
+}
+
+export function recordSearchRecent(item: SearchListItem): void {
+  const entry: SearchRecentEntry = {
+    id: item.id,
+    group: item.group,
+    title: item.title,
+    subtitle: item.subtitle,
+    path: item.path,
+    visitedAt: new Date().toISOString(),
+  }
+  const prev = readStore().filter((r) => r.id !== entry.id)
+  writeStore([entry, ...prev].slice(0, MAX_RECENTS))
+}
+
+export function recentsToSearchItems(recents: SearchRecentEntry[]): SearchListItem[] {
+  return recents.map((r) => ({
+    id: `recent:${r.id}`,
+    group: 'recent' as const,
+    title: r.title,
+    subtitle: r.subtitle,
+    path: r.path,
+    haystack: `${r.title} ${r.subtitle} recent`.toLowerCase(),
+  }))
+}

--- a/clients/web/src/test/mocks/handlers.ts
+++ b/clients/web/src/test/mocks/handlers.ts
@@ -44,6 +44,12 @@ export const handlers = [
       people: [],
     })
   }),
+  http.get('http://localhost:8080/api/v1/search/query', () => {
+    return HttpResponse.json({
+      groups: [],
+      tookMs: 0,
+    })
+  }),
   http.get('http://localhost:8080/api/v1/courses', () => {
     return HttpResponse.json({ courses: [] })
   }),

--- a/server/internal/httpserver/search.go
+++ b/server/internal/httpserver/search.go
@@ -3,6 +3,8 @@ package httpserver
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/lextures/lextures/server/internal/apierr"
 	"github.com/lextures/lextures/server/internal/authz"
@@ -12,6 +14,8 @@ import (
 	"github.com/lextures/lextures/server/internal/repos/enrollment"
 	"github.com/lextures/lextures/server/internal/repos/rbac"
 )
+
+const searchQueryPerGroupLimit = 5
 
 func (d Deps) handleSearchIndex() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -53,6 +57,176 @@ func (d Deps) handleSearchIndex() http.HandlerFunc {
 			People:  people,
 		})
 	}
+}
+
+func (d Deps) handleSearchQuery() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		q := strings.TrimSpace(r.URL.Query().Get("q"))
+		if len(q) < 2 {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Query must be at least 2 characters.")
+			return
+		}
+		scope := strings.TrimSpace(r.URL.Query().Get("scope"))
+		var scopePtr *string
+		if scope != "" {
+			scopePtr = &scope
+		}
+		types := parseSearchQueryTypes(r.URL.Query().Get("types"))
+		start := time.Now()
+
+		grants, err := rbac.ListGrantedPermissionStrings(r.Context(), d.Pool, userID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Search failed.")
+			return
+		}
+		rosterCourses, rosterAll := courseCodesForPermission(grants, "enrollments:read")
+		gradebookCourses, _ := courseCodesForPermission(grants, "gradebook:view")
+		editCourses, editAll := courseCodesForPermissions(grants, "item:create", "items:create")
+
+		var groups []search.QueryGroup
+		ctx := r.Context()
+
+		if types["course"] {
+			items, total, err := course.SearchCoursesQuery(ctx, d.Pool, userID, q, scopePtr, searchQueryPerGroupLimit)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Search failed.")
+				return
+			}
+			if items == nil {
+				items = []search.QueryResultItem{}
+			}
+			groups = append(groups, search.QueryGroup{
+				Type:  "course",
+				Label: "Courses",
+				Total: total,
+				Items: items,
+			})
+		}
+
+		if types["content"] {
+			items, total, err := course.SearchContentQuery(
+				ctx, d.Pool, userID, q, scopePtr, editCourses, editAll, searchQueryPerGroupLimit,
+			)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Search failed.")
+				return
+			}
+			if items == nil {
+				items = []search.QueryResultItem{}
+			}
+			groups = append(groups, search.QueryGroup{
+				Type:  "content",
+				Label: "Content",
+				Total: total,
+				Items: items,
+			})
+		}
+
+		if types["person"] && (rosterAll || len(rosterCourses) > 0) {
+			rosterFilter := rosterCourses
+			if rosterAll {
+				rosterFilter = nil
+			}
+			items, total, err := enrollment.SearchPeopleQuery(
+				ctx, d.Pool, userID, q, scopePtr, rosterFilter, gradebookCourses, searchQueryPerGroupLimit,
+			)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Search failed.")
+				return
+			}
+			if items == nil {
+				items = []search.QueryResultItem{}
+			}
+			groups = append(groups, search.QueryGroup{
+				Type:  "person",
+				Label: "People",
+				Total: total,
+				Items: items,
+			})
+		}
+
+		if groups == nil {
+			groups = []search.QueryGroup{}
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(search.QueryResponse{
+			Groups: groups,
+			TookMs: time.Since(start).Milliseconds(),
+		})
+	}
+}
+
+func parseSearchQueryTypes(raw string) map[string]bool {
+	defaultTypes := map[string]bool{
+		"course":  true,
+		"person":  true,
+		"content": true,
+	}
+	if strings.TrimSpace(raw) == "" {
+		return defaultTypes
+	}
+	out := map[string]bool{}
+	for _, part := range strings.Split(raw, ",") {
+		switch strings.TrimSpace(strings.ToLower(part)) {
+		case "course":
+			out["course"] = true
+		case "person":
+			out["person"] = true
+		case "content":
+			out["content"] = true
+		}
+	}
+	if len(out) == 0 {
+		return defaultTypes
+	}
+	return out
+}
+
+func courseCodesForPermission(grants []string, suffix string) (map[string]struct{}, bool) {
+	return courseCodesForPermissions(grants, suffix)
+}
+
+func courseCodesForPermissions(grants []string, suffixes ...string) (map[string]struct{}, bool) {
+	out := map[string]struct{}{}
+	all := false
+	for _, g := range grants {
+		if !strings.HasPrefix(g, "course:") {
+			continue
+		}
+		parts := strings.Split(g, ":")
+		if len(parts) != 4 {
+			continue
+		}
+		matched := false
+		for _, suffix := range suffixes {
+			if parts[2]+":"+parts[3] == suffix {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		code := parts[1]
+		if code == "*" {
+			all = true
+			continue
+		}
+		if code == coursegrants.CourseCodePlaceholder {
+			continue
+		}
+		out[code] = struct{}{}
+	}
+	return out, all
 }
 
 func filterSearchPeopleByRosterRead(grants []string, in []search.PersonItem) []search.PersonItem {

--- a/server/internal/httpserver/search_query_test.go
+++ b/server/internal/httpserver/search_query_test.go
@@ -1,0 +1,31 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleSearchQuery_Unauthorized(t *testing.T) {
+	h := NewHandler(Deps{Pool: nil, JWTSigner: nil})
+	rr := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/search/query?q=hello", nil)
+	h.ServeHTTP(rr, r)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("code: %d", rr.Code)
+	}
+}
+
+func TestParseSearchQueryTypes_Defaults(t *testing.T) {
+	types := parseSearchQueryTypes("")
+	if !types["course"] || !types["person"] || !types["content"] {
+		t.Fatalf("defaults: %+v", types)
+	}
+}
+
+func TestCourseCodesForPermissions_Wildcard(t *testing.T) {
+	codes, all := courseCodesForPermissions([]string{"course:*:enrollments:read"}, "enrollments:read")
+	if !all || len(codes) != 0 {
+		t.Fatalf("wildcard: all=%v codes=%+v", all, codes)
+	}
+}

--- a/server/internal/httpserver/server.go
+++ b/server/internal/httpserver/server.go
@@ -88,6 +88,7 @@ func NewHandler(d Deps) http.Handler {
 	r.Get("/api/v1/public/locale-defaults", d.handleGetPublicLocaleDefaults())
 	r.Get("/api/v1/public/org-branding/{orgId}/{asset}", d.handlePublicOrgBrandAsset())
 	r.Get("/api/v1/search", d.handleSearchIndex())
+	r.Get("/api/v1/search/query", d.handleSearchQuery())
 	r.Get("/api/v1/reports/learning-activity", d.handleLearningActivityReport())
 	d.registerReportExportRoutes(r)
 	r.Post("/api/v1/recommendations/event", d.handleRecommendationEvent())

--- a/server/internal/models/search/search.go
+++ b/server/internal/models/search/search.go
@@ -19,6 +19,14 @@ type CourseItem struct {
 	HintScaffoldingEnabled        bool   `json:"hintScaffoldingEnabled"`
 	MisconceptionDetectionEnabled bool   `json:"misconceptionDetectionEnabled"`
 	DiscussionsEnabled            bool   `json:"discussionsEnabled"`
+	CollabDocsEnabled             bool   `json:"collabDocsEnabled"`
+	SbgEnabled                    bool   `json:"sbgEnabled"`
+	LiveSessionsEnabled           bool   `json:"liveSessionsEnabled"`
+	GroupSpacesEnabled            bool   `json:"groupSpacesEnabled"`
+	OfficeHoursEnabled            bool   `json:"officeHoursEnabled"`
+	FilesEnabled                  bool   `json:"filesEnabled"`
+	AttendanceEnabled             bool   `json:"attendanceEnabled"`
+	WhiteboardEnabled             bool   `json:"whiteboardEnabled"`
 }
 
 // PersonItem is a roster person visible to the caller (when they have enrollments:read for that course).
@@ -35,4 +43,28 @@ type PersonItem struct {
 type IndexResponse struct {
 	Courses []CourseItem `json:"courses"`
 	People  []PersonItem `json:"people"`
+}
+
+// QueryResultItem is one row in GET /api/v1/search/query grouped results.
+type QueryResultItem struct {
+	ID       string  `json:"id"`
+	Type     string  `json:"type"`
+	Title    string  `json:"title"`
+	Subtitle string  `json:"subtitle"`
+	Path     string  `json:"path"`
+	Score    float64 `json:"score,omitempty"`
+}
+
+// QueryGroup is a capped result bucket (courses, people, content, …).
+type QueryGroup struct {
+	Type  string            `json:"type"`
+	Label string            `json:"label"`
+	Total int               `json:"total"`
+	Items []QueryResultItem `json:"items"`
+}
+
+// QueryResponse is the top-level /api/v1/search/query payload.
+type QueryResponse struct {
+	Groups []QueryGroup `json:"groups"`
+	TookMs int64        `json:"tookMs"`
 }

--- a/server/internal/openapi/openapi.go
+++ b/server/internal/openapi/openapi.go
@@ -161,6 +161,19 @@ const spec = `{
         "responses": { "200": { "description": "courses, people" }, "401": { "description": "Not signed in" } }
       }
     },
+    "/api/v1/search/query": {
+      "get": {
+        "tags": ["search", "me"],
+        "summary": "Query-driven command palette search (courses, people, module content)",
+        "security": [ { "bearerAuth": [] } ],
+        "parameters": [
+          { "name": "q", "in": "query", "required": true, "schema": { "type": "string", "minLength": 2 } },
+          { "name": "scope", "in": "query", "schema": { "type": "string" }, "description": "Optional course code scope" },
+          { "name": "types", "in": "query", "schema": { "type": "string" }, "description": "Comma-separated: course,person,content" }
+        ],
+        "responses": { "200": { "description": "QueryResponse grouped results" }, "400": { "description": "Query too short" }, "401": { "description": "Not signed in" } }
+      }
+    },
     "/api/v1/reports/learning-activity": {
       "get": {
         "tags": ["reports"],

--- a/server/internal/repos/course/search_index.go
+++ b/server/internal/repos/course/search_index.go
@@ -25,7 +25,15 @@ SELECT
     c.diagnostic_assessments_enabled,
     c.hint_scaffolding_enabled,
     c.misconception_detection_enabled,
-    c.discussions_enabled
+    c.discussions_enabled,
+    c.collab_docs_enabled,
+    c.sbg_enabled,
+    c.live_sessions_enabled,
+    c.group_spaces_enabled,
+    c.office_hours_enabled,
+    c.files_enabled,
+    c.attendance_enabled,
+    c.whiteboard_enabled
 FROM course.courses c
 LEFT JOIN course.user_course_catalog_order o ON o.user_id = $1 AND o.course_id = c.id
 WHERE c.id IN (SELECT e.course_id FROM course.course_enrollments e WHERE e.user_id = $1 AND e.active)
@@ -54,6 +62,14 @@ ORDER BY o.sort_order NULLS LAST, c.title ASC
 			&it.HintScaffoldingEnabled,
 			&it.MisconceptionDetectionEnabled,
 			&it.DiscussionsEnabled,
+			&it.CollabDocsEnabled,
+			&it.SbgEnabled,
+			&it.LiveSessionsEnabled,
+			&it.GroupSpacesEnabled,
+			&it.OfficeHoursEnabled,
+			&it.FilesEnabled,
+			&it.AttendanceEnabled,
+			&it.WhiteboardEnabled,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/repos/course/search_query.go
+++ b/server/internal/repos/course/search_query.go
@@ -1,0 +1,231 @@
+package course
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lextures/lextures/server/internal/models/search"
+)
+
+// SearchCoursesQuery finds enrolled, non-archived courses matching free text (FTS + ILIKE fallback).
+func SearchCoursesQuery(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	userID uuid.UUID,
+	q string,
+	scopeCourseCode *string,
+	limit int,
+) ([]search.QueryResultItem, int, error) {
+	q = strings.TrimSpace(q)
+	if q == "" || limit <= 0 {
+		return nil, 0, nil
+	}
+	if limit > 50 {
+		limit = 50
+	}
+	like := "%" + q + "%"
+
+	rows, err := pool.Query(ctx, `
+WITH matched AS (
+    SELECT
+        c.course_code,
+        c.title,
+        GREATEST(
+            ts_rank(c.search_vector, websearch_to_tsquery('english', $2)),
+            CASE
+                WHEN lower(c.course_code) = lower($2) THEN 1.0
+                WHEN c.course_code ILIKE $3 OR c.title ILIKE $3 THEN 0.4
+                ELSE 0
+            END
+        ) AS rank
+    FROM course.courses c
+    WHERE c.archived = false
+      AND c.id IN (
+          SELECT e.course_id
+          FROM course.course_enrollments e
+          WHERE e.user_id = $1 AND e.active
+      )
+      AND ($4::text IS NULL OR lower(c.course_code) = lower($4))
+      AND (
+          c.search_vector @@ websearch_to_tsquery('english', $2)
+          OR c.course_code ILIKE $3
+          OR c.title ILIKE $3
+      )
+)
+SELECT course_code, title, rank, COUNT(*) OVER () AS total
+FROM matched
+ORDER BY rank DESC, title ASC
+LIMIT $5
+`, userID, q, like, scopeCourseCode, limit)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var out []search.QueryResultItem
+	var total int
+	for rows.Next() {
+		var code, title string
+		var rank float64
+		if err := rows.Scan(&code, &title, &rank, &total); err != nil {
+			return nil, 0, err
+		}
+		out = append(out, search.QueryResultItem{
+			ID:       "course:" + code,
+			Type:     "course",
+			Title:    title,
+			Subtitle: code,
+			Path:     "/courses/" + url.PathEscape(code),
+			Score:    rank,
+		})
+	}
+	return out, total, rows.Err()
+}
+
+// SearchContentQuery finds published module items the user can open (FTS + ILIKE fallback).
+// editCourseCodes lists course codes where the caller may see unpublished items.
+func SearchContentQuery(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	userID uuid.UUID,
+	q string,
+	scopeCourseCode *string,
+	editCourseCodes map[string]struct{},
+	allowUnpublishedAll bool,
+	limit int,
+) ([]search.QueryResultItem, int, error) {
+	q = strings.TrimSpace(q)
+	if q == "" || limit <= 0 {
+		return nil, 0, nil
+	}
+	if limit > 50 {
+		limit = 50
+	}
+	like := "%" + q + "%"
+	editCodes := make([]string, 0, len(editCourseCodes))
+	for code := range editCourseCodes {
+		editCodes = append(editCodes, code)
+	}
+
+	rows, err := pool.Query(ctx, `
+WITH enrolled AS (
+    SELECT e.course_id
+    FROM course.course_enrollments e
+    WHERE e.user_id = $1 AND e.active
+),
+matched AS (
+    SELECT
+        csi.id,
+        csi.kind,
+        csi.title,
+        c.course_code,
+        c.title AS course_title,
+        GREATEST(
+            ts_rank(csi.search_vector, websearch_to_tsquery('english', $2)),
+            CASE WHEN csi.title ILIKE $3 THEN 0.35 ELSE 0 END
+        ) AS rank
+    FROM course.course_structure_items csi
+    INNER JOIN course.courses c ON c.id = csi.course_id
+    INNER JOIN enrolled e ON e.course_id = c.id
+    WHERE c.archived = false
+      AND csi.archived = false
+      AND csi.kind NOT IN ('module', 'heading')
+      AND ($4::text IS NULL OR lower(c.course_code) = lower($4))
+      AND (
+          csi.search_vector @@ websearch_to_tsquery('english', $2)
+          OR csi.title ILIKE $3
+      )
+      AND (
+          csi.published = true
+          OR $7::boolean = true
+          OR c.course_code = ANY($6::text[])
+      )
+)
+SELECT id, kind, title, course_code, course_title, rank, COUNT(*) OVER () AS total
+FROM matched
+ORDER BY rank DESC, title ASC
+LIMIT $5
+`, userID, q, like, scopeCourseCode, limit, editCodes, allowUnpublishedAll)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var out []search.QueryResultItem
+	var total int
+	for rows.Next() {
+		var id uuid.UUID
+		var kind, title, courseCode, courseTitle string
+		var rank float64
+		if err := rows.Scan(&id, &kind, &title, &courseCode, &courseTitle, &rank, &total); err != nil {
+			return nil, 0, err
+		}
+		subtitle := contentKindLabel(kind)
+		if t := strings.TrimSpace(courseTitle); t != "" {
+			subtitle = fmt.Sprintf("%s · %s · %s", subtitle, t, courseCode)
+		} else {
+			subtitle = fmt.Sprintf("%s · %s", subtitle, courseCode)
+		}
+		out = append(out, search.QueryResultItem{
+			ID:       fmt.Sprintf("content:%s:%s", courseCode, id.String()),
+			Type:     "content",
+			Title:    title,
+			Subtitle: subtitle,
+			Path:     structureItemPath(courseCode, kind, id),
+			Score:    rank,
+		})
+	}
+	return out, total, rows.Err()
+}
+
+func contentKindLabel(kind string) string {
+	switch kind {
+	case "content_page":
+		return "Page"
+	case "assignment":
+		return "Assignment"
+	case "quiz":
+		return "Quiz"
+	case "external_link":
+		return "External link"
+	case "survey":
+		return "Survey"
+	case "lti_link":
+		return "LTI"
+	case "h5p":
+		return "H5P"
+	case "vibe_activity":
+		return "Vibe activity"
+	default:
+		return "Item"
+	}
+}
+
+func structureItemPath(courseCode, kind string, itemID uuid.UUID) string {
+	cc := url.PathEscape(courseCode)
+	id := itemID.String()
+	switch kind {
+	case "content_page":
+		return fmt.Sprintf("/courses/%s/modules/content/%s", cc, id)
+	case "assignment":
+		return fmt.Sprintf("/courses/%s/modules/assignment/%s", cc, id)
+	case "quiz":
+		return fmt.Sprintf("/courses/%s/modules/quiz/%s", cc, id)
+	case "external_link":
+		return fmt.Sprintf("/courses/%s/modules/external-link/%s", cc, id)
+	case "survey":
+		return fmt.Sprintf("/courses/%s/modules/survey/%s", cc, id)
+	case "lti_link":
+		return fmt.Sprintf("/courses/%s/modules/lti/%s", cc, id)
+	case "h5p":
+		return fmt.Sprintf("/courses/%s/modules/h5p/%s", cc, id)
+	case "vibe_activity":
+		return fmt.Sprintf("/courses/%s/modules/vibe-activity/%s", cc, id)
+	default:
+		return fmt.Sprintf("/courses/%s/modules", cc)
+	}
+}

--- a/server/internal/repos/enrollment/search_people_query.go
+++ b/server/internal/repos/enrollment/search_people_query.go
@@ -1,0 +1,127 @@
+package enrollment
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lextures/lextures/server/internal/models/search"
+)
+
+// SearchPeopleQuery lists roster people matching free text in courses the requester is enrolled in.
+func SearchPeopleQuery(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	requesterUserID uuid.UUID,
+	q string,
+	scopeCourseCode *string,
+	rosterCourseCodes map[string]struct{},
+	gradebookCourseCodes map[string]struct{},
+	limit int,
+) ([]search.QueryResultItem, int, error) {
+	q = strings.TrimSpace(q)
+	if q == "" || limit <= 0 {
+		return nil, 0, nil
+	}
+	if limit > 50 {
+		limit = 50
+	}
+	like := "%" + q + "%"
+	rosterCodes := make([]string, 0, len(rosterCourseCodes))
+	for code := range rosterCourseCodes {
+		rosterCodes = append(rosterCodes, code)
+	}
+
+	rows, err := pool.Query(ctx, `
+WITH matched AS (
+    SELECT
+        u.id AS user_id,
+        u.email,
+        u.display_name,
+        COALESCE(er.display_name, initcap(ce.role)) AS role_label,
+        c.course_code,
+        c.title AS course_title,
+        GREATEST(
+            ts_rank(
+                to_tsvector(
+                    'english',
+                    coalesce(u.display_name, '') || ' ' || coalesce(u.email, '')
+                ),
+                websearch_to_tsquery('english', $2)
+            ),
+            CASE
+                WHEN u.email ILIKE $3 OR u.display_name ILIKE $3 THEN 0.4
+                ELSE 0
+            END
+        ) AS rank
+    FROM course.course_enrollments ce
+    INNER JOIN course.courses c ON c.id = ce.course_id
+    INNER JOIN "user".users u ON u.id = ce.user_id
+    LEFT JOIN course.enrollment_roles er ON er.role_key = ce.role
+    WHERE c.archived = false
+      AND ce.active
+      AND c.id IN (
+          SELECT ce2.course_id
+          FROM course.course_enrollments ce2
+          WHERE ce2.user_id = $1 AND ce2.active
+      )
+      AND ($4::text IS NULL OR lower(c.course_code) = lower($4))
+      AND (
+          cardinality($6::text[]) = 0
+          OR c.course_code = ANY($6::text[])
+      )
+      AND (
+          to_tsvector('english', coalesce(u.display_name, '') || ' ' || coalesce(u.email, ''))
+              @@ websearch_to_tsquery('english', $2)
+          OR u.email ILIKE $3
+          OR u.display_name ILIKE $3
+      )
+)
+SELECT user_id, email, display_name, role_label, course_code, course_title, rank, COUNT(*) OVER () AS total
+FROM matched
+ORDER BY rank DESC, course_title ASC, email ASC
+LIMIT $5
+`, requesterUserID, q, like, scopeCourseCode, limit, rosterCodes)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var out []search.QueryResultItem
+	var total int
+	for rows.Next() {
+		var userID uuid.UUID
+		var email, roleLabel, courseCode, courseTitle string
+		var display sql.NullString
+		var rank float64
+		if err := rows.Scan(&userID, &email, &display, &roleLabel, &courseCode, &courseTitle, &rank, &total); err != nil {
+			return nil, 0, err
+		}
+		title := email
+		if display.Valid && strings.TrimSpace(display.String) != "" {
+			title = display.String
+		}
+		subtitle := fmt.Sprintf("%s · %s · %s", courseTitle, courseCode, roleLabel)
+		path := fmt.Sprintf("/courses/%s/enrollments", url.PathEscape(courseCode))
+		if _, ok := gradebookCourseCodes[courseCode]; ok {
+			path = fmt.Sprintf(
+				"/courses/%s/gradebook?student=%s",
+				url.PathEscape(courseCode),
+				url.QueryEscape(userID.String()),
+			)
+		}
+		out = append(out, search.QueryResultItem{
+			ID:       fmt.Sprintf("person:%s:%s:%s", userID.String(), courseCode, roleLabel),
+			Type:     "person",
+			Title:    title,
+			Subtitle: subtitle,
+			Path:     path,
+			Score:    rank,
+		})
+	}
+	return out, total, rows.Err()
+}

--- a/server/migrations/236_command_palette_search.sql
+++ b/server/migrations/236_command_palette_search.sql
@@ -1,0 +1,26 @@
+-- Full-text search indexes for command-palette course and content discovery.
+
+ALTER TABLE course.courses
+    ADD COLUMN IF NOT EXISTS search_vector tsvector
+    GENERATED ALWAYS AS (
+        to_tsvector(
+            'english',
+            coalesce(course_code, '') || ' ' || coalesce(title, '')
+        )
+    ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_courses_search_vector_gin
+    ON course.courses USING gin (search_vector);
+
+ALTER TABLE course.course_structure_items
+    ADD COLUMN IF NOT EXISTS search_vector tsvector
+    GENERATED ALWAYS AS (
+        CASE
+            WHEN kind NOT IN ('module', 'heading') AND archived = false
+                THEN to_tsvector('english', coalesce(title, ''))
+            ELSE ''::tsvector
+        END
+    ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_course_structure_items_search_vector_gin
+    ON course.course_structure_items USING gin (search_vector);


### PR DESCRIPTION
## Summary

- Extend the command palette with a **search hub** when the query is empty (recent items, pinned course shortcuts, and curated navigation without exploding every course page into results).
- Add a **server-backed search API** (`GET /api/v1/search/query`) for courses, people, and course content, backed by PostgreSQL full-text search (`tsvector` + GIN indexes in migration 236).
- Support **query modifiers** on the client (`@course`, `in:biol101`, `type:person|course|content`) with debounced server fetches, course picker UX, and local recents persistence.

## Test plan

- [ ] Run migrations and verify `search_vector` columns/indexes exist on `course.courses` and `course.course_structure_items`
- [ ] Open command palette with empty query — hub shows recents, current-course shortcuts, and role-appropriate actions
- [ ] Search by course code/title, person name, and content title; results group correctly
- [ ] Try scoped queries: `in:biol101`, `type:content`, `@bio` course picker
- [ ] `cd server && go test ./... -count=1 -short -timeout=1m`
- [ ] `cd clients/web && npm run test && npm run typecheck`