### PR TITLE
feat: notebook groups, markdown slash commands, and smoother module reorder

### DIFF
--- a/clients/web/src/components/editor/block-editor/__tests__/markdown-body-slash.test.ts
+++ b/clients/web/src/components/editor/block-editor/__tests__/markdown-body-slash.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  filterSlashCommands,
+  getBlockSlashRange,
+  getSlashState,
+  slashCommandsForEditor,
+} from '../markdown-body-slash'
+
+describe('getSlashState', () => {
+  it('detects slash at block start', () => {
+    expect(getSlashState('/', 1)).toEqual({ start: 0, query: '' })
+  })
+
+  it('detects slash after whitespace', () => {
+    expect(getSlashState('hello /he', 9)).toEqual({ start: 6, query: 'he' })
+  })
+
+  it('rejects slash mid-word', () => {
+    expect(getSlashState('foo/bar', 7)).toBeNull()
+  })
+
+  it('rejects slash query with spaces', () => {
+    expect(getSlashState('/hello world', 13)).toBeNull()
+  })
+})
+
+describe('filterSlashCommands', () => {
+  const commands = slashCommandsForEditor({ equation: true })
+
+  it('returns all commands for empty query', () => {
+    expect(filterSlashCommands(commands, '')).toHaveLength(commands.length)
+  })
+
+  it('filters by label', () => {
+    const filtered = filterSlashCommands(commands, 'head')
+    expect(filtered.map((c) => c.id)).toEqual(['heading1', 'heading2', 'heading3'])
+  })
+
+  it('filters by keyword', () => {
+    const filtered = filterSlashCommands(commands, 'latex')
+    expect(filtered.some((c) => c.id === 'equation')).toBe(true)
+  })
+
+  it('filters image by id and photo keyword', () => {
+    const commands = slashCommandsForEditor({ image: true })
+    expect(filterSlashCommands(commands, 'image').map((c) => c.id)).toEqual(['image'])
+    expect(filterSlashCommands(commands, 'photo').map((c) => c.id)).toEqual(['image'])
+  })
+
+  it('does not match unrelated blocks for photo query', () => {
+    const commands = slashCommandsForEditor({ image: false })
+    expect(filterSlashCommands(commands, 'photo').some((c) => c.id === 'paragraph')).toBe(false)
+    expect(filterSlashCommands(commands, 'photo')).toEqual([])
+  })
+
+  it('omits image command when disabled', () => {
+    const commands = slashCommandsForEditor({ image: false })
+    expect(commands.some((c) => c.id === 'image')).toBe(false)
+  })
+})
+
+describe('getBlockSlashRange', () => {
+  it('returns null for non-text blocks', () => {
+    expect(getBlockSlashRange({ selection: { empty: false } } as never)).toBeNull()
+  })
+})

--- a/clients/web/src/components/editor/block-editor/course-aware-tip-tap-image.tsx
+++ b/clients/web/src/components/editor/block-editor/course-aware-tip-tap-image.tsx
@@ -155,7 +155,7 @@ function CourseImageNodeView(props: NodeViewProps) {
     enforcementEnabled && !imageHasValidAlt(alt, decorative) && !panelOpen
 
   return (
-    <NodeViewWrapper as="figure" className="group/image-node relative my-3 flex justify-center [&_img]:rounded-lg">
+    <NodeViewWrapper as="figure" className="group/image-node relative my-3 flex justify-start [&_img]:rounded-lg">
       <div className="relative inline-block max-w-full">
         {url ? (
           <img

--- a/clients/web/src/components/editor/block-editor/markdown-body-editor.tsx
+++ b/clients/web/src/components/editor/block-editor/markdown-body-editor.tsx
@@ -13,7 +13,15 @@ import { fetchCourseStructure, type CourseStructureItem } from '../../../lib/cou
 import { hrefForModuleCourseItem } from '../../../lib/course-item-ref-tokens'
 import { filterTaggable, kindLabel } from '../../course-item-prompt-mention'
 import { getBlockMentionRange } from './markdown-body-mention'
+import {
+  applySlashCommand,
+  filterSlashCommands,
+  getBlockSlashRange,
+  slashCommandsForEditor,
+  type SlashCommand,
+} from './markdown-body-slash'
 import { CourseAwareTipTapImage } from './course-aware-tip-tap-image'
+import { MarkdownImageUploadModal } from './markdown-image-upload-modal'
 import { MathBlock, MathInline } from '../extensions/math-tip-tap'
 import { altTextEnforcementFeatureEnabled } from '../../../lib/platform-features'
 
@@ -90,6 +98,14 @@ type MentionUi = {
   top: number
 }
 
+type SlashUi = {
+  from: number
+  to: number
+  query: string
+  left: number
+  top: number
+}
+
 type LinkPopoverState = {
   href: string
   text: string
@@ -134,17 +150,26 @@ export function MarkdownBodyEditor({
   }, [onEquationSlash])
 
   const listId = useId()
+  const slashListId = useId()
   const [structure, setStructure] = useState<CourseStructureItem[]>([])
   const [structureLoading, setStructureLoading] = useState(false)
   const [structureError, setStructureError] = useState(false)
   const [mentionUi, setMentionUi] = useState<MentionUi | null>(null)
   const [activeIndex, setActiveIndex] = useState(0)
+  const [slashUi, setSlashUi] = useState<SlashUi | null>(null)
+  const [slashActiveIndex, setSlashActiveIndex] = useState(0)
+  const [imageUploadOpen, setImageUploadOpen] = useState(false)
   const [linkPopover, setLinkPopover] = useState<LinkPopoverState | null>(null)
 
   const mentionCtxRef = useRef({
     mentionUi: null as MentionUi | null,
     filtered: [] as CourseStructureItem[],
     activeIndex: 0,
+  })
+  const slashCtxRef = useRef({
+    slashUi: null as SlashUi | null,
+    filtered: [] as SlashCommand[],
+    slashActiveIndex: 0,
   })
 
   useEffect(() => {
@@ -175,7 +200,7 @@ export function MarkdownBodyEditor({
         dragover: (_view: EditorView, e: Event) => {
           const ev = e as DragEvent
           if (disabledRef.current) return false
-          if (!uploadCourseImageRef.current || !courseCodeRef.current) return false
+          if (!uploadCourseImageRef.current) return false
           if (ev.dataTransfer?.types?.includes('Files')) {
             ev.preventDefault()
           }
@@ -185,8 +210,7 @@ export function MarkdownBodyEditor({
       handlePaste(view: EditorView, event: ClipboardEvent) {
         if (disabledRef.current) return false
         const upload = uploadCourseImageRef.current
-        const code = courseCodeRef.current
-        if (!upload || !code) return false
+        if (!upload) return false
         const items = event.clipboardData?.items
         if (!items?.length) return false
         const files: File[] = []
@@ -225,8 +249,7 @@ export function MarkdownBodyEditor({
       handleDrop(view: EditorView, event: DragEvent) {
         if (disabledRef.current) return false
         const upload = uploadCourseImageRef.current
-        const code = courseCodeRef.current
-        if (!upload || !code) return false
+        if (!upload) return false
         const dt = event.dataTransfer
         if (!dt?.files?.length) return false
         const files = [...dt.files].filter((f) => f.type.startsWith('image/'))
@@ -319,6 +342,22 @@ export function MarkdownBodyEditor({
     [structure, mentionUi],
   )
 
+  const imageSlashEnabled = Boolean(uploadCourseImage) || Boolean(showImagePickerRow)
+
+  const slashCommands = useMemo(
+    () =>
+      slashCommandsForEditor({
+        equation: Boolean(onEquationSlash),
+        image: imageSlashEnabled,
+      }),
+    [onEquationSlash, imageSlashEnabled],
+  )
+
+  const filteredSlashCommands = useMemo(
+    () => (slashUi ? filterSlashCommands(slashCommands, slashUi.query) : []),
+    [slashCommands, slashUi],
+  )
+
   useEffect(() => {
     queueMicrotask(() => {
       setActiveIndex(0)
@@ -332,8 +371,25 @@ export function MarkdownBodyEditor({
     })
   }, [filtered.length])
 
+  useEffect(() => {
+    queueMicrotask(() => {
+      setSlashActiveIndex(0)
+    })
+  }, [slashUi?.from, slashUi?.query])
+
+  useEffect(() => {
+    if (filteredSlashCommands.length === 0) return
+    queueMicrotask(() => {
+      setSlashActiveIndex((i) => Math.min(i, filteredSlashCommands.length - 1))
+    })
+  }, [filteredSlashCommands.length])
+
   useLayoutEffect(() => {
     mentionCtxRef.current = { mentionUi, filtered, activeIndex }
+  })
+
+  useLayoutEffect(() => {
+    slashCtxRef.current = { slashUi, filtered: filteredSlashCommands, slashActiveIndex }
   })
 
   const editor = useEditor(
@@ -356,7 +412,7 @@ export function MarkdownBodyEditor({
         }),
         CourseAwareTipTapImage.configure({
           inline: false,
-          allowBase64: false,
+          allowBase64: true,
         }),
         Placeholder.configure({
           placeholder: placeholder ?? 'Start writing…',
@@ -422,6 +478,26 @@ export function MarkdownBodyEditor({
     })
   }, [editor, disabled, courseCode])
 
+  const syncSlash = useCallback(() => {
+    if (!editor || disabled) {
+      setSlashUi(null)
+      return
+    }
+    const r = getBlockSlashRange(editor.state)
+    if (!r) {
+      setSlashUi(null)
+      return
+    }
+    const coords = editor.view.coordsAtPos(editor.state.selection.from)
+    setSlashUi({
+      from: r.from,
+      to: r.to,
+      query: r.query,
+      left: coords.left,
+      top: coords.bottom + 4,
+    })
+  }, [editor, disabled])
+
   useEffect(() => {
     if (!editor) return
     editor.on('selectionUpdate', syncMention)
@@ -434,6 +510,19 @@ export function MarkdownBodyEditor({
       editor.off('update', syncMention)
     }
   }, [editor, syncMention])
+
+  useEffect(() => {
+    if (!editor) return
+    editor.on('selectionUpdate', syncSlash)
+    editor.on('update', syncSlash)
+    queueMicrotask(() => {
+      syncSlash()
+    })
+    return () => {
+      editor.off('selectionUpdate', syncSlash)
+      editor.off('update', syncSlash)
+    }
+  }, [editor, syncSlash])
 
   useEffect(() => {
     if (courseCode) return
@@ -470,6 +559,28 @@ export function MarkdownBodyEditor({
     if (!mu) return
     editor.chain().focus().deleteRange({ from: mu.from, to: mu.to }).run()
     setMentionUi(null)
+  }, [editor])
+
+  const applySlashPick = useCallback(
+    (command: SlashCommand) => {
+      if (!editor) return
+      const su = slashCtxRef.current.slashUi
+      if (!su) return
+      applySlashCommand(editor, command, { from: su.from, to: su.to }, {
+        onEquation: onEquationSlashRef.current,
+        onImage: () => setImageUploadOpen(true),
+      })
+      setSlashUi(null)
+    },
+    [editor],
+  )
+
+  const cancelSlash = useCallback(() => {
+    if (!editor) return
+    const su = slashCtxRef.current.slashUi
+    if (!su) return
+    editor.chain().focus().deleteRange({ from: su.from, to: su.to }).run()
+    setSlashUi(null)
   }, [editor])
 
   const applyLinkEdit = useCallback(() => {
@@ -517,6 +628,48 @@ export function MarkdownBodyEditor({
     if (!editor) return
     const dom = editor.view.dom
     const onKeyDown = (e: KeyboardEvent) => {
+      const {
+        slashUi: su,
+        filtered: slashFiltered,
+        slashActiveIndex: slashAi,
+      } = slashCtxRef.current
+      if (su && !disabled) {
+        if (slashFiltered.length === 0) {
+          if (e.key === 'Escape') {
+            e.preventDefault()
+            e.stopPropagation()
+            cancelSlash()
+          }
+          return
+        }
+
+        if (e.key === 'ArrowDown') {
+          e.preventDefault()
+          e.stopPropagation()
+          setSlashActiveIndex((i) => (i + 1) % slashFiltered.length)
+          return
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault()
+          e.stopPropagation()
+          setSlashActiveIndex((i) => (i - 1 + slashFiltered.length) % slashFiltered.length)
+          return
+        }
+        if (e.key === 'Enter') {
+          e.preventDefault()
+          e.stopPropagation()
+          const command = slashFiltered[slashAi]
+          if (command) applySlashPick(command)
+          return
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault()
+          e.stopPropagation()
+          cancelSlash()
+          return
+        }
+      }
+
       const { mentionUi: mu, filtered: f, activeIndex: ai } = mentionCtxRef.current
       if (!mu || disabled || !courseCode) return
       if (structureLoading) return
@@ -557,7 +710,16 @@ export function MarkdownBodyEditor({
     }
     dom.addEventListener('keydown', onKeyDown, true)
     return () => dom.removeEventListener('keydown', onKeyDown, true)
-  }, [editor, disabled, courseCode, structureLoading, applyPick, cancelMention])
+  }, [
+    editor,
+    disabled,
+    courseCode,
+    structureLoading,
+    applyPick,
+    cancelMention,
+    applySlashPick,
+    cancelSlash,
+  ])
 
   useEffect(() => {
     if (editor) editor.setEditable(!disabled)
@@ -580,7 +742,29 @@ export function MarkdownBodyEditor({
   }, [editor, sectionId])
 
   const listOpen = Boolean(mentionUi && !disabled && courseCode)
-  const canCourseImageUpload = Boolean(courseCode && uploadCourseImage)
+  const slashListOpen = Boolean(slashUi && !disabled)
+  const canCourseImageUpload = Boolean(uploadCourseImage)
+
+  const insertImagesAt = useCallback(
+    async (from: number, files: File[]) => {
+      if (!editor || !uploadCourseImage) return
+      let pos = from
+      for (const file of files) {
+        if (!file.type.startsWith('image/')) continue
+        const path = await uploadCourseImage(file)
+        editor
+          .chain()
+          .focus()
+          .insertContentAt(pos, {
+            type: 'image',
+            attrs: imageInsertAttrs(path, file.name),
+          })
+          .run()
+        pos = editor.state.selection.to
+      }
+    },
+    [editor, uploadCourseImage],
+  )
 
   const onImageInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -588,28 +772,19 @@ export function MarkdownBodyEditor({
       e.target.value = ''
       if (!files?.length || !editor || !uploadCourseImage) return
       const from = editor.state.selection.from
-      void (async () => {
-        let pos = from
-        for (const file of [...files]) {
-          if (!file.type.startsWith('image/')) continue
-          try {
-            const path = await uploadCourseImage(file)
-            editor
-              .chain()
-              .focus()
-              .insertContentAt(pos, {
-                type: 'image',
-                attrs: imageInsertAttrs(path, file.name),
-              })
-              .run()
-            pos = editor.state.selection.to
-          } catch {
-            /* ignore */
-          }
-        }
-      })()
+      void insertImagesAt(from, [...files]).catch(() => {
+        /* ignore failed upload */
+      })
     },
-    [editor, uploadCourseImage],
+    [editor, uploadCourseImage, insertImagesAt],
+  )
+
+  const handleImageModalUpload = useCallback(
+    async (files: File[]) => {
+      if (!editor) throw new Error('Editor is not ready.')
+      await insertImagesAt(editor.state.selection.from, files)
+    },
+    [editor, insertImagesAt],
   )
 
   if (!editor) {
@@ -651,25 +826,9 @@ export function MarkdownBodyEditor({
               const files = [...e.dataTransfer.files].filter((f) => f.type.startsWith('image/'))
               if (!files.length || !editor || !uploadCourseImage) return
               const from = editor.state.selection.from
-              void (async () => {
-                let pos = from
-                for (const file of files) {
-                  try {
-                    const path = await uploadCourseImage(file)
-                    editor
-                      .chain()
-                      .focus()
-                      .insertContentAt(pos, {
-                        type: 'image',
-                        attrs: imageInsertAttrs(path, file.name),
-                      })
-                      .run()
-                    pos = editor.state.selection.to
-                  } catch {
-                    /* ignore */
-                  }
-                }
-              })()
+              void insertImagesAt(from, files).catch(() => {
+                /* ignore failed upload */
+              })
             }}
             className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
           >
@@ -684,6 +843,53 @@ export function MarkdownBodyEditor({
       <div className="w-full [&_.ProseMirror]:min-h-[100px]">
         <EditorContent editor={editor} className="w-full" />
       </div>
+      {slashListOpen && slashUi
+        ? createPortal(
+            <div
+              id={slashListId}
+              role="listbox"
+              aria-label="Insert block"
+              style={{
+                position: 'fixed',
+                left: slashUi.left,
+                top: slashUi.top,
+                zIndex: 60,
+                width: 'min(20rem, calc(100vw - 2rem))',
+              }}
+              className="max-h-56 overflow-auto rounded-xl border border-slate-200 bg-white py-1 shadow-lg shadow-slate-900/15 dark:border-neutral-600 dark:bg-neutral-900"
+            >
+              {filteredSlashCommands.length === 0 ? (
+                <p className="px-3 py-2 text-sm text-slate-500 dark:text-neutral-400">
+                  No matching blocks. Keep typing to filter.
+                </p>
+              ) : (
+                filteredSlashCommands.map((command, idx) => (
+                  <button
+                    key={command.id}
+                    type="button"
+                    role="option"
+                    id={`${slashListId}-opt-${idx}`}
+                    aria-selected={idx === slashActiveIndex}
+                    className={`flex w-full flex-col items-start gap-0.5 px-3 py-2 text-start text-sm transition ${
+                      idx === slashActiveIndex
+                        ? 'bg-indigo-50 text-indigo-950 dark:bg-indigo-950/50 dark:text-indigo-50'
+                        : 'text-slate-800 hover:bg-slate-50 dark:text-neutral-100 dark:hover:bg-neutral-800'
+                    }`}
+                    onMouseDown={(e) => {
+                      e.preventDefault()
+                      applySlashPick(command)
+                    }}
+                    onMouseEnter={() => setSlashActiveIndex(idx)}
+                  >
+                    <span className="font-medium">{command.label}</span>
+                    <span className="text-xs text-slate-500 dark:text-neutral-400">{command.description}</span>
+                  </button>
+                ))
+              )}
+            </div>,
+            document.body,
+          )
+        : null}
       {listOpen && mentionUi
         ? createPortal(
             <div
@@ -835,6 +1041,13 @@ export function MarkdownBodyEditor({
             document.body,
           )
         : null}
+      {canCourseImageUpload ? (
+        <MarkdownImageUploadModal
+          open={imageUploadOpen}
+          onClose={() => setImageUploadOpen(false)}
+          onUpload={handleImageModalUpload}
+        />
+      ) : null}
     </>
   )
 }

--- a/clients/web/src/components/editor/block-editor/markdown-body-slash.ts
+++ b/clients/web/src/components/editor/block-editor/markdown-body-slash.ts
@@ -1,0 +1,203 @@
+import type { Editor } from '@tiptap/core'
+import type { EditorState } from '@tiptap/pm/state'
+import { getMentionBlockContext } from './markdown-body-mention'
+
+export type SlashCommandId =
+  | 'heading1'
+  | 'heading2'
+  | 'heading3'
+  | 'paragraph'
+  | 'image'
+  | 'bulletList'
+  | 'orderedList'
+  | 'codeBlock'
+  | 'blockquote'
+  | 'horizontalRule'
+  | 'equation'
+
+export type SlashCommand = {
+  id: SlashCommandId
+  label: string
+  description: string
+  keywords: string[]
+}
+
+const BASE_SLASH_COMMANDS: SlashCommand[] = [
+  {
+    id: 'heading1',
+    label: 'Heading 1',
+    description: 'Large section heading',
+    keywords: ['h1', 'title', 'heading'],
+  },
+  {
+    id: 'heading2',
+    label: 'Heading 2',
+    description: 'Medium section heading',
+    keywords: ['h2', 'heading'],
+  },
+  {
+    id: 'heading3',
+    label: 'Heading 3',
+    description: 'Small section heading',
+    keywords: ['h3', 'heading'],
+  },
+  {
+    id: 'paragraph',
+    label: 'Paragraph',
+    description: 'Plain text block',
+    keywords: ['text', 'p', 'body'],
+  },
+  {
+    id: 'image',
+    label: 'Insert image',
+    description: 'Upload and embed an image',
+    keywords: ['image', 'photo', 'picture', 'img', 'upload'],
+  },
+  {
+    id: 'bulletList',
+    label: 'Bullet list',
+    description: 'Unordered list',
+    keywords: ['ul', 'list', 'bullets'],
+  },
+  {
+    id: 'orderedList',
+    label: 'Numbered list',
+    description: 'Ordered list',
+    keywords: ['ol', 'list', 'numbers'],
+  },
+  {
+    id: 'codeBlock',
+    label: 'Code',
+    description: 'Code block with syntax highlighting',
+    keywords: ['code', 'pre', 'snippet'],
+  },
+  {
+    id: 'blockquote',
+    label: 'Quote',
+    description: 'Indented quotation',
+    keywords: ['quote', 'blockquote'],
+  },
+  {
+    id: 'horizontalRule',
+    label: 'Divider',
+    description: 'Horizontal line',
+    keywords: ['hr', 'divider', 'line', 'rule'],
+  },
+]
+
+const EQUATION_COMMAND: SlashCommand = {
+  id: 'equation',
+  label: 'Equation',
+  description: 'Insert LaTeX math',
+  keywords: ['math', 'latex', 'equation', 'formula'],
+}
+
+/** Slash command in the current block: `/` after whitespace or block start, query has no spaces. */
+export function getSlashState(text: string, caret: number): { start: number; query: string } | null {
+  const before = text.slice(0, caret)
+  const slash = before.lastIndexOf('/')
+  if (slash < 0) return null
+  if (slash > 0 && !/\s/.test(before[slash - 1]!)) return null
+  const afterSlash = before.slice(slash + 1)
+  if (afterSlash.includes('\n') || afterSlash.includes(' ')) return null
+  return { start: slash, query: afterSlash }
+}
+
+/** Active `/` query inside the current block, with document positions for replace. */
+export function getBlockSlashRange(
+  state: EditorState,
+): { from: number; to: number; query: string } | null {
+  const ctx = getMentionBlockContext(state)
+  if (!ctx) return null
+  const slash = getSlashState(ctx.text, ctx.text.length)
+  if (!slash) return null
+  return {
+    from: ctx.blockStart + slash.start,
+    to: ctx.cursorPos,
+    query: slash.query,
+  }
+}
+
+export function slashCommandsForEditor(options?: {
+  equation?: boolean
+  image?: boolean
+}): SlashCommand[] {
+  return BASE_SLASH_COMMANDS.filter((cmd) => {
+    if (cmd.id === 'image') return Boolean(options?.image)
+    return true
+  }).concat(options?.equation ? [EQUATION_COMMAND] : [])
+}
+
+export function filterSlashCommands(commands: SlashCommand[], query: string): SlashCommand[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return commands
+  return commands.filter((cmd) => slashCommandMatchesQuery(cmd, q))
+}
+
+function slashCommandMatchesQuery(cmd: SlashCommand, q: string): boolean {
+  if (cmd.id === q || cmd.id.startsWith(q) || q.startsWith(cmd.id)) return true
+  const label = cmd.label.toLowerCase()
+  const description = cmd.description.toLowerCase()
+  if (label.includes(q) || description.includes(q)) return true
+  return cmd.keywords.some((kw) => keywordMatchesQuery(kw, q))
+}
+
+function keywordMatchesQuery(keyword: string, q: string): boolean {
+  if (keyword === q) return true
+  if (keyword.length < 2 || q.length < 2) return false
+  return keyword.startsWith(q) || q.startsWith(keyword)
+}
+
+export function applySlashCommand(
+  editor: Editor,
+  command: SlashCommand,
+  range: { from: number; to: number },
+  options?: { onEquation?: () => void; onImage?: () => void },
+): void {
+  if (command.id === 'equation') {
+    editor.chain().focus().deleteRange({ from: range.from, to: range.to }).run()
+    options?.onEquation?.()
+    return
+  }
+  if (command.id === 'image') {
+    editor.chain().focus().deleteRange({ from: range.from, to: range.to }).run()
+    options?.onImage?.()
+    return
+  }
+
+  const chain = editor.chain().focus().deleteRange({ from: range.from, to: range.to })
+
+  switch (command.id) {
+    case 'heading1':
+      chain.setHeading({ level: 1 }).run()
+      break
+    case 'heading2':
+      chain.setHeading({ level: 2 }).run()
+      break
+    case 'heading3':
+      chain.setHeading({ level: 3 }).run()
+      break
+    case 'paragraph':
+      chain.setParagraph().run()
+      break
+    case 'bulletList':
+      chain.toggleBulletList().run()
+      break
+    case 'orderedList':
+      chain.toggleOrderedList().run()
+      break
+    case 'codeBlock':
+      chain.toggleCodeBlock().run()
+      break
+    case 'blockquote':
+      chain.toggleBlockquote().run()
+      break
+    case 'horizontalRule':
+      chain.setHorizontalRule().run()
+      break
+    default: {
+      const _exhaustive: never = command.id
+      void _exhaustive
+    }
+  }
+}

--- a/clients/web/src/components/editor/block-editor/markdown-image-upload-modal.tsx
+++ b/clients/web/src/components/editor/block-editor/markdown-image-upload-modal.tsx
@@ -1,0 +1,181 @@
+import { Image as ImageIcon, Upload, X } from 'lucide-react'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+
+const ACCEPT = 'image/png,image/jpeg,image/jpg,image/gif,image/webp'
+
+export type MarkdownImageUploadModalProps = {
+  open: boolean
+  onClose: () => void
+  onUpload: (files: File[]) => Promise<void>
+}
+
+export function MarkdownImageUploadModal({ open, onClose, onUpload }: MarkdownImageUploadModalProps) {
+  const titleId = useId()
+  const inputId = useId()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [dragOver, setDragOver] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const reset = useCallback(() => {
+    setDragOver(false)
+    setBusy(false)
+    setError(null)
+  }, [])
+
+  const handleClose = useCallback(() => {
+    if (busy) return
+    reset()
+    onClose()
+  }, [busy, onClose, reset])
+
+  useEffect(() => {
+    if (!open) return
+    reset()
+    const t = window.setTimeout(() => inputRef.current?.focus(), 0)
+    return () => window.clearTimeout(t)
+  }, [open, reset])
+
+  useEffect(() => {
+    if (!open) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape' && !busy) {
+        e.preventDefault()
+        handleClose()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, busy, handleClose])
+
+  const uploadFiles = useCallback(
+    async (files: File[]) => {
+      const images = files.filter((f) => f.type.startsWith('image/'))
+      if (!images.length) {
+        setError('Choose a PNG, JPEG, GIF, or WebP image.')
+        return
+      }
+      setError(null)
+      setBusy(true)
+      try {
+        await onUpload(images)
+        reset()
+        onClose()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Could not upload image.')
+        setBusy(false)
+      }
+    },
+    [onClose, onUpload, reset],
+  )
+
+  const onInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files ? [...e.target.files] : []
+      e.target.value = ''
+      if (files.length) void uploadFiles(files)
+    },
+    [uploadFiles],
+  )
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-[95] flex items-end justify-center bg-black/40 p-4 sm:items-center"
+      role="presentation"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) handleClose()
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-xl dark:border-neutral-600 dark:bg-neutral-900"
+      >
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div>
+            <h2 id={titleId} className="text-lg font-semibold text-slate-950 dark:text-neutral-100">
+              Insert image
+            </h2>
+            <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+              Upload an image to embed it in your notebook.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={busy}
+            className="rounded p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-600 disabled:opacity-50 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <input
+          ref={inputRef}
+          id={inputId}
+          type="file"
+          accept={ACCEPT}
+          multiple
+          className="sr-only"
+          disabled={busy}
+          onChange={onInputChange}
+        />
+
+        <label
+          htmlFor={inputId}
+          onDragEnter={(e) => {
+            e.preventDefault()
+            if (!busy) setDragOver(true)
+          }}
+          onDragOver={(e) => {
+            e.preventDefault()
+            if (!busy) {
+              e.dataTransfer.dropEffect = 'copy'
+              setDragOver(true)
+            }
+          }}
+          onDragLeave={(e) => {
+            e.preventDefault()
+            if (e.currentTarget.contains(e.relatedTarget as Node | null)) return
+            setDragOver(false)
+          }}
+          onDrop={(e) => {
+            e.preventDefault()
+            setDragOver(false)
+            if (busy) return
+            void uploadFiles([...e.dataTransfer.files])
+          }}
+          className={`flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed px-6 py-10 text-center transition ${
+            dragOver
+              ? 'border-indigo-400 bg-indigo-50/80 dark:border-indigo-500 dark:bg-indigo-950/30'
+              : 'border-slate-200 bg-slate-50/70 hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-950/50 dark:hover:border-neutral-600 dark:hover:bg-neutral-950'
+          } ${busy ? 'pointer-events-none opacity-60' : ''}`}
+        >
+          <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm dark:bg-neutral-800">
+            {busy ? (
+              <Upload className="h-5 w-5 animate-pulse text-indigo-500" aria-hidden />
+            ) : (
+              <ImageIcon className="h-5 w-5 text-indigo-500" aria-hidden />
+            )}
+          </div>
+          <span className="text-sm font-medium text-slate-800 dark:text-neutral-100">
+            {busy ? 'Uploading…' : 'Drop an image here'}
+          </span>
+          <span className="mt-1 text-xs text-slate-500 dark:text-neutral-400">
+            or click to browse (PNG, JPEG, GIF, WebP)
+          </span>
+        </label>
+
+        {error ? (
+          <p className="mt-3 text-sm text-rose-600 dark:text-rose-400" role="alert">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/clients/web/src/components/notebook/course-notebook-sidebar.tsx
+++ b/clients/web/src/components/notebook/course-notebook-sidebar.tsx
@@ -1,12 +1,15 @@
-import { useCallback, useMemo, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import {
   DndContext,
   KeyboardSensor,
   PointerSensor,
   closestCenter,
+  useDroppable,
   useSensor,
   useSensors,
+  type DragCancelEvent,
   type DragEndEvent,
+  type DragOverEvent,
 } from '@dnd-kit/core'
 import {
   SortableContext,
@@ -15,9 +18,12 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { FileText, GripVertical, Plus, Trash2 } from 'lucide-react'
+import { ChevronRight, FileText, Folder, GripVertical, Plus, Trash2 } from 'lucide-react'
 import {
   type CourseNotebookPage,
+  isNotebookGroup,
+  isUnderAncestor,
+  pageHasChildren,
   reparentPage,
   reorderAmongSiblings,
   sortedChildren,
@@ -25,15 +31,39 @@ import {
 
 const PARENT_ROOT = '__root__'
 
+function nestDropId(pageId: string): string {
+  return `nest-${pageId}`
+}
+
+function parseNestDropId(id: string): string | null {
+  return id.startsWith('nest-') ? id.slice('nest-'.length) : null
+}
+
 function parentKey(parentId: string | null): string {
   return parentId ?? PARENT_ROOT
+}
+
+function resolveNestTargetId(
+  pages: CourseNotebookPage[],
+  overId: string,
+  shiftHeld: boolean,
+): string | null {
+  const nestId = parseNestDropId(overId)
+  if (nestId) return nestId
+  const overPage = pages.find((p) => p.id === overId)
+  if (overPage && (shiftHeld || isNotebookGroup(overPage))) return overPage.id
+  return null
 }
 
 type NotebookTreeRowProps = {
   page: CourseNotebookPage
   depth: number
   selectedId: string | null
+  collapsed: boolean
+  hasChildren: boolean
+  dropHighlight: boolean
   onSelect: (id: string) => void
+  onToggleCollapse: (id: string) => void
   editingId: string | null
   draftTitle: string
   onDraftTitle: (v: string) => void
@@ -41,6 +71,7 @@ type NotebookTreeRowProps = {
   onStartRename: (id: string, title: string) => void
   onCancelRename: () => void
   onAddChild: (parentId: string) => void
+  onAddChildGroup: (parentId: string) => void
   onDelete: (id: string) => void
   childrenBlock: ReactNode
 }
@@ -49,7 +80,11 @@ function NotebookTreeRow({
   page,
   depth,
   selectedId,
+  collapsed,
+  hasChildren,
+  dropHighlight,
   onSelect,
+  onToggleCollapse,
   editingId,
   draftTitle,
   onDraftTitle,
@@ -57,13 +92,27 @@ function NotebookTreeRow({
   onStartRename,
   onCancelRename,
   onAddChild,
+  onAddChildGroup,
   onDelete,
   childrenBlock,
 }: NotebookTreeRowProps) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+  const isGroup = isNotebookGroup(page)
+  const { attributes, listeners, setNodeRef: setSortableRef, transform, transition, isDragging } = useSortable({
     id: page.id,
-    data: { notebookParent: parentKey(page.parentId) },
+    data: { notebookParent: parentKey(page.parentId), notebookKind: page.kind },
   })
+  const { setNodeRef: setNestDropRef, isOver: isNestOver } = useDroppable({
+    id: nestDropId(page.id),
+    disabled: !isGroup,
+    data: { nestTargetId: page.id },
+  })
+  const setNodeRef = useCallback(
+    (node: HTMLElement | null) => {
+      setSortableRef(node)
+      if (isGroup) setNestDropRef(node)
+    },
+    [isGroup, setNestDropRef, setSortableRef],
+  )
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -71,24 +120,46 @@ function NotebookTreeRow({
   }
   const isSelected = selectedId === page.id
   const isEditing = editingId === page.id
+  const showDropHint = isGroup && (dropHighlight || isNestOver)
 
   return (
     <li ref={setNodeRef} style={style} className="list-none">
       <div
-        className={`group flex items-center gap-0.5 rounded-lg pe-1 transition ${
-          isSelected ? 'bg-indigo-50 dark:bg-indigo-950/50' : 'hover:bg-slate-100 dark:hover:bg-neutral-800/80'
+        className={`group flex items-center gap-0 rounded-lg pe-1 transition ${
+          showDropHint
+            ? 'bg-amber-50 ring-2 ring-amber-400/70 dark:bg-amber-950/40 dark:ring-amber-500/60'
+            : isSelected
+              ? 'bg-indigo-50 dark:bg-indigo-950/50'
+              : 'hover:bg-slate-100 dark:hover:bg-neutral-800/80'
         }`}
         style={{ paddingLeft: `${8 + depth * 14}px` }}
       >
         <button
           type="button"
-          className="mt-0.5 flex h-8 w-7 shrink-0 cursor-grab touch-none items-center justify-center rounded-md border-0 bg-transparent p-0 text-slate-400 hover:text-slate-600 active:cursor-grabbing dark:text-neutral-500 dark:hover:text-neutral-300"
+          className="flex h-7 w-5 shrink-0 cursor-grab touch-none items-center justify-center rounded-md border-0 bg-transparent p-0 text-slate-400 hover:text-slate-600 active:cursor-grabbing dark:text-neutral-500 dark:hover:text-neutral-300"
           aria-label={`Drag to reorder ${page.title}`}
           {...listeners}
           {...attributes}
         >
           <GripVertical className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />
         </button>
+        {hasChildren || isGroup ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              onToggleCollapse(page.id)
+            }}
+            className="me-1 flex h-7 w-4 shrink-0 items-center justify-center rounded-md text-slate-400 transition hover:bg-white hover:text-slate-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+            aria-label={collapsed ? `Expand ${page.title}` : `Collapse ${page.title}`}
+            aria-expanded={!collapsed}
+          >
+            <ChevronRight
+              className={`h-3.5 w-3.5 transition ${collapsed ? '' : 'rotate-90'}`}
+              aria-hidden
+            />
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={() => onSelect(page.id)}
@@ -98,7 +169,11 @@ function NotebookTreeRow({
           }}
           className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md py-1.5 text-start text-sm outline-none ring-indigo-500/30 focus-visible:ring-2"
         >
-          <FileText className="h-3.5 w-3.5 shrink-0 text-slate-400 dark:text-neutral-500" aria-hidden />
+          {isGroup ? (
+            <Folder className="h-3.5 w-3.5 shrink-0 text-amber-500 dark:text-amber-400" aria-hidden />
+          ) : (
+            <FileText className="h-3.5 w-3.5 shrink-0 text-slate-400 dark:text-neutral-500" aria-hidden />
+          )}
           {isEditing ? (
             <input
               autoFocus
@@ -128,11 +203,25 @@ function NotebookTreeRow({
             onAddChild(page.id)
           }}
           className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 opacity-0 transition hover:bg-white hover:text-indigo-600 group-hover:opacity-100 dark:hover:bg-neutral-800 dark:hover:text-indigo-300"
-          aria-label={`Add subpage under ${page.title}`}
-          title="Add subpage"
+          aria-label={`Add page under ${page.title}`}
+          title="Add page"
         >
           <Plus className="h-3.5 w-3.5" aria-hidden />
         </button>
+        {isGroup ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              onAddChildGroup(page.id)
+            }}
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 opacity-0 transition hover:bg-white hover:text-amber-600 group-hover:opacity-100 dark:hover:bg-neutral-800 dark:hover:text-amber-300"
+            aria-label={`Add subgroup under ${page.title}`}
+            title="Add subgroup"
+          >
+            <Folder className="h-3.5 w-3.5" aria-hidden />
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={(e) => {
@@ -141,12 +230,12 @@ function NotebookTreeRow({
           }}
           className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 opacity-0 transition hover:bg-rose-50 hover:text-rose-600 group-hover:opacity-100 dark:hover:bg-rose-950/40 dark:hover:text-rose-300"
           aria-label={`Delete ${page.title}`}
-          title="Delete page"
+          title="Delete"
         >
           <Trash2 className="h-3.5 w-3.5" aria-hidden />
         </button>
       </div>
-      {childrenBlock}
+      {!collapsed ? childrenBlock : null}
     </li>
   )
 }
@@ -156,14 +245,18 @@ type NotebookBranchProps = {
   depth: number
   pages: CourseNotebookPage[]
   selectedId: string | null
-  onSelect: (id: string) => void
+  collapsedIds: Set<string>
+  dropHighlightId: string | null
+  onToggleCollapse: (id: string) => void
   editingId: string | null
   draftTitle: string
   onDraftTitle: (v: string) => void
   onCommitTitle: (id: string) => void
   onStartRename: (id: string, title: string) => void
   onCancelRename: () => void
+  onSelect: (id: string) => void
   onAddChild: (parentId: string) => void
+  onAddChildGroup: (parentId: string) => void
   onDelete: (id: string) => void
 }
 
@@ -172,14 +265,18 @@ function NotebookBranch({
   depth,
   pages,
   selectedId,
-  onSelect,
+  collapsedIds,
+  dropHighlightId,
+  onToggleCollapse,
   editingId,
   draftTitle,
   onDraftTitle,
   onCommitTitle,
   onStartRename,
   onCancelRename,
+  onSelect,
   onAddChild,
+  onAddChildGroup,
   onDelete,
 }: NotebookBranchProps) {
   const children = sortedChildren(pages, parentId)
@@ -196,7 +293,11 @@ function NotebookBranch({
             page={page}
             depth={depth}
             selectedId={selectedId}
+            collapsed={collapsedIds.has(page.id)}
+            hasChildren={pageHasChildren(pages, page.id)}
+            dropHighlight={dropHighlightId === page.id}
             onSelect={onSelect}
+            onToggleCollapse={onToggleCollapse}
             editingId={editingId}
             draftTitle={draftTitle}
             onDraftTitle={onDraftTitle}
@@ -204,6 +305,7 @@ function NotebookBranch({
             onStartRename={onStartRename}
             onCancelRename={onCancelRename}
             onAddChild={onAddChild}
+            onAddChildGroup={onAddChildGroup}
             onDelete={onDelete}
             childrenBlock={
               <NotebookBranch
@@ -211,14 +313,18 @@ function NotebookBranch({
                 depth={depth + 1}
                 pages={pages}
                 selectedId={selectedId}
-                onSelect={onSelect}
+                collapsedIds={collapsedIds}
+                dropHighlightId={dropHighlightId}
+                onToggleCollapse={onToggleCollapse}
                 editingId={editingId}
                 draftTitle={draftTitle}
                 onDraftTitle={onDraftTitle}
                 onCommitTitle={onCommitTitle}
                 onStartRename={onStartRename}
                 onCancelRename={onCancelRename}
+                onSelect={onSelect}
                 onAddChild={onAddChild}
+                onAddChildGroup={onAddChildGroup}
                 onDelete={onDelete}
               />
             }
@@ -235,7 +341,9 @@ type CourseNotebookSidebarProps = {
   onSelect: (id: string) => void
   onPagesChange: (next: CourseNotebookPage[]) => void
   onAddRootPage: () => void
+  onAddRootGroup: () => void
   onAddChildPage: (parentId: string) => void
+  onAddChildGroup: (parentId: string) => void
   onRenamePage: (pageId: string, title: string) => void
   onDeletePage: (pageId: string) => void
 }
@@ -246,25 +354,97 @@ export function CourseNotebookSidebar({
   onSelect,
   onPagesChange,
   onAddRootPage,
+  onAddRootGroup,
   onAddChildPage,
+  onAddChildGroup,
   onRenamePage,
   onDeletePage,
 }: CourseNotebookSidebarProps) {
   const [editingId, setEditingId] = useState<string | null>(null)
   const [draftTitle, setDraftTitle] = useState('')
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(() => new Set())
+  const [dropHighlightId, setDropHighlightId] = useState<string | null>(null)
+  const nestOnDropRef = useRef(false)
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   )
 
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Shift') nestOnDropRef.current = true
+    }
+    function onKeyUp(e: KeyboardEvent) {
+      if (e.key === 'Shift') nestOnDropRef.current = false
+    }
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', onKeyUp)
+    }
+  }, [])
+
+  const toggleCollapse = useCallback((id: string) => {
+    setCollapsedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const clearDragUi = useCallback(() => {
+    setDropHighlightId(null)
+    nestOnDropRef.current = false
+  }, [])
+
+  const onDragOver = useCallback(
+    (event: DragOverEvent) => {
+      const over = event.over
+      if (!over) {
+        setDropHighlightId(null)
+        return
+      }
+      const nestTargetId = resolveNestTargetId(pages, String(over.id), nestOnDropRef.current)
+      const nestPage = nestTargetId ? pages.find((p) => p.id === nestTargetId) : null
+      if (nestPage && isNotebookGroup(nestPage)) {
+        setDropHighlightId(nestTargetId)
+        return
+      }
+      setDropHighlightId(null)
+    },
+    [pages],
+  )
+
   const onDragEnd = useCallback(
     (event: DragEndEvent) => {
+      const shiftHeld = nestOnDropRef.current
+      clearDragUi()
       const { active, over } = event
       if (!over) return
       const activeId = String(active.id)
       const overId = String(over.id)
       if (activeId === overId) return
+
+      const nestTargetId = resolveNestTargetId(pages, overId, shiftHeld)
+      if (
+        nestTargetId &&
+        activeId !== nestTargetId &&
+        !isUnderAncestor(pages, activeId, nestTargetId)
+      ) {
+        const next = reparentPage(pages, activeId, nestTargetId, null)
+        if (next) {
+          onPagesChange(next)
+          setCollapsedIds((prev) => {
+            const nextCollapsed = new Set(prev)
+            nextCollapsed.delete(nestTargetId)
+            return nextCollapsed
+          })
+        }
+        return
+      }
 
       const activeParentRaw = active.data.current?.notebookParent as string | undefined
       const overParentRaw = over.data.current?.notebookParent as string | undefined
@@ -279,14 +459,24 @@ export function CourseNotebookSidebar({
       const next = reparentPage(pages, activeId, overParent, overId)
       if (next) onPagesChange(next)
     },
-    [onPagesChange, pages],
+    [clearDragUi, onPagesChange, pages],
   )
 
-  const startRename = useCallback((id: string, title: string) => {
-    setEditingId(id)
-    setDraftTitle(title)
-    onSelect(id)
-  }, [onSelect])
+  const onDragCancel = useCallback(
+    (_event: DragCancelEvent) => {
+      clearDragUi()
+    },
+    [clearDragUi],
+  )
+
+  const startRename = useCallback(
+    (id: string, title: string) => {
+      setEditingId(id)
+      setDraftTitle(title)
+      onSelect(id)
+    },
+    [onSelect],
+  )
 
   const commitRename = useCallback(
     (id: string) => {
@@ -312,7 +502,16 @@ export function CourseNotebookSidebar({
           Pages
         </span>
       </div>
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+      <p className="border-b border-slate-200 px-3 py-2 text-[11px] leading-snug text-slate-500 dark:border-neutral-800 dark:text-neutral-400">
+        Drag a page onto a group folder to move it inside. Hold Shift while dropping to nest under any page.
+      </p>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragOver={onDragOver}
+        onDragEnd={onDragEnd}
+        onDragCancel={onDragCancel}
+      >
         <nav className="min-h-0 flex-1 overflow-y-auto px-2 py-2" aria-label="Notebook pages">
           {rootHasPages ? (
             <NotebookBranch
@@ -320,14 +519,18 @@ export function CourseNotebookSidebar({
               depth={0}
               pages={pages}
               selectedId={selectedId}
-              onSelect={onSelect}
+              collapsedIds={collapsedIds}
+              dropHighlightId={dropHighlightId}
+              onToggleCollapse={toggleCollapse}
               editingId={editingId}
               draftTitle={draftTitle}
               onDraftTitle={setDraftTitle}
               onCommitTitle={commitRename}
               onStartRename={startRename}
               onCancelRename={cancelRename}
+              onSelect={onSelect}
               onAddChild={onAddChildPage}
+              onAddChildGroup={onAddChildGroup}
               onDelete={onDeletePage}
             />
           ) : (
@@ -335,7 +538,7 @@ export function CourseNotebookSidebar({
           )}
         </nav>
       </DndContext>
-      <div className="border-t border-slate-200 p-2 dark:border-neutral-800">
+      <div className="flex flex-col gap-1 border-t border-slate-200 p-2 dark:border-neutral-800">
         <button
           type="button"
           onClick={onAddRootPage}
@@ -343,6 +546,14 @@ export function CourseNotebookSidebar({
         >
           <Plus className="h-4 w-4 shrink-0" aria-hidden />
           New page
+        </button>
+        <button
+          type="button"
+          onClick={onAddRootGroup}
+          className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-start text-sm font-medium text-slate-600 transition hover:bg-white hover:text-amber-700 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:hover:text-amber-200"
+        >
+          <Folder className="h-4 w-4 shrink-0 text-amber-500 dark:text-amber-400" aria-hidden />
+          New group
         </button>
       </div>
     </div>

--- a/clients/web/src/components/notebook/notebook-group-panel.tsx
+++ b/clients/web/src/components/notebook/notebook-group-panel.tsx
@@ -1,0 +1,91 @@
+import { FileText, Folder, Plus } from 'lucide-react'
+import {
+  isNotebookGroup,
+  sortedChildren,
+  type CourseNotebookPage,
+} from '../../lib/course-notebook-tree'
+
+type NotebookGroupPanelProps = {
+  group: CourseNotebookPage
+  pages: CourseNotebookPage[]
+  onSelectPage: (id: string) => void
+  onAddPage: (parentId: string) => void
+  onAddGroup: (parentId: string) => void
+}
+
+export function NotebookGroupPanel({
+  group,
+  pages,
+  onSelectPage,
+  onAddPage,
+  onAddGroup,
+}: NotebookGroupPanelProps) {
+  const children = sortedChildren(pages, group.id)
+
+  return (
+    <div className="mx-auto flex min-h-0 w-full max-w-[72ch] flex-1 flex-col px-4 py-6 md:px-6 md:py-8">
+      <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50/80 p-6 dark:border-neutral-700 dark:bg-neutral-900/40">
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-indigo-100 text-indigo-600 dark:bg-indigo-950/60 dark:text-indigo-300">
+            <Folder className="h-5 w-5" aria-hidden />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium text-slate-900 dark:text-neutral-100">Page group</p>
+            <p className="mt-1 text-sm text-slate-600 dark:text-neutral-400">
+              Groups organize nested pages in the sidebar. Add pages or subgroups below, or use the
+              buttons in the sidebar tree.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => onAddPage(group.id)}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              >
+                <Plus className="h-4 w-4" aria-hidden />
+                Add page
+              </button>
+              <button
+                type="button"
+                onClick={() => onAddGroup(group.id)}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              >
+                <Plus className="h-4 w-4" aria-hidden />
+                Add subgroup
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {children.length > 0 ? (
+        <div className="mt-6">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+            In this group
+          </h3>
+          <ul className="mt-2 flex flex-col gap-1">
+            {children.map((child) => (
+              <li key={child.id}>
+                <button
+                  type="button"
+                  onClick={() => onSelectPage(child.id)}
+                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-start text-sm text-slate-700 transition hover:bg-slate-100 dark:text-neutral-200 dark:hover:bg-neutral-800/80"
+                >
+                  {isNotebookGroup(child) ? (
+                    <Folder className="h-4 w-4 shrink-0 text-amber-500 dark:text-amber-400" aria-hidden />
+                  ) : (
+                    <FileText className="h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500" aria-hidden />
+                  )}
+                  <span className="min-w-0 flex-1 truncate font-medium">{child.title || 'Untitled'}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <p className="mt-6 text-sm text-slate-500 dark:text-neutral-400">
+          No pages in this group yet. Add one with the buttons above.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/clients/web/src/components/notebook/notebook-page-actions-menu.tsx
+++ b/clients/web/src/components/notebook/notebook-page-actions-menu.tsx
@@ -1,0 +1,157 @@
+import { ChevronDown, ChevronRight, Folder, Sparkles } from 'lucide-react'
+import { useMemo, useState, type RefObject } from 'react'
+import {
+  isNotebookGroup,
+  notebookGroupMoveTargets,
+  notebookPagePathLabel,
+  type CourseNotebookPage,
+} from '../../lib/course-notebook-tree'
+
+export type NotebookPageActionsMenuProps = {
+  open: boolean
+  onToggle: () => void
+  onClose: () => void
+  menuRef: RefObject<HTMLDivElement | null>
+  pages: CourseNotebookPage[]
+  activePage: CourseNotebookPage
+  onMoveToGroup: (pageId: string, groupId: string) => void
+  onMoveToRoot: (pageId: string) => void
+  onFlashcards: () => void
+}
+
+export function NotebookPageActionsMenu({
+  open,
+  onToggle,
+  onClose,
+  menuRef,
+  pages,
+  activePage,
+  onMoveToGroup,
+  onMoveToRoot,
+  onFlashcards,
+}: NotebookPageActionsMenuProps) {
+  const [moveOpen, setMoveOpen] = useState(false)
+  const moveTargets = useMemo(
+    () => notebookGroupMoveTargets(pages, activePage.id),
+    [pages, activePage.id],
+  )
+  const canMoveToRoot = activePage.parentId !== null
+  const currentParent = activePage.parentId
+    ? pages.find((p) => p.id === activePage.parentId)
+    : null
+
+  function closeAll() {
+    setMoveOpen(false)
+    onClose()
+  }
+
+  return (
+    <div className="relative shrink-0" ref={menuRef}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800"
+        aria-expanded={open}
+        aria-haspopup="menu"
+      >
+        Actions
+        <ChevronDown className="h-3.5 w-3.5" aria-hidden />
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="absolute right-0 top-full z-20 mt-1 w-56 rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-neutral-700 dark:bg-neutral-900"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              closeAll()
+              onFlashcards()
+            }}
+            className="flex w-full items-center gap-2 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
+          >
+            <Sparkles className="h-4 w-4 text-indigo-500" aria-hidden />
+            Create Flash Cards
+          </button>
+
+          {moveTargets.length > 0 || canMoveToRoot ? (
+            <>
+              <div className="my-1 border-t border-slate-100 dark:border-neutral-800" role="separator" />
+              <div className="relative">
+                <button
+                  type="button"
+                  role="menuitem"
+                  aria-expanded={moveOpen}
+                  aria-haspopup="menu"
+                  onClick={() => setMoveOpen((v) => !v)}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                >
+                  <Folder className="h-4 w-4 text-amber-500 dark:text-amber-400" aria-hidden />
+                  <span className="flex-1 text-start">Move to group</span>
+                  <ChevronRight className="h-3.5 w-3.5 text-slate-400" aria-hidden />
+                </button>
+                {moveOpen ? (
+                  <div
+                    role="menu"
+                    className="absolute right-full top-0 z-30 me-1 max-h-64 w-60 overflow-y-auto rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-neutral-700 dark:bg-neutral-900"
+                  >
+                    {moveTargets.length === 0 ? (
+                      <p className="px-3 py-2 text-xs text-slate-500 dark:text-neutral-400">
+                        No groups available.
+                      </p>
+                    ) : (
+                      moveTargets.map((group) => {
+                        const selected = currentParent?.id === group.id
+                        return (
+                          <button
+                            key={group.id}
+                            type="button"
+                            role="menuitem"
+                            disabled={selected}
+                            onClick={() => {
+                              closeAll()
+                              onMoveToGroup(activePage.id, group.id)
+                            }}
+                            className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-start text-sm transition hover:bg-slate-50 disabled:cursor-default disabled:opacity-50 dark:hover:bg-neutral-800"
+                          >
+                            <span className="font-medium text-slate-800 dark:text-neutral-100">
+                              {group.title || 'Untitled group'}
+                              {selected ? ' (current)' : ''}
+                            </span>
+                            <span className="text-xs text-slate-500 dark:text-neutral-400">
+                              {notebookPagePathLabel(pages, group.id)}
+                            </span>
+                          </button>
+                        )
+                      })
+                    )}
+                  </div>
+                ) : null}
+              </div>
+              {canMoveToRoot ? (
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    closeAll()
+                    onMoveToRoot(activePage.id)
+                  }}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                >
+                  Move to top level
+                </button>
+              ) : null}
+            </>
+          ) : null}
+
+          {isNotebookGroup(activePage) && moveTargets.length === 0 && !canMoveToRoot ? (
+            <p className="px-3 py-2 text-xs text-slate-500 dark:text-neutral-400">
+              Create a group in the sidebar to organize pages.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/clients/web/src/lib/__tests__/course-notebook-tree.test.ts
+++ b/clients/web/src/lib/__tests__/course-notebook-tree.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from 'vitest'
-import { reorderAmongSiblings, reparentPage, type CourseNotebookPage } from '../course-notebook-tree'
+import {
+  addNotebookGroup,
+  addNotebookPage,
+  isNotebookGroup,
+  movePageToParent,
+  notebookGroupMoveTargets,
+  reorderAmongSiblings,
+  reparentPage,
+  type CourseNotebookPage,
+} from '../course-notebook-tree'
 
 function pagesSeed(): CourseNotebookPage[] {
   return [
-    { id: 'a', title: 'A', parentId: null, sortOrder: 0, contentMd: '' },
-    { id: 'b', title: 'B', parentId: null, sortOrder: 1, contentMd: '' },
-    { id: 'c', title: 'C', parentId: null, sortOrder: 2, contentMd: '' },
+    { id: 'a', title: 'A', parentId: null, sortOrder: 0, kind: 'page', contentMd: '' },
+    { id: 'b', title: 'B', parentId: null, sortOrder: 1, kind: 'page', contentMd: '' },
+    { id: 'c', title: 'C', parentId: null, sortOrder: 2, kind: 'page', contentMd: '' },
   ]
 }
 
@@ -20,8 +29,8 @@ describe('reorderAmongSiblings', () => {
 describe('reparentPage', () => {
   it('moves a page under another parent', () => {
     const pages: CourseNotebookPage[] = [
-      { id: 'a', title: 'A', parentId: null, sortOrder: 0, contentMd: '' },
-      { id: 'b', title: 'B', parentId: null, sortOrder: 1, contentMd: '' },
+      { id: 'a', title: 'A', parentId: null, sortOrder: 0, kind: 'page', contentMd: '' },
+      { id: 'b', title: 'B', parentId: null, sortOrder: 1, kind: 'page', contentMd: '' },
     ]
     const next = reparentPage(pages, 'b', 'a', 'a')
     expect(next).not.toBeNull()
@@ -31,9 +40,58 @@ describe('reparentPage', () => {
 
   it('rejects nesting into own descendant', () => {
     const pages: CourseNotebookPage[] = [
-      { id: 'a', title: 'A', parentId: null, sortOrder: 0, contentMd: '' },
-      { id: 'b', title: 'B', parentId: 'a', sortOrder: 0, contentMd: '' },
+      { id: 'a', title: 'A', parentId: null, sortOrder: 0, kind: 'page', contentMd: '' },
+      { id: 'b', title: 'B', parentId: 'a', sortOrder: 0, kind: 'page', contentMd: '' },
     ]
     expect(reparentPage(pages, 'a', 'b', null)).toBeNull()
+  })
+})
+
+describe('addNotebookGroup', () => {
+  it('creates a group page', () => {
+    const { pages, newId } = addNotebookGroup(pagesSeed(), null, 'Week 1')
+    const group = pages.find((p) => p.id === newId)
+    expect(group).toMatchObject({ title: 'Week 1', kind: 'group', parentId: null })
+    expect(isNotebookGroup(group!)).toBe(true)
+  })
+
+  it('creates nested pages under a group', () => {
+    const { pages: withGroup, newId: groupId } = addNotebookGroup([], null, 'Topics')
+    const { pages, newId } = addNotebookPage(withGroup, groupId, 'Notes')
+    const page = pages.find((p) => p.id === newId)
+    expect(page?.parentId).toBe(groupId)
+    expect(page?.kind).toBe('page')
+  })
+})
+
+describe('movePageToParent', () => {
+  it('moves a root page into a group', () => {
+    const pages: CourseNotebookPage[] = [
+      { id: 'g', title: 'Group', parentId: null, sortOrder: 0, kind: 'group', contentMd: '' },
+      { id: 'p', title: 'Page', parentId: null, sortOrder: 1, kind: 'page', contentMd: '' },
+    ]
+    const next = movePageToParent(pages, 'p', 'g')
+    expect(next?.find((p) => p.id === 'p')?.parentId).toBe('g')
+  })
+
+  it('moves a nested page into another group', () => {
+    const pages: CourseNotebookPage[] = [
+      { id: 'a', title: 'A', parentId: null, sortOrder: 0, kind: 'group', contentMd: '' },
+      { id: 'b', title: 'B', parentId: null, sortOrder: 1, kind: 'group', contentMd: '' },
+      { id: 'p', title: 'P', parentId: 'a', sortOrder: 0, kind: 'page', contentMd: '' },
+    ]
+    const next = movePageToParent(pages, 'p', 'b')
+    expect(next?.find((p) => p.id === 'p')?.parentId).toBe('b')
+  })
+})
+
+describe('notebookGroupMoveTargets', () => {
+  it('excludes self and descendant groups', () => {
+    const pages: CourseNotebookPage[] = [
+      { id: 'g', title: 'G', parentId: null, sortOrder: 0, kind: 'group', contentMd: '' },
+      { id: 'sg', title: 'SG', parentId: 'g', sortOrder: 0, kind: 'group', contentMd: '' },
+    ]
+    expect(notebookGroupMoveTargets(pages, 'g').map((p) => p.id)).toEqual([])
+    expect(notebookGroupMoveTargets(pages, 'sg').map((p) => p.id)).toEqual(['g'])
   })
 })

--- a/clients/web/src/lib/course-notebook-tree.ts
+++ b/clients/web/src/lib/course-notebook-tree.ts
@@ -1,12 +1,23 @@
 import { arrayMove } from '@dnd-kit/sortable'
 
+export type NotebookPageKind = 'page' | 'group'
+
 export type CourseNotebookPage = {
   id: string
   title: string
   parentId: string | null
   sortOrder: number
-  /** TipTap / MarkdownBodyEditor markdown */
+  kind: NotebookPageKind
+  /** TipTap / MarkdownBodyEditor markdown (groups may stay empty) */
   contentMd: string
+}
+
+export function isNotebookGroup(page: CourseNotebookPage): boolean {
+  return page.kind === 'group'
+}
+
+export function pageHasChildren(pages: CourseNotebookPage[], pageId: string): boolean {
+  return pages.some((p) => p.parentId === pageId)
 }
 
 export function newNotebookPageId(): string {
@@ -118,6 +129,26 @@ export function addNotebookPage(
     title,
     parentId,
     sortOrder: maxOrder + 1,
+    kind: 'page',
+    contentMd: '',
+  }
+  return { pages: [...pages, row], newId: id }
+}
+
+export function addNotebookGroup(
+  pages: CourseNotebookPage[],
+  parentId: string | null,
+  title = 'Untitled group',
+): { pages: CourseNotebookPage[]; newId: string } {
+  const id = newNotebookPageId()
+  const siblings = sortedChildren(pages, parentId)
+  const maxOrder = siblings.length ? Math.max(...siblings.map((s) => s.sortOrder)) : -1
+  const row: CourseNotebookPage = {
+    id,
+    title,
+    parentId,
+    sortOrder: maxOrder + 1,
+    kind: 'group',
     contentMd: '',
   }
   return { pages: [...pages, row], newId: id }
@@ -141,4 +172,38 @@ export function updatePageTitle(pages: CourseNotebookPage[], pageId: string, tit
 
 export function updatePageContent(pages: CourseNotebookPage[], pageId: string, contentMd: string): CourseNotebookPage[] {
   return pages.map((p) => (p.id === pageId ? { ...p, contentMd } : p))
+}
+
+/** Groups the page can be moved into (excludes self and own descendants). */
+export function notebookGroupMoveTargets(
+  pages: CourseNotebookPage[],
+  pageId: string,
+): CourseNotebookPage[] {
+  return pages
+    .filter((p) => isNotebookGroup(p))
+    .filter((p) => p.id !== pageId)
+    .filter((p) => !isUnderAncestor(pages, pageId, p.id))
+    .sort((a, b) => notebookPagePathLabel(pages, a.id).localeCompare(notebookPagePathLabel(pages, b.id)))
+}
+
+export function notebookPagePathLabel(pages: CourseNotebookPage[], pageId: string): string {
+  const map = byId(pages)
+  const parts: string[] = []
+  let cur: string | null = pageId
+  while (cur) {
+    const row = map.get(cur)
+    if (!row) break
+    parts.unshift(row.title || 'Untitled')
+    cur = row.parentId
+  }
+  return parts.join(' / ')
+}
+
+/** Move a page or group under `newParentId` (null = top level). Returns null on invalid move. */
+export function movePageToParent(
+  pages: CourseNotebookPage[],
+  pageId: string,
+  newParentId: string | null,
+): CourseNotebookPage[] | null {
+  return reparentPage(pages, pageId, newParentId, null)
 }

--- a/clients/web/src/lib/read-file-as-data-url.ts
+++ b/clients/web/src/lib/read-file-as-data-url.ts
@@ -1,0 +1,8 @@
+export function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result))
+    reader.onerror = () => reject(reader.error ?? new Error('Could not read image'))
+    reader.readAsDataURL(file)
+  })
+}

--- a/clients/web/src/lib/student-notebook-storage.ts
+++ b/clients/web/src/lib/student-notebook-storage.ts
@@ -1,8 +1,13 @@
 import { getAccessToken } from './auth'
-import { newNotebookPageId, updatePageContent, type CourseNotebookPage } from './course-notebook-tree'
+import {
+  newNotebookPageId,
+  updatePageContent,
+  type CourseNotebookPage,
+  type NotebookPageKind,
+} from './course-notebook-tree'
 import { decodeJwtSub } from './jwt-payload'
 
-export type { CourseNotebookPage } from './course-notebook-tree'
+export type { CourseNotebookPage, NotebookPageKind } from './course-notebook-tree'
 
 export const STUDENT_NOTEBOOKS_CHANGED = 'lextures-student-notebooks-changed'
 
@@ -85,6 +90,21 @@ function normalizeActivePage(data: CourseNotebookStore): CourseNotebookStore {
   return { ...data, activePageId: valid }
 }
 
+function normalizePageKind(raw: unknown): NotebookPageKind {
+  return raw === 'group' ? 'group' : 'page'
+}
+
+function parseNotebookPageRow(raw: unknown): CourseNotebookPage {
+  const row = raw as Record<string, unknown>
+  return {
+    id: String(row.id ?? newNotebookPageId()),
+    title: typeof row.title === 'string' ? row.title : 'Untitled',
+    parentId: row.parentId === null || typeof row.parentId === 'string' ? (row.parentId as string | null) : null,
+    sortOrder: typeof row.sortOrder === 'number' ? row.sortOrder : 0,
+    kind: normalizePageKind(row.kind),
+    contentMd: typeof row.contentMd === 'string' ? row.contentMd : '',
+  }
+}
 function migrateLegacyToV2(row: StudentCourseNotebookLegacy): CourseNotebookStore {
   const id = newNotebookPageId()
   const body = typeof row.body === 'string' ? row.body : ''
@@ -92,7 +112,7 @@ function migrateLegacyToV2(row: StudentCourseNotebookLegacy): CourseNotebookStor
     formatVersion: 2,
     updatedAt: row.updatedAt ?? new Date().toISOString(),
     courseTitle: row.courseTitle,
-    pages: [{ id, title: 'Notes', parentId: null, sortOrder: 0, contentMd: body }],
+    pages: [{ id, title: 'Notes', parentId: null, sortOrder: 0, kind: 'page', contentMd: body }],
     activePageId: id,
   })
 }
@@ -102,7 +122,7 @@ function emptyNotebook(): CourseNotebookStore {
   return {
     formatVersion: 2,
     updatedAt: new Date().toISOString(),
-    pages: [{ id, title: 'Untitled', parentId: null, sortOrder: 0, contentMd: '' }],
+    pages: [{ id, title: 'Untitled', parentId: null, sortOrder: 0, kind: 'page', contentMd: '' }],
     activePageId: id,
   }
 }
@@ -111,16 +131,7 @@ function parseStoredNotebookRow(raw: unknown): CourseNotebookStore {
   if (!raw || typeof raw !== 'object') return emptyNotebook()
   const r = raw as Record<string, unknown>
   if (r.formatVersion === 2 && Array.isArray(r.pages) && r.pages.length > 0) {
-    const pages = (r.pages as unknown[]).map((p) => {
-      const row = p as Record<string, unknown>
-      return {
-        id: String(row.id ?? newNotebookPageId()),
-        title: typeof row.title === 'string' ? row.title : 'Untitled',
-        parentId: row.parentId === null || typeof row.parentId === 'string' ? (row.parentId as string | null) : null,
-        sortOrder: typeof row.sortOrder === 'number' ? row.sortOrder : 0,
-        contentMd: typeof row.contentMd === 'string' ? row.contentMd : '',
-      } satisfies CourseNotebookPage
-    })
+    const pages = (r.pages as unknown[]).map((p) => parseNotebookPageRow(p))
     return normalizeActivePage({
       formatVersion: 2,
       updatedAt: typeof r.updatedAt === 'string' ? r.updatedAt : new Date().toISOString(),

--- a/clients/web/src/pages/lms/course-modules.tsx
+++ b/clients/web/src/pages/lms/course-modules.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from 'react'
 import { Link, useParams } from 'react-router-dom'
 import {
   DndContext,
@@ -8,6 +17,7 @@ import {
   useSensor,
   useSensors,
   type DragEndEvent,
+  type DragOverEvent,
   type DragStartEvent,
 } from '@dnd-kit/core'
 import {
@@ -17,7 +27,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { KeyboardSensor, defaultKeyboardSensorOptions } from '../../lib/dnd/keyboardSensorConfig'
-import { CSS } from '@dnd-kit/utilities'
+import { CSS, type Transform } from '@dnd-kit/utilities'
 import {
   AlertCircle,
   Check,
@@ -113,22 +123,92 @@ function findModuleIdForChildItem(
   return undefined
 }
 
+const STRUCTURE_CHILD_KINDS = new Set<CourseStructureItem['kind']>([
+  'heading',
+  'content_page',
+  'assignment',
+  'quiz',
+  'external_link',
+  'survey',
+  'lti_link',
+  'h5p',
+  'vibe_activity',
+])
+
+function buildModuleChildrenMap(items: CourseStructureItem[]): Map<string, CourseStructureItem[]> {
+  const m = new Map<string, CourseStructureItem[]>()
+  for (const i of items) {
+    if (STRUCTURE_CHILD_KINDS.has(i.kind) && i.parentId) {
+      const list = m.get(i.parentId) ?? []
+      list.push(i)
+      m.set(i.parentId, list)
+    }
+  }
+  for (const [, list] of m) {
+    list.sort((a, b) => a.sortOrder - b.sortOrder)
+  }
+  return m
+}
+
+function flattenOrderedStructure(
+  topLevelOrdered: CourseStructureItem[],
+  childrenByModule: Map<string, CourseStructureItem[]>,
+): CourseStructureItem[] {
+  let sortOrder = 0
+  const out: CourseStructureItem[] = []
+  for (const top of topLevelOrdered) {
+    out.push({ ...top, sortOrder: sortOrder++ })
+    if (top.kind === 'module') {
+      for (const child of childrenByModule.get(top.id) ?? []) {
+        out.push({ ...child, sortOrder: sortOrder++ })
+      }
+    }
+  }
+  return out
+}
+
+function reorderModulesInStructure(
+  items: CourseStructureItem[],
+  activeModuleId: string,
+  overModuleId: string,
+): CourseStructureItem[] | null {
+  const childrenByModule = buildModuleChildrenMap(items)
+  const topLevel = items
+    .filter((i) => !i.parentId)
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+  const modules = topLevel.filter((i) => i.kind === 'module')
+  const oldIndex = modules.findIndex((m) => m.id === activeModuleId)
+  const newIndex = modules.findIndex((m) => m.id === overModuleId)
+  if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) return null
+
+  const nonModules = topLevel.filter((i) => i.kind !== 'module')
+  const nextModules = arrayMove(modules, oldIndex, newIndex)
+  return flattenOrderedStructure([...nonModules, ...nextModules], childrenByModule)
+}
+
+function reorderChildrenInStructure(
+  items: CourseStructureItem[],
+  moduleId: string,
+  activeChildId: string,
+  overChildId: string,
+): CourseStructureItem[] | null {
+  const childrenByModule = buildModuleChildrenMap(items)
+  const children = [...(childrenByModule.get(moduleId) ?? [])]
+  const oldIndex = children.findIndex((c) => c.id === activeChildId)
+  const newIndex = children.findIndex((c) => c.id === overChildId)
+  if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) return null
+
+  childrenByModule.set(moduleId, arrayMove(children, oldIndex, newIndex))
+  const topLevel = items
+    .filter((i) => !i.parentId)
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+  return flattenOrderedStructure(topLevel, childrenByModule)
+}
+
 function buildReorderPayloadFromItems(items: CourseStructureItem[]): {
   moduleOrder: string[]
   childOrderByModule: Record<string, string[]>
 } {
-  const childItemKinds = new Set<CourseStructureItem['kind']>([
-    'heading',
-    'content_page',
-    'assignment',
-    'quiz',
-    'external_link',
-    'survey',
-    'lti_link',
-    'h5p',
-    'vibe_activity',
-  ])
-
   const modules = items
     .filter((i) => i.kind === 'module' && !i.parentId)
     .sort((a, b) => a.sortOrder - b.sortOrder)
@@ -136,11 +216,24 @@ function buildReorderPayloadFromItems(items: CourseStructureItem[]): {
   const childOrderByModule: Record<string, string[]> = {}
   for (const m of modules) {
     childOrderByModule[m.id] = items
-      .filter((i) => i.parentId === m.id && childItemKinds.has(i.kind))
+      .filter((i) => i.parentId === m.id && STRUCTURE_CHILD_KINDS.has(i.kind))
       .sort((a, b) => a.sortOrder - b.sortOrder)
       .map((c) => c.id)
   }
   return { moduleOrder, childOrderByModule }
+}
+
+function sortableDragStyle(
+  transform: Transform | null,
+  transition: string | undefined,
+  isDragging: boolean,
+): CSSProperties {
+  return {
+    transform: CSS.Transform.toString(transform),
+    transition: isDragging ? undefined : transition,
+    opacity: isDragging ? 0 : undefined,
+    pointerEvents: isDragging ? 'none' : undefined,
+  }
 }
 
 const moduleChildMetaLineClasses =
@@ -785,11 +878,7 @@ function SortableChildRow({
     disabled,
     data: { type: 'child' as const, moduleId },
   })
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.45 : undefined,
-  }
+  const style = sortableDragStyle(transform, transition, isDragging)
 
   const showRowChrome = canManageItemRow && !child.archived
   const gripAlwaysOn = dragHandlesVisible || isDragging
@@ -1252,11 +1341,7 @@ function SortableModuleCard({
     disabled: !canEditModules,
     data: { type: 'module' as const },
   })
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.55 : undefined,
-  }
+  const style = sortableDragStyle(transform, transition, isDragging)
 
   const children = moduleChildrenById.get(item.id) ?? []
   const childIds = children.map((c) => c.id)
@@ -1410,7 +1495,6 @@ export default function CourseModules() {
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [reorderError, setReorderError] = useState<string | null>(null)
-  const [reorderSaving, setReorderSaving] = useState(false)
 
   const [moduleModalOpen, setModuleModalOpen] = useState(false)
   const [moduleModalKey, setModuleModalKey] = useState(0)
@@ -1488,8 +1572,8 @@ export default function CourseModules() {
   const [moduleDeleting, setModuleDeleting] = useState(false)
   const [moduleDeleteError, setModuleDeleteError] = useState<string | null>(null)
 
-  const [isDraggingModule, setIsDraggingModule] = useState(false)
   const [activeDragId, setActiveDragId] = useState<string | null>(null)
+  const dragReorderCommittedRef = useRef(false)
   const [collapsedModuleIds, setCollapsedModuleIds] = useState<Set<string>>(() => new Set())
   const [dragHandlesVisible, setDragHandlesVisible] = useState(false)
   const [courseMeta, setCourseMeta] = useState<CoursePublic | null>(null)
@@ -1555,7 +1639,7 @@ export default function CourseModules() {
     moduleDeleteTarget !== null ||
     moduleDeleting
 
-  const anyModalBusy = blockingUi || reorderSaving
+  const anyModalBusy = blockingUi
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
@@ -2161,77 +2245,100 @@ export default function CourseModules() {
     async (body: { moduleOrder: string[]; childOrderByModule: Record<string, string[]> }) => {
       if (!courseCode) return
       setReorderError(null)
-      setReorderSaving(true)
       try {
         const next = await reorderCourseStructure(courseCode, body)
         setItems(next)
       } catch (e) {
         setReorderError(e instanceof Error ? e.message : 'Could not save order.')
         await load({ silent: true })
-      } finally {
-        setReorderSaving(false)
       }
     },
     [courseCode, load],
   )
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
+    dragReorderCommittedRef.current = false
     setActiveDragId(String(event.active.id))
-    if (event.active.data.current?.type === 'module') {
-      setIsDraggingModule(true)
+  }, [])
+
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const activeType = active.data.current?.type as string | undefined
+    if (activeType === 'module') {
+      if (over.data.current?.type !== 'module') return
+      setItems((prev) => {
+        const next = reorderModulesInStructure(prev, String(active.id), String(over.id))
+        if (!next) return prev
+        dragReorderCommittedRef.current = true
+        return next
+      })
+      return
+    }
+
+    if (activeType === 'child') {
+      const moduleId = active.data.current?.moduleId as string | undefined
+      if (!moduleId) return
+      setItems((prev) => {
+        const overModuleId =
+          (over.data.current?.moduleId as string | undefined) ??
+          findModuleIdForChildItem(String(over.id), buildModuleChildrenMap(prev))
+        if (!overModuleId || moduleId !== overModuleId) return prev
+        const next = reorderChildrenInStructure(prev, moduleId, String(active.id), String(over.id))
+        if (!next) return prev
+        dragReorderCommittedRef.current = true
+        return next
+      })
     }
   }, [])
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event
-      setIsDraggingModule(false)
       setActiveDragId(null)
-      if (!over || !courseCode || reorderSaving) return
+      if (!over || !courseCode || active.id === over.id) return
 
       const activeType = active.data.current?.type as string | undefined
-      if (activeType === 'module') {
-        if (active.id === over.id) return
-        const oldIndex = moduleIds.indexOf(String(active.id))
-        const newIndex = moduleIds.indexOf(String(over.id))
-        if (oldIndex < 0 || newIndex < 0) return
-        const nextModuleOrder = arrayMove(moduleIds, oldIndex, newIndex)
-        const base = buildReorderPayloadFromItems(items)
-        void persistReorder({
-          moduleOrder: nextModuleOrder,
-          childOrderByModule: base.childOrderByModule,
-        })
-        return
-      }
+      setItems((prev) => {
+        let next = prev
+        if (activeType === 'module') {
+          if (over.data.current?.type !== 'module') return prev
+          const reordered = reorderModulesInStructure(prev, String(active.id), String(over.id))
+          if (reordered) next = reordered
+        } else if (activeType === 'child') {
+          const moduleId = active.data.current?.moduleId as string | undefined
+          if (!moduleId) return prev
+          const overModuleId =
+            (over.data.current?.moduleId as string | undefined) ??
+            findModuleIdForChildItem(String(over.id), buildModuleChildrenMap(prev))
+          if (!overModuleId || moduleId !== overModuleId) return prev
+          const reordered = reorderChildrenInStructure(
+            prev,
+            moduleId,
+            String(active.id),
+            String(over.id),
+          )
+          if (reordered) next = reordered
+        } else {
+          return prev
+        }
 
-      if (activeType === 'child') {
-        const moduleId = active.data.current?.moduleId as string | undefined
-        if (!moduleId) return
-        const overModuleId =
-          (over.data.current?.moduleId as string | undefined) ??
-          findModuleIdForChildItem(String(over.id), moduleChildrenById)
-        if (!overModuleId || moduleId !== overModuleId) return
-        if (active.id === over.id) return
-        const childList = moduleChildrenById.get(moduleId) ?? []
-        const childIds = childList.map((c) => c.id)
-        const oldIndex = childIds.indexOf(String(active.id))
-        const newIndex = childIds.indexOf(String(over.id))
-        if (oldIndex < 0 || newIndex < 0) return
-        const nextChildren = arrayMove(childIds, oldIndex, newIndex)
-        const base = buildReorderPayloadFromItems(items)
-        void persistReorder({
-          moduleOrder: base.moduleOrder,
-          childOrderByModule: { ...base.childOrderByModule, [moduleId]: nextChildren },
-        })
-      }
+        if (next === prev && !dragReorderCommittedRef.current) return prev
+        void persistReorder(buildReorderPayloadFromItems(next))
+        return next
+      })
     },
-    [courseCode, items, moduleChildrenById, moduleIds, persistReorder, reorderSaving],
+    [courseCode, persistReorder],
   )
 
   const handleDragCancel = useCallback(() => {
-    setIsDraggingModule(false)
     setActiveDragId(null)
-  }, [])
+    if (dragReorderCommittedRef.current) {
+      void load({ silent: true })
+    }
+    dragReorderCommittedRef.current = false
+  }, [load])
 
   const activeItem = useMemo(() => {
     if (!activeDragId) return null
@@ -2308,6 +2415,7 @@ export default function CourseModules() {
           sensors={sensors}
           collisionDetection={closestCenter}
           onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
           onDragEnd={handleDragEnd}
           onDragCancel={handleDragCancel}
           accessibility={{
@@ -2324,18 +2432,8 @@ export default function CourseModules() {
                 const pos = siblings.findIndex((c) => c.id === String(active.id)) + 1
                 return `Picked up "${item.title}". Position: ${pos} of ${siblings.length}. Press arrow keys to move, Space to drop, Escape to cancel.`
               },
-              onDragOver({ active, over }) {
-                if (!over) return
-                const item = items.find((i) => i.id === String(active.id))
-                if (!item) return
-                if (item.kind === 'module') {
-                  const pos = moduleIds.indexOf(String(over.id)) + 1
-                  return `"${item.title}" is now at position ${pos} of ${moduleIds.length}.`
-                }
-                const moduleId = active.data.current?.moduleId as string | undefined
-                const siblings = moduleId ? (moduleChildrenById.get(moduleId) ?? []) : []
-                const pos = siblings.findIndex((c) => c.id === String(over.id)) + 1
-                return `"${item.title}" is now at position ${pos} of ${siblings.length}.`
+              onDragOver() {
+                return undefined
               },
               onDragEnd({ active, over }) {
                 const item = items.find((i) => i.id === String(active.id))
@@ -2395,7 +2493,7 @@ export default function CourseModules() {
                       setOerPanelOpen(true)
                     }}
                     oerLibraryEnabled={oerEnabled}
-                    minified={isDraggingModule}
+                    minified={false}
                     collapsed={collapsedModuleIds.has(item.id)}
                     onToggleCollapsed={toggleModuleCollapsed}
                     busyModuleId={busyModuleId}
@@ -2415,30 +2513,38 @@ export default function CourseModules() {
                 ))}
             </ul>
           </SortableContext>
-          {/* DragOverlay disables node rect-delta compensation; collapsing modules shifts layout and
-              desyncs the overlay from the cursor. Only use DragOverlay for in-module item drags. */}
-          {activeDragId && activeItem && activeItem.kind !== 'module' ? (
+          {activeDragId && activeItem ? (
             <DragOverlay dropAnimation={null}>
-              <div className="pointer-events-none max-w-lg rounded-xl border border-slate-300 bg-white px-3 py-2 shadow-lg dark:border-neutral-600 dark:bg-neutral-800">
-                <p className="text-sm font-semibold text-slate-950 dark:text-neutral-100">{activeItem.title}</p>
-                <p className="text-xs text-slate-500 dark:text-neutral-400">
-                  {activeItem.kind === 'content_page'
-                    ? 'Page'
-                    : activeItem.kind === 'assignment'
-                      ? 'Assignment'
-                      : activeItem.kind === 'quiz'
-                        ? activeItem.isAdaptive
-                          ? 'Adaptive quiz'
-                          : 'Quiz'
-                        : activeItem.kind === 'external_link'
-                          ? 'External link'
-                          : activeItem.kind === 'lti_link'
-                          ? 'LTI tool'
-                          : activeItem.kind === 'h5p'
-                            ? 'Interactive H5P'
-                            : 'Heading'}
-                </p>
-              </div>
+              {activeItem.kind === 'module' ? (
+                <div className="pointer-events-none w-full rounded-2xl border border-slate-200/70 bg-slate-50/95 px-4 py-3 shadow-lg dark:border-neutral-600 dark:bg-neutral-800/95">
+                  <p className="text-sm font-semibold text-slate-950 dark:text-neutral-100">{activeItem.title}</p>
+                  <p className="mt-0.5 text-xs text-slate-500 dark:text-neutral-400">
+                    {(moduleChildrenById.get(activeItem.id) ?? []).length}{' '}
+                    {(moduleChildrenById.get(activeItem.id) ?? []).length === 1 ? 'item' : 'items'}
+                  </p>
+                </div>
+              ) : (
+                <div className="pointer-events-none max-w-lg rounded-xl border border-slate-300 bg-white px-3 py-2 shadow-lg dark:border-neutral-600 dark:bg-neutral-800">
+                  <p className="text-sm font-semibold text-slate-950 dark:text-neutral-100">{activeItem.title}</p>
+                  <p className="text-xs text-slate-500 dark:text-neutral-400">
+                    {activeItem.kind === 'content_page'
+                      ? 'Page'
+                      : activeItem.kind === 'assignment'
+                        ? 'Assignment'
+                        : activeItem.kind === 'quiz'
+                          ? activeItem.isAdaptive
+                            ? 'Adaptive quiz'
+                            : 'Quiz'
+                          : activeItem.kind === 'external_link'
+                            ? 'External link'
+                            : activeItem.kind === 'lti_link'
+                              ? 'LTI tool'
+                              : activeItem.kind === 'h5p'
+                                ? 'Interactive H5P'
+                                : 'Heading'}
+                  </p>
+                </div>
+              )}
             </DragOverlay>
           ) : null}
         </DndContext>

--- a/clients/web/src/pages/lms/course-notebook-page.tsx
+++ b/clients/web/src/pages/lms/course-notebook-page.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react-hooks/set-state-in-effect -- sync localStorage notebook and course title from network */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Navigate, useParams } from 'react-router-dom'
-import { ChevronDown, Sparkles } from 'lucide-react'
 import { ConfirmDialog } from '../../components/confirm-dialog'
 import { ReadingFocusToggle } from '../../components/layout/reading-focus-toggle'
 import { useCourseNavFeatures } from '../../context/course-nav-features-context'
@@ -10,7 +9,10 @@ import { CourseNotebookSidebar } from '../../components/notebook/course-notebook
 import { FlashcardsModal } from '../../components/notebook/flashcards-modal'
 import {
   addNotebookPage,
+  addNotebookGroup,
   deleteNotebookPage,
+  isNotebookGroup,
+  movePageToParent,
   updatePageContent,
   updatePageTitle,
   type CourseNotebookPage,
@@ -21,6 +23,8 @@ import {
   saveCourseNotebookStore,
   type CourseNotebookStore,
 } from '../../lib/student-notebook-storage'
+import { NotebookGroupPanel } from '../../components/notebook/notebook-group-panel'
+import { NotebookPageActionsMenu } from '../../components/notebook/notebook-page-actions-menu'
 import { LmsPage } from './lms-page'
 
 const CONTENT_SAVE_MS = 500
@@ -167,6 +171,29 @@ export default function CourseNotebookPage() {
     [persistStore],
   )
 
+  const onAddRootGroup = useCallback(() => {
+    setData((d) => {
+      if (!d) return d
+      const { pages, newId } = addNotebookGroup(d.pages, null)
+      const next = { ...d, pages, activePageId: newId }
+      persistStore(next)
+      return next
+    })
+  }, [persistStore])
+
+  const onAddChildGroup = useCallback(
+    (parentId: string) => {
+      setData((d) => {
+        if (!d) return d
+        const { pages, newId } = addNotebookGroup(d.pages, parentId)
+        const next = { ...d, pages, activePageId: newId }
+        persistStore(next)
+        return next
+      })
+    },
+    [persistStore],
+  )
+
   const onRenamePage = useCallback(
     (pageId: string, title: string) => {
       setData((d) => {
@@ -206,6 +233,34 @@ export default function CourseNotebookPage() {
     setDeleteTyped('')
     setDeleteConfirmOpen(true)
   }, [])
+
+  const onMovePageToGroup = useCallback(
+    (pageId: string, groupId: string) => {
+      setData((d) => {
+        if (!d) return d
+        const pages = movePageToParent(d.pages, pageId, groupId)
+        if (!pages) return d
+        const next = { ...d, pages }
+        persistStore(next)
+        return next
+      })
+    },
+    [persistStore],
+  )
+
+  const onMovePageToRoot = useCallback(
+    (pageId: string) => {
+      setData((d) => {
+        if (!d) return d
+        const pages = movePageToParent(d.pages, pageId, null)
+        if (!pages) return d
+        const next = { ...d, pages }
+        persistStore(next)
+        return next
+      })
+    },
+    [persistStore],
+  )
 
   const onEditorChange = useCallback(
     (markdown: string) => {
@@ -276,7 +331,9 @@ export default function CourseNotebookPage() {
             onSelect={onSelectPage}
             onPagesChange={onPagesChange}
             onAddRootPage={onAddRootPage}
+            onAddRootGroup={onAddRootGroup}
             onAddChildPage={onAddChildPage}
+            onAddChildGroup={onAddChildGroup}
             onRenamePage={onRenamePage}
             onDeletePage={onDeletePage}
           />
@@ -301,45 +358,41 @@ export default function CourseNotebookPage() {
                     className="flex-1 min-w-0 border-0 bg-transparent text-lg font-semibold tracking-tight text-slate-900 outline-none ring-indigo-500/25 placeholder:text-slate-400 focus:ring-2 dark:text-neutral-100 dark:placeholder:text-neutral-500"
                     placeholder="Untitled page"
                   />
-                  <div className="relative shrink-0" ref={actionsRef}>
-                    <button
-                      type="button"
-                      onClick={() => setActionsOpen((v) => !v)}
-                      className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800"
-                    >
-                      Actions
-                      <ChevronDown className="h-3.5 w-3.5" aria-hidden />
-                    </button>
-                    {actionsOpen && (
-                      <div className="absolute right-0 top-full mt-1 z-20 w-52 rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-neutral-700 dark:bg-neutral-900">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setActionsOpen(false)
-                            setFlashcardsOpen(true)
-                          }}
-                          className="flex w-full items-center gap-2 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
-                        >
-                          <Sparkles className="h-4 w-4 text-indigo-500" aria-hidden />
-                          Create Flash Cards
-                        </button>
-                      </div>
-                    )}
-                  </div>
+                  <NotebookPageActionsMenu
+                    open={actionsOpen}
+                    onToggle={() => setActionsOpen((v) => !v)}
+                    onClose={() => setActionsOpen(false)}
+                    menuRef={actionsRef}
+                    pages={data.pages}
+                    activePage={activePage}
+                    onMoveToGroup={onMovePageToGroup}
+                    onMoveToRoot={onMovePageToRoot}
+                    onFlashcards={() => setFlashcardsOpen(true)}
+                  />
                 </div>
                 <div className="mx-auto min-h-0 w-full max-w-[72ch] flex-1 overflow-y-auto px-4 py-4 text-[1.0625rem] leading-relaxed md:px-6 md:py-5">
-                  <MarkdownBodyEditor
-                    key={activePage.id}
-                    sectionId={activePage.id}
-                    value={activePage.contentMd}
-                    onChange={onEditorChange}
-                    courseCode={courseCode}
-                    uploadCourseImage={(file) =>
-                      uploadCourseFile(courseCode, file).then((r) => r.contentPath)
-                    }
-                    showImagePickerRow
-                    placeholder="Start writing… Headings, lists, and @ mentions work here."
-                  />
+                  {isNotebookGroup(activePage) ? (
+                    <NotebookGroupPanel
+                      group={activePage}
+                      pages={data.pages}
+                      onSelectPage={onSelectPage}
+                      onAddPage={onAddChildPage}
+                      onAddGroup={onAddChildGroup}
+                    />
+                  ) : (
+                    <MarkdownBodyEditor
+                      key={activePage.id}
+                      sectionId={activePage.id}
+                      value={activePage.contentMd}
+                      onChange={onEditorChange}
+                      courseCode={courseCode}
+                      uploadCourseImage={(file) =>
+                        uploadCourseFile(courseCode, file).then((r) => r.contentPath)
+                      }
+                      showImagePickerRow
+                      placeholder="Start writing… Type / for blocks, or nest pages in the sidebar."
+                    />
+                  )}
                 </div>
               </>
             ) : (

--- a/clients/web/src/pages/lms/global-notebook-page.tsx
+++ b/clients/web/src/pages/lms/global-notebook-page.tsx
@@ -1,15 +1,18 @@
 /* eslint-disable react-hooks/set-state-in-effect -- sync localStorage notebook on load */
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ChevronDown, Sparkles } from 'lucide-react'
 
 import { ConfirmDialog } from '../../components/confirm-dialog'
 import { ReadingFocusToggle } from '../../components/layout/reading-focus-toggle'
 import { MarkdownBodyEditor } from '../../components/editor/block-editor/markdown-body-editor'
 import { CourseNotebookSidebar } from '../../components/notebook/course-notebook-sidebar'
 import { FlashcardsModal } from '../../components/notebook/flashcards-modal'
+import { readFileAsDataUrl } from '../../lib/read-file-as-data-url'
 import {
   addNotebookPage,
+  addNotebookGroup,
   deleteNotebookPage,
+  isNotebookGroup,
+  movePageToParent,
   updatePageContent,
   updatePageTitle,
   type CourseNotebookPage,
@@ -21,6 +24,8 @@ import {
   saveCourseNotebookStore,
   type CourseNotebookStore,
 } from '../../lib/student-notebook-storage'
+import { NotebookGroupPanel } from '../../components/notebook/notebook-group-panel'
+import { NotebookPageActionsMenu } from '../../components/notebook/notebook-page-actions-menu'
 import { LmsPage } from './lms-page'
 
 const CONTENT_SAVE_MS = 500
@@ -125,6 +130,29 @@ export default function GlobalNotebookPage() {
     [persistStore],
   )
 
+  const onAddRootGroup = useCallback(() => {
+    setData((d) => {
+      if (!d) return d
+      const { pages, newId } = addNotebookGroup(d.pages, null)
+      const next = { ...d, pages, activePageId: newId }
+      persistStore(next)
+      return next
+    })
+  }, [persistStore])
+
+  const onAddChildGroup = useCallback(
+    (parentId: string) => {
+      setData((d) => {
+        if (!d) return d
+        const { pages, newId } = addNotebookGroup(d.pages, parentId)
+        const next = { ...d, pages, activePageId: newId }
+        persistStore(next)
+        return next
+      })
+    },
+    [persistStore],
+  )
+
   const onRenamePage = useCallback(
     (pageId: string, title: string) => {
       setData((d) => {
@@ -164,6 +192,34 @@ export default function GlobalNotebookPage() {
     setDeleteTyped('')
     setDeleteConfirmOpen(true)
   }, [])
+
+  const onMovePageToGroup = useCallback(
+    (pageId: string, groupId: string) => {
+      setData((d) => {
+        if (!d) return d
+        const pages = movePageToParent(d.pages, pageId, groupId)
+        if (!pages) return d
+        const next = { ...d, pages }
+        persistStore(next)
+        return next
+      })
+    },
+    [persistStore],
+  )
+
+  const onMovePageToRoot = useCallback(
+    (pageId: string) => {
+      setData((d) => {
+        if (!d) return d
+        const pages = movePageToParent(d.pages, pageId, null)
+        if (!pages) return d
+        const next = { ...d, pages }
+        persistStore(next)
+        return next
+      })
+    },
+    [persistStore],
+  )
 
   const onEditorChange = useCallback(
     (markdown: string) => {
@@ -223,7 +279,9 @@ export default function GlobalNotebookPage() {
             onSelect={onSelectPage}
             onPagesChange={onPagesChange}
             onAddRootPage={onAddRootPage}
+            onAddRootGroup={onAddRootGroup}
             onAddChildPage={onAddChildPage}
+            onAddChildGroup={onAddChildGroup}
             onRenamePage={onRenamePage}
             onDeletePage={onDeletePage}
           />
@@ -248,40 +306,38 @@ export default function GlobalNotebookPage() {
                     className="flex-1 min-w-0 border-0 bg-transparent text-lg font-semibold tracking-tight text-slate-900 outline-none ring-indigo-500/25 placeholder:text-slate-400 focus:ring-2 dark:text-neutral-100 dark:placeholder:text-neutral-500"
                     placeholder="Untitled page"
                   />
-                  <div className="relative shrink-0" ref={actionsRef}>
-                    <button
-                      type="button"
-                      onClick={() => setActionsOpen((v) => !v)}
-                      className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800"
-                    >
-                      Actions
-                      <ChevronDown className="h-3.5 w-3.5" aria-hidden />
-                    </button>
-                    {actionsOpen && (
-                      <div className="absolute right-0 top-full mt-1 z-20 w-52 rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-neutral-700 dark:bg-neutral-900">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setActionsOpen(false)
-                            setFlashcardsOpen(true)
-                          }}
-                          className="flex w-full items-center gap-2 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
-                        >
-                          <Sparkles className="h-4 w-4 text-indigo-500" aria-hidden />
-                          Create Flash Cards
-                        </button>
-                      </div>
-                    )}
-                  </div>
+                  <NotebookPageActionsMenu
+                    open={actionsOpen}
+                    onToggle={() => setActionsOpen((v) => !v)}
+                    onClose={() => setActionsOpen(false)}
+                    menuRef={actionsRef}
+                    pages={data.pages}
+                    activePage={activePage}
+                    onMoveToGroup={onMovePageToGroup}
+                    onMoveToRoot={onMovePageToRoot}
+                    onFlashcards={() => setFlashcardsOpen(true)}
+                  />
                 </div>
                 <div className="mx-auto min-h-0 w-full max-w-[72ch] flex-1 overflow-y-auto px-4 py-4 text-[1.0625rem] leading-relaxed md:px-6 md:py-5">
-                  <MarkdownBodyEditor
-                    key={activePage.id}
-                    sectionId={activePage.id}
-                    value={activePage.contentMd}
-                    onChange={onEditorChange}
-                    placeholder="Start writing… Headings and lists work here. @ mentions and course image uploads are available in course notebooks."
-                  />
+                  {isNotebookGroup(activePage) ? (
+                    <NotebookGroupPanel
+                      group={activePage}
+                      pages={data.pages}
+                      onSelectPage={onSelectPage}
+                      onAddPage={onAddChildPage}
+                      onAddGroup={onAddChildGroup}
+                    />
+                  ) : (
+                    <MarkdownBodyEditor
+                      key={activePage.id}
+                      sectionId={activePage.id}
+                      value={activePage.contentMd}
+                      onChange={onEditorChange}
+                      uploadCourseImage={readFileAsDataUrl}
+                      showImagePickerRow
+                      placeholder="Start writing… Type / for blocks, or nest pages in the sidebar."
+                    />
+                  )}
                 </div>
               </>
             ) : (

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -28,11 +28,16 @@ services:
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-studydrift}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:-studydrift}
     healthcheck:
-      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      # ping alone can pass before the AMQP listener on 5672 accepts connections.
+      test:
+        [
+          "CMD-SHELL",
+          "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_port_connectivity",
+        ]
       interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 20s
+      timeout: 10s
+      retries: 8
+      start_period: 30s
 
   server:
     image: ${LEXTURES_SERVER_IMAGE:?LEXTURES_SERVER_IMAGE is required}

--- a/server/internal/httpserver/courses_routes.go
+++ b/server/internal/httpserver/courses_routes.go
@@ -16,6 +16,7 @@ func (d Deps) registerCourseRoutes(r chi.Router) {
 	r.Post("/api/v1/courses/{course_code}/course-context", d.handlePostCourseContext())
 	r.Get("/api/v1/courses/{course_code}/structure", d.handleCourseStructure())
 	r.Get("/api/v1/courses/{course_code}/structure/archived", d.handleCourseStructureArchived())
+	r.Post("/api/v1/courses/{course_code}/structure/reorder", d.handleReorderCourseStructure())
 	r.Post("/api/v1/courses/{course_code}/structure/modules", d.handleCreateCourseModule())
 	r.Patch("/api/v1/courses/{course_code}/structure/modules/{module_id}", d.handlePatchCourseModule())
 	r.Delete("/api/v1/courses/{course_code}/structure/modules/{module_id}", d.handleDeleteCourseModule())

--- a/server/internal/httpserver/structure_reorder.go
+++ b/server/internal/httpserver/structure_reorder.go
@@ -1,0 +1,79 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/models/coursestructure"
+	coursestructurerepo "github.com/lextures/lextures/server/internal/repos/coursestructure"
+	"github.com/lextures/lextures/server/internal/repos/course"
+	"github.com/lextures/lextures/server/internal/courseroles"
+)
+
+// handleReorderCourseStructure is POST /api/v1/courses/{course_code}/structure/reorder.
+func (d Deps) handleReorderCourseStructure() http.HandlerFunc {
+	type resp struct {
+		Items []coursestructurerepo.ItemResponse `json:"items"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost+","+http.MethodOptions)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		courseCode, viewer, ok := d.requireCourseAccess(w, r)
+		if !ok {
+			return
+		}
+		hasPerm, err := courseroles.UserHasPermission(r.Context(), d.Pool, viewer, "course:"+courseCode+":item:create")
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")
+			return
+		}
+		if !hasPerm {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission to edit course structure.")
+			return
+		}
+		cid, err := course.GetIDByCourseCode(r.Context(), d.Pool, courseCode)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course.")
+			return
+		}
+		if cid == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+			return
+		}
+		var body coursestructure.ReorderCourseStructureRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		err = coursestructurerepo.ApplyModuleAndChildOrder(
+			r.Context(), d.Pool, *cid, body.ModuleOrder, body.ChildOrderByModule,
+		)
+		if errors.Is(err, coursestructurerepo.ErrInvalidReorder) {
+			apierr.WriteJSON(
+				w, http.StatusBadRequest, apierr.CodeInvalidInput,
+				"Invalid reorder: module or child ids must match the current structure.",
+			)
+			return
+		}
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to reorder course structure.")
+			return
+		}
+		items, err := coursestructurerepo.ListForCourseWithEnrichment(r.Context(), d.Pool, *cid, true)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course structure.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(resp{Items: items})
+	}
+}

--- a/server/internal/repos/coursestructure/reorder.go
+++ b/server/internal/repos/coursestructure/reorder.go
@@ -1,0 +1,183 @@
+package coursestructure
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const reorderOffset = 10_000_000
+
+// ErrInvalidReorder is returned when module or child ids do not match the current structure.
+var ErrInvalidReorder = errors.New("coursestructure: invalid reorder")
+
+// ApplyModuleAndChildOrder reassigns sort_order for top-level modules and each module's children.
+// moduleIDsInOrder must list every non-archived top-level module id. For each such module,
+// childrenByModule must list every non-archived child id in the desired order; modules with no
+// children use an empty slice (or may be omitted from the map). Archived modules and children
+// are unchanged.
+func ApplyModuleAndChildOrder(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	courseID uuid.UUID,
+	moduleIDsInOrder []uuid.UUID,
+	childrenByModule map[uuid.UUID][]uuid.UUID,
+) error {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var lockedCourse uuid.UUID
+	err = tx.QueryRow(ctx, `SELECT id FROM course.courses WHERE id = $1 FOR UPDATE`, courseID).Scan(&lockedCourse)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrInvalidReorder
+	}
+	if err != nil {
+		return err
+	}
+
+	rows, err := tx.Query(ctx, `
+		SELECT id, archived
+		FROM course.course_structure_items
+		WHERE course_id = $1 AND parent_id IS NULL AND kind = 'module'
+		ORDER BY sort_order
+	`, courseID)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var visibleModules []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		var archived bool
+		if err := rows.Scan(&id, &archived); err != nil {
+			return err
+		}
+		if !archived {
+			visibleModules = append(visibleModules, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	visibleModSet := make(map[uuid.UUID]struct{}, len(visibleModules))
+	for _, id := range visibleModules {
+		visibleModSet[id] = struct{}{}
+	}
+	orderSet := make(map[uuid.UUID]struct{}, len(moduleIDsInOrder))
+	for _, id := range moduleIDsInOrder {
+		orderSet[id] = struct{}{}
+	}
+	if len(visibleModSet) != len(orderSet) {
+		return ErrInvalidReorder
+	}
+	for id := range visibleModSet {
+		if _, ok := orderSet[id]; !ok {
+			return ErrInvalidReorder
+		}
+	}
+
+	for _, mid := range visibleModules {
+		childRows, err := tx.Query(ctx, `
+			SELECT id, archived
+			FROM course.course_structure_items
+			WHERE parent_id = $1
+			ORDER BY sort_order
+		`, mid)
+		if err != nil {
+			return err
+		}
+		var visibleChildIDs []uuid.UUID
+		for childRows.Next() {
+			var id uuid.UUID
+			var archived bool
+			if err := childRows.Scan(&id, &archived); err != nil {
+				childRows.Close()
+				return err
+			}
+			if !archived {
+				visibleChildIDs = append(visibleChildIDs, id)
+			}
+		}
+		childRows.Close()
+		if err := childRows.Err(); err != nil {
+			return err
+		}
+
+		visibleChildSet := make(map[uuid.UUID]struct{}, len(visibleChildIDs))
+		for _, id := range visibleChildIDs {
+			visibleChildSet[id] = struct{}{}
+		}
+		specified := childrenByModule[mid]
+		if specified == nil {
+			specified = []uuid.UUID{}
+		}
+		specSet := make(map[uuid.UUID]struct{}, len(specified))
+		for _, id := range specified {
+			specSet[id] = struct{}{}
+		}
+		if len(visibleChildSet) != len(specSet) {
+			return ErrInvalidReorder
+		}
+		for id := range visibleChildSet {
+			if _, ok := specSet[id]; !ok {
+				return ErrInvalidReorder
+			}
+		}
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE course.course_structure_items
+		SET sort_order = sort_order + $2
+		WHERE course_id = $1 AND parent_id IS NULL AND kind = 'module'
+	`, courseID, reorderOffset); err != nil {
+		return err
+	}
+
+	for ord, id := range moduleIDsInOrder {
+		if _, err := tx.Exec(ctx, `
+			UPDATE course.course_structure_items
+			SET sort_order = $3
+			WHERE id = $1 AND course_id = $2 AND parent_id IS NULL AND kind = 'module'
+		`, id, courseID, ord); err != nil {
+			return err
+		}
+	}
+
+	for _, mid := range visibleModules {
+		childIDs := childrenByModule[mid]
+		if childIDs == nil {
+			childIDs = []uuid.UUID{}
+		}
+		if len(childIDs) == 0 {
+			continue
+		}
+
+		if _, err := tx.Exec(ctx, `
+			UPDATE course.course_structure_items
+			SET sort_order = sort_order + $2
+			WHERE parent_id = $1
+		`, mid, reorderOffset); err != nil {
+			return err
+		}
+
+		for ord, cid := range childIDs {
+			if _, err := tx.Exec(ctx, `
+				UPDATE course.course_structure_items
+				SET sort_order = $3
+				WHERE id = $1 AND parent_id = $2
+			`, cid, mid, ord); err != nil {
+				return err
+			}
+		}
+	}
+
+	return tx.Commit(ctx)
+}


### PR DESCRIPTION
## Summary

- Add **notebook folder groups** with collapse/expand, drag-to-nest (including Shift+drop), move-to-group menus, and backward-compatible storage for existing notebooks.
- Add **markdown editor slash commands** (`/` menu) for block insertion, plus an image upload modal with drag-and-drop, paste, and base64 support.
- Improve **course module drag-and-drop** with live reordering during drag, cleaner drag overlays, and extract the structure reorder handler into dedicated server/repo modules.

## Test plan

- [ ] Create a course notebook group and nested pages; collapse/expand and drag pages into groups (with and without Shift held).
- [ ] Open global notebook and verify group/move actions work the same way.
- [ ] In markdown editor, type `/` and insert headings, lists, code blocks, and images via the slash menu.
- [ ] Upload/paste/drop images in the markdown editor (course and non-course contexts).
- [ ] Reorder modules and module items on the course modules page; confirm order persists after refresh.
- [ ] Run `npm run test` in `clients/web/` and `go test ./... -short` in `server/`.