### PR TITLE
feat: notebook tasks, embedded whiteboards, and course feed announcements

### DIFF
--- a/clients/web/src/components/dashboard/notebook-tasks-card.tsx
+++ b/clients/web/src/components/dashboard/notebook-tasks-card.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { CalendarDays, CheckSquare, Square } from 'lucide-react'
+import { formatDate } from '../../lib/format'
+import { NOTEBOOK_TASKS_CHANGED } from '../../lib/notebook-task-sync'
+import {
+  fetchNotebookTasks,
+  patchNotebookTask,
+  type NotebookTask,
+} from '../../lib/notebook-tasks-api'
+import {
+  GLOBAL_STUDENT_NOTEBOOK_KEY,
+  GLOBAL_STUDENT_NOTEBOOK_TITLE,
+  hrefForNotebookPage,
+  markNotebookTaskComplete,
+} from '../../lib/student-notebook-storage'
+
+function taskCourseLabel(courseCode: string, courseTitles: Record<string, string>): string {
+  if (courseCode === GLOBAL_STUDENT_NOTEBOOK_KEY) return GLOBAL_STUDENT_NOTEBOOK_TITLE
+  return courseTitles[courseCode] ?? courseCode
+}
+
+export type NotebookTasksCardProps = {
+  courseTitles: Record<string, string>
+}
+
+export function NotebookTasksCard({ courseTitles }: NotebookTasksCardProps) {
+  const [tasks, setTasks] = useState<NotebookTask[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [completingId, setCompletingId] = useState<string | null>(null)
+
+  const load = useCallback(() => {
+    void fetchNotebookTasks()
+      .then((rows) => {
+        setTasks(rows)
+        setError(null)
+      })
+      .catch((e: unknown) => {
+        setTasks([])
+        setError(e instanceof Error ? e.message : 'Could not load notebook tasks.')
+      })
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  useEffect(() => {
+    function onTasksChanged() {
+      load()
+    }
+    function onFocus() {
+      load()
+    }
+    window.addEventListener(NOTEBOOK_TASKS_CHANGED, onTasksChanged)
+    window.addEventListener('focus', onFocus)
+    return () => {
+      window.removeEventListener(NOTEBOOK_TASKS_CHANGED, onTasksChanged)
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [load])
+
+  const onComplete = useCallback(
+    async (task: NotebookTask) => {
+      if (completingId) return
+      setCompletingId(task.id)
+      try {
+        await patchNotebookTask(task.id, { completed: true })
+        markNotebookTaskComplete(task.courseCode, task.notebookPageId, task.id)
+        setTasks((prev) => (prev ?? []).filter((t) => t.id !== task.id))
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : 'Could not complete task.')
+      } finally {
+        setCompletingId(null)
+      }
+    },
+    [completingId],
+  )
+
+  if (tasks === null) return null
+
+  return (
+    <section aria-label="Notebook tasks">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+        Notebook tasks
+      </h2>
+      {error ? (
+        <p className="mt-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100">
+          {error}
+        </p>
+      ) : null}
+      {tasks.length === 0 && !error ? (
+        <p className="mt-3 rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm text-slate-600 dark:border-neutral-700 dark:bg-neutral-900/50 dark:text-neutral-300">
+          Add tasks in a notebook with <span className="font-mono text-xs">/task</span> or{' '}
+          <span className="font-mono text-xs">/todo</span>. Open tasks show up here.
+        </p>
+      ) : null}
+      <ul className="mt-3 space-y-2">
+        {tasks.map((task) => {
+          const label = task.taskText.trim() || 'Untitled task'
+          const href = hrefForNotebookPage(task.courseCode, task.notebookPageId)
+          const busy = completingId === task.id
+          return (
+            <li
+              key={task.id}
+              className="flex items-start gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 shadow-sm dark:border-neutral-700 dark:bg-neutral-900"
+            >
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void onComplete(task)}
+                className="mt-0.5 shrink-0 rounded p-0.5 text-slate-400 transition hover:bg-slate-100 hover:text-indigo-600 disabled:opacity-50 dark:hover:bg-neutral-800 dark:hover:text-indigo-400"
+                aria-label={`Complete task: ${label}`}
+              >
+                <Square className="h-4 w-4" aria-hidden />
+              </button>
+              <div className="min-w-0 flex-1">
+                <Link
+                  to={href}
+                  className="block text-sm font-medium text-slate-900 hover:text-indigo-700 dark:text-neutral-100 dark:hover:text-indigo-300"
+                >
+                  {label}
+                </Link>
+                <p className="mt-0.5 text-xs text-slate-500 dark:text-neutral-400">
+                  {taskCourseLabel(task.courseCode, courseTitles)}
+                </p>
+                {task.dueAt ? (
+                  <p className="mt-1 flex items-center gap-1 text-xs text-slate-500 dark:text-neutral-400">
+                    <CalendarDays className="h-3 w-3 shrink-0" aria-hidden />
+                    Due {formatDate(task.dueAt, { dateStyle: 'medium' })}
+                  </p>
+                ) : null}
+              </div>
+              <Link
+                to={href}
+                className="shrink-0 self-center text-xs font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400"
+              >
+                Open
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+      {tasks.length > 0 ? (
+        <p className="mt-2 flex items-center gap-1.5 text-xs text-slate-500 dark:text-neutral-400">
+          <CheckSquare className="h-3.5 w-3.5" aria-hidden />
+          Complete a task here to remove it from this list. In your notebook it stays visible, crossed out.
+        </p>
+      ) : null}
+    </section>
+  )
+}

--- a/clients/web/src/components/editor/block-editor/__tests__/markdown-body-slash.test.ts
+++ b/clients/web/src/components/editor/block-editor/__tests__/markdown-body-slash.test.ts
@@ -57,6 +57,18 @@ describe('filterSlashCommands', () => {
     const commands = slashCommandsForEditor({ image: false })
     expect(commands.some((c) => c.id === 'image')).toBe(false)
   })
+
+  it('filters drawing by keyword', () => {
+    const commands = slashCommandsForEditor({ equation: true })
+    expect(filterSlashCommands(commands, 'draw').some((c) => c.id === 'drawing')).toBe(true)
+    expect(filterSlashCommands(commands, 'whiteboard').map((c) => c.id)).toEqual(['drawing'])
+  })
+
+  it('filters task by todo keyword', () => {
+    const commands = slashCommandsForEditor({ equation: false })
+    expect(filterSlashCommands(commands, 'todo').map((c) => c.id)).toEqual(['task'])
+    expect(filterSlashCommands(commands, 'task').map((c) => c.id)).toEqual(['task'])
+  })
 })
 
 describe('getBlockSlashRange', () => {

--- a/clients/web/src/components/editor/block-editor/markdown-body-editor.tsx
+++ b/clients/web/src/components/editor/block-editor/markdown-body-editor.tsx
@@ -23,6 +23,9 @@ import {
 import { CourseAwareTipTapImage } from './course-aware-tip-tap-image'
 import { MarkdownImageUploadModal } from './markdown-image-upload-modal'
 import { MathBlock, MathInline } from '../extensions/math-tip-tap'
+import { setNotebookTaskContext } from '../../../lib/notebook-task-context'
+import { NotebookTask, type NotebookTaskContext } from '../extensions/notebook-task-tip-tap'
+import { WhiteboardBlock } from '../extensions/whiteboard-tip-tap'
 import { altTextEnforcementFeatureEnabled } from '../../../lib/platform-features'
 
 const editorShellClass = [
@@ -88,6 +91,8 @@ export type MarkdownBodyEditorProps = {
   showImagePickerRow?: boolean
   /** When the user types `/equation`, open the equation editor (caller removes the trigger text). */
   onEquationSlash?: () => void
+  /** When set (student notebooks), notebook tasks sync to the server. */
+  notebookTaskContext?: NotebookTaskContext | null
 }
 
 type MentionUi = {
@@ -133,6 +138,7 @@ export function MarkdownBodyEditor({
   uploadCourseImage,
   showImagePickerRow,
   onEquationSlash,
+  notebookTaskContext = null,
 }: MarkdownBodyEditorProps) {
   const skipEmit = useRef(false)
   const onChangeRef = useRef(onChange)
@@ -398,9 +404,12 @@ export function MarkdownBodyEditor({
       extensions: [
         StarterKit.configure({
           heading: { levels: [1, 2, 3, 4, 5, 6] },
+          link: false,
         }),
         MathBlock,
         MathInline,
+        WhiteboardBlock,
+        NotebookTask.configure({ notebookTaskContext }),
         Markdown.configure({ markedOptions: { gfm: true } }),
         Link.configure({
           openOnClick: false,
@@ -724,6 +733,16 @@ export function MarkdownBodyEditor({
   useEffect(() => {
     if (editor) editor.setEditable(!disabled)
   }, [disabled, editor])
+
+  useEffect(() => {
+    setNotebookTaskContext(notebookTaskContext)
+    if (!editor) return
+    const ext = editor.extensionManager.extensions.find((e) => e.name === 'notebook_task')
+    if (ext) {
+      ext.options.notebookTaskContext = notebookTaskContext
+    }
+    return () => setNotebookTaskContext(null)
+  }, [editor, notebookTaskContext])
 
   useEffect(() => {
     if (!editor) return

--- a/clients/web/src/components/editor/block-editor/markdown-body-slash.ts
+++ b/clients/web/src/components/editor/block-editor/markdown-body-slash.ts
@@ -1,5 +1,7 @@
 import type { Editor } from '@tiptap/core'
 import type { EditorState } from '@tiptap/pm/state'
+import { TextSelection } from '@tiptap/pm/state'
+import { newNotebookTaskId } from '../extensions/notebook-task-tip-tap'
 import { getMentionBlockContext } from './markdown-body-mention'
 
 export type SlashCommandId =
@@ -8,6 +10,8 @@ export type SlashCommandId =
   | 'heading3'
   | 'paragraph'
   | 'image'
+  | 'drawing'
+  | 'task'
   | 'bulletList'
   | 'orderedList'
   | 'codeBlock'
@@ -52,6 +56,18 @@ const BASE_SLASH_COMMANDS: SlashCommand[] = [
     label: 'Insert image',
     description: 'Upload and embed an image',
     keywords: ['image', 'photo', 'picture', 'img', 'upload'],
+  },
+  {
+    id: 'drawing',
+    label: 'Drawing',
+    description: 'Insert a whiteboard to draw on',
+    keywords: ['drawing', 'whiteboard', 'sketch', 'draw', 'canvas'],
+  },
+  {
+    id: 'task',
+    label: 'Task',
+    description: 'Checkbox task with optional due date',
+    keywords: ['task', 'todo', 'checkbox', 'checklist'],
   },
   {
     id: 'bulletList',
@@ -162,6 +178,38 @@ export function applySlashCommand(
   if (command.id === 'image') {
     editor.chain().focus().deleteRange({ from: range.from, to: range.to }).run()
     options?.onImage?.()
+    return
+  }
+  if (command.id === 'drawing') {
+    editor
+      .chain()
+      .focus()
+      .deleteRange({ from: range.from, to: range.to })
+      .insertContentAt(range.from, { type: 'whiteboard_block', attrs: { elements: '[]' } })
+      .run()
+    return
+  }
+  if (command.id === 'task') {
+    const taskId = newNotebookTaskId()
+    const insertAt = range.from
+    editor
+      .chain()
+      .focus()
+      .deleteRange({ from: range.from, to: range.to })
+      .insertContentAt(insertAt, {
+        type: 'notebook_task',
+        attrs: { taskId, checked: false, dueAt: null },
+      })
+      .command(({ tr, dispatch }) => {
+        const node = tr.doc.nodeAt(insertAt)
+        if (!node || node.type.name !== 'notebook_task') return false
+        if (dispatch) {
+          const inside = insertAt + 1
+          tr.setSelection(TextSelection.near(tr.doc.resolve(inside)))
+        }
+        return true
+      })
+      .run()
     return
   }
 

--- a/clients/web/src/components/editor/extensions/notebook-task-node-view.tsx
+++ b/clients/web/src/components/editor/extensions/notebook-task-node-view.tsx
@@ -1,0 +1,214 @@
+import { NodeViewContent, NodeViewWrapper, type NodeViewProps } from '@tiptap/react'
+import { CalendarDays, ChevronDown, X } from 'lucide-react'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { formatDate } from '../../../lib/format'
+import { getNotebookTaskContext } from '../../../lib/notebook-task-context'
+import { emitNotebookTasksChanged } from '../../../lib/notebook-task-sync'
+import { patchNotebookTask, upsertNotebookTask } from '../../../lib/notebook-tasks-api'
+
+function dueAtToDateInputValue(dueAt: string | null | undefined): string {
+  if (!dueAt) return ''
+  const d = new Date(dueAt)
+  if (Number.isNaN(d.getTime())) return ''
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function dateInputToDueAt(value: string): string | null {
+  if (!value) return null
+  const d = new Date(`${value}T23:59:59`)
+  if (Number.isNaN(d.getTime())) return null
+  return d.toISOString()
+}
+
+export function NotebookTaskNodeView(props: NodeViewProps) {
+  const menuId = useId()
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [dateDraft, setDateDraft] = useState('')
+  const syncTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const createdRef = useRef(false)
+
+  const taskId = String(props.node.attrs.taskId ?? '')
+  const checked = props.node.attrs.checked === true
+  const dueAt = (props.node.attrs.dueAt as string | null) ?? null
+  const editable = props.editor.isEditable
+  const text = props.node.textContent
+
+  const upsertCurrent = useCallback(() => {
+    const ctx = getNotebookTaskContext()
+    if (!ctx || !taskId) return
+    void upsertNotebookTask({
+      id: taskId,
+      courseCode: ctx.courseCode,
+      notebookPageId: ctx.pageId,
+      taskText: text,
+      completed: checked,
+      dueAt,
+    })
+      .then(() => emitNotebookTasksChanged())
+      .catch(() => {})
+  }, [taskId, text, checked, dueAt])
+
+  const syncTask = useCallback(
+    (patch: { taskText?: string; completed?: boolean; dueAt?: string | null; clearDue?: boolean }) => {
+      if (!taskId) return
+      const ctx = getNotebookTaskContext()
+      if (!ctx) return
+      if (patch.taskText !== undefined) {
+        upsertCurrent()
+        return
+      }
+      void patchNotebookTask(taskId, patch)
+        .then(() => emitNotebookTasksChanged())
+        .catch(() => upsertCurrent())
+    },
+    [taskId, upsertCurrent],
+  )
+
+  useEffect(() => {
+    if (!taskId || createdRef.current) return
+    const ctx = getNotebookTaskContext()
+    if (!ctx) return
+    createdRef.current = true
+    upsertCurrent()
+  }, [taskId, upsertCurrent])
+
+  useEffect(() => {
+    if (!taskId) return
+    if (syncTimer.current) clearTimeout(syncTimer.current)
+    syncTimer.current = setTimeout(() => {
+      upsertCurrent()
+      syncTimer.current = null
+    }, 600)
+    return () => {
+      if (syncTimer.current) clearTimeout(syncTimer.current)
+    }
+  }, [taskId, text, checked, dueAt, upsertCurrent])
+
+  useEffect(() => {
+    if (!menuOpen) return
+    function onClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onClickOutside)
+    return () => document.removeEventListener('mousedown', onClickOutside)
+  }, [menuOpen])
+
+  const onToggleChecked = useCallback(() => {
+    const next = !checked
+    props.updateAttributes({ checked: next })
+    syncTask({ completed: next })
+  }, [checked, props.updateAttributes, syncTask])
+
+  const onOpenDueMenu = useCallback(() => {
+    setDateDraft(dueAtToDateInputValue(dueAt))
+    setMenuOpen((v) => !v)
+  }, [dueAt])
+
+  const onSaveDueDate = useCallback(() => {
+    const iso = dateInputToDueAt(dateDraft)
+    props.updateAttributes({ dueAt: iso })
+    syncTask({ dueAt: iso })
+    setMenuOpen(false)
+  }, [dateDraft, props.updateAttributes, syncTask])
+
+  const onClearDueDate = useCallback(() => {
+    props.updateAttributes({ dueAt: null })
+    syncTask({ clearDue: true })
+    setDateDraft('')
+    setMenuOpen(false)
+  }, [props.updateAttributes, syncTask])
+
+  const textClass = [
+    'min-w-0 flex-1 outline-none [&_p]:my-0',
+    checked
+      ? 'text-slate-500 line-through decoration-slate-400 dark:text-neutral-500 dark:decoration-neutral-500'
+      : 'text-slate-800 dark:text-neutral-200',
+  ].join(' ')
+
+  return (
+    <NodeViewWrapper
+      as="div"
+      className="lex-notebook-task group my-2 flex items-start gap-2 rounded-lg border border-transparent px-1 py-1 transition hover:border-slate-200 dark:hover:border-neutral-700"
+      data-type="notebook-task"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={checked}
+            disabled={!editable}
+            onChange={onToggleChecked}
+            className="h-4 w-4 shrink-0 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-neutral-600"
+            aria-label={checked ? 'Mark task incomplete' : 'Mark task complete'}
+          />
+          <NodeViewContent as="div" className={textClass} />
+        </div>
+        {dueAt ? (
+          <p className="mt-0.5 flex items-center gap-1 ps-6 text-xs text-slate-500 dark:text-neutral-400">
+            <CalendarDays className="h-3 w-3 shrink-0" aria-hidden />
+            Due {formatDate(dueAt, { dateStyle: 'medium' })}
+          </p>
+        ) : null}
+      </div>
+      {editable ? (
+        <div className="relative shrink-0 opacity-0 transition group-hover:opacity-100 group-focus-within:opacity-100" ref={menuRef}>
+          <button
+            type="button"
+            onClick={onOpenDueMenu}
+            className="inline-flex items-center rounded-md p-1 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+            aria-expanded={menuOpen}
+            aria-haspopup="menu"
+            aria-controls={menuId}
+            aria-label="Task options"
+          >
+            <ChevronDown className="h-4 w-4" aria-hidden />
+          </button>
+          {menuOpen ? (
+            <div
+              id={menuId}
+              role="menu"
+              className="absolute right-0 top-full z-30 mt-1 w-52 rounded-xl border border-slate-200 bg-white p-3 shadow-lg dark:border-neutral-700 dark:bg-neutral-900"
+            >
+              <label className="block text-xs font-medium text-slate-600 dark:text-neutral-400">
+                Due date
+                <input
+                  type="date"
+                  value={dateDraft}
+                  onChange={(e) => setDateDraft(e.target.value)}
+                  className="mt-1 w-full rounded-lg border border-slate-200 px-2 py-1.5 text-sm text-slate-800 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100"
+                />
+              </label>
+              <div className="mt-2 flex gap-2">
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={onSaveDueDate}
+                  className="flex-1 rounded-lg bg-indigo-600 px-2 py-1.5 text-xs font-semibold text-white hover:bg-indigo-500"
+                >
+                  Save
+                </button>
+                {dueAt ? (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={onClearDueDate}
+                    className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-1.5 text-xs text-slate-600 hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                    aria-label="Clear due date"
+                  >
+                    <X className="h-3 w-3" aria-hidden />
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </NodeViewWrapper>
+  )
+}

--- a/clients/web/src/components/editor/extensions/notebook-task-tip-tap.ts
+++ b/clients/web/src/components/editor/extensions/notebook-task-tip-tap.ts
@@ -1,0 +1,140 @@
+import { mergeAttributes, Node, type JSONContent, type MarkdownToken } from '@tiptap/core'
+import { ReactNodeViewRenderer } from '@tiptap/react'
+import { NotebookTaskNodeView } from './notebook-task-node-view'
+
+export type NotebookTaskContext = {
+  courseCode: string
+  pageId: string
+}
+
+export type NotebookTaskExtensionOptions = {
+  notebookTaskContext: NotebookTaskContext | null
+}
+
+const taskBlockTokenizer = {
+  name: 'notebook_task',
+  level: 'block' as const,
+  start: (src: string) => src.indexOf('```task'),
+  tokenize: (src: string) => {
+    const m = /^```task\s*\n([\s\S]*?)```/.exec(src)
+    if (!m) return undefined
+    const inner = (m[1] ?? '').trimEnd()
+    const nl = inner.indexOf('\n')
+    const metaLine = nl >= 0 ? inner.slice(0, nl).trim() : inner.trim()
+    const text = nl >= 0 ? inner.slice(nl + 1) : ''
+    return {
+      type: 'notebook_task',
+      raw: m[0],
+      metaLine,
+      text,
+    }
+  },
+}
+
+function parseTaskMeta(metaLine: string): { taskId: string; checked: boolean; dueAt: string | null } {
+  try {
+    const raw = JSON.parse(metaLine) as Record<string, unknown>
+    return {
+      taskId: typeof raw.id === 'string' ? raw.id : crypto.randomUUID(),
+      checked: raw.checked === true,
+      dueAt: typeof raw.dueAt === 'string' ? raw.dueAt : null,
+    }
+  } catch {
+    return { taskId: crypto.randomUUID(), checked: false, dueAt: null }
+  }
+}
+
+export function newNotebookTaskId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+  return `task-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+}
+
+export const NotebookTask = Node.create<NotebookTaskExtensionOptions>({
+  name: 'notebook_task',
+  group: 'block',
+  content: 'inline*',
+  defining: true,
+
+  addOptions() {
+    return {
+      notebookTaskContext: null,
+    }
+  },
+
+  addAttributes() {
+    return {
+      taskId: {
+        default: null,
+        parseHTML: (el) => (el as HTMLElement).getAttribute('data-task-id'),
+        renderHTML: (attrs) => {
+          if (!attrs.taskId) return {}
+          return { 'data-task-id': attrs.taskId as string }
+        },
+      },
+      checked: {
+        default: false,
+        parseHTML: (el) => (el as HTMLElement).getAttribute('data-checked') === 'true',
+        renderHTML: (attrs) => ({ 'data-checked': attrs.checked ? 'true' : 'false' }),
+      },
+      dueAt: {
+        default: null,
+        parseHTML: (el) => (el as HTMLElement).getAttribute('data-due-at'),
+        renderHTML: (attrs) => {
+          if (!attrs.dueAt) return {}
+          return { 'data-due-at': attrs.dueAt as string }
+        },
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="notebook-task"]' }]
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        'data-type': 'notebook-task',
+        'data-task-id': String(node.attrs.taskId ?? ''),
+        'data-checked': node.attrs.checked ? 'true' : 'false',
+        ...(node.attrs.dueAt ? { 'data-due-at': String(node.attrs.dueAt) } : {}),
+      }),
+      0,
+    ]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(NotebookTaskNodeView)
+  },
+
+  markdownTokenizer: taskBlockTokenizer,
+
+  parseMarkdown: (token: MarkdownToken) => {
+    const metaLine = typeof token.metaLine === 'string' ? token.metaLine : '{}'
+    const text = typeof token.text === 'string' ? token.text : ''
+    const meta = parseTaskMeta(metaLine)
+    const content: JSONContent[] = text ? [{ type: 'text', text }] : []
+    return {
+      type: 'notebook_task',
+      attrs: {
+        taskId: meta.taskId,
+        checked: meta.checked,
+        dueAt: meta.dueAt,
+      },
+      content,
+    } as JSONContent
+  },
+
+  renderMarkdown: (node: JSONContent, helpers) => {
+    const meta = JSON.stringify({
+      id: node.attrs?.taskId ?? newNotebookTaskId(),
+      checked: node.attrs?.checked === true,
+      dueAt: node.attrs?.dueAt ?? null,
+    })
+    const text = helpers.renderChildren(node.content ?? [], '\n')
+    return `\`\`\`task\n${meta}\n${text}\n\`\`\`\n`
+  },
+})

--- a/clients/web/src/components/editor/extensions/whiteboard-node-view.tsx
+++ b/clients/web/src/components/editor/extensions/whiteboard-node-view.tsx
@@ -1,0 +1,28 @@
+import { useCallback } from 'react'
+import { NodeViewWrapper, type NodeViewProps } from '@tiptap/react'
+import { EmbeddedWhiteboard } from '../../whiteboard/embedded-whiteboard'
+import { parseWhiteboardElements, serializeWhiteboardElements } from '../../../lib/whiteboard/serialize'
+import type { DrawEl } from '../../../lib/whiteboard/types'
+
+export function WhiteboardNodeView(props: NodeViewProps) {
+  const elements = parseWhiteboardElements(props.node.attrs.elements)
+  const editable = props.editor.isEditable
+
+  const onElementsChange = useCallback(
+    (next: DrawEl[]) => {
+      props.updateAttributes({ elements: serializeWhiteboardElements(next) })
+    },
+    [props.updateAttributes],
+  )
+
+  return (
+    <NodeViewWrapper
+      as="div"
+      className="lex-whiteboard-block my-4"
+      contentEditable={false}
+      data-type="whiteboard-block"
+    >
+      <EmbeddedWhiteboard elements={elements} onElementsChange={onElementsChange} disabled={!editable} />
+    </NodeViewWrapper>
+  )
+}

--- a/clients/web/src/components/editor/extensions/whiteboard-tip-tap.ts
+++ b/clients/web/src/components/editor/extensions/whiteboard-tip-tap.ts
@@ -1,0 +1,72 @@
+import { mergeAttributes, Node, type JSONContent, type MarkdownToken } from '@tiptap/core'
+import { ReactNodeViewRenderer } from '@tiptap/react'
+import { parseWhiteboardElements, serializeWhiteboardElements } from '../../../lib/whiteboard/serialize'
+import type { DrawEl } from '../../../lib/whiteboard/types'
+import { WhiteboardNodeView } from './whiteboard-node-view'
+
+const drawingBlockTokenizer = {
+  name: 'whiteboard_block',
+  level: 'block' as const,
+  start: (src: string) => src.indexOf('```drawing'),
+  tokenize: (src: string) => {
+    const m = /^```drawing\s*\n([\s\S]*?)```/.exec(src)
+    if (!m) return undefined
+    return {
+      type: 'whiteboard_block',
+      raw: m[0],
+      elementsJson: (m[1] ?? '').trim(),
+    }
+  },
+}
+
+export const WhiteboardBlock = Node.create({
+  name: 'whiteboard_block',
+  group: 'block',
+  atom: true,
+  draggable: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      elements: {
+        default: '[]',
+        parseHTML: (el) => (el as HTMLElement).getAttribute('data-elements') ?? '[]',
+        renderHTML: (attrs) => ({ 'data-elements': attrs.elements as string }),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="whiteboard-block"]' }]
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        'data-type': 'whiteboard-block',
+        'data-elements': String(node.attrs.elements ?? '[]'),
+      }),
+    ]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(WhiteboardNodeView)
+  },
+
+  markdownTokenizer: drawingBlockTokenizer,
+
+  parseMarkdown: (token: MarkdownToken) => {
+    const json = typeof token.elementsJson === 'string' ? token.elementsJson : '[]'
+    return {
+      type: 'whiteboard_block',
+      attrs: { elements: json || '[]' },
+    } as JSONContent
+  },
+
+  renderMarkdown: (node: JSONContent) => {
+    const elements = parseWhiteboardElements(node.attrs?.elements ?? '[]')
+    const body = serializeWhiteboardElements(elements as DrawEl[])
+    return `\`\`\`drawing\n${body}\n\`\`\``
+  },
+})

--- a/clients/web/src/components/ui/icon-action-tooltip.tsx
+++ b/clients/web/src/components/ui/icon-action-tooltip.tsx
@@ -1,0 +1,77 @@
+import { useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+type Placement = 'top' | 'bottom'
+
+type IconActionTooltipProps = {
+  label: string
+  children: ReactNode
+  placement?: Placement
+}
+
+export function IconActionTooltip({
+  label,
+  children,
+  placement = 'top',
+}: IconActionTooltipProps) {
+  const [open, setOpen] = useState(false)
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null)
+  const ref = useRef<HTMLSpanElement>(null)
+
+  useLayoutEffect(() => {
+    if (!open || !ref.current) {
+      return
+    }
+    const measure = () => {
+      if (!ref.current) return
+      const rect = ref.current.getBoundingClientRect()
+      setPos({
+        top: placement === 'top' ? rect.top - 6 : rect.bottom + 6,
+        left: rect.left + rect.width / 2,
+      })
+    }
+    measure()
+    window.addEventListener('scroll', measure, true)
+    window.addEventListener('resize', measure)
+    return () => {
+      window.removeEventListener('scroll', measure, true)
+      window.removeEventListener('resize', measure)
+    }
+  }, [open, placement])
+
+  const show = () => setOpen(true)
+  const hide = () => {
+    setOpen(false)
+    setPos(null)
+  }
+
+  return (
+    <span
+      ref={ref}
+      className="inline-flex"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocusCapture={show}
+      onBlurCapture={hide}
+    >
+      {children}
+      {open && pos
+        ? createPortal(
+            <div
+              role="tooltip"
+              style={{
+                top: pos.top,
+                left: pos.left,
+                transform:
+                  placement === 'top' ? 'translate(-50%, -100%)' : 'translate(-50%, 0)',
+              }}
+              className="pointer-events-none fixed z-[200] whitespace-nowrap rounded-md bg-slate-950 px-2 py-1 text-xs font-medium text-white shadow-lg ring-1 ring-white/10 dark:bg-neutral-800"
+            >
+              {label}
+            </div>,
+            document.body,
+          )
+        : null}
+    </span>
+  )
+}

--- a/clients/web/src/components/whiteboard/embedded-whiteboard.tsx
+++ b/clients/web/src/components/whiteboard/embedded-whiteboard.tsx
@@ -1,0 +1,62 @@
+import { useWhiteboardCanvas } from './use-whiteboard-canvas'
+import { WhiteboardToolbar } from './whiteboard-toolbar'
+import type { DrawEl } from '../../lib/whiteboard/types'
+
+export type EmbeddedWhiteboardProps = {
+  elements: DrawEl[]
+  onElementsChange: (elements: DrawEl[]) => void
+  disabled?: boolean
+  className?: string
+}
+
+export function EmbeddedWhiteboard({
+  elements,
+  onElementsChange,
+  disabled = false,
+  className,
+}: EmbeddedWhiteboardProps) {
+  const wb = useWhiteboardCanvas({ elements, onElementsChange, disabled })
+
+  return (
+    <div
+      className={`overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-950 ${className ?? ''}`}
+      onMouseDown={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      <WhiteboardToolbar
+        layout="horizontal"
+        tool={wb.tool}
+        onToolChange={wb.setTool}
+        color={wb.color}
+        onColorChange={wb.setColor}
+        strokeWidth={wb.strokeWidth}
+        onStrokeWidthChange={wb.setStrokeWidth}
+        eraserSize={wb.eraserSize}
+        onEraserSizeChange={wb.setEraserSize}
+        onClear={wb.clearCanvas}
+        onExportPng={() => wb.exportPng('drawing')}
+      />
+      <div ref={wb.containerRef} className="relative h-[min(420px,50vh)] w-full">
+        <canvas
+          ref={wb.canvasRef}
+          className={`touch-none ${wb.cursor}`}
+          onPointerDown={wb.onPointerDown}
+          onPointerMove={wb.onPointerMove}
+          onPointerUp={wb.onPointerUp}
+          onPointerLeave={() => wb.setEraserCursorPos(null)}
+        />
+        {wb.tool === 'eraser' && wb.eraserCursorPos ? (
+          <div
+            className="pointer-events-none absolute rounded-full border border-slate-500 bg-white/15 dark:border-slate-400"
+            style={{
+              left: wb.eraserCursorPos[0] - wb.eraserSize,
+              top: wb.eraserCursorPos[1] - wb.eraserSize,
+              width: wb.eraserSize * 2,
+              height: wb.eraserSize * 2,
+            }}
+          />
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/clients/web/src/components/whiteboard/use-whiteboard-canvas.ts
+++ b/clients/web/src/components/whiteboard/use-whiteboard-canvas.ts
@@ -1,0 +1,277 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
+import {
+  eraseFromElements,
+  pickElement,
+  redrawWhiteboard,
+  translateElement,
+} from '../../lib/whiteboard/canvas-core'
+import {
+  WHITEBOARD_COLORS,
+  WHITEBOARD_ERASER_SIZES,
+  WHITEBOARD_STROKE_WIDTHS,
+  type DrawEl,
+  type WhiteboardTool,
+} from '../../lib/whiteboard/types'
+
+type UseWhiteboardCanvasOptions = {
+  elements: DrawEl[]
+  onElementsChange: (elements: DrawEl[]) => void
+  disabled?: boolean
+}
+
+export function useWhiteboardCanvas({ elements, onElementsChange, disabled = false }: UseWhiteboardCanvasOptions) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const [draft, setDraft] = useState<DrawEl | null>(null)
+  const [tool, setTool] = useState<WhiteboardTool>('pen')
+  const [color, setColor] = useState<string>(WHITEBOARD_COLORS[0])
+  const [strokeWidth, setStrokeWidth] = useState<number>(WHITEBOARD_STROKE_WIDTHS[1])
+  const [eraserSize, setEraserSize] = useState<number>(WHITEBOARD_ERASER_SIZES[1])
+  const [eraserCursorPos, setEraserCursorPos] = useState<[number, number] | null>(null)
+  const [selectedIdx, setSelectedIdx] = useState<number | null>(null)
+  const [dragInfo, setDragInfo] = useState<{
+    idx: number
+    startPos: [number, number]
+    origEl: DrawEl
+  } | null>(null)
+  const [isDrawing, setIsDrawing] = useState(false)
+  const [origin, setOrigin] = useState<[number, number]>([0, 0])
+
+  const isDark = typeof document !== 'undefined' && document.documentElement.classList.contains('dark')
+
+  const elementsRef = useRef(elements)
+  elementsRef.current = elements
+
+  const setElements = useCallback(
+    (updater: DrawEl[] | ((prev: DrawEl[]) => DrawEl[])) => {
+      if (disabled) return
+      const next = typeof updater === 'function' ? updater(elementsRef.current) : updater
+      onElementsChange(next)
+    },
+    [disabled, onElementsChange],
+  )
+
+  useEffect(() => {
+    if (!isDrawing) {
+      setDraft(null)
+      setDragInfo(null)
+    }
+  }, [elements, isDrawing])
+
+  const resizeCanvas = useCallback(() => {
+    const canvas = canvasRef.current
+    const container = containerRef.current
+    if (!canvas || !container) return
+    const { width, height } = container.getBoundingClientRect()
+    canvas.width = width
+    canvas.height = height
+    const ctx = canvas.getContext('2d')
+    if (ctx) redrawWhiteboard(ctx, width, height, elements, draft, isDark, selectedIdx)
+  }, [elements, draft, isDark, selectedIdx])
+
+  useEffect(() => {
+    resizeCanvas()
+    const obs = new ResizeObserver(() => resizeCanvas())
+    if (containerRef.current) obs.observe(containerRef.current)
+    return () => obs.disconnect()
+  }, [resizeCanvas])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    redrawWhiteboard(ctx, canvas.width, canvas.height, elements, draft, isDark, selectedIdx)
+  }, [elements, draft, isDark, selectedIdx])
+
+  useEffect(() => {
+    setIsDrawing(false)
+    setDraft(null)
+    setDragInfo(null)
+    if (tool !== 'select') setSelectedIdx(null)
+  }, [tool])
+
+  const getPos = useCallback(
+    (e: ReactPointerEvent<HTMLCanvasElement> | ReactMouseEvent<HTMLCanvasElement>): [number, number] => {
+      const canvas = canvasRef.current!
+      const rect = canvas.getBoundingClientRect()
+      return [e.clientX - rect.left, e.clientY - rect.top]
+    },
+    [],
+  )
+
+  const onPointerDown = useCallback(
+    (e: ReactPointerEvent<HTMLCanvasElement>) => {
+      if (disabled) return
+      e.stopPropagation()
+      const [x, y] = getPos(e)
+      ;(e.target as HTMLCanvasElement).setPointerCapture(e.pointerId)
+
+      if (tool === 'select') {
+        const idx = pickElement(elements, x, y)
+        setSelectedIdx(idx >= 0 ? idx : null)
+        if (idx >= 0) {
+          setDragInfo({ idx, startPos: [x, y], origEl: elements[idx] })
+          setIsDrawing(true)
+        }
+        return
+      }
+
+      setOrigin([x, y])
+      setIsDrawing(true)
+
+      if (tool === 'pen') {
+        setDraft({ type: 'stroke', color, width: strokeWidth, pts: [[x, y]] })
+      } else if (tool === 'eraser') {
+        setElements((prev) => eraseFromElements(prev, x, y, eraserSize))
+      }
+    },
+    [color, disabled, elements, eraserSize, getPos, setElements, strokeWidth, tool],
+  )
+
+  const onPointerMove = useCallback(
+    (e: ReactPointerEvent<HTMLCanvasElement>) => {
+      if (disabled) return
+      e.stopPropagation()
+      const [x, y] = getPos(e)
+
+      if (tool === 'eraser') {
+        setEraserCursorPos([x, y])
+      }
+
+      if (!isDrawing) return
+
+      if (tool === 'select') {
+        if (dragInfo) {
+          const dx = x - dragInfo.startPos[0]
+          const dy = y - dragInfo.startPos[1]
+          setElements((prev) =>
+            prev.map((el, i) => (i === dragInfo.idx ? translateElement(dragInfo.origEl, dx, dy) : el)),
+          )
+        }
+        return
+      }
+
+      if (tool === 'eraser') {
+        const canvas = canvasRef.current!
+        const rect = canvas.getBoundingClientRect()
+        const coalesced = e.nativeEvent.getCoalescedEvents?.() ?? []
+        const pts: [number, number][] =
+          coalesced.length > 0
+            ? coalesced.map((ce) => [ce.clientX - rect.left, ce.clientY - rect.top])
+            : [[x, y]]
+        setElements((prev) => {
+          let els = prev
+          for (const [px, py] of pts) {
+            els = eraseFromElements(els, px, py, eraserSize)
+          }
+          return els
+        })
+        return
+      }
+
+      const [ox, oy] = origin
+
+      if (tool === 'pen') {
+        setDraft((prev) => {
+          if (!prev || prev.type !== 'stroke') return prev
+          return { ...prev, pts: [...prev.pts, [x, y]] }
+        })
+        return
+      }
+
+      if (tool === 'line') {
+        setDraft({ type: 'line', color, width: strokeWidth, x1: ox, y1: oy, x2: x, y2: y })
+      } else if (tool === 'rect') {
+        setDraft({ type: 'rect', color, width: strokeWidth, x: ox, y: oy, w: x - ox, h: y - oy })
+      } else if (tool === 'circle') {
+        setDraft({
+          type: 'circle',
+          color,
+          width: strokeWidth,
+          cx: ox,
+          cy: oy,
+          rx: (x - ox) / 2,
+          ry: (y - oy) / 2,
+        })
+      } else if (tool === 'triangle') {
+        const mx = (ox + x) / 2
+        setDraft({
+          type: 'triangle',
+          color,
+          width: strokeWidth,
+          x1: mx,
+          y1: oy,
+          x2: x,
+          y2: y,
+          x3: ox,
+          y3: y,
+        })
+      }
+    },
+    [color, disabled, dragInfo, eraserSize, getPos, isDrawing, origin, setElements, strokeWidth, tool],
+  )
+
+  const onPointerUp = useCallback(() => {
+    if (disabled || !isDrawing) return
+    setIsDrawing(false)
+    setDragInfo(null)
+    if (draft) {
+      setElements((prev) => [...prev, draft])
+      setDraft(null)
+    }
+  }, [disabled, draft, isDrawing, setElements])
+
+  const clearCanvas = useCallback(() => {
+    setElements([])
+    setDraft(null)
+    setSelectedIdx(null)
+  }, [setElements])
+
+  const exportPng = useCallback((filename = 'whiteboard') => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const a = document.createElement('a')
+    a.href = canvas.toDataURL('image/png')
+    a.download = `${filename}.png`
+    a.click()
+  }, [])
+
+  const cursor =
+    tool === 'select'
+      ? dragInfo
+        ? 'cursor-grabbing'
+        : 'cursor-grab'
+      : tool === 'eraser'
+        ? 'cursor-none'
+        : 'cursor-crosshair'
+
+  return {
+    canvasRef,
+    containerRef,
+    tool,
+    setTool,
+    color,
+    setColor,
+    strokeWidth,
+    setStrokeWidth,
+    eraserSize,
+    setEraserSize,
+    eraserCursorPos,
+    setEraserCursorPos,
+    clearCanvas,
+    exportPng,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    cursor,
+  }
+}

--- a/clients/web/src/components/whiteboard/whiteboard-popover-group.tsx
+++ b/clients/web/src/components/whiteboard/whiteboard-popover-group.tsx
@@ -1,0 +1,29 @@
+import { useRef, useState, type ReactNode } from 'react'
+
+export function WhiteboardPopoverGroup({ trigger, children }: { trigger: ReactNode; children: ReactNode }) {
+  const [open, setOpen] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const show = () => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    setOpen(true)
+  }
+  const hide = () => {
+    timerRef.current = setTimeout(() => setOpen(false), 80)
+  }
+
+  return (
+    <div className="relative" onMouseEnter={show} onMouseLeave={hide}>
+      <div onClick={() => setOpen((o) => !o)}>{trigger}</div>
+      {open && (
+        <div
+          className="absolute left-full top-0 z-50 ml-2 rounded-xl border border-slate-200 bg-white p-2 shadow-lg dark:border-neutral-800 dark:bg-neutral-950"
+          onMouseEnter={show}
+          onMouseLeave={hide}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/clients/web/src/components/whiteboard/whiteboard-toolbar.tsx
+++ b/clients/web/src/components/whiteboard/whiteboard-toolbar.tsx
@@ -1,0 +1,267 @@
+import {
+  Circle,
+  Download,
+  Eraser,
+  FolderOpen,
+  Minus,
+  MousePointer2,
+  Pencil,
+  Save,
+  Square,
+  Trash2,
+  Triangle,
+} from 'lucide-react'
+import type { ReactNode } from 'react'
+import {
+  WHITEBOARD_COLORS,
+  WHITEBOARD_ERASER_SIZES,
+  WHITEBOARD_STROKE_WIDTHS,
+  type WhiteboardTool,
+} from '../../lib/whiteboard/types'
+import { WhiteboardPopoverGroup } from './whiteboard-popover-group'
+
+const TOOLS: { id: WhiteboardTool; icon: ReactNode; label: string }[] = [
+  { id: 'select', icon: <MousePointer2 className="h-5 w-5" />, label: 'Select' },
+  { id: 'pen', icon: <Pencil className="h-5 w-5" />, label: 'Pen' },
+  { id: 'line', icon: <Minus className="h-5 w-5" />, label: 'Line' },
+  { id: 'rect', icon: <Square className="h-5 w-5" />, label: 'Rectangle' },
+  { id: 'circle', icon: <Circle className="h-5 w-5" />, label: 'Circle' },
+  { id: 'triangle', icon: <Triangle className="h-5 w-5" />, label: 'Triangle' },
+]
+
+export type WhiteboardToolbarProps = {
+  tool: WhiteboardTool
+  onToolChange: (tool: WhiteboardTool) => void
+  color: string
+  onColorChange: (color: string) => void
+  strokeWidth: number
+  onStrokeWidthChange: (width: number) => void
+  eraserSize: number
+  onEraserSizeChange: (size: number) => void
+  onClear: () => void
+  onExportPng?: () => void
+  onSave?: () => void
+  onLoad?: () => void
+  saving?: boolean
+  layout?: 'vertical' | 'horizontal'
+}
+
+export function WhiteboardToolbar({
+  tool,
+  onToolChange,
+  color,
+  onColorChange,
+  strokeWidth,
+  onStrokeWidthChange,
+  eraserSize,
+  onEraserSizeChange,
+  onClear,
+  onExportPng,
+  onSave,
+  onLoad,
+  saving = false,
+  layout = 'vertical',
+}: WhiteboardToolbarProps) {
+  const isHorizontal = layout === 'horizontal'
+  const activeTool = TOOLS.find((t) => t.id === tool) ?? TOOLS[0]
+
+  const toolButtons = (
+    <>
+      <WhiteboardPopoverGroup
+        trigger={
+          <button
+            type="button"
+            title={activeTool.label}
+            className="flex h-9 w-9 items-center justify-center rounded-lg bg-indigo-100 text-indigo-700 transition-colors dark:bg-indigo-950 dark:text-indigo-300"
+          >
+            {activeTool.icon}
+          </button>
+        }
+      >
+        <div className="flex flex-col gap-1">
+          {TOOLS.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              title={t.label}
+              onClick={() => onToolChange(t.id)}
+              className={`flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${
+                tool === t.id
+                  ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300'
+                  : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-200'
+              }`}
+            >
+              {t.icon}
+            </button>
+          ))}
+        </div>
+      </WhiteboardPopoverGroup>
+
+      <WhiteboardPopoverGroup
+        trigger={
+          <button
+            type="button"
+            title="Eraser"
+            onClick={() => onToolChange('eraser')}
+            className={`flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${
+              tool === 'eraser'
+                ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300'
+                : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-200'
+            }`}
+          >
+            <Eraser className="h-5 w-5" />
+          </button>
+        }
+      >
+        <div className="flex flex-col gap-1">
+          {WHITEBOARD_ERASER_SIZES.map((s) => (
+            <button
+              key={s}
+              type="button"
+              title={`Eraser ${s}px`}
+              onClick={() => {
+                onEraserSizeChange(s)
+                onToolChange('eraser')
+              }}
+              className={`flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${
+                eraserSize === s && tool === 'eraser'
+                  ? 'bg-indigo-100 dark:bg-indigo-950'
+                  : 'hover:bg-slate-100 dark:hover:bg-neutral-800'
+              }`}
+            >
+              <span
+                className="rounded-full border border-slate-400 bg-white dark:border-neutral-500 dark:bg-neutral-800"
+                style={{ width: s, height: s }}
+              />
+            </button>
+          ))}
+        </div>
+      </WhiteboardPopoverGroup>
+
+      <div className={`${isHorizontal ? 'h-8 w-px' : 'my-1 h-px w-8'} bg-slate-200 dark:bg-neutral-800`} />
+
+      <WhiteboardPopoverGroup
+        trigger={
+          <button
+            type="button"
+            title={`Stroke ${strokeWidth}px`}
+            className="flex h-9 w-9 items-center justify-center rounded-lg bg-indigo-100 transition-colors dark:bg-indigo-950"
+          >
+            <span
+              className="rounded-full bg-slate-700 dark:bg-neutral-300"
+              style={{ width: strokeWidth * 2, height: strokeWidth * 2 }}
+            />
+          </button>
+        }
+      >
+        <div className="flex flex-col gap-1">
+          {WHITEBOARD_STROKE_WIDTHS.map((w) => (
+            <button
+              key={w}
+              type="button"
+              title={`Stroke ${w}px`}
+              onClick={() => onStrokeWidthChange(w)}
+              className={`flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${
+                strokeWidth === w
+                  ? 'bg-indigo-100 dark:bg-indigo-950'
+                  : 'hover:bg-slate-100 dark:hover:bg-neutral-800'
+              }`}
+            >
+              <span
+                className="rounded-full bg-slate-700 dark:bg-neutral-300"
+                style={{ width: w * 2, height: w * 2 }}
+              />
+            </button>
+          ))}
+        </div>
+      </WhiteboardPopoverGroup>
+
+      <div className={`${isHorizontal ? 'h-8 w-px' : 'my-1 h-px w-8'} bg-slate-200 dark:bg-neutral-800`} />
+
+      <WhiteboardPopoverGroup
+        trigger={
+          <button
+            type="button"
+            title={color}
+            className="flex h-7 w-7 items-center justify-center rounded-full ring-2 ring-indigo-500 ring-offset-1 scale-110 transition-transform"
+            style={{ backgroundColor: color, border: color === '#ffffff' ? '1px solid #e2e8f0' : undefined }}
+          />
+        }
+      >
+        <div className="grid gap-2 p-1" style={{ gridTemplateColumns: 'repeat(3, 1.75rem)' }}>
+          {WHITEBOARD_COLORS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              title={c}
+              onClick={() => onColorChange(c)}
+              className={`h-7 w-7 rounded-full transition-transform ${
+                color === c ? 'ring-2 ring-indigo-500 ring-offset-1 scale-110' : 'hover:scale-110'
+              }`}
+              style={{ backgroundColor: c, border: c === '#ffffff' ? '1px solid #e2e8f0' : undefined }}
+            />
+          ))}
+        </div>
+      </WhiteboardPopoverGroup>
+
+      <div className={`${isHorizontal ? 'h-8 w-px' : 'my-1 h-px w-8'} bg-slate-200 dark:bg-neutral-800`} />
+
+      <button
+        type="button"
+        title="Clear canvas"
+        onClick={onClear}
+        className="flex h-9 w-9 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 hover:text-rose-500 dark:text-neutral-400 dark:hover:bg-neutral-800"
+      >
+        <Trash2 className="h-5 w-5" />
+      </button>
+
+      {onExportPng ? (
+        <button
+          type="button"
+          title="Export PNG"
+          onClick={onExportPng}
+          className="flex h-9 w-9 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-neutral-400 dark:hover:bg-neutral-800"
+        >
+          <Download className="h-5 w-5" />
+        </button>
+      ) : null}
+
+      {onLoad ? (
+        <button
+          type="button"
+          title="Load whiteboard"
+          onClick={onLoad}
+          className="flex h-9 w-9 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-neutral-400 dark:hover:bg-neutral-800"
+        >
+          <FolderOpen className="h-5 w-5" />
+        </button>
+      ) : null}
+
+      {onSave ? (
+        <button
+          type="button"
+          title="Save whiteboard"
+          disabled={saving}
+          onClick={onSave}
+          className="flex h-9 w-9 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 hover:text-indigo-600 disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-800"
+        >
+          <Save className="h-5 w-5" />
+        </button>
+      ) : null}
+    </>
+  )
+
+  if (isHorizontal) {
+    return (
+      <div className="flex flex-wrap items-center gap-1 border-b border-slate-200 bg-white px-2 py-1.5 dark:border-neutral-800 dark:bg-neutral-950">
+        {toolButtons}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex w-14 flex-col items-center gap-1 border-r border-slate-200 bg-white py-3 dark:border-neutral-800 dark:bg-neutral-950">
+      {toolButtons}
+    </div>
+  )
+}

--- a/clients/web/src/context/inbox-notifications-provider.tsx
+++ b/clients/web/src/context/inbox-notifications-provider.tsx
@@ -2,10 +2,10 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { authorizedFetch, apiUrl } from '../lib/api'
 import { getAccessToken } from '../lib/auth'
 import {
-  loadCanvasImportToastedIds,
-  pickCanvasImportNotificationsToToast,
-  rememberCanvasImportToastedIds,
-} from '../lib/canvas-import-toast'
+  loadNotificationToastedIds,
+  pickNotificationsToToast,
+  rememberNotificationToastedIds,
+} from '../lib/notification-toast'
 import { toast } from '../lib/lms-toast'
 import { InboxNotificationsContext, type InboxNotification } from './inbox-notifications-context'
 
@@ -15,7 +15,7 @@ export function InboxNotificationsProvider({ children }: { children: ReactNode }
   const [loading, setLoading] = useState(false)
   const sseRef = useRef<EventSource | null>(null)
   const inboxHydratedRef = useRef(false)
-  const toastedIdsRef = useRef<Set<string>>(loadCanvasImportToastedIds())
+  const toastedIdsRef = useRef<Set<string>>(loadNotificationToastedIds())
 
   const refresh = useCallback(async () => {
     setLoading(true)
@@ -25,19 +25,23 @@ export function InboxNotificationsProvider({ children }: { children: ReactNode }
       const data = (await res.json()) as { notifications: InboxNotification[]; unreadCount: number }
       const incoming = data.notifications ?? []
       setNotifications((prev) => {
-        const toToast = pickCanvasImportNotificationsToToast(
+        const toToast = pickNotificationsToToast(
           prev,
           incoming,
           toastedIdsRef.current,
           inboxHydratedRef.current,
         )
         if (toToast.length > 0) {
-          rememberCanvasImportToastedIds(
+          rememberNotificationToastedIds(
             toastedIdsRef.current,
             toToast.map((n) => n.id),
           )
           for (const n of toToast) {
-            toast.success(n.title, { description: n.body })
+            if (n.eventType === 'inbox_message') {
+              toast.info(n.title, { description: n.body })
+            } else {
+              toast.success(n.title, { description: n.body })
+            }
           }
         }
         return incoming

--- a/clients/web/src/lib/__tests__/notebook-task-markdown.test.ts
+++ b/clients/web/src/lib/__tests__/notebook-task-markdown.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { markTaskCheckedInMarkdown, parseNotebookTasksFromMarkdown } from '../notebook-task-markdown'
+
+describe('parseNotebookTasksFromMarkdown', () => {
+  it('parses task blocks from markdown', () => {
+    const md = [
+      '```task',
+      '{"id":"abc-123","checked":false,"dueAt":null}',
+      'Walk in the garden',
+      '```',
+    ].join('\n')
+    expect(parseNotebookTasksFromMarkdown(md)).toEqual([
+      { id: 'abc-123', text: 'Walk in the garden', checked: false, dueAt: null },
+    ])
+  })
+})
+
+describe('markTaskCheckedInMarkdown', () => {
+  it('marks the matching task block checked', () => {
+    const md = [
+      'Intro',
+      '',
+      '```task',
+      '{"id":"abc-123","checked":false,"dueAt":null}',
+      'Finish reading',
+      '```',
+    ].join('\n')
+    const next = markTaskCheckedInMarkdown(md, 'abc-123')
+    expect(next).toContain('"checked":true')
+    expect(next).toContain('Finish reading')
+  })
+
+  it('leaves other task blocks unchanged', () => {
+    const md = [
+      '```task',
+      '{"id":"one","checked":false,"dueAt":null}',
+      'A',
+      '```',
+      '',
+      '```task',
+      '{"id":"two","checked":false,"dueAt":null}',
+      'B',
+      '```',
+    ].join('\n')
+    const next = markTaskCheckedInMarkdown(md, 'one')
+    expect(next).toContain('"id":"one","checked":true')
+    expect(next).toContain('"id":"two","checked":false')
+  })
+})

--- a/clients/web/src/lib/canvas-import-toast.ts
+++ b/clients/web/src/lib/canvas-import-toast.ts
@@ -1,4 +1,10 @@
 import type { InboxNotification } from '../context/inbox-notifications-context'
+import {
+  loadNotificationToastedIds,
+  NOTIFICATION_TOASTED_IDS_KEY,
+  pickNotificationsToToast,
+  rememberNotificationToastedIds,
+} from './notification-toast'
 
 /** Returns canvas import notifications that were not in the previous inbox snapshot. */
 export function newCanvasImportNotifications(
@@ -9,30 +15,11 @@ export function newCanvasImportNotifications(
   return incoming.filter((n) => !prevIds.has(n.id) && n.eventType === 'canvas_course_imported')
 }
 
-/** sessionStorage key for notification ids that already triggered a completion toast. */
-export const CANVAS_IMPORT_TOASTED_IDS_KEY = 'lextures:canvas-import-toasted-ids'
+/** @deprecated Use NOTIFICATION_TOASTED_IDS_KEY */
+export const CANVAS_IMPORT_TOASTED_IDS_KEY = NOTIFICATION_TOASTED_IDS_KEY
 
-export function loadCanvasImportToastedIds(): Set<string> {
-  try {
-    const raw = sessionStorage.getItem(CANVAS_IMPORT_TOASTED_IDS_KEY)
-    if (!raw) return new Set()
-    const parsed = JSON.parse(raw) as unknown
-    if (!Array.isArray(parsed)) return new Set()
-    return new Set(parsed.filter((id): id is string => typeof id === 'string'))
-  } catch {
-    return new Set()
-  }
-}
-
-export function rememberCanvasImportToastedIds(existing: Set<string>, ids: string[]): void {
-  for (const id of ids) existing.add(id)
-  const trimmed = [...existing].slice(-100)
-  try {
-    sessionStorage.setItem(CANVAS_IMPORT_TOASTED_IDS_KEY, JSON.stringify(trimmed))
-  } catch {
-    /* quota / private mode */
-  }
-}
+export const loadCanvasImportToastedIds = loadNotificationToastedIds
+export const rememberCanvasImportToastedIds = rememberNotificationToastedIds
 
 export function pickCanvasImportNotificationsToToast(
   prev: readonly InboxNotification[],
@@ -40,6 +27,7 @@ export function pickCanvasImportNotificationsToToast(
   alreadyToasted: ReadonlySet<string>,
   inboxHydrated: boolean,
 ): InboxNotification[] {
-  if (!inboxHydrated) return []
-  return newCanvasImportNotifications(prev, incoming).filter((n) => !alreadyToasted.has(n.id))
+  return pickNotificationsToToast(prev, incoming, alreadyToasted, inboxHydrated).filter(
+    (n) => n.eventType === 'canvas_course_imported',
+  )
 }

--- a/clients/web/src/lib/courses-api.ts
+++ b/clients/web/src/lib/courses-api.ts
@@ -1268,6 +1268,25 @@ export function courseEnrollmentsUpdatePermission(courseCode: string): string {
   return `course:${courseCode}:enrollments:update`
 }
 
+export async function sendEnrollmentMessage(
+  courseCode: string,
+  enrollmentId: string,
+  body: { subject: string; body: string },
+): Promise<string> {
+  const res = await authorizedFetch(
+    `/api/v1/courses/${encodeURIComponent(courseCode)}/enrollments/${encodeURIComponent(enrollmentId)}/message`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  )
+  const raw: unknown = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  const data = raw as { id?: string }
+  return data.id ?? ''
+}
+
 export type EnrollmentGroupMembership = {
   groupSetId: string
   groupId: string

--- a/clients/web/src/lib/notebook-task-context.ts
+++ b/clients/web/src/lib/notebook-task-context.ts
@@ -1,0 +1,11 @@
+import type { NotebookTaskContext } from '../components/editor/extensions/notebook-task-tip-tap'
+
+let activeContext: NotebookTaskContext | null = null
+
+export function setNotebookTaskContext(ctx: NotebookTaskContext | null): void {
+  activeContext = ctx
+}
+
+export function getNotebookTaskContext(): NotebookTaskContext | null {
+  return activeContext
+}

--- a/clients/web/src/lib/notebook-task-markdown.ts
+++ b/clients/web/src/lib/notebook-task-markdown.ts
@@ -1,0 +1,60 @@
+export type NotebookTaskMeta = {
+  id: string
+  checked: boolean
+  dueAt: string | null
+}
+
+const TASK_BLOCK_RE = /```task\s*\n([\s\S]*?)```/g
+
+function parseMetaLine(line: string): NotebookTaskMeta | null {
+  try {
+    const raw = JSON.parse(line) as Record<string, unknown>
+    const id = typeof raw.id === 'string' ? raw.id : ''
+    if (!id) return null
+    return {
+      id,
+      checked: raw.checked === true,
+      dueAt: typeof raw.dueAt === 'string' ? raw.dueAt : null,
+    }
+  } catch {
+    return null
+  }
+}
+
+export type ParsedNotebookTask = {
+  id: string
+  text: string
+  checked: boolean
+  dueAt: string | null
+}
+
+/** Extract task blocks from notebook markdown. */
+export function parseNotebookTasksFromMarkdown(contentMd: string): ParsedNotebookTask[] {
+  const out: ParsedNotebookTask[] = []
+  for (const match of contentMd.matchAll(TASK_BLOCK_RE)) {
+    const inner = match[1] ?? ''
+    const lines = inner.split('\n')
+    const meta = parseMetaLine(lines[0] ?? '')
+    if (!meta) continue
+    out.push({
+      id: meta.id,
+      text: lines.slice(1).join('\n').trim(),
+      checked: meta.checked,
+      dueAt: meta.dueAt,
+    })
+  }
+  return out
+}
+
+/** Mark a task block as checked in notebook markdown by task id. */
+export function markTaskCheckedInMarkdown(contentMd: string, taskId: string): string {
+  return contentMd.replace(TASK_BLOCK_RE, (block, inner: string) => {
+    const lines = inner.split('\n')
+    const metaLine = lines[0] ?? ''
+    const meta = parseMetaLine(metaLine)
+    if (!meta || meta.id !== taskId) return block
+    const nextMeta = JSON.stringify({ ...meta, checked: true })
+    const body = lines.slice(1).join('\n')
+    return `\`\`\`task\n${nextMeta}\n${body}\n\`\`\``
+  })
+}

--- a/clients/web/src/lib/notebook-task-sync.ts
+++ b/clients/web/src/lib/notebook-task-sync.ts
@@ -1,0 +1,32 @@
+import { parseNotebookTasksFromMarkdown } from './notebook-task-markdown'
+import { upsertNotebookTask } from './notebook-tasks-api'
+
+export const NOTEBOOK_TASKS_CHANGED = 'lextures-notebook-tasks-changed'
+
+export function emitNotebookTasksChanged(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new Event(NOTEBOOK_TASKS_CHANGED))
+}
+
+/** Upsert every task block in page markdown to the server. */
+export async function syncNotebookTasksFromMarkdown(
+  courseCode: string,
+  pageId: string,
+  markdown: string,
+): Promise<void> {
+  const tasks = parseNotebookTasksFromMarkdown(markdown)
+  if (tasks.length === 0) return
+  await Promise.all(
+    tasks.map((task) =>
+      upsertNotebookTask({
+        id: task.id,
+        courseCode,
+        notebookPageId: pageId,
+        taskText: task.text,
+        completed: task.checked,
+        dueAt: task.dueAt,
+      }),
+    ),
+  )
+  emitNotebookTasksChanged()
+}

--- a/clients/web/src/lib/notebook-tasks-api.ts
+++ b/clients/web/src/lib/notebook-tasks-api.ts
@@ -1,0 +1,60 @@
+import { authorizedFetch } from './api'
+import { readApiErrorMessage } from './errors'
+
+export type NotebookTask = {
+  id: string
+  courseCode: string
+  notebookPageId: string
+  taskText: string
+  completed: boolean
+  dueAt?: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+async function parseError(res: Response, fallback: string): Promise<never> {
+  const raw: unknown = await res.json().catch(() => null)
+  throw new Error(readApiErrorMessage(raw) || fallback)
+}
+
+export async function fetchNotebookTasks(): Promise<NotebookTask[]> {
+  const res = await authorizedFetch('/api/v1/me/notebook-tasks')
+  if (!res.ok) await parseError(res, 'Could not load notebook tasks.')
+  const data = (await res.json()) as { tasks?: NotebookTask[] }
+  return data.tasks ?? []
+}
+
+export async function upsertNotebookTask(body: {
+  id: string
+  courseCode: string
+  notebookPageId: string
+  taskText: string
+  completed?: boolean
+  dueAt?: string | null
+}): Promise<NotebookTask> {
+  const res = await authorizedFetch('/api/v1/me/notebook-tasks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) await parseError(res, 'Could not save notebook task.')
+  return res.json() as Promise<NotebookTask>
+}
+
+export async function patchNotebookTask(
+  id: string,
+  body: {
+    taskText?: string
+    completed?: boolean
+    dueAt?: string | null
+    clearDue?: boolean
+  },
+): Promise<NotebookTask> {
+  const res = await authorizedFetch(`/api/v1/me/notebook-tasks/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) await parseError(res, 'Could not update notebook task.')
+  return res.json() as Promise<NotebookTask>
+}

--- a/clients/web/src/lib/notification-toast.ts
+++ b/clients/web/src/lib/notification-toast.ts
@@ -1,0 +1,44 @@
+import type { InboxNotification } from '../context/inbox-notifications-context'
+
+const TOAST_EVENT_TYPES = new Set(['canvas_course_imported', 'inbox_message'])
+
+/** sessionStorage key for notification ids that already triggered a toast. */
+export const NOTIFICATION_TOASTED_IDS_KEY = 'lextures:notification-toasted-ids'
+
+export function loadNotificationToastedIds(): Set<string> {
+  try {
+    const raw = sessionStorage.getItem(NOTIFICATION_TOASTED_IDS_KEY)
+    if (!raw) return new Set()
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return new Set()
+    return new Set(parsed.filter((id): id is string => typeof id === 'string'))
+  } catch {
+    return new Set()
+  }
+}
+
+export function rememberNotificationToastedIds(existing: Set<string>, ids: string[]): void {
+  for (const id of ids) existing.add(id)
+  const trimmed = [...existing].slice(-100)
+  try {
+    sessionStorage.setItem(NOTIFICATION_TOASTED_IDS_KEY, JSON.stringify(trimmed))
+  } catch {
+    /* quota / private mode */
+  }
+}
+
+export function pickNotificationsToToast(
+  prev: readonly InboxNotification[],
+  incoming: readonly InboxNotification[],
+  alreadyToasted: ReadonlySet<string>,
+  inboxHydrated: boolean,
+): InboxNotification[] {
+  if (!inboxHydrated) return []
+  const prevIds = new Set(prev.map((n) => n.id))
+  return incoming.filter(
+    (n) =>
+      !prevIds.has(n.id) &&
+      TOAST_EVENT_TYPES.has(n.eventType) &&
+      !alreadyToasted.has(n.id),
+  )
+}

--- a/clients/web/src/lib/student-notebook-storage.ts
+++ b/clients/web/src/lib/student-notebook-storage.ts
@@ -5,6 +5,7 @@ import {
   type CourseNotebookPage,
   type NotebookPageKind,
 } from './course-notebook-tree'
+import { markTaskCheckedInMarkdown } from './notebook-task-markdown'
 import { decodeJwtSub } from './jwt-payload'
 
 export type { CourseNotebookPage, NotebookPageKind } from './course-notebook-tree'
@@ -27,6 +28,31 @@ export function hrefForStudentNotebook(courseCode: string): string {
   return isGlobalStudentNotebookKey(courseCode)
     ? '/notebooks/global'
     : `/courses/${encodeURIComponent(courseCode)}/notebook`
+}
+
+export function hrefForNotebookPage(courseCode: string, pageId: string): string {
+  const base = hrefForStudentNotebook(courseCode)
+  return `${base}?page=${encodeURIComponent(pageId)}`
+}
+
+/** Activate a notebook page (e.g. from dashboard deep link). */
+export function setActiveNotebookPage(courseCode: string, pageId: string): boolean {
+  const data = loadCourseNotebook(courseCode)
+  if (!data.pages.some((p) => p.id === pageId)) return false
+  saveCourseNotebookStore(courseCode, { ...data, activePageId: pageId })
+  return true
+}
+
+/** Mark a notebook task checked in local markdown (dashboard completion). */
+export function markNotebookTaskComplete(courseCode: string, pageId: string, taskId: string): boolean {
+  const data = loadCourseNotebook(courseCode)
+  const page = data.pages.find((p) => p.id === pageId)
+  if (!page) return false
+  const nextMd = markTaskCheckedInMarkdown(page.contentMd, taskId)
+  if (nextMd === page.contentMd) return false
+  const pages = updatePageContent(data.pages, pageId, nextMd)
+  saveCourseNotebookStore(courseCode, { ...data, pages })
+  return true
 }
 
 /** Legacy v1 row (single body). */

--- a/clients/web/src/lib/whiteboard/canvas-core.ts
+++ b/clients/web/src/lib/whiteboard/canvas-core.ts
@@ -1,0 +1,381 @@
+import type { DrawEl, StrokeEl } from './types'
+
+const GRID_SPACING = 24
+
+export function drawGrid(ctx: CanvasRenderingContext2D, w: number, h: number, dark: boolean) {
+  ctx.save()
+  ctx.fillStyle = dark ? '#171717' : '#ffffff'
+  ctx.fillRect(0, 0, w, h)
+  ctx.fillStyle = dark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.18)'
+  for (let x = GRID_SPACING; x < w; x += GRID_SPACING) {
+    for (let y = GRID_SPACING; y < h; y += GRID_SPACING) {
+      ctx.beginPath()
+      ctx.arc(x, y, 1, 0, Math.PI * 2)
+      ctx.fill()
+    }
+  }
+  ctx.restore()
+}
+
+export function drawElement(ctx: CanvasRenderingContext2D, el: DrawEl) {
+  ctx.save()
+  ctx.strokeStyle = el.color
+  ctx.fillStyle = 'transparent'
+  ctx.lineWidth = el.width
+  ctx.lineCap = 'round'
+  ctx.lineJoin = 'round'
+
+  switch (el.type) {
+    case 'stroke': {
+      if (el.pts.length < 2) break
+      ctx.beginPath()
+      ctx.moveTo(el.pts[0][0], el.pts[0][1])
+      for (let i = 1; i < el.pts.length; i++) ctx.lineTo(el.pts[i][0], el.pts[i][1])
+      ctx.stroke()
+      break
+    }
+    case 'rect': {
+      ctx.beginPath()
+      ctx.strokeRect(el.x, el.y, el.w, el.h)
+      break
+    }
+    case 'circle': {
+      ctx.beginPath()
+      ctx.ellipse(el.cx, el.cy, Math.abs(el.rx), Math.abs(el.ry), 0, 0, Math.PI * 2)
+      ctx.stroke()
+      break
+    }
+    case 'triangle': {
+      ctx.beginPath()
+      ctx.moveTo(el.x1, el.y1)
+      ctx.lineTo(el.x2, el.y2)
+      ctx.lineTo(el.x3, el.y3)
+      ctx.closePath()
+      ctx.stroke()
+      break
+    }
+    case 'line': {
+      ctx.beginPath()
+      ctx.moveTo(el.x1, el.y1)
+      ctx.lineTo(el.x2, el.y2)
+      ctx.stroke()
+      break
+    }
+  }
+  ctx.restore()
+}
+
+function distToSegment(px: number, py: number, ax: number, ay: number, bx: number, by: number): number {
+  const dx = bx - ax
+  const dy = by - ay
+  if (dx === 0 && dy === 0) return Math.hypot(px - ax, py - ay)
+  const t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / (dx * dx + dy * dy)))
+  return Math.hypot(px - (ax + t * dx), py - (ay + t * dy))
+}
+
+function effectiveEraserRadius(radius: number, lineWidth: number): number {
+  return radius + lineWidth / 2
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t
+}
+
+function segmentCircleIntersections(
+  cx: number,
+  cy: number,
+  r: number,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+): number[] {
+  const dx = x2 - x1
+  const dy = y2 - y1
+  const fx = x1 - cx
+  const fy = y1 - cy
+  const a = dx * dx + dy * dy
+  if (a === 0) return Math.hypot(fx, fy) <= r ? [0] : []
+  const b = 2 * (fx * dx + fy * dy)
+  const c = fx * fx + fy * fy - r * r
+  const disc = b * b - 4 * a * c
+  if (disc < 0) return []
+  const sd = Math.sqrt(disc)
+  const t1 = (-b - sd) / (2 * a)
+  const t2 = (-b + sd) / (2 * a)
+  const out: number[] = []
+  if (t1 >= 0 && t1 <= 1) out.push(t1)
+  if (t2 >= 0 && t2 <= 1 && Math.abs(t2 - t1) > 1e-9) out.push(t2)
+  return out.sort((u, v) => u - v)
+}
+
+function hitTestStroke(stroke: StrokeEl, px: number, py: number, radius: number): boolean {
+  const r = effectiveEraserRadius(radius, stroke.width)
+  for (let i = 0; i < stroke.pts.length; i++) {
+    const [ex, ey] = stroke.pts[i]
+    if (Math.hypot(ex - px, ey - py) <= r) return true
+    if (i > 0) {
+      const [ax, ay] = stroke.pts[i - 1]
+      if (distToSegment(px, py, ax, ay, ex, ey) <= r) return true
+    }
+  }
+  return false
+}
+
+function elementToStrokes(el: DrawEl): StrokeEl[] {
+  const { color, width } = el
+  switch (el.type) {
+    case 'stroke':
+      return [el]
+    case 'line':
+      return [{ type: 'stroke', color, width, pts: [[el.x1, el.y1], [el.x2, el.y2]] }]
+    case 'rect': {
+      const x1 = el.x
+      const y1 = el.y
+      const x2 = el.x + el.w
+      const y2 = el.y + el.h
+      const edge = (a: [number, number], b: [number, number]): StrokeEl => ({
+        type: 'stroke',
+        color,
+        width,
+        pts: [a, b],
+      })
+      return [
+        edge([x1, y1], [x2, y1]),
+        edge([x2, y1], [x2, y2]),
+        edge([x2, y2], [x1, y2]),
+        edge([x1, y2], [x1, y1]),
+      ]
+    }
+    case 'triangle': {
+      const edge = (a: [number, number], b: [number, number]): StrokeEl => ({
+        type: 'stroke',
+        color,
+        width,
+        pts: [a, b],
+      })
+      return [
+        edge([el.x1, el.y1], [el.x2, el.y2]),
+        edge([el.x2, el.y2], [el.x3, el.y3]),
+        edge([el.x3, el.y3], [el.x1, el.y1]),
+      ]
+    }
+    case 'circle': {
+      const segments = 36
+      const strokes: StrokeEl[] = []
+      let prev: [number, number] | null = null
+      for (let i = 0; i <= segments; i++) {
+        const angle = (2 * Math.PI * i) / segments
+        const pt: [number, number] = [el.cx + el.rx * Math.cos(angle), el.cy + el.ry * Math.sin(angle)]
+        if (prev) strokes.push({ type: 'stroke', color, width, pts: [prev, pt] })
+        prev = pt
+      }
+      return strokes
+    }
+  }
+}
+
+function hitTest(el: DrawEl, px: number, py: number, radius: number): boolean {
+  switch (el.type) {
+    case 'stroke':
+      return hitTestStroke(el, px, py, radius)
+    case 'line':
+      return distToSegment(px, py, el.x1, el.y1, el.x2, el.y2) <= effectiveEraserRadius(radius, el.width)
+    case 'rect': {
+      const x1 = Math.min(el.x, el.x + el.w)
+      const x2 = Math.max(el.x, el.x + el.w)
+      const y1 = Math.min(el.y, el.y + el.h)
+      const y2 = Math.max(el.y, el.y + el.h)
+      const r = effectiveEraserRadius(radius, el.width)
+      return (
+        distToSegment(px, py, x1, y1, x2, y1) <= r ||
+        distToSegment(px, py, x2, y1, x2, y2) <= r ||
+        distToSegment(px, py, x2, y2, x1, y2) <= r ||
+        distToSegment(px, py, x1, y2, x1, y1) <= r
+      )
+    }
+    case 'circle': {
+      const rx = Math.abs(el.rx) || 1
+      const ry = Math.abs(el.ry) || 1
+      const norm = Math.hypot((px - el.cx) / rx, (py - el.cy) / ry)
+      return Math.abs(norm - 1) * Math.min(rx, ry) <= effectiveEraserRadius(radius, el.width)
+    }
+    case 'triangle': {
+      const r = effectiveEraserRadius(radius, el.width)
+      return (
+        distToSegment(px, py, el.x1, el.y1, el.x2, el.y2) <= r ||
+        distToSegment(px, py, el.x2, el.y2, el.x3, el.y3) <= r ||
+        distToSegment(px, py, el.x3, el.y3, el.x1, el.y1) <= r
+      )
+    }
+  }
+}
+
+function pushUniquePoint(cur: [number, number][], x: number, y: number) {
+  const n = cur.length
+  if (n === 0 || cur[n - 1][0] !== x || cur[n - 1][1] !== y) cur.push([x, y])
+}
+
+function splitStroke(stroke: StrokeEl, px: number, py: number, radius: number): StrokeEl[] {
+  const pts = stroke.pts
+  if (pts.length < 2) return pts.length === 1 && hitTestStroke(stroke, px, py, radius) ? [] : [stroke]
+
+  const r = effectiveEraserRadius(radius, stroke.width)
+  const inside = (x: number, y: number) => Math.hypot(x - px, y - py) <= r
+  const result: StrokeEl[] = []
+  let cur: [number, number][] = []
+
+  const flush = () => {
+    if (cur.length >= 2) result.push({ ...stroke, pts: cur })
+    cur = []
+  }
+
+  const first = pts[0]
+  if (!inside(first[0], first[1])) cur.push(first)
+
+  for (let i = 1; i < pts.length; i++) {
+    const [x0, y0] = pts[i - 1]
+    const [x1, y1] = pts[i]
+    const aIn = inside(x0, y0)
+    const bIn = inside(x1, y1)
+
+    if (aIn && bIn) {
+      flush()
+      continue
+    }
+
+    const hits = segmentCircleIntersections(px, py, r, x0, y0, x1, y1)
+
+    if (!aIn && !bIn) {
+      if (hits.length >= 2) {
+        pushUniquePoint(cur, lerp(x0, x1, hits[0]), lerp(y0, y1, hits[0]))
+        flush()
+        pushUniquePoint(cur, lerp(x0, x1, hits[1]), lerp(y0, y1, hits[1]))
+      } else {
+        pushUniquePoint(cur, x1, y1)
+      }
+      continue
+    }
+
+    const t = hits[0] ?? (aIn ? 0 : 1)
+    const bx = lerp(x0, x1, t)
+    const by = lerp(y0, y1, t)
+
+    if (!aIn && bIn) {
+      pushUniquePoint(cur, bx, by)
+      flush()
+    } else {
+      flush()
+      pushUniquePoint(cur, bx, by)
+      pushUniquePoint(cur, x1, y1)
+    }
+  }
+
+  flush()
+  return result
+}
+
+export function eraseFromElements(elements: DrawEl[], px: number, py: number, radius: number): DrawEl[] {
+  const out: DrawEl[] = []
+  for (const el of elements) {
+    for (const stroke of elementToStrokes(el)) {
+      out.push(...splitStroke(stroke, px, py, radius))
+    }
+  }
+  return out
+}
+
+export function translateElement(el: DrawEl, dx: number, dy: number): DrawEl {
+  switch (el.type) {
+    case 'stroke':
+      return { ...el, pts: el.pts.map(([x, y]) => [x + dx, y + dy] as [number, number]) }
+    case 'rect':
+      return { ...el, x: el.x + dx, y: el.y + dy }
+    case 'circle':
+      return { ...el, cx: el.cx + dx, cy: el.cy + dy }
+    case 'line':
+      return { ...el, x1: el.x1 + dx, y1: el.y1 + dy, x2: el.x2 + dx, y2: el.y2 + dy }
+    case 'triangle':
+      return {
+        ...el,
+        x1: el.x1 + dx,
+        y1: el.y1 + dy,
+        x2: el.x2 + dx,
+        y2: el.y2 + dy,
+        x3: el.x3 + dx,
+        y3: el.y3 + dy,
+      }
+  }
+}
+
+export function pickElement(elements: DrawEl[], px: number, py: number): number {
+  for (let i = elements.length - 1; i >= 0; i--) {
+    if (hitTest(elements[i], px, py, 8)) return i
+  }
+  return -1
+}
+
+function getBoundingBox(el: DrawEl): { x: number; y: number; w: number; h: number } | null {
+  switch (el.type) {
+    case 'stroke': {
+      if (!el.pts.length) return null
+      let [minX, minY, maxX, maxY] = [Infinity, Infinity, -Infinity, -Infinity]
+      for (const [x, y] of el.pts) {
+        minX = Math.min(minX, x)
+        minY = Math.min(minY, y)
+        maxX = Math.max(maxX, x)
+        maxY = Math.max(maxY, y)
+      }
+      return { x: minX, y: minY, w: maxX - minX, h: maxY - minY }
+    }
+    case 'rect': {
+      const x = Math.min(el.x, el.x + el.w)
+      const y = Math.min(el.y, el.y + el.h)
+      return { x, y, w: Math.abs(el.w), h: Math.abs(el.h) }
+    }
+    case 'circle':
+      return {
+        x: el.cx - Math.abs(el.rx),
+        y: el.cy - Math.abs(el.ry),
+        w: 2 * Math.abs(el.rx),
+        h: 2 * Math.abs(el.ry),
+      }
+    case 'line': {
+      const x = Math.min(el.x1, el.x2)
+      const y = Math.min(el.y1, el.y2)
+      return { x, y, w: Math.abs(el.x2 - el.x1), h: Math.abs(el.y2 - el.y1) }
+    }
+    case 'triangle': {
+      const xs = [el.x1, el.x2, el.x3]
+      const ys = [el.y1, el.y2, el.y3]
+      const x = Math.min(...xs)
+      const y = Math.min(...ys)
+      return { x, y, w: Math.max(...xs) - x, h: Math.max(...ys) - y }
+    }
+  }
+}
+
+export function redrawWhiteboard(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  elements: DrawEl[],
+  draft: DrawEl | null,
+  dark: boolean,
+  selectedIdx?: number | null,
+) {
+  drawGrid(ctx, w, h, dark)
+  for (const el of elements) drawElement(ctx, el)
+  if (draft) drawElement(ctx, draft)
+  if (selectedIdx != null && selectedIdx >= 0 && elements[selectedIdx]) {
+    const bb = getBoundingBox(elements[selectedIdx])
+    if (bb) {
+      ctx.save()
+      ctx.strokeStyle = '#6366f1'
+      ctx.lineWidth = 1.5
+      ctx.setLineDash([4, 3])
+      ctx.strokeRect(bb.x - 6, bb.y - 6, bb.w + 12, bb.h + 12)
+      ctx.restore()
+    }
+  }
+}

--- a/clients/web/src/lib/whiteboard/serialize.ts
+++ b/clients/web/src/lib/whiteboard/serialize.ts
@@ -1,0 +1,34 @@
+import type { DrawEl } from './types'
+
+export function parseWhiteboardElements(raw: unknown): DrawEl[] {
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim()
+    if (!trimmed) return []
+    try {
+      return parseWhiteboardElements(JSON.parse(trimmed))
+    } catch {
+      return []
+    }
+  }
+  if (!Array.isArray(raw)) return []
+  return raw.filter(isDrawEl)
+}
+
+function isDrawEl(value: unknown): value is DrawEl {
+  if (!value || typeof value !== 'object') return false
+  const el = value as { type?: string }
+  switch (el.type) {
+    case 'stroke':
+    case 'rect':
+    case 'circle':
+    case 'triangle':
+    case 'line':
+      return true
+    default:
+      return false
+  }
+}
+
+export function serializeWhiteboardElements(elements: DrawEl[]): string {
+  return JSON.stringify(elements)
+}

--- a/clients/web/src/lib/whiteboard/types.ts
+++ b/clients/web/src/lib/whiteboard/types.ts
@@ -1,0 +1,67 @@
+export type StrokeEl = {
+  type: 'stroke'
+  color: string
+  width: number
+  pts: [number, number][]
+}
+
+export type RectEl = {
+  type: 'rect'
+  color: string
+  width: number
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export type CircleEl = {
+  type: 'circle'
+  color: string
+  width: number
+  cx: number
+  cy: number
+  rx: number
+  ry: number
+}
+
+export type TriangleEl = {
+  type: 'triangle'
+  color: string
+  width: number
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+  x3: number
+  y3: number
+}
+
+export type LineEl = {
+  type: 'line'
+  color: string
+  width: number
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+}
+
+export type DrawEl = StrokeEl | RectEl | CircleEl | TriangleEl | LineEl
+
+export type WhiteboardTool = 'select' | 'pen' | 'line' | 'rect' | 'circle' | 'triangle' | 'eraser'
+
+export const WHITEBOARD_COLORS = [
+  '#1e293b',
+  '#ef4444',
+  '#f97316',
+  '#eab308',
+  '#22c55e',
+  '#3b82f6',
+  '#a855f7',
+  '#ec4899',
+  '#ffffff',
+] as const
+
+export const WHITEBOARD_STROKE_WIDTHS = [2, 4, 8] as const
+export const WHITEBOARD_ERASER_SIZES = [8, 16, 32] as const

--- a/clients/web/src/pages/lms/course-enrollments.tsx
+++ b/clients/web/src/pages/lms/course-enrollments.tsx
@@ -9,13 +9,15 @@ import {
 } from 'react'
 import { Link, Navigate, useParams } from 'react-router-dom'
 import { studentProgressFeatureEnabled } from '../../lib/student-progress'
-import { ClipboardList, Pencil, Shuffle, Trash2, UsersRound, X } from 'lucide-react'
+import { BarChart3, ClipboardList, Mail, Pencil, Send, Shuffle, Trash2, UsersRound, X } from 'lucide-react'
 import { EnrollmentRoleBadge } from './enrollment-role-badge'
 import { EnrollmentGroupsPanel } from './enrollment-groups-panel'
 import { EnrollmentsActionsMenu } from './enrollments-actions-menu'
+import { IconActionTooltip } from '../../components/ui/icon-action-tooltip'
 import { LmsPage } from './lms-page'
 import { usePermission, usePermissions } from '../../context/use-permissions'
 import { authorizedFetch } from '../../lib/api'
+import { getJwtSubject } from '../../lib/auth'
 import {
   courseEnrollmentsReadPermission,
   courseEnrollmentsUpdatePermission,
@@ -28,6 +30,7 @@ import {
   patchEnrollmentSection,
   postEnrollmentGroupsEnable,
   putEnrollmentGroupMembership,
+  sendEnrollmentMessage,
   viewerShouldHideCourseEnrollmentsNav,
   type CourseScopedAppRole,
   type CourseSection,
@@ -37,6 +40,7 @@ import {
 import { notifyCourseViewerEnrollmentChanged, useCourseViewAs } from '../../lib/course-view-as'
 import { readApiErrorMessage } from '../../lib/errors'
 import { formatTimeAgoFromIso } from '../../lib/format-time-ago'
+import { toast } from '../../lib/lms-toast'
 
 export type CourseEnrollment = {
   id: string
@@ -100,7 +104,9 @@ export default function CourseEnrollments() {
   const canViewGradebook = usePermission(
     courseCode ? courseGradebookViewPermission(courseCode) : 'global:app:noop:noop',
   )
-  const showActionsColumn = canUpdateEnrollments || canViewGradebook
+  const canMessageEnrollments = canUpdateEnrollments || canViewGradebook
+  const viewerUserId = useMemo(() => getJwtSubject(), [])
+  const showActionsColumn = canUpdateEnrollments || canViewGradebook || canMessageEnrollments
   const [enrollments, setEnrollments] = useState<CourseEnrollment[] | null>(null)
   /** enrollment id → has active accommodations (non-PII indicator for instructors). */
   const [accommodationActiveByEnrollment, setAccommodationActiveByEnrollment] = useState<
@@ -149,6 +155,12 @@ export default function CourseEnrollments() {
   const [sectionTransferPick, setSectionTransferPick] = useState('')
   const [sectionTransferStatus, setSectionTransferStatus] = useState<'idle' | 'loading' | 'error'>('idle')
   const [sectionTransferMessage, setSectionTransferMessage] = useState<string | null>(null)
+
+  const [messageTarget, setMessageTarget] = useState<CourseEnrollment | null>(null)
+  const [messageSubject, setMessageSubject] = useState('')
+  const [messageBody, setMessageBody] = useState('')
+  const [messageStatus, setMessageStatus] = useState<'idle' | 'loading' | 'error'>('idle')
+  const [messageError, setMessageError] = useState<string | null>(null)
 
   const viewerIsTeacher = useMemo(
     () => viewerRoles.some((r) => normEnrollmentRole(r) === 'teacher'),
@@ -443,6 +455,22 @@ export default function CourseEnrollments() {
     setGroupAssignMessage(null)
   }, [])
 
+  const closeMessageModal = useCallback(() => {
+    setMessageTarget(null)
+    setMessageSubject('')
+    setMessageBody('')
+    setMessageStatus('idle')
+    setMessageError(null)
+  }, [])
+
+  const openMessageModal = useCallback((enrollment: CourseEnrollment) => {
+    setMessageTarget(enrollment)
+    setMessageSubject('')
+    setMessageBody('')
+    setMessageStatus('idle')
+    setMessageError(null)
+  }, [])
+
   const closeSectionTransferModal = useCallback(() => {
     setSectionTransferTarget(null)
     setSectionTransferPick('')
@@ -483,6 +511,31 @@ export default function CourseEnrollments() {
     }
   }
 
+  async function onSubmitEnrollmentMessage(ev: FormEvent) {
+    ev.preventDefault()
+    if (!courseCode || !messageTarget) return
+    const body = messageBody.trim()
+    if (!body) {
+      setMessageError('Enter a message.')
+      setMessageStatus('error')
+      return
+    }
+    setMessageStatus('loading')
+    setMessageError(null)
+    try {
+      await sendEnrollmentMessage(courseCode, messageTarget.id, {
+        subject: messageSubject.trim(),
+        body,
+      })
+      const name = messageTarget.displayName?.trim() || 'this person'
+      toast.success('Message sent', { description: `Delivered to ${name}'s inbox.` })
+      closeMessageModal()
+    } catch (err) {
+      setMessageStatus('error')
+      setMessageError(err instanceof Error ? err.message : 'Could not send message.')
+    }
+  }
+
   useEffect(() => {
     if (!modalOpen || !courseCode || !viewerIsTeacher) {
       return
@@ -519,7 +572,9 @@ export default function CourseEnrollments() {
   }, [modalOpen, courseCode, viewerIsTeacher])
 
   useEffect(() => {
-    if (!modalOpen && !editTarget && !groupAssignTarget && !sectionTransferTarget) return
+    if (!modalOpen && !editTarget && !groupAssignTarget && !sectionTransferTarget && !messageTarget) {
+      return
+    }
     function onKey(e: KeyboardEvent) {
       if (e.key !== 'Escape') return
       e.preventDefault()
@@ -527,6 +582,7 @@ export default function CourseEnrollments() {
       else if (editTarget) closeEditModal()
       else if (groupAssignTarget) closeGroupAssignModal()
       else if (sectionTransferTarget) closeSectionTransferModal()
+      else if (messageTarget) closeMessageModal()
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
@@ -535,10 +591,12 @@ export default function CourseEnrollments() {
     editTarget,
     groupAssignTarget,
     sectionTransferTarget,
+    messageTarget,
     closeModal,
     closeEditModal,
     closeGroupAssignModal,
     closeSectionTransferModal,
+    closeMessageModal,
   ])
 
   async function onSubmitAddEnrollments(e: FormEvent) {
@@ -886,6 +944,11 @@ export default function CourseEnrollments() {
                 const showSectionTransfer =
                   sectionsEnabled && canUpdateEnrollments && er === 'student' && sections.length > 1
                 const showGradebook = courseCode != null && er === 'student' && canViewGradebook
+                const showReport = courseCode != null && er === 'student' && canViewGradebook
+                const showMessage =
+                  canMessageEnrollments &&
+                  viewerUserId != null &&
+                  e.userId !== viewerUserId
                 return (
                   <tr
                     key={e.id}
@@ -932,63 +995,102 @@ export default function CourseEnrollments() {
                     </td>
                     {showActionsColumn && (
                       <td className="px-2 py-3 text-end align-middle">
-                        {showEdit || showRemove || showGroupAssign || showSectionTransfer || showGradebook ? (
+                        {showEdit ||
+                        showRemove ||
+                        showGroupAssign ||
+                        showSectionTransfer ||
+                        showGradebook ||
+                        showReport ||
+                        showMessage ? (
                           <div className="inline-flex items-center justify-end gap-0.5">
                             {showSectionTransfer ? (
-                              <button
-                                type="button"
-                                onClick={() => openSectionTransferModal(e)}
-                                className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
-                                aria-label={`Change section for ${e.displayName?.trim() || 'this student'}`}
-                              >
-                                <Shuffle className="h-4 w-4" aria-hidden />
-                              </button>
+                              <IconActionTooltip label="Change section">
+                                <button
+                                  type="button"
+                                  onClick={() => openSectionTransferModal(e)}
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
+                                  aria-label={`Change section for ${e.displayName?.trim() || 'this student'}`}
+                                >
+                                  <Shuffle className="h-4 w-4" aria-hidden />
+                                </button>
+                              </IconActionTooltip>
                             ) : null}
                             {showGroupAssign ? (
-                              <button
-                                type="button"
-                                onClick={() => openGroupAssignModal(e)}
-                                className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
-                                aria-label={`Assign groups for ${e.displayName?.trim() || 'this person'}`}
-                              >
-                                <UsersRound className="h-4 w-4" aria-hidden />
-                              </button>
+                              <IconActionTooltip label="Assign groups">
+                                <button
+                                  type="button"
+                                  onClick={() => openGroupAssignModal(e)}
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
+                                  aria-label={`Assign groups for ${e.displayName?.trim() || 'this person'}`}
+                                >
+                                  <UsersRound className="h-4 w-4" aria-hidden />
+                                </button>
+                              </IconActionTooltip>
                             ) : null}
                             {showEdit ? (
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  setEditTarget(e)
-                                  setEditBuiltinCourseRole(normEnrollmentRole(e.role))
-                                  setEditSaveStatus('idle')
-                                  setEditMessage(null)
-                                  setDemoteStatus('idle')
-                                }}
-                                className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100"
-                                aria-label={`Edit role for ${e.displayName?.trim() || 'this person'}`}
-                              >
-                                <Pencil className="h-4 w-4" aria-hidden />
-                              </button>
+                              <IconActionTooltip label="Edit role">
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    setEditTarget(e)
+                                    setEditBuiltinCourseRole(normEnrollmentRole(e.role))
+                                    setEditSaveStatus('idle')
+                                    setEditMessage(null)
+                                    setDemoteStatus('idle')
+                                  }}
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100"
+                                  aria-label={`Edit role for ${e.displayName?.trim() || 'this person'}`}
+                                >
+                                  <Pencil className="h-4 w-4" aria-hidden />
+                                </button>
+                              </IconActionTooltip>
+                            ) : null}
+                            {showMessage ? (
+                              <IconActionTooltip label="Send message">
+                                <button
+                                  type="button"
+                                  onClick={() => openMessageModal(e)}
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
+                                  aria-label={`Send message to ${e.displayName?.trim() || 'this person'}`}
+                                >
+                                  <Mail className="h-4 w-4" aria-hidden />
+                                </button>
+                              </IconActionTooltip>
                             ) : null}
                             {showGradebook ? (
-                              <Link
-                                to={`/courses/${encodeURIComponent(courseCode)}/gradebook?student=${encodeURIComponent(e.userId)}`}
-                                className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
-                                aria-label={`View gradebook for ${e.displayName?.trim() || 'this student'}`}
-                              >
-                                <ClipboardList className="h-4 w-4" aria-hidden />
-                              </Link>
+                              <IconActionTooltip label="Gradebook">
+                                <Link
+                                  to={`/courses/${encodeURIComponent(courseCode)}/gradebook?student=${encodeURIComponent(e.userId)}`}
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
+                                  aria-label={`View gradebook for ${e.displayName?.trim() || 'this student'}`}
+                                >
+                                  <ClipboardList className="h-4 w-4" aria-hidden />
+                                </Link>
+                              </IconActionTooltip>
+                            ) : null}
+                            {showReport ? (
+                              <IconActionTooltip label="Student report">
+                                <Link
+                                  to={`/courses/${encodeURIComponent(courseCode)}/students/${encodeURIComponent(e.id)}/progress`}
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
+                                  aria-label={`View report for ${e.displayName?.trim() || 'this student'}`}
+                                >
+                                  <BarChart3 className="h-4 w-4" aria-hidden />
+                                </Link>
+                              </IconActionTooltip>
                             ) : null}
                             {showRemove ? (
-                              <button
-                                type="button"
-                                onClick={() => void onRemoveEnrollment(e.id)}
-                                disabled={removingId === e.id}
-                                className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-rose-50 hover:text-rose-700 group-hover:opacity-100 focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
-                                aria-label={`Remove ${e.role} enrollment for ${e.displayName?.trim() || 'this person'}`}
-                              >
-                                <Trash2 className="h-4 w-4" aria-hidden />
-                              </button>
+                              <IconActionTooltip label="Remove enrollment">
+                                <button
+                                  type="button"
+                                  onClick={() => void onRemoveEnrollment(e.id)}
+                                  disabled={removingId === e.id}
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-rose-50 hover:text-rose-700 group-hover:opacity-100 focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
+                                  aria-label={`Remove ${e.role} enrollment for ${e.displayName?.trim() || 'this person'}`}
+                                >
+                                  <Trash2 className="h-4 w-4" aria-hidden />
+                                </button>
+                              </IconActionTooltip>
                             ) : null}
                           </div>
                         ) : null}
@@ -1188,6 +1290,92 @@ export default function CourseEnrollments() {
                   className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
                 >
                   {sectionTransferStatus === 'loading' ? 'Saving…' : 'Save'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {messageTarget && (
+        <div
+          className={LMS_MODAL_OVERLAY_CLASS}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="enrollment-message-title"
+          onClick={(ev) => {
+            if (ev.target === ev.currentTarget) closeMessageModal()
+          }}
+        >
+          <div className="w-full max-w-lg overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl dark:border-neutral-700 dark:bg-neutral-900">
+            <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3 dark:border-neutral-700">
+              <h3
+                id="enrollment-message-title"
+                className="text-sm font-semibold text-slate-900 dark:text-neutral-100"
+              >
+                Send message
+              </h3>
+              <button
+                type="button"
+                onClick={() => closeMessageModal()}
+                className="rounded-lg p-1.5 text-slate-500 hover:bg-slate-100 hover:text-slate-800 dark:text-neutral-400 dark:hover:bg-neutral-800"
+                aria-label="Close"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <form
+              onSubmit={(ev) => void onSubmitEnrollmentMessage(ev)}
+              className="space-y-3 px-4 py-4 text-sm text-slate-700 dark:text-neutral-300"
+            >
+              <p className="text-slate-600 dark:text-neutral-400">
+                To{' '}
+                <span className="font-medium text-slate-900 dark:text-neutral-100">
+                  {messageTarget.displayName?.trim() || '—'}
+                </span>
+              </p>
+              {messageError ? (
+                <p className="text-sm text-rose-700 dark:text-rose-300" role="alert">
+                  {messageError}
+                </p>
+              ) : null}
+              <label className="block">
+                <span className="text-xs font-medium text-slate-600 dark:text-neutral-400">Subject</span>
+                <input
+                  value={messageSubject}
+                  onChange={(ev) => setMessageSubject(ev.target.value)}
+                  className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-indigo-300 focus:ring-2 focus:ring-indigo-500/20 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100"
+                  placeholder="Optional subject"
+                  disabled={messageStatus === 'loading'}
+                />
+              </label>
+              <label className="block">
+                <span className="text-xs font-medium text-slate-600 dark:text-neutral-400">Message</span>
+                <textarea
+                  value={messageBody}
+                  onChange={(ev) => setMessageBody(ev.target.value)}
+                  rows={6}
+                  className="mt-1 w-full resize-y rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-indigo-300 focus:ring-2 focus:ring-indigo-500/20 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100"
+                  placeholder="Write your message…"
+                  disabled={messageStatus === 'loading'}
+                  required
+                />
+              </label>
+              <div className="flex justify-end gap-2 border-t border-slate-200 pt-3 dark:border-neutral-700">
+                <button
+                  type="button"
+                  onClick={() => closeMessageModal()}
+                  className="rounded-xl px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={messageStatus === 'loading' || !messageBody.trim()}
+                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <Send className="h-4 w-4" aria-hidden />
+                  {messageStatus === 'loading' ? 'Sending…' : 'Send'}
                 </button>
               </div>
             </form>

--- a/clients/web/src/pages/lms/course-notebook-page.tsx
+++ b/clients/web/src/pages/lms/course-notebook-page.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/set-state-in-effect -- sync localStorage notebook and course title from network */
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Navigate, useParams } from 'react-router-dom'
+import { Navigate, useParams, useSearchParams } from 'react-router-dom'
 import { ConfirmDialog } from '../../components/confirm-dialog'
 import { ReadingFocusToggle } from '../../components/layout/reading-focus-toggle'
 import { useCourseNavFeatures } from '../../context/course-nav-features-context'
@@ -18,6 +18,7 @@ import {
   type CourseNotebookPage,
 } from '../../lib/course-notebook-tree'
 import { fetchCourse, uploadCourseFile } from '../../lib/courses-api'
+import { syncNotebookTasksFromMarkdown } from '../../lib/notebook-task-sync'
 import {
   loadCourseNotebook,
   saveCourseNotebookStore,
@@ -31,6 +32,7 @@ const CONTENT_SAVE_MS = 500
 
 export default function CourseNotebookPage() {
   const { courseCode } = useParams<{ courseCode: string }>()
+  const [searchParams] = useSearchParams()
   const { notebookEnabled: courseNotebookEnabled, loading: courseFeatureFlagsLoading } =
     useCourseNavFeatures()
   const [data, setData] = useState<CourseNotebookStore | null>(null)
@@ -68,10 +70,18 @@ export default function CourseNotebookPage() {
   useEffect(() => {
     if (!courseCode) return
     const loaded = loadCourseNotebook(courseCode)
-    setData(loaded)
-    const page = loaded.pages.find((p) => p.id === loaded.activePageId)
+    const pageId = searchParams.get('page')
+    const next =
+      pageId && loaded.pages.some((p) => p.id === pageId)
+        ? { ...loaded, activePageId: pageId }
+        : loaded
+    if (next !== loaded) {
+      saveCourseNotebookStore(courseCode, next)
+    }
+    setData(next)
+    const page = next.pages.find((p) => p.id === next.activePageId)
     setHeaderTitleDraft(page?.title ?? '')
-  }, [courseCode])
+  }, [courseCode, searchParams])
 
   useEffect(() => {
     if (!courseCode) return
@@ -113,7 +123,13 @@ export default function CourseNotebookPage() {
     if (contentSaveTimer.current) clearTimeout(contentSaveTimer.current)
     contentSaveTimer.current = setTimeout(() => {
       const d = dataRef.current
-      if (d && courseCode) persistStore(d)
+      if (d && courseCode) {
+        persistStore(d)
+        const page = d.pages.find((p) => p.id === d.activePageId)
+        if (page) {
+          void syncNotebookTasksFromMarkdown(courseCode, page.id, page.contentMd)
+        }
+      }
       contentSaveTimer.current = null
     }, CONTENT_SAVE_MS)
   }, [courseCode, persistStore])
@@ -123,6 +139,11 @@ export default function CourseNotebookPage() {
   useEffect(() => {
     if (activePage) setHeaderTitleDraft(activePage.title)
   }, [activePage])
+
+  useEffect(() => {
+    if (!courseCode || !activePage) return
+    void syncNotebookTasksFromMarkdown(courseCode, activePage.id, activePage.contentMd)
+  }, [courseCode, activePage?.id])
 
   const onSelectPage = useCallback(
     (id: string) => {
@@ -386,6 +407,7 @@ export default function CourseNotebookPage() {
                       value={activePage.contentMd}
                       onChange={onEditorChange}
                       courseCode={courseCode}
+                      notebookTaskContext={{ courseCode, pageId: activePage.id }}
                       uploadCourseImage={(file) =>
                         uploadCourseFile(courseCode, file).then((r) => r.contentPath)
                       }

--- a/clients/web/src/pages/lms/course-whiteboard-page.tsx
+++ b/clients/web/src/pages/lms/course-whiteboard-page.tsx
@@ -1,26 +1,8 @@
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type MouseEvent as ReactMouseEvent,
-  type PointerEvent as ReactPointerEvent,
-  type ReactNode,
-} from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import {
-  Circle,
-  Download,
-  Eraser,
-  FolderOpen,
-  Minus,
-  MousePointer2,
-  Pencil,
-  Save,
-  Square,
-  Trash2,
-  Triangle,
-} from 'lucide-react'
+import { Trash2 } from 'lucide-react'
+import { useWhiteboardCanvas } from '../../components/whiteboard/use-whiteboard-canvas'
+import { WhiteboardToolbar } from '../../components/whiteboard/whiteboard-toolbar'
 import {
   createWhiteboard,
   deleteWhiteboard,
@@ -28,393 +10,8 @@ import {
   updateWhiteboard,
   type WhiteboardRow,
 } from '../../lib/courses-api'
+import type { DrawEl } from '../../lib/whiteboard/types'
 import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
-
-// ---------------------------------------------------------------------------
-// Drawing data model
-// ---------------------------------------------------------------------------
-
-type StrokeEl = { type: 'stroke'; color: string; width: number; pts: [number, number][] }
-type RectEl = { type: 'rect'; color: string; width: number; x: number; y: number; w: number; h: number }
-type CircleEl = { type: 'circle'; color: string; width: number; cx: number; cy: number; rx: number; ry: number }
-type TriangleEl = { type: 'triangle'; color: string; width: number; x1: number; y1: number; x2: number; y2: number; x3: number; y3: number }
-type LineEl = { type: 'line'; color: string; width: number; x1: number; y1: number; x2: number; y2: number }
-
-type DrawEl = StrokeEl | RectEl | CircleEl | TriangleEl | LineEl
-
-type Tool = 'select' | 'pen' | 'line' | 'rect' | 'circle' | 'triangle' | 'eraser'
-
-const COLORS = ['#1e293b', '#ef4444', '#f97316', '#eab308', '#22c55e', '#3b82f6', '#a855f7', '#ec4899', '#ffffff']
-const STROKE_WIDTHS = [2, 4, 8]
-const ERASER_SIZES = [8, 16, 32]
-const GRID_SPACING = 24
-
-// ---------------------------------------------------------------------------
-// Canvas helpers
-// ---------------------------------------------------------------------------
-
-function drawGrid(ctx: CanvasRenderingContext2D, w: number, h: number, dark: boolean) {
-  ctx.save()
-  ctx.fillStyle = dark ? '#171717' : '#ffffff'
-  ctx.fillRect(0, 0, w, h)
-  ctx.fillStyle = dark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.18)'
-  for (let x = GRID_SPACING; x < w; x += GRID_SPACING) {
-    for (let y = GRID_SPACING; y < h; y += GRID_SPACING) {
-      ctx.beginPath()
-      ctx.arc(x, y, 1, 0, Math.PI * 2)
-      ctx.fill()
-    }
-  }
-  ctx.restore()
-}
-
-function drawElement(ctx: CanvasRenderingContext2D, el: DrawEl) {
-  ctx.save()
-  ctx.strokeStyle = el.color
-  ctx.fillStyle = 'transparent'
-  ctx.lineWidth = el.width
-  ctx.lineCap = 'round'
-  ctx.lineJoin = 'round'
-
-  switch (el.type) {
-    case 'stroke': {
-      if (el.pts.length < 2) break
-      ctx.beginPath()
-      ctx.moveTo(el.pts[0][0], el.pts[0][1])
-      for (let i = 1; i < el.pts.length; i++) ctx.lineTo(el.pts[i][0], el.pts[i][1])
-      ctx.stroke()
-      break
-    }
-    case 'rect': {
-      ctx.beginPath()
-      ctx.strokeRect(el.x, el.y, el.w, el.h)
-      break
-    }
-    case 'circle': {
-      ctx.beginPath()
-      ctx.ellipse(el.cx, el.cy, Math.abs(el.rx), Math.abs(el.ry), 0, 0, Math.PI * 2)
-      ctx.stroke()
-      break
-    }
-    case 'triangle': {
-      ctx.beginPath()
-      ctx.moveTo(el.x1, el.y1)
-      ctx.lineTo(el.x2, el.y2)
-      ctx.lineTo(el.x3, el.y3)
-      ctx.closePath()
-      ctx.stroke()
-      break
-    }
-    case 'line': {
-      ctx.beginPath()
-      ctx.moveTo(el.x1, el.y1)
-      ctx.lineTo(el.x2, el.y2)
-      ctx.stroke()
-      break
-    }
-  }
-  ctx.restore()
-}
-
-// ---------------------------------------------------------------------------
-// Eraser hit-testing & partial erase
-// ---------------------------------------------------------------------------
-
-function distToSegment(px: number, py: number, ax: number, ay: number, bx: number, by: number): number {
-  const dx = bx - ax
-  const dy = by - ay
-  if (dx === 0 && dy === 0) return Math.hypot(px - ax, py - ay)
-  const t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / (dx * dx + dy * dy)))
-  return Math.hypot(px - (ax + t * dx), py - (ay + t * dy))
-}
-
-function effectiveEraserRadius(radius: number, lineWidth: number): number {
-  return radius + lineWidth / 2
-}
-
-function lerp(a: number, b: number, t: number): number {
-  return a + (b - a) * t
-}
-
-/** Parameter values t ∈ [0,1] where segment (x1,y1)→(x2,y2) meets circle (cx,cy,r). */
-function segmentCircleIntersections(
-  cx: number,
-  cy: number,
-  r: number,
-  x1: number,
-  y1: number,
-  x2: number,
-  y2: number,
-): number[] {
-  const dx = x2 - x1
-  const dy = y2 - y1
-  const fx = x1 - cx
-  const fy = y1 - cy
-  const a = dx * dx + dy * dy
-  if (a === 0) return Math.hypot(fx, fy) <= r ? [0] : []
-  const b = 2 * (fx * dx + fy * dy)
-  const c = fx * fx + fy * fy - r * r
-  const disc = b * b - 4 * a * c
-  if (disc < 0) return []
-  const sd = Math.sqrt(disc)
-  const t1 = (-b - sd) / (2 * a)
-  const t2 = (-b + sd) / (2 * a)
-  const out: number[] = []
-  if (t1 >= 0 && t1 <= 1) out.push(t1)
-  if (t2 >= 0 && t2 <= 1 && Math.abs(t2 - t1) > 1e-9) out.push(t2)
-  return out.sort((u, v) => u - v)
-}
-
-function hitTestStroke(stroke: StrokeEl, px: number, py: number, radius: number): boolean {
-  const r = effectiveEraserRadius(radius, stroke.width)
-  for (let i = 0; i < stroke.pts.length; i++) {
-    const [ex, ey] = stroke.pts[i]
-    if (Math.hypot(ex - px, ey - py) <= r) return true
-    if (i > 0) {
-      const [ax, ay] = stroke.pts[i - 1]
-      if (distToSegment(px, py, ax, ay, ex, ey) <= r) return true
-    }
-  }
-  return false
-}
-
-/** Convert any drawable element into one or more polylines for partial erasing. */
-function elementToStrokes(el: DrawEl): StrokeEl[] {
-  const { color, width } = el
-  switch (el.type) {
-    case 'stroke':
-      return [el]
-    case 'line':
-      return [{ type: 'stroke', color, width, pts: [[el.x1, el.y1], [el.x2, el.y2]] }]
-    case 'rect': {
-      const x1 = el.x
-      const y1 = el.y
-      const x2 = el.x + el.w
-      const y2 = el.y + el.h
-      const edge = (a: [number, number], b: [number, number]): StrokeEl => ({ type: 'stroke', color, width, pts: [a, b] })
-      return [
-        edge([x1, y1], [x2, y1]),
-        edge([x2, y1], [x2, y2]),
-        edge([x2, y2], [x1, y2]),
-        edge([x1, y2], [x1, y1]),
-      ]
-    }
-    case 'triangle': {
-      const edge = (a: [number, number], b: [number, number]): StrokeEl => ({ type: 'stroke', color, width, pts: [a, b] })
-      return [
-        edge([el.x1, el.y1], [el.x2, el.y2]),
-        edge([el.x2, el.y2], [el.x3, el.y3]),
-        edge([el.x3, el.y3], [el.x1, el.y1]),
-      ]
-    }
-    case 'circle': {
-      const segments = 36
-      const strokes: StrokeEl[] = []
-      let prev: [number, number] | null = null
-      for (let i = 0; i <= segments; i++) {
-        const angle = (2 * Math.PI * i) / segments
-        const pt: [number, number] = [el.cx + el.rx * Math.cos(angle), el.cy + el.ry * Math.sin(angle)]
-        if (prev) strokes.push({ type: 'stroke', color, width, pts: [prev, pt] })
-        prev = pt
-      }
-      return strokes
-    }
-  }
-}
-
-function hitTest(el: DrawEl, px: number, py: number, radius: number): boolean {
-  switch (el.type) {
-    case 'stroke':
-      return hitTestStroke(el, px, py, radius)
-    case 'line':
-      return distToSegment(px, py, el.x1, el.y1, el.x2, el.y2) <= effectiveEraserRadius(radius, el.width)
-    case 'rect': {
-      const x1 = Math.min(el.x, el.x + el.w)
-      const x2 = Math.max(el.x, el.x + el.w)
-      const y1 = Math.min(el.y, el.y + el.h)
-      const y2 = Math.max(el.y, el.y + el.h)
-      const r = effectiveEraserRadius(radius, el.width)
-      return (
-        distToSegment(px, py, x1, y1, x2, y1) <= r ||
-        distToSegment(px, py, x2, y1, x2, y2) <= r ||
-        distToSegment(px, py, x2, y2, x1, y2) <= r ||
-        distToSegment(px, py, x1, y2, x1, y1) <= r
-      )
-    }
-    case 'circle': {
-      const rx = Math.abs(el.rx) || 1
-      const ry = Math.abs(el.ry) || 1
-      const norm = Math.hypot((px - el.cx) / rx, (py - el.cy) / ry)
-      return Math.abs(norm - 1) * Math.min(rx, ry) <= effectiveEraserRadius(radius, el.width)
-    }
-    case 'triangle': {
-      const r = effectiveEraserRadius(radius, el.width)
-      return (
-        distToSegment(px, py, el.x1, el.y1, el.x2, el.y2) <= r ||
-        distToSegment(px, py, el.x2, el.y2, el.x3, el.y3) <= r ||
-        distToSegment(px, py, el.x3, el.y3, el.x1, el.y1) <= r
-      )
-    }
-  }
-}
-
-function pushUniquePoint(cur: [number, number][], x: number, y: number) {
-  const n = cur.length
-  if (n === 0 || cur[n - 1][0] !== x || cur[n - 1][1] !== y) cur.push([x, y])
-}
-
-/** Split a stroke at the eraser circle, clipping segments rather than dropping dense points. */
-function splitStroke(stroke: StrokeEl, px: number, py: number, radius: number): StrokeEl[] {
-  const pts = stroke.pts
-  if (pts.length < 2) return pts.length === 1 && hitTestStroke(stroke, px, py, radius) ? [] : [stroke]
-
-  const r = effectiveEraserRadius(radius, stroke.width)
-  const inside = (x: number, y: number) => Math.hypot(x - px, y - py) <= r
-  const result: StrokeEl[] = []
-  let cur: [number, number][] = []
-
-  const flush = () => {
-    if (cur.length >= 2) result.push({ ...stroke, pts: cur })
-    cur = []
-  }
-
-  const first = pts[0]
-  if (!inside(first[0], first[1])) cur.push(first)
-
-  for (let i = 1; i < pts.length; i++) {
-    const [x0, y0] = pts[i - 1]
-    const [x1, y1] = pts[i]
-    const aIn = inside(x0, y0)
-    const bIn = inside(x1, y1)
-
-    if (aIn && bIn) {
-      flush()
-      continue
-    }
-
-    const hits = segmentCircleIntersections(px, py, r, x0, y0, x1, y1)
-
-    if (!aIn && !bIn) {
-      if (hits.length >= 2) {
-        pushUniquePoint(cur, lerp(x0, x1, hits[0]), lerp(y0, y1, hits[0]))
-        flush()
-        pushUniquePoint(cur, lerp(x0, x1, hits[1]), lerp(y0, y1, hits[1]))
-      } else {
-        pushUniquePoint(cur, x1, y1)
-      }
-      continue
-    }
-
-    const t = hits[0] ?? (aIn ? 0 : 1)
-    const bx = lerp(x0, x1, t)
-    const by = lerp(y0, y1, t)
-
-    if (!aIn && bIn) {
-      pushUniquePoint(cur, bx, by)
-      flush()
-    } else {
-      flush()
-      pushUniquePoint(cur, bx, by)
-      pushUniquePoint(cur, x1, y1)
-    }
-  }
-
-  flush()
-  return result
-}
-
-/** Partial erase: clip every drawable at the eraser circle boundary. */
-function eraseFromElements(elements: DrawEl[], px: number, py: number, radius: number): DrawEl[] {
-  const out: DrawEl[] = []
-  for (const el of elements) {
-    for (const stroke of elementToStrokes(el)) {
-      out.push(...splitStroke(stroke, px, py, radius))
-    }
-  }
-  return out
-}
-
-// ---------------------------------------------------------------------------
-// Select-mode helpers
-// ---------------------------------------------------------------------------
-
-function translateElement(el: DrawEl, dx: number, dy: number): DrawEl {
-  switch (el.type) {
-    case 'stroke': return { ...el, pts: el.pts.map(([x, y]) => [x + dx, y + dy] as [number, number]) }
-    case 'rect':   return { ...el, x: el.x + dx, y: el.y + dy }
-    case 'circle': return { ...el, cx: el.cx + dx, cy: el.cy + dy }
-    case 'line':   return { ...el, x1: el.x1 + dx, y1: el.y1 + dy, x2: el.x2 + dx, y2: el.y2 + dy }
-    case 'triangle': return { ...el, x1: el.x1+dx, y1: el.y1+dy, x2: el.x2+dx, y2: el.y2+dy, x3: el.x3+dx, y3: el.y3+dy }
-  }
-}
-
-/** Returns the index of the topmost element whose outline is within 8px of (px,py), or -1. */
-function pickElement(elements: DrawEl[], px: number, py: number): number {
-  for (let i = elements.length - 1; i >= 0; i--) {
-    if (hitTest(elements[i], px, py, 8)) return i
-  }
-  return -1
-}
-
-function getBoundingBox(el: DrawEl): { x: number; y: number; w: number; h: number } | null {
-  switch (el.type) {
-    case 'stroke': {
-      if (!el.pts.length) return null
-      let [minX, minY, maxX, maxY] = [Infinity, Infinity, -Infinity, -Infinity]
-      for (const [x, y] of el.pts) { minX=Math.min(minX,x); minY=Math.min(minY,y); maxX=Math.max(maxX,x); maxY=Math.max(maxY,y) }
-      return { x: minX, y: minY, w: maxX - minX, h: maxY - minY }
-    }
-    case 'rect': {
-      const x = Math.min(el.x, el.x + el.w), y = Math.min(el.y, el.y + el.h)
-      return { x, y, w: Math.abs(el.w), h: Math.abs(el.h) }
-    }
-    case 'circle':
-      return { x: el.cx - Math.abs(el.rx), y: el.cy - Math.abs(el.ry), w: 2*Math.abs(el.rx), h: 2*Math.abs(el.ry) }
-    case 'line': {
-      const x = Math.min(el.x1, el.x2), y = Math.min(el.y1, el.y2)
-      return { x, y, w: Math.abs(el.x2 - el.x1), h: Math.abs(el.y2 - el.y1) }
-    }
-    case 'triangle': {
-      const xs = [el.x1, el.x2, el.x3], ys = [el.y1, el.y2, el.y3]
-      const x = Math.min(...xs), y = Math.min(...ys)
-      return { x, y, w: Math.max(...xs) - x, h: Math.max(...ys) - y }
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Redraw
-// ---------------------------------------------------------------------------
-
-function redraw(
-  ctx: CanvasRenderingContext2D,
-  w: number,
-  h: number,
-  elements: DrawEl[],
-  draft: DrawEl | null,
-  dark: boolean,
-  selectedIdx?: number | null,
-) {
-  drawGrid(ctx, w, h, dark)
-  for (const el of elements) drawElement(ctx, el)
-  if (draft) drawElement(ctx, draft)
-  // Selection highlight
-  if (selectedIdx != null && selectedIdx >= 0 && elements[selectedIdx]) {
-    const bb = getBoundingBox(elements[selectedIdx])
-    if (bb) {
-      ctx.save()
-      ctx.strokeStyle = '#6366f1'
-      ctx.lineWidth = 1.5
-      ctx.setLineDash([4, 3])
-      ctx.strokeRect(bb.x - 6, bb.y - 6, bb.w + 12, bb.h + 12)
-      ctx.restore()
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Save dialog
-// ---------------------------------------------------------------------------
 
 function SaveDialog({
   initialTitle,
@@ -466,10 +63,6 @@ function SaveDialog({
     </div>
   )
 }
-
-// ---------------------------------------------------------------------------
-// Load panel
-// ---------------------------------------------------------------------------
 
 function LoadPanel({
   boards,
@@ -528,231 +121,31 @@ function LoadPanel({
   )
 }
 
-// ---------------------------------------------------------------------------
-// Popover group — shows trigger; hover/click reveals options panel to the right
-// ---------------------------------------------------------------------------
-
-function PopoverGroup({ trigger, children }: { trigger: ReactNode; children: ReactNode }) {
-  const [open, setOpen] = useState(false)
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const show = () => {
-    if (timerRef.current) clearTimeout(timerRef.current)
-    setOpen(true)
-  }
-  const hide = () => {
-    timerRef.current = setTimeout(() => setOpen(false), 80)
-  }
-
-  return (
-    <div className="relative" onMouseEnter={show} onMouseLeave={hide}>
-      <div onClick={() => setOpen((o) => !o)}>{trigger}</div>
-      {open && (
-        <div
-          className="absolute left-full top-0 z-50 ml-2 rounded-xl border border-slate-200 bg-white p-2 shadow-lg dark:border-neutral-800 dark:bg-neutral-950"
-          onMouseEnter={show}
-          onMouseLeave={hide}
-        >
-          {children}
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Main page
-// ---------------------------------------------------------------------------
-
 export default function CourseWhiteboardPage() {
   const { courseCode = '' } = useParams<{ courseCode: string }>()
 
-  const canvasRef = useRef<HTMLCanvasElement>(null)
-  const containerRef = useRef<HTMLDivElement>(null)
-
   const [elements, setElements] = useState<DrawEl[]>([])
-  const [draft, setDraft] = useState<DrawEl | null>(null)
-  const [tool, setTool] = useState<Tool>('pen')
-  const [color, setColor] = useState(COLORS[0])
-  const [strokeWidth, setStrokeWidth] = useState(STROKE_WIDTHS[1])
-  const [eraserSize, setEraserSize] = useState(ERASER_SIZES[1])
-  const [eraserCursorPos, setEraserCursorPos] = useState<[number, number] | null>(null)
-  const [selectedIdx, setSelectedIdx] = useState<number | null>(null)
-  const [dragInfo, setDragInfo] = useState<{
-    idx: number
-    startPos: [number, number]
-    origEl: DrawEl
-  } | null>(null)
-  const [isDrawing, setIsDrawing] = useState(false)
-  const [origin, setOrigin] = useState<[number, number]>([0, 0])
-
   const [boards, setBoards] = useState<WhiteboardRow[]>([])
   const [currentBoard, setCurrentBoard] = useState<WhiteboardRow | null>(null)
   const [showSave, setShowSave] = useState(false)
   const [showLoad, setShowLoad] = useState(false)
   const [saving, setSaving] = useState(false)
 
-  const isDark = document.documentElement.classList.contains('dark')
+  const onElementsChange = useCallback((next: DrawEl[]) => {
+    setElements(next)
+  }, [])
 
-  // Size canvas to container
-  const resizeCanvas = useCallback(() => {
-    const canvas = canvasRef.current
-    const container = containerRef.current
-    if (!canvas || !container) return
-    const { width, height } = container.getBoundingClientRect()
-    canvas.width = width
-    canvas.height = height
-    const ctx = canvas.getContext('2d')
-    if (ctx) redraw(ctx, width, height, elements, draft, isDark, selectedIdx)
-  }, [elements, draft, isDark, selectedIdx])
+  const wb = useWhiteboardCanvas({ elements, onElementsChange })
 
-  useEffect(() => {
-    resizeCanvas()
-    const obs = new ResizeObserver(() => resizeCanvas())
-    if (containerRef.current) obs.observe(containerRef.current)
-    return () => obs.disconnect()
-  }, [resizeCanvas])
-
-  // Redraw whenever elements/draft/selection change
-  useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas) return
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-    redraw(ctx, canvas.width, canvas.height, elements, draft, isDark, selectedIdx)
-  }, [elements, draft, isDark, selectedIdx])
-
-  // Reset drawing state when tool changes (prevents eraser/state leaking across tools)
-  useEffect(() => {
-    setIsDrawing(false)
-    setDraft(null)
-    setDragInfo(null)
-    if (tool !== 'select') setSelectedIdx(null)
-  }, [tool])
-
-  // Load board list on mount
   useEffect(() => {
     listWhiteboards(courseCode)
       .then(setBoards)
       .catch(() => {})
   }, [courseCode])
 
-  // --------------- pointer helpers ---------------
-  function getPos(e: ReactPointerEvent<HTMLCanvasElement> | ReactMouseEvent<HTMLCanvasElement>): [number, number] {
-    const canvas = canvasRef.current!
-    const rect = canvas.getBoundingClientRect()
-    return [e.clientX - rect.left, e.clientY - rect.top]
-  }
-
-  function onPointerDown(e: ReactPointerEvent<HTMLCanvasElement>) {
-    const [x, y] = getPos(e)
-    ;(e.target as HTMLCanvasElement).setPointerCapture(e.pointerId)
-
-    if (tool === 'select') {
-      const idx = pickElement(elements, x, y)
-      setSelectedIdx(idx >= 0 ? idx : null)
-      if (idx >= 0) {
-        setDragInfo({ idx, startPos: [x, y], origEl: elements[idx] })
-        setIsDrawing(true)
-      }
-      return
-    }
-
-    setOrigin([x, y])
-    setIsDrawing(true)
-
-    if (tool === 'pen') {
-      setDraft({ type: 'stroke', color, width: strokeWidth, pts: [[x, y]] })
-    } else if (tool === 'eraser') {
-      setElements((prev) => eraseFromElements(prev, x, y, eraserSize))
-    }
-  }
-
-  function onPointerMove(e: ReactPointerEvent<HTMLCanvasElement>) {
-    const [x, y] = getPos(e)
-
-    if (tool === 'eraser') {
-      setEraserCursorPos([x, y])
-    }
-
-    if (!isDrawing) return
-
-    if (tool === 'select') {
-      if (dragInfo) {
-        const dx = x - dragInfo.startPos[0]
-        const dy = y - dragInfo.startPos[1]
-        setElements((prev) =>
-          prev.map((el, i) => (i === dragInfo.idx ? translateElement(dragInfo.origEl, dx, dy) : el)),
-        )
-      }
-      return
-    }
-
-    if (tool === 'eraser') {
-      const canvas = canvasRef.current!
-      const rect = canvas.getBoundingClientRect()
-      // getCoalescedEvents gives all sub-frame pointer positions the browser recorded,
-      // so we erase only where the mouse actually was without artificial interpolation.
-      const coalesced = e.nativeEvent.getCoalescedEvents?.() ?? []
-      const pts: [number, number][] = coalesced.length > 0
-        ? coalesced.map((ce) => [ce.clientX - rect.left, ce.clientY - rect.top])
-        : [[x, y]]
-      setElements((prev) => {
-        let els = prev
-        for (const [px, py] of pts) {
-          els = eraseFromElements(els, px, py, eraserSize)
-        }
-        return els
-      })
-      return
-    }
-
-    const [ox, oy] = origin
-
-    if (tool === 'pen') {
-      setDraft((prev) => {
-        if (!prev || prev.type !== 'stroke') return prev
-        return { ...prev, pts: [...prev.pts, [x, y]] }
-      })
-      return
-    }
-
-    if (tool === 'line') {
-      setDraft({ type: 'line', color, width: strokeWidth, x1: ox, y1: oy, x2: x, y2: y })
-    } else if (tool === 'rect') {
-      setDraft({ type: 'rect', color, width: strokeWidth, x: ox, y: oy, w: x - ox, h: y - oy })
-    } else if (tool === 'circle') {
-      setDraft({ type: 'circle', color, width: strokeWidth, cx: ox, cy: oy, rx: (x - ox) / 2, ry: (y - oy) / 2 })
-    } else if (tool === 'triangle') {
-      const mx = (ox + x) / 2
-      setDraft({ type: 'triangle', color, width: strokeWidth, x1: mx, y1: oy, x2: x, y2: y, x3: ox, y3: y })
-    }
-  }
-
-  function onPointerUp() {
-    if (!isDrawing) return
-    setIsDrawing(false)
-    setDragInfo(null)
-    if (draft) {
-      setElements((prev) => [...prev, draft])
-      setDraft(null)
-    }
-  }
-
-  // --------------- actions ---------------
   function clearCanvas() {
-    setElements([])
-    setDraft(null)
+    wb.clearCanvas()
     setCurrentBoard(null)
-  }
-
-  function exportPng() {
-    const canvas = canvasRef.current
-    if (!canvas) return
-    const a = document.createElement('a')
-    a.href = canvas.toDataURL('image/png')
-    a.download = `${currentBoard?.title ?? 'whiteboard'}.png`
-    a.click()
   }
 
   async function handleSave(title: string) {
@@ -781,7 +174,6 @@ export default function CourseWhiteboardPage() {
     setCurrentBoard(b)
     const data = Array.isArray(b.canvasData) ? (b.canvasData as DrawEl[]) : []
     setElements(data)
-    setDraft(null)
   }
 
   async function handleDelete(id: string) {
@@ -797,253 +189,66 @@ export default function CourseWhiteboardPage() {
     }
   }
 
-  // --------------- toolbar items ---------------
-  const tools: { id: Tool; icon: React.ReactNode; label: string }[] = [
-    { id: 'select', icon: <MousePointer2 className="h-5 w-5" />, label: 'Select' },
-    { id: 'pen', icon: <Pencil className="h-5 w-5" />, label: 'Pen' },
-    { id: 'line', icon: <Minus className="h-5 w-5" />, label: 'Line' },
-    { id: 'rect', icon: <Square className="h-5 w-5" />, label: 'Rectangle' },
-    { id: 'circle', icon: <Circle className="h-5 w-5" />, label: 'Circle' },
-    { id: 'triangle', icon: <Triangle className="h-5 w-5" />, label: 'Triangle' },
-  ]
-
-  const cursor =
-    tool === 'select' ? (dragInfo ? 'cursor-grabbing' : 'cursor-grab') :
-    tool === 'eraser' ? 'cursor-none' :
-    'cursor-crosshair'
-
   return (
     <div className="flex h-[calc(100vh-4rem)] overflow-hidden">
-      {/* Left toolbar */}
-      <div className="flex w-14 flex-col items-center gap-1 border-r border-slate-200 bg-white py-3 dark:border-neutral-800 dark:bg-neutral-950">
-        {/* Tool buttons — collapsed to selected, popover on hover/click */}
-        {(() => {
-          const activeTool = tools.find((t) => t.id === tool) ?? tools[0]
-          return (
-            <PopoverGroup
-              trigger={
-                <button
-                  type="button"
-                  title={activeTool.label}
-                  className="flex h-9 w-9 items-center justify-center rounded-lg transition-colors bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300"
-                >
-                  {activeTool.icon}
-                </button>
-              }
-            >
-              <div className="flex flex-col gap-1">
-                {tools.map((t) => (
-                  <button
-                    key={t.id}
-                    type="button"
-                    title={t.label}
-                    onClick={() => setTool(t.id)}
-                    className={`flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${
-                      tool === t.id
-                        ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300'
-                        : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-200'
-                    }`}
-                  >
-                    {t.icon}
-                  </button>
-                ))}
-              </div>
-            </PopoverGroup>
-          )
-        })()}
+      <WhiteboardToolbar
+        tool={wb.tool}
+        onToolChange={wb.setTool}
+        color={wb.color}
+        onColorChange={wb.setColor}
+        strokeWidth={wb.strokeWidth}
+        onStrokeWidthChange={wb.setStrokeWidth}
+        eraserSize={wb.eraserSize}
+        onEraserSizeChange={wb.setEraserSize}
+        onClear={clearCanvas}
+        onExportPng={() => wb.exportPng(currentBoard?.title ?? 'whiteboard')}
+        onLoad={() => setShowLoad(true)}
+        onSave={() => setShowSave(true)}
+        saving={saving}
+      />
 
-        {/* Eraser — collapsed to icon, popover shows 3 sizes */}
-        <PopoverGroup
-          trigger={
-            <button
-              type="button"
-              title="Eraser"
-              onClick={() => setTool('eraser')}
-              className={`flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${
-                tool === 'eraser'
-                  ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300'
-                  : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-200'
-              }`}
-            >
-              <Eraser className="h-5 w-5" />
-            </button>
-          }
-        >
-          <div className="flex flex-col gap-1">
-            {ERASER_SIZES.map((s) => (
-              <button
-                key={s}
-                type="button"
-                title={`Eraser ${s}px`}
-                onClick={() => { setEraserSize(s); setTool('eraser') }}
-                className={`flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${
-                  eraserSize === s && tool === 'eraser'
-                    ? 'bg-indigo-100 dark:bg-indigo-950'
-                    : 'hover:bg-slate-100 dark:hover:bg-neutral-800'
-                }`}
-              >
-                <span
-                  className="rounded-full border border-slate-400 bg-white dark:border-neutral-500 dark:bg-neutral-800"
-                  style={{ width: s, height: s }}
-                />
-              </button>
-            ))}
-          </div>
-        </PopoverGroup>
-
-        <div className="my-1 h-px w-8 bg-slate-200 dark:bg-neutral-800" />
-
-        {/* Stroke width — collapsed to selected, popover on hover/click */}
-        <PopoverGroup
-          trigger={
-            <button
-              type="button"
-              title={`Stroke ${strokeWidth}px`}
-              className="flex h-9 w-9 items-center justify-center rounded-lg transition-colors bg-indigo-100 dark:bg-indigo-950"
-            >
-              <span
-                className="rounded-full bg-slate-700 dark:bg-neutral-300"
-                style={{ width: strokeWidth * 2, height: strokeWidth * 2 }}
-              />
-            </button>
-          }
-        >
-          <div className="flex flex-col gap-1">
-            {STROKE_WIDTHS.map((w) => (
-              <button
-                key={w}
-                type="button"
-                title={`Stroke ${w}px`}
-                onClick={() => setStrokeWidth(w)}
-                className={`flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${
-                  strokeWidth === w
-                    ? 'bg-indigo-100 dark:bg-indigo-950'
-                    : 'hover:bg-slate-100 dark:hover:bg-neutral-800'
-                }`}
-              >
-                <span
-                  className="rounded-full bg-slate-700 dark:bg-neutral-300"
-                  style={{ width: w * 2, height: w * 2 }}
-                />
-              </button>
-            ))}
-          </div>
-        </PopoverGroup>
-
-        <div className="my-1 h-px w-8 bg-slate-200 dark:bg-neutral-800" />
-
-        {/* Color — collapsed to selected, popover on hover/click */}
-        <PopoverGroup
-          trigger={
-            <button
-              type="button"
-              title={color}
-              className="flex h-7 w-7 items-center justify-center rounded-full ring-2 ring-indigo-500 ring-offset-1 scale-110 transition-transform"
-              style={{ backgroundColor: color, border: color === '#ffffff' ? '1px solid #e2e8f0' : undefined }}
-            />
-          }
-        >
-          <div
-            className="grid gap-2 p-1"
-            style={{ gridTemplateColumns: 'repeat(3, 1.75rem)' }}
-          >
-            {COLORS.map((c) => (
-              <button
-                key={c}
-                type="button"
-                title={c}
-                onClick={() => setColor(c)}
-                className={`h-7 w-7 rounded-full transition-transform ${
-                  color === c ? 'ring-2 ring-indigo-500 ring-offset-1 scale-110' : 'hover:scale-110'
-                }`}
-                style={{ backgroundColor: c, border: c === '#ffffff' ? '1px solid #e2e8f0' : undefined }}
-              />
-            ))}
-          </div>
-        </PopoverGroup>
-
-        <div className="my-1 h-px w-8 bg-slate-200 dark:bg-neutral-800" />
-
-        {/* Actions */}
-        <button
-          type="button"
-          title="Clear canvas"
-          onClick={clearCanvas}
-          className="flex h-9 w-9 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 hover:text-rose-500 dark:text-neutral-400 dark:hover:bg-neutral-800"
-        >
-          <Trash2 className="h-5 w-5" />
-        </button>
-        <button
-          type="button"
-          title="Export PNG"
-          onClick={exportPng}
-          className="flex h-9 w-9 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-neutral-400 dark:hover:bg-neutral-800"
-        >
-          <Download className="h-5 w-5" />
-        </button>
-        <button
-          type="button"
-          title="Load whiteboard"
-          onClick={() => setShowLoad(true)}
-          className="flex h-9 w-9 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-neutral-400 dark:hover:bg-neutral-800"
-        >
-          <FolderOpen className="h-5 w-5" />
-        </button>
-        <button
-          type="button"
-          title="Save whiteboard"
-          disabled={saving}
-          onClick={() => setShowSave(true)}
-          className="flex h-9 w-9 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 hover:text-indigo-600 disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-800"
-        >
-          <Save className="h-5 w-5" />
-        </button>
-      </div>
-
-      {/* Canvas area */}
-      <div ref={containerRef} className="relative flex-1 overflow-hidden">
-        {currentBoard && (
+      <div ref={wb.containerRef} className="relative flex-1 overflow-hidden">
+        {currentBoard ? (
           <div className="pointer-events-none absolute left-4 top-3 z-10 text-xs text-slate-400 dark:text-neutral-500">
             {currentBoard.title}
           </div>
-        )}
+        ) : null}
         <canvas
-          ref={canvasRef}
-          className={`touch-none ${cursor}`}
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
-          onPointerLeave={() => setEraserCursorPos(null)}
+          ref={wb.canvasRef}
+          className={`touch-none ${wb.cursor}`}
+          onPointerDown={wb.onPointerDown}
+          onPointerMove={wb.onPointerMove}
+          onPointerUp={wb.onPointerUp}
+          onPointerLeave={() => wb.setEraserCursorPos(null)}
         />
-        {tool === 'eraser' && eraserCursorPos && (
+        {wb.tool === 'eraser' && wb.eraserCursorPos ? (
           <div
             className="pointer-events-none absolute rounded-full border border-slate-500 bg-white/15 dark:border-slate-400"
             style={{
-              left: eraserCursorPos[0] - eraserSize,
-              top: eraserCursorPos[1] - eraserSize,
-              width: eraserSize * 2,
-              height: eraserSize * 2,
+              left: wb.eraserCursorPos[0] - wb.eraserSize,
+              top: wb.eraserCursorPos[1] - wb.eraserSize,
+              width: wb.eraserSize * 2,
+              height: wb.eraserSize * 2,
             }}
           />
-        )}
+        ) : null}
       </div>
 
-      {/* Dialogs */}
-      {showSave && (
+      {showSave ? (
         <SaveDialog
           initialTitle={currentBoard?.title ?? ''}
           onSave={(t) => void handleSave(t)}
           onClose={() => setShowSave(false)}
         />
-      )}
-      {showLoad && (
+      ) : null}
+      {showLoad ? (
         <LoadPanel
           boards={boards}
           onLoad={handleLoad}
           onDelete={(id) => void handleDelete(id)}
           onClose={() => setShowLoad(false)}
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/clients/web/src/pages/lms/dashboard.tsx
+++ b/clients/web/src/pages/lms/dashboard.tsx
@@ -51,6 +51,7 @@ import {
   type GradebookColumnForFinal,
 } from './gradebook/compute-course-final-percent'
 import { DashboardLoadingSkeleton } from '../../components/ui/lms-content-skeletons'
+import { NotebookTasksCard } from '../../components/dashboard/notebook-tasks-card'
 import { StudyStatsCard } from '../../components/study-stats/study-stats-card'
 import { LmsPage } from './lms-page'
 
@@ -441,6 +442,14 @@ export default function Dashboard() {
 
   const courseCodes = useMemo(() => (courses ?? []).map((c) => c.courseCode), [courses])
 
+  const courseTitles = useMemo(() => {
+    const out: Record<string, string> = {}
+    for (const c of courses ?? []) {
+      out[c.courseCode] = c.title
+    }
+    return out
+  }, [courses])
+
   /** Read on each render so returning from a module picks up the latest `localStorage` write. */
   const continueTarget =
     courseCodes.length > 0 ? getMostRecentLastVisited(courseCodes) : null
@@ -607,6 +616,8 @@ export default function Dashboard() {
           )}
 
           <StudyStatsCard />
+
+          <NotebookTasksCard courseTitles={courseTitles} />
 
           {reviewStats != null && (
             <section aria-label="Spaced repetition review">

--- a/clients/web/src/pages/lms/global-notebook-page.tsx
+++ b/clients/web/src/pages/lms/global-notebook-page.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/set-state-in-effect -- sync localStorage notebook on load */
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 
 import { ConfirmDialog } from '../../components/confirm-dialog'
 import { ReadingFocusToggle } from '../../components/layout/reading-focus-toggle'
@@ -17,6 +18,7 @@ import {
   updatePageTitle,
   type CourseNotebookPage,
 } from '../../lib/course-notebook-tree'
+import { syncNotebookTasksFromMarkdown } from '../../lib/notebook-task-sync'
 import {
   GLOBAL_STUDENT_NOTEBOOK_KEY,
   GLOBAL_STUDENT_NOTEBOOK_TITLE,
@@ -31,6 +33,7 @@ import { LmsPage } from './lms-page'
 const CONTENT_SAVE_MS = 500
 
 export default function GlobalNotebookPage() {
+  const [searchParams] = useSearchParams()
   const [data, setData] = useState<CourseNotebookStore | null>(null)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
   const [deletePageId, setDeletePageId] = useState<string | null>(null)
@@ -55,10 +58,18 @@ export default function GlobalNotebookPage() {
 
   useEffect(() => {
     const loaded = loadCourseNotebook(GLOBAL_STUDENT_NOTEBOOK_KEY)
-    setData(loaded)
-    const page = loaded.pages.find((p) => p.id === loaded.activePageId)
+    const pageId = searchParams.get('page')
+    const next =
+      pageId && loaded.pages.some((p) => p.id === pageId)
+        ? { ...loaded, activePageId: pageId }
+        : loaded
+    if (next !== loaded) {
+      saveCourseNotebookStore(GLOBAL_STUDENT_NOTEBOOK_KEY, next)
+    }
+    setData(next)
+    const page = next.pages.find((p) => p.id === next.activePageId)
     setHeaderTitleDraft(page?.title ?? '')
-  }, [])
+  }, [searchParams])
 
   useEffect(() => {
     return () => {
@@ -72,12 +83,31 @@ export default function GlobalNotebookPage() {
     if (contentSaveTimer.current) clearTimeout(contentSaveTimer.current)
     contentSaveTimer.current = setTimeout(() => {
       const d = dataRef.current
-      if (d) persistStore(d)
+      if (d) {
+        persistStore(d)
+        const page = d.pages.find((p) => p.id === d.activePageId)
+        if (page) {
+          void syncNotebookTasksFromMarkdown(
+            GLOBAL_STUDENT_NOTEBOOK_KEY,
+            page.id,
+            page.contentMd,
+          )
+        }
+      }
       contentSaveTimer.current = null
     }, CONTENT_SAVE_MS)
   }, [persistStore])
 
   const activePage = data?.pages.find((p) => p.id === data.activePageId) ?? null
+
+  useEffect(() => {
+    if (!activePage) return
+    void syncNotebookTasksFromMarkdown(
+      GLOBAL_STUDENT_NOTEBOOK_KEY,
+      activePage.id,
+      activePage.contentMd,
+    )
+  }, [activePage?.id])
 
   useEffect(() => {
     if (activePage) setHeaderTitleDraft(activePage.title)
@@ -333,6 +363,10 @@ export default function GlobalNotebookPage() {
                       sectionId={activePage.id}
                       value={activePage.contentMd}
                       onChange={onEditorChange}
+                      notebookTaskContext={{
+                        courseCode: GLOBAL_STUDENT_NOTEBOOK_KEY,
+                        pageId: activePage.id,
+                      }}
                       uploadCourseImage={readFileAsDataUrl}
                       showImagePickerRow
                       placeholder="Start writing… Type / for blocks, or nest pages in the sidebar."

--- a/clients/web/src/pages/lms/student-progress-page.tsx
+++ b/clients/web/src/pages/lms/student-progress-page.tsx
@@ -4,6 +4,7 @@ import { LmsPage } from './lms-page'
 import { fetchCourse } from '../../lib/courses-api'
 import { formatTimeAgoFromIso } from '../../lib/format-time-ago'
 import { formatAbsolute } from '../../lib/format-datetime'
+import { formatDate } from '../../lib/format'
 import {
   createStudentProgressNote,
   deleteStudentProgressNote,
@@ -12,6 +13,7 @@ import {
   updateStudentProgressNote,
   type StudentProgressActivityEvent,
   type StudentProgressNote,
+  type StudentProgressQuizRow,
   type StudentProgressResponse,
 } from '../../lib/student-progress-api'
 import { usePlatformFeatures } from '../../context/platform-features-context'
@@ -31,6 +33,21 @@ function statusBadgeClass(status: string): string {
   }
 }
 
+function formatQuizAxisDate(iso: string): string {
+  return formatDate(iso, { month: 'short', day: 'numeric' })
+}
+
+function formatQuizScorePercent(score: number | null | undefined): string {
+  if (score == null) return '—'
+  return `${Math.round(score * 10) / 10}%`
+}
+
+function sortedQuizAttempts(quizzes: StudentProgressQuizRow[]): StudentProgressQuizRow[] {
+  return [...quizzes].sort(
+    (a, b) => new Date(a.submittedAt).getTime() - new Date(b.submittedAt).getTime(),
+  )
+}
+
 function QuizScoreChart({
   quizzes,
   captionId,
@@ -41,80 +58,147 @@ function QuizScoreChart({
   if (quizzes.length === 0) {
     return <p className="text-sm text-slate-500 dark:text-neutral-400">No quiz attempts yet.</p>
   }
-  const width = 320
-  const height = 120
-  const pad = 16
-  const scores = quizzes.map((q) => q.scorePercent ?? 0)
-  const minY = 0
-  const maxY = 100
-  const innerW = width - pad * 2
-  const innerH = height - pad * 2
-  const points = quizzes.map((_, i) => {
-    const x = pad + (quizzes.length === 1 ? innerW / 2 : (i / (quizzes.length - 1)) * innerW)
-    const y = pad + innerH - ((scores[i] - minY) / (maxY - minY)) * innerH
-    return `${x},${y}`
+
+  const sorted = sortedQuizAttempts(quizzes)
+  const scores = sorted.map((q) => q.scorePercent ?? 0)
+  const minScore = Math.min(...scores)
+  const maxScore = Math.max(...scores)
+  const roundedMin = Math.round(minScore * 10) / 10
+  const roundedMax = Math.round(maxScore * 10) / 10
+
+  if (sorted.length === 1) {
+    const only = sorted[0]
+    return (
+      <p className="text-sm text-slate-600 dark:text-neutral-400">
+        One quiz attempt so far ({formatQuizAxisDate(only.submittedAt)}):{' '}
+        <strong className="text-slate-900 dark:text-neutral-100">
+          {formatQuizScorePercent(only.scorePercent)}
+        </strong>
+        . A trend chart appears after a second attempt.
+      </p>
+    )
+  }
+
+  const width = 520
+  const height = 220
+  const marginLeft = 44
+  const marginRight = 12
+  const marginTop = 12
+  const marginBottom = 52
+  const innerW = width - marginLeft - marginRight
+  const innerH = height - marginTop - marginBottom
+  const yTicks = [0, 25, 50, 75, 100]
+
+  const points = sorted.map((quiz, i) => {
+    const x =
+      marginLeft + (sorted.length === 1 ? innerW / 2 : (i / (sorted.length - 1)) * innerW)
+    const y = marginTop + innerH - (scores[i] / 100) * innerH
+    return { x, y, quiz, score: scores[i] }
   })
+
+  const labelStep = sorted.length <= 6 ? 1 : Math.ceil(sorted.length / 6)
+
   return (
-    <figure className="mt-4">
+    <figure className="mt-2">
+      <figcaption className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+        Quiz scores over time
+      </figcaption>
+      <p className="mt-1 text-sm text-slate-600 dark:text-neutral-400">
+        Each dot is one submitted quiz, ordered oldest to newest (left to right). The vertical axis
+        is the score percentage.
+        {roundedMin === roundedMax
+          ? ` Every attempt so far scored ${formatQuizScorePercent(roundedMin)}.`
+          : ` Scores range from ${formatQuizScorePercent(roundedMin)} to ${formatQuizScorePercent(roundedMax)}.`}
+      </p>
       <svg
         role="img"
         aria-labelledby={captionId}
         viewBox={`0 0 ${width} ${height}`}
-        className="max-w-full rounded-lg border border-slate-200 bg-white dark:border-neutral-700 dark:bg-neutral-900"
+        className="mt-4 max-w-full rounded-lg border border-slate-200 bg-white dark:border-neutral-700 dark:bg-neutral-900"
       >
-        <title id={captionId}>Quiz score trend over time</title>
-        <polyline
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          className="text-indigo-600 dark:text-indigo-400"
-          points={points.join(' ')}
-        />
-        {quizzes.map((q, i) => {
-          const [x, y] = points[i].split(',').map(Number)
+        <title id={captionId}>Quiz scores over time</title>
+        {yTicks.map((tick) => {
+          const y = marginTop + innerH - (tick / 100) * innerH
           return (
-            <circle
-              key={q.attemptId}
-              cx={x}
-              cy={y}
-              r={4}
-              className="fill-indigo-600 dark:fill-indigo-400"
-            />
+            <g key={tick}>
+              <line
+                x1={marginLeft}
+                y1={y}
+                x2={width - marginRight}
+                y2={y}
+                className="stroke-slate-200 dark:stroke-neutral-700"
+                strokeWidth="1"
+              />
+              <text
+                x={marginLeft - 8}
+                y={y + 4}
+                textAnchor="end"
+                className="fill-slate-500 text-[10px] dark:fill-neutral-400"
+              >
+                {tick}%
+              </text>
+            </g>
           )
         })}
+        <line
+          x1={marginLeft}
+          y1={marginTop + innerH}
+          x2={width - marginRight}
+          y2={marginTop + innerH}
+          className="stroke-slate-300 dark:stroke-neutral-600"
+          strokeWidth="1"
+        />
+        <text
+          x={marginLeft + innerW / 2}
+          y={height - 6}
+          textAnchor="middle"
+          className="fill-slate-500 text-[10px] dark:fill-neutral-400"
+        >
+          Submission date (oldest → newest)
+        </text>
+        <polyline
+          fill="none"
+          strokeWidth="2"
+          className="stroke-indigo-600 dark:stroke-indigo-400"
+          points={points.map((p) => `${p.x},${p.y}`).join(' ')}
+        />
+        {points.map((p) => (
+          <g key={p.quiz.attemptId}>
+            <circle
+              cx={p.x}
+              cy={p.y}
+              r={5}
+              className="fill-indigo-600 dark:fill-indigo-400"
+            >
+              <title>
+                {p.quiz.title}: {formatQuizScorePercent(p.score)} on{' '}
+                {formatAbsolute(new Date(p.quiz.submittedAt))}
+              </title>
+            </circle>
+          </g>
+        ))}
+        {points.map((p, i) =>
+          i % labelStep === 0 || i === points.length - 1 ? (
+            <text
+              key={`${p.quiz.attemptId}-label`}
+              x={p.x}
+              y={marginTop + innerH + 16}
+              textAnchor="middle"
+              className="fill-slate-600 text-[9px] dark:fill-neutral-400"
+            >
+              {formatQuizAxisDate(p.quiz.submittedAt)}
+            </text>
+          ) : null,
+        )}
       </svg>
-      <figcaption id={captionId} className="sr-only">
-        Quiz scores by attempt date
-      </figcaption>
-      <table className="mt-3 w-full text-sm">
-        <caption className="text-start text-xs font-medium text-slate-600 dark:text-neutral-400">
-          Quiz score data (text alternative)
-        </caption>
-        <thead>
-          <tr className="border-b border-slate-200 dark:border-neutral-700">
-            <th scope="col" className="py-1 pe-3 text-start font-medium">
-              Quiz
-            </th>
-            <th scope="col" className="py-1 pe-3 text-start font-medium">
-              Date
-            </th>
-            <th scope="col" className="py-1 text-end font-medium">
-              Score %
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {quizzes.map((q) => (
-            <tr key={q.attemptId} className="border-b border-slate-100 dark:border-neutral-800">
-              <td className="py-1 pe-3">{q.title}</td>
-              <td className="py-1 pe-3">{formatAbsolute(new Date(q.submittedAt))}</td>
-              <td className="py-1 text-end tabular-nums">
-                {q.scorePercent != null ? `${Math.round(q.scorePercent * 10) / 10}%` : '—'}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <p id={captionId} className="sr-only">
+        {sorted
+          .map(
+            (q) =>
+              `${q.title}: ${formatQuizScorePercent(q.scorePercent)} on ${formatAbsolute(new Date(q.submittedAt))}`,
+          )
+          .join('; ')}
+      </p>
     </figure>
   )
 }
@@ -475,7 +559,10 @@ export default function StudentProgressPage() {
               {tab === 'quizzes' && (
                 <>
                   <QuizScoreChart quizzes={data.quizzes} captionId={chartCaptionId} />
-                  <div className="mt-6 overflow-x-auto">
+                  <h3 className="mt-8 text-sm font-semibold text-slate-900 dark:text-neutral-100">
+                    All quiz attempts
+                  </h3>
+                  <div className="mt-3 overflow-x-auto">
                     <table className="min-w-full text-sm">
                       <thead>
                         <tr className="border-b border-slate-200 text-start dark:border-neutral-700">

--- a/e2e/tests/student-progress.spec.ts
+++ b/e2e/tests/student-progress.spec.ts
@@ -67,6 +67,30 @@ test.describe('Student progress', () => {
     await expect(page.getByText(noteText)).toBeVisible({ timeout: 8000 })
   })
 
+  test('instructor opens student report from enrollments roster', async ({
+    coursePage: page,
+    seededCourse,
+  }) => {
+    const enrollmentId = await studentEnrollmentId(
+      seededCourse.instructorToken,
+      seededCourse.courseCode,
+    )
+    const apiProgress = `${apiBase}/api/v1/courses/${encodeURIComponent(seededCourse.courseCode)}/enrollments/${encodeURIComponent(enrollmentId)}/progress`
+    await page.goto(`/courses/${seededCourse.courseCode}/enrollments`)
+    const studentRow = page.locator('tr').filter({ hasText: 'E2E Student' })
+    await studentRow.hover()
+    await studentRow.getByRole('link', { name: /view report for e2e student/i }).click()
+
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/courses/${seededCourse.courseCode}/students/${enrollmentId}/progress`,
+      ),
+    )
+    await expect(page.getByText(/assignments submitted|modules viewed/i).first()).toBeVisible({
+      timeout: 15000,
+    })
+  })
+
   test('student views own progress without instructor notes tab', async ({
     page,
     seededCourse,

--- a/server/internal/httpserver/communication.go
+++ b/server/internal/httpserver/communication.go
@@ -141,6 +141,7 @@ func (d Deps) handleCommMessagesPost() http.HandlerFunc {
 		if u, e := user.FindByEmail(r.Context(), d.Pool, user.NormalizeEmail(to)); e == nil && u != nil {
 			if rid, e2 := uuid.Parse(u.ID); e2 == nil && rid != userID {
 				d.notifyMailbox(rid)
+				d.emitInboxMessageNotification(r.Context(), rid, userID, req.Subject)
 			}
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/server/internal/httpserver/course_enrollments_http.go
+++ b/server/internal/httpserver/course_enrollments_http.go
@@ -13,9 +13,12 @@ import (
 	"github.com/lextures/lextures/server/internal/apierr"
 	"github.com/lextures/lextures/server/internal/courseroles"
 	modelenrollment "github.com/lextures/lextures/server/internal/models/enrollment"
+	"github.com/lextures/lextures/server/internal/repos/communication"
 	"github.com/lextures/lextures/server/internal/repos/course"
+	"github.com/lextures/lextures/server/internal/repos/coursegrants"
 	"github.com/lextures/lextures/server/internal/repos/enrollment"
 	"github.com/lextures/lextures/server/internal/repos/orgroles"
+	"github.com/lextures/lextures/server/internal/repos/user"
 	"github.com/lextures/lextures/server/internal/service/learningevents"
 )
 
@@ -552,5 +555,103 @@ WHERE ce.id = $1 AND c.course_code = $2 AND ce.active
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (d Deps) handleCourseEnrollmentMessagePost() http.HandlerFunc {
+	type reqBody struct {
+		Subject string `json:"subject"`
+		Body    string `json:"body"`
+	}
+	type respBody struct {
+		ID string `json:"id"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		viewer, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		courseCode, ok := chiCourseCode(w, r)
+		if !ok {
+			return
+		}
+		eid, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "enrollment_id")))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid enrollment id.")
+			return
+		}
+		en, err := enrollment.GetByID(r.Context(), d.Pool, eid)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load enrollment.")
+			return
+		}
+		if en == nil || !strings.EqualFold(en.CourseCode, courseCode) {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Enrollment not found.")
+			return
+		}
+		if en.UserID == viewer {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "You cannot message yourself.")
+			return
+		}
+		canRead, err := courseroles.UserHasPermission(r.Context(), d.Pool, viewer, coursegrants.CourseEnrollmentsReadPermission(courseCode))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")
+			return
+		}
+		if !canRead {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission to message this enrollment.")
+			return
+		}
+		staff, err := enrollment.UserIsCourseStaff(r.Context(), d.Pool, courseCode, viewer)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")
+			return
+		}
+		if !staff {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "Only course staff can message enrollments from the roster.")
+			return
+		}
+		var body reqBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		body.Subject = strings.TrimSpace(body.Subject)
+		body.Body = strings.TrimSpace(body.Body)
+		if body.Body == "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Message body is required.")
+			return
+		}
+		if body.Subject == "" {
+			body.Subject = "(no subject)"
+		}
+		recipient, err := user.FindByID(r.Context(), d.Pool, en.UserID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load recipient.")
+			return
+		}
+		if recipient == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Recipient not found.")
+			return
+		}
+		msgID, err := communication.SendMessage(r.Context(), d.Pool, viewer, recipient.Email, body.Subject, body.Body)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not send message.")
+			return
+		}
+		if msgID == nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Recipient is not registered.")
+			return
+		}
+		d.notifyMailbox(viewer)
+		d.notifyMailbox(en.UserID)
+		d.emitInboxMessageNotification(r.Context(), en.UserID, viewer, body.Subject)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(respBody{ID: msgID.String()})
 	}
 }

--- a/server/internal/httpserver/courses_routes.go
+++ b/server/internal/httpserver/courses_routes.go
@@ -121,6 +121,7 @@ func (d Deps) registerCourseRoutes(r chi.Router) {
 	r.Post("/api/v1/courses/{course_code}/enrollments/self-as-student", d.handleCourseEnrollmentsSelfStudent())
 	r.Patch("/api/v1/courses/{course_code}/enrollments/{enrollment_id}", d.handleCourseEnrollmentsPatch())
 	r.Delete("/api/v1/courses/{course_code}/enrollments/{enrollment_id}", d.handleCourseEnrollmentsDelete())
+	r.Post("/api/v1/courses/{course_code}/enrollments/{enrollment_id}/message", d.handleCourseEnrollmentMessagePost())
 	r.Get("/api/v1/courses/{course_code}/enrollments", d.handleCourseEnrollmentsList())
 	r.Get("/api/v1/courses/{course_code}/enrollments/{enrollment_id}/progress", d.handleEnrollmentProgressGet())
 	r.Get("/api/v1/courses/{course_code}/enrollments/{enrollment_id}/progress/activity", d.handleEnrollmentProgressActivity())

--- a/server/internal/httpserver/me.go
+++ b/server/internal/httpserver/me.go
@@ -207,6 +207,7 @@ func (d Deps) registerMeRoutes(r chi.Router) {
 	r.Delete("/api/v1/me/oidc-identities/{id}", d.handleDeleteMyOIDCIdentity())
 	r.Post("/api/v1/me/notebooks/query", d.handleNotebookQuery())
 	r.Post("/api/v1/me/notebooks/flashcards", d.handleGenerateNotebookFlashcards())
+	d.registerNotebookTaskRoutes(r)
 	r.Post("/api/v1/stt/transcribe", d.handlePostSTTTranscribe())
 	d.registerTTSRoutes(r)
 	d.registerSelfReflectionRoutes(r)

--- a/server/internal/httpserver/notebook_tasks.go
+++ b/server/internal/httpserver/notebook_tasks.go
@@ -1,0 +1,219 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/lextures/lextures/server/internal/apierr"
+	repo "github.com/lextures/lextures/server/internal/repos/notebooktasks"
+)
+
+func (d Deps) registerNotebookTaskRoutes(r chi.Router) {
+	r.Get("/api/v1/me/notebook-tasks", d.handleListNotebookTasks())
+	r.Post("/api/v1/me/notebook-tasks", d.handleUpsertNotebookTask())
+	r.Patch("/api/v1/me/notebook-tasks/{id}", d.handlePatchNotebookTask())
+}
+
+type notebookTaskJSON struct {
+	ID             string  `json:"id"`
+	CourseCode     string  `json:"courseCode"`
+	NotebookPageID string  `json:"notebookPageId"`
+	TaskText       string  `json:"taskText"`
+	Completed      bool    `json:"completed"`
+	DueAt          *string `json:"dueAt"`
+	CreatedAt      string  `json:"createdAt"`
+	UpdatedAt      string  `json:"updatedAt"`
+}
+
+func notebookTaskToJSON(t repo.Task) notebookTaskJSON {
+	out := notebookTaskJSON{
+		ID:             t.ID.String(),
+		CourseCode:     t.CourseCode,
+		NotebookPageID: t.NotebookPageID,
+		TaskText:       t.TaskText,
+		Completed:      t.Completed,
+		CreatedAt:      t.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:      t.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+	if t.DueAt != nil {
+		s := t.DueAt.UTC().Format(time.RFC3339)
+		out.DueAt = &s
+	}
+	return out
+}
+
+func (d Deps) handleListNotebookTasks() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database not available.")
+			return
+		}
+		tasks, err := repo.ListOpen(r.Context(), d.Pool, userID, 50)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not load notebook tasks.")
+			return
+		}
+		out := make([]notebookTaskJSON, 0, len(tasks))
+		for _, t := range tasks {
+			out = append(out, notebookTaskToJSON(t))
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{"tasks": out})
+	}
+}
+
+type upsertNotebookTaskBody struct {
+	ID             string  `json:"id"`
+	CourseCode     string  `json:"courseCode"`
+	NotebookPageID string  `json:"notebookPageId"`
+	TaskText       string  `json:"taskText"`
+	Completed      *bool   `json:"completed"`
+	DueAt          *string `json:"dueAt"`
+}
+
+func (d Deps) handleUpsertNotebookTask() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database not available.")
+			return
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		var body upsertNotebookTaskBody
+		if err := json.Unmarshal(b, &body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		taskID, err := uuid.Parse(strings.TrimSpace(body.ID))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid task id.")
+			return
+		}
+		courseCode := strings.TrimSpace(body.CourseCode)
+		pageID := strings.TrimSpace(body.NotebookPageID)
+		if courseCode == "" || pageID == "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "courseCode and notebookPageId are required.")
+			return
+		}
+		text := strings.TrimSpace(body.TaskText)
+		if utf8.RuneCountInString(text) > 2000 {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Task text is too long.")
+			return
+		}
+		completed := false
+		if body.Completed != nil {
+			completed = *body.Completed
+		}
+		var dueAt *time.Time
+		if body.DueAt != nil && strings.TrimSpace(*body.DueAt) != "" {
+			parsed, perr := time.Parse(time.RFC3339, strings.TrimSpace(*body.DueAt))
+			if perr != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid dueAt.")
+				return
+			}
+			dueAt = &parsed
+		}
+		t := repo.Task{
+			ID:             taskID,
+			UserID:         userID,
+			CourseCode:     courseCode,
+			NotebookPageID: pageID,
+			TaskText:       text,
+			Completed:      completed,
+			DueAt:          dueAt,
+		}
+		if err := repo.Upsert(r.Context(), d.Pool, userID, t); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not save notebook task.")
+			return
+		}
+		saved, err := repo.Get(r.Context(), d.Pool, userID, taskID)
+		if err != nil || saved == nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not load saved task.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(notebookTaskToJSON(*saved))
+	}
+}
+
+type patchNotebookTaskBody struct {
+	TaskText  *string `json:"taskText"`
+	Completed *bool   `json:"completed"`
+	DueAt     *string `json:"dueAt"`
+	ClearDue  *bool   `json:"clearDue"`
+}
+
+func (d Deps) handlePatchNotebookTask() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database not available.")
+			return
+		}
+		rawID := chi.URLParam(r, "id")
+		taskID, err := uuid.Parse(strings.TrimSpace(rawID))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid task id.")
+			return
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		var body patchNotebookTaskBody
+		if err := json.Unmarshal(b, &body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		var text *string
+		if body.TaskText != nil {
+			t := strings.TrimSpace(*body.TaskText)
+			if utf8.RuneCountInString(t) > 2000 {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Task text is too long.")
+				return
+			}
+			text = &t
+		}
+		var dueAt *time.Time
+		clearDue := body.ClearDue != nil && *body.ClearDue
+		if !clearDue && body.DueAt != nil && strings.TrimSpace(*body.DueAt) != "" {
+			parsed, perr := time.Parse(time.RFC3339, strings.TrimSpace(*body.DueAt))
+			if perr != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid dueAt.")
+				return
+			}
+			dueAt = &parsed
+		}
+		updated, err := repo.Patch(r.Context(), d.Pool, userID, taskID, text, body.Completed, dueAt, clearDue)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not update notebook task.")
+			return
+		}
+		if updated == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Task not found.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(notebookTaskToJSON(*updated))
+	}
+}

--- a/server/internal/httpserver/notebook_tasks_nodb_test.go
+++ b/server/internal/httpserver/notebook_tasks_nodb_test.go
@@ -1,0 +1,47 @@
+package httpserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/auth"
+)
+
+func notebookTasksTestToken(t *testing.T, signer *auth.JWTSigner) string {
+	t.Helper()
+	tok, err := signer.Sign(context.Background(), "00000000-0000-0000-0000-000000000001", "u@test.invalid", "", "", nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return tok
+}
+
+func TestNotebookTasks_Unauthenticated_Returns401(t *testing.T) {
+	d := Deps{}
+	h := NewHandler(d)
+	for _, path := range []string{
+		"/api/v1/me/notebook-tasks",
+	} {
+		r := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("%s: status=%d want 401", path, w.Code)
+		}
+	}
+}
+
+func TestNotebookTasks_NoDB_Returns500(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	d := Deps{Pool: nil, JWTSigner: signer}
+	h := NewHandler(d)
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/me/notebook-tasks", nil)
+	r.Header.Set("Authorization", "Bearer "+notebookTasksTestToken(t, signer))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d want 500", w.Code)
+	}
+}

--- a/server/internal/httpserver/notifications_emit.go
+++ b/server/internal/httpserver/notifications_emit.go
@@ -2,12 +2,16 @@ package httpserver
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
+	"strings"
 
 	"github.com/google/uuid"
 
 	"github.com/lextures/lextures/server/internal/repos/course"
 	"github.com/lextures/lextures/server/internal/repos/discussions"
 	"github.com/lextures/lextures/server/internal/repos/enrollment"
+	"github.com/lextures/lextures/server/internal/repos/user"
 	"github.com/lextures/lextures/server/internal/service/notifications"
 )
 
@@ -42,6 +46,28 @@ func (d Deps) emitDiscussionReplyNotifications(ctx context.Context, courseID uui
 		orgID = oid
 	}
 	ns.NotifyDiscussionReply(ctx, participants, courseName, threadTitle, courseCode, threadID.String(), orgID)
+}
+
+func (d Deps) emitInboxMessageNotification(ctx context.Context, recipientID, senderID uuid.UUID, subject string) {
+	if recipientID == senderID {
+		return
+	}
+	senderName := "Someone"
+	if sender, err := user.FindByID(ctx, d.Pool, senderID); err == nil && sender != nil {
+		if sender.DisplayName != nil && strings.TrimSpace(*sender.DisplayName) != "" {
+			senderName = strings.TrimSpace(*sender.DisplayName)
+		} else if strings.TrimSpace(sender.Email) != "" {
+			senderName = strings.TrimSpace(sender.Email)
+		}
+	}
+	title := strings.TrimSpace(subject)
+	if title == "" {
+		title = "New message"
+	}
+	body := fmt.Sprintf("From %s", senderName)
+	if err := d.pushNotificationService().Enqueue(ctx, recipientID, notifications.EventInboxMessage, title, body, "/inbox"); err != nil {
+		slog.Warn("inbox_message.notification", "err", err, "recipient_id", recipientID.String())
+	}
 }
 
 func (d Deps) emitAssignmentCreatedNotifications(ctx context.Context, courseCode, assignmentTitle string) {

--- a/server/internal/notificationevents/events.go
+++ b/server/internal/notificationevents/events.go
@@ -15,6 +15,7 @@ const (
 	ConferenceReminder       = "conference_reminder"
 	CoachingTipWeekly      = "coaching_tip_weekly"
 	CanvasCourseImported   = "canvas_course_imported"
+	InboxMessage           = "inbox_message"
 )
 
 // All is the canonical list for defaults and UI.
@@ -32,4 +33,5 @@ var All = []string{
 	ConferenceReminder,
 	CoachingTipWeekly,
 	CanvasCourseImported,
+	InboxMessage,
 }

--- a/server/internal/repos/coursefeed/channels.go
+++ b/server/internal/repos/coursefeed/channels.go
@@ -15,23 +15,51 @@ type ChannelPublic struct {
 	CreatedAt time.Time `json:"createdAt"`
 }
 
-func ensureDefaultChannel(ctx context.Context, pool *pgxpool.Pool, courseID, createdBy uuid.UUID) error {
+func ensureDefaultChannels(ctx context.Context, pool *pgxpool.Pool, courseID, createdBy uuid.UUID) error {
 	_, err := pool.Exec(ctx, `
 		INSERT INTO course.feed_channels (course_id, name, sort_order, created_by_user_id)
-		SELECT $1, $2, 0, $3
-		WHERE NOT EXISTS (SELECT 1 FROM course.feed_channels WHERE course_id = $1)
-	`, courseID, "general", createdBy)
+		SELECT $1, 'general', 0, $2
+		WHERE NOT EXISTS (
+			SELECT 1 FROM course.feed_channels
+			WHERE course_id = $1 AND group_id IS NULL AND lower(name) = 'general'
+		)
+	`, courseID, createdBy)
+	if err != nil {
+		return err
+	}
+
+	tag, err := pool.Exec(ctx, `
+		INSERT INTO course.feed_channels (course_id, name, sort_order, created_by_user_id)
+		SELECT $1, 'announcements', 1, $2
+		WHERE NOT EXISTS (
+			SELECT 1 FROM course.feed_channels
+			WHERE course_id = $1 AND group_id IS NULL AND lower(name) = 'announcements'
+		)
+	`, courseID, createdBy)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return nil
+	}
+	_, err = pool.Exec(ctx, `
+		UPDATE course.feed_channels
+		SET sort_order = sort_order + 1
+		WHERE course_id = $1 AND group_id IS NULL
+		  AND lower(name) NOT IN ('general', 'announcements')
+		  AND sort_order >= 1
+	`, courseID)
 	return err
 }
 
 func ListChannels(ctx context.Context, pool *pgxpool.Pool, courseID, viewerID uuid.UUID) ([]ChannelPublic, error) {
-	if err := ensureDefaultChannel(ctx, pool, courseID, viewerID); err != nil {
+	if err := ensureDefaultChannels(ctx, pool, courseID, viewerID); err != nil {
 		return nil, err
 	}
 	rows, err := pool.Query(ctx, `
 		SELECT id, name, sort_order, created_at
 		FROM course.feed_channels
-		WHERE course_id = $1
+		WHERE course_id = $1 AND group_id IS NULL
 		ORDER BY sort_order ASC, created_at ASC
 	`, courseID)
 	if err != nil {
@@ -50,11 +78,11 @@ func ListChannels(ctx context.Context, pool *pgxpool.Pool, courseID, viewerID uu
 }
 
 func CreateChannel(ctx context.Context, pool *pgxpool.Pool, courseID, viewerID uuid.UUID, name string) (*ChannelPublic, error) {
-	if err := ensureDefaultChannel(ctx, pool, courseID, viewerID); err != nil {
+	if err := ensureDefaultChannels(ctx, pool, courseID, viewerID); err != nil {
 		return nil, err
 	}
 	var next int
-	if err := pool.QueryRow(ctx, `SELECT COALESCE(MAX(sort_order), 0) + 1 FROM course.feed_channels WHERE course_id = $1`, courseID).Scan(&next); err != nil {
+	if err := pool.QueryRow(ctx, `SELECT COALESCE(MAX(sort_order), 0) + 1 FROM course.feed_channels WHERE course_id = $1 AND group_id IS NULL`, courseID).Scan(&next); err != nil {
 		return nil, err
 	}
 	var c ChannelPublic

--- a/server/internal/repos/notebooktasks/repo.go
+++ b/server/internal/repos/notebooktasks/repo.go
@@ -1,0 +1,135 @@
+// Package notebooktasks persists learner tasks from notebook editors.
+package notebooktasks
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Task is one notebook checkbox item for a learner.
+type Task struct {
+	ID             uuid.UUID
+	UserID         uuid.UUID
+	CourseCode     string
+	NotebookPageID string
+	TaskText       string
+	Completed      bool
+	DueAt          *time.Time
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// Upsert inserts or updates a task row owned by userID.
+func Upsert(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, t Task) error {
+	_, err := pool.Exec(ctx, `
+INSERT INTO analytics.student_notebook_tasks (
+    id, user_id, course_code, notebook_page_id, task_text, completed, due_at, updated_at
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, now())
+ON CONFLICT (id) DO UPDATE SET
+    task_text = EXCLUDED.task_text,
+    completed = EXCLUDED.completed,
+    due_at = EXCLUDED.due_at,
+    updated_at = now()
+WHERE analytics.student_notebook_tasks.user_id = $2
+`, t.ID, userID, t.CourseCode, t.NotebookPageID, t.TaskText, t.Completed, t.DueAt)
+	return err
+}
+
+// Get returns a task when it belongs to userID.
+func Get(ctx context.Context, pool *pgxpool.Pool, userID, taskID uuid.UUID) (*Task, error) {
+	var t Task
+	err := pool.QueryRow(ctx, `
+SELECT id, user_id, course_code, notebook_page_id, task_text, completed, due_at, created_at, updated_at
+FROM analytics.student_notebook_tasks
+WHERE id = $1 AND user_id = $2
+`, taskID, userID).Scan(
+		&t.ID, &t.UserID, &t.CourseCode, &t.NotebookPageID, &t.TaskText, &t.Completed, &t.DueAt, &t.CreatedAt, &t.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+// ListOpen returns incomplete tasks for a user, ordered by due date then recency.
+func ListOpen(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, limit int) ([]Task, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	rows, err := pool.Query(ctx, `
+SELECT id, user_id, course_code, notebook_page_id, task_text, completed, due_at, created_at, updated_at
+FROM analytics.student_notebook_tasks
+WHERE user_id = $1 AND completed = false
+ORDER BY due_at NULLS LAST, created_at DESC
+LIMIT $2
+`, userID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Task
+	for rows.Next() {
+		var t Task
+		if err := rows.Scan(
+			&t.ID, &t.UserID, &t.CourseCode, &t.NotebookPageID, &t.TaskText, &t.Completed, &t.DueAt, &t.CreatedAt, &t.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// Patch updates mutable fields on a task owned by userID.
+func Patch(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	userID, taskID uuid.UUID,
+	taskText *string,
+	completed *bool,
+	dueAt *time.Time,
+	clearDueAt bool,
+) (*Task, error) {
+	cur, err := Get(ctx, pool, userID, taskID)
+	if err != nil {
+		return nil, err
+	}
+	if cur == nil {
+		return nil, nil
+	}
+	text := cur.TaskText
+	done := cur.Completed
+	due := cur.DueAt
+	if taskText != nil {
+		text = *taskText
+	}
+	if completed != nil {
+		done = *completed
+	}
+	if clearDueAt {
+		due = nil
+	} else if dueAt != nil {
+		due = dueAt
+	}
+	_, err = pool.Exec(ctx, `
+UPDATE analytics.student_notebook_tasks
+SET task_text = $3, completed = $4, due_at = $5, updated_at = now()
+WHERE id = $1 AND user_id = $2
+`, taskID, userID, text, done, due)
+	if err != nil {
+		return nil, err
+	}
+	return Get(ctx, pool, userID, taskID)
+}

--- a/server/internal/repos/platformconfig/features.go
+++ b/server/internal/repos/platformconfig/features.go
@@ -45,7 +45,7 @@ func applyPlatformBools(out *config.Config, db *Row, def Defaults) {
 	out.OERLibraryEnabled = mergeBool(db.OERLibraryEnabled, false)
 	out.OERStub = mergeBool(db.OERStub, false)
 	out.ItemAnalysisEnabled = mergeBool(db.ItemAnalysisEnabled, false)
-	out.StudentProgressEnabled = mergeBool(db.StudentProgressEnabled, false)
+	out.StudentProgressEnabled = mergeBool(db.StudentProgressEnabled, true)
 	out.EngagementTrackingEnabled = mergeBool(db.EngagementTrackingEnabled, false)
 	out.SelfReflectionEnabled = mergeBool(db.SelfReflectionEnabled, false)
 	out.OutcomesReportEnabled = mergeBool(db.OutcomesReportEnabled, false)

--- a/server/internal/service/notifications/event_types.go
+++ b/server/internal/service/notifications/event_types.go
@@ -16,6 +16,7 @@ const (
 	EventConferenceReminder    = notificationevents.ConferenceReminder
 	EventCoachingTipWeekly     = notificationevents.CoachingTipWeekly
 	EventCanvasCourseImported  = notificationevents.CanvasCourseImported
+	EventInboxMessage          = notificationevents.InboxMessage
 )
 
 // AllEventTypes re-exports the canonical event list for callers outside this package.

--- a/server/migrations/241_feed_announcements_channel.sql
+++ b/server/migrations/241_feed_announcements_channel.sql
@@ -1,0 +1,23 @@
+-- Every course feed gets a default #announcements channel directly under #general.
+
+INSERT INTO course.feed_channels (course_id, name, sort_order, created_by_user_id)
+SELECT c.id, 'announcements', 1, NULL
+FROM course.courses c
+WHERE NOT EXISTS (
+    SELECT 1 FROM course.feed_channels fc
+    WHERE fc.course_id = c.id
+      AND fc.group_id IS NULL
+      AND lower(fc.name) = 'announcements'
+);
+
+UPDATE course.feed_channels fc
+SET sort_order = fc.sort_order + 1
+WHERE fc.group_id IS NULL
+  AND lower(fc.name) NOT IN ('general', 'announcements')
+  AND fc.sort_order >= 1
+  AND EXISTS (
+    SELECT 1 FROM course.feed_channels ann
+    WHERE ann.course_id = fc.course_id
+      AND ann.group_id IS NULL
+      AND lower(ann.name) = 'announcements'
+  );

--- a/server/migrations/242_student_notebook_tasks.sql
+++ b/server/migrations/242_student_notebook_tasks.sql
@@ -1,0 +1,19 @@
+-- Student notebook tasks (checkbox items from /task or /todo slash commands).
+
+CREATE TABLE analytics.student_notebook_tasks (
+    id               UUID PRIMARY KEY,
+    user_id          UUID NOT NULL REFERENCES "user".users (id) ON DELETE CASCADE,
+    course_code      TEXT NOT NULL,
+    notebook_page_id TEXT NOT NULL,
+    task_text        TEXT NOT NULL DEFAULT '',
+    completed        BOOLEAN NOT NULL DEFAULT false,
+    due_at           TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_student_notebook_tasks_user_open
+    ON analytics.student_notebook_tasks (user_id, completed, due_at NULLS LAST, created_at DESC);
+
+COMMENT ON TABLE analytics.student_notebook_tasks IS
+    'Learner tasks created in course or global notebooks; synced from client-side notebook editor.';


### PR DESCRIPTION
## Summary

- Add student notebook tasks: `/task` and `/todo` slash commands insert syncable TipTap blocks, backed by a new `analytics.student_notebook_tasks` table and `/api/v1/me/notebook-tasks` CRUD endpoints; open tasks surface on the learner dashboard.
- Embed whiteboards in notebooks via `/whiteboard` slash command, extracting shared canvas components (`embedded-whiteboard`, toolbar, serialization) and slimming down the standalone course whiteboard page.
- Seed a default `#announcements` channel on every course feed and improve course enrollments, student progress views, and notification toasts.

## Test plan

- [ ] Run migrations (`241`, `242`) and verify `GET/POST/PATCH /api/v1/me/notebook-tasks` works
- [ ] In a course or global notebook, use `/task` and `/todo` to create tasks; confirm they persist after reload and appear on the dashboard card
- [ ] Use `/whiteboard` in a notebook page; draw, save, and reload to confirm canvas state is preserved
- [ ] Confirm existing course whiteboard page still works with the refactored components
- [ ] Verify new courses (or migrated ones) have `#announcements` under `#general` in the course feed
- [ ] Check course enrollments and student progress pages for layout/regression issues
- [ ] Run `npm run test` and `go test ./... -short` in `server/`
- [ ] Run `e2e/tests/student-progress.spec.ts` if e2e environment is available