### PR TITLE
feat: server-side course file breadcrumbs, reliable import toasts, and richer PPTX preview

### DIFF
--- a/clients/web/src/context/inbox-notifications-provider.tsx
+++ b/clients/web/src/context/inbox-notifications-provider.tsx
@@ -2,9 +2,8 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { authorizedFetch, apiUrl } from '../lib/api'
 import { getAccessToken } from '../lib/auth'
 import {
+  applyInboxRefreshForToasts,
   loadNotificationToastedIds,
-  pickNotificationsToToast,
-  rememberNotificationToastedIds,
 } from '../lib/notification-toast'
 import { toast } from '../lib/lms-toast'
 import { InboxNotificationsContext, type InboxNotification } from './inbox-notifications-context'
@@ -24,29 +23,25 @@ export function InboxNotificationsProvider({ children }: { children: ReactNode }
       if (!res.ok) return
       const data = (await res.json()) as { notifications: InboxNotification[]; unreadCount: number }
       const incoming = data.notifications ?? []
+      let toToast: InboxNotification[] = []
       setNotifications((prev) => {
-        const toToast = pickNotificationsToToast(
+        const result = applyInboxRefreshForToasts(
           prev,
           incoming,
           toastedIdsRef.current,
           inboxHydratedRef.current,
         )
-        if (toToast.length > 0) {
-          rememberNotificationToastedIds(
-            toastedIdsRef.current,
-            toToast.map((n) => n.id),
-          )
-          for (const n of toToast) {
-            if (n.eventType === 'inbox_message') {
-              toast.info(n.title, { description: n.body })
-            } else {
-              toast.success(n.title, { description: n.body })
-            }
-          }
-        }
-        return incoming
+        inboxHydratedRef.current = result.nowHydrated
+        toToast = result.toToast
+        return result.next
       })
-      inboxHydratedRef.current = true
+      for (const n of toToast) {
+        if (n.eventType === 'inbox_message') {
+          toast.info(n.title, { description: n.body })
+        } else {
+          toast.success(n.title, { description: n.body })
+        }
+      }
       setUnreadCount(data.unreadCount ?? 0)
     } catch {
       /* ignore */

--- a/clients/web/src/lib/__tests__/notification-toast.test.ts
+++ b/clients/web/src/lib/__tests__/notification-toast.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import type { InboxNotification } from '../../context/inbox-notifications-context'
+import { applyInboxRefreshForToasts } from '../notification-toast'
+
+function notif(id: string, eventType: string): InboxNotification {
+  return {
+    id,
+    userId: 'u1',
+    eventType,
+    title: 'Course imported from Canvas',
+    body: 'Demo is ready.',
+    actionUrl: '/courses/demo',
+    isRead: false,
+    createdAt: '2026-06-07T00:00:00.000Z',
+  }
+}
+
+describe('applyInboxRefreshForToasts', () => {
+  it('does not toast existing notifications on first hydration', () => {
+    const incoming = [notif('a', 'canvas_course_imported')]
+    const toasted = new Set<string>()
+    const result = applyInboxRefreshForToasts([], incoming, toasted, false)
+    expect(result.toToast).toEqual([])
+    expect(result.nowHydrated).toBe(true)
+    expect(toasted.has('a')).toBe(true)
+  })
+
+  it('toasts only notifications that arrive after hydration', () => {
+    const prev = [notif('a', 'canvas_course_imported')]
+    const incoming = [notif('a', 'canvas_course_imported'), notif('b', 'canvas_course_imported')]
+    const toasted = new Set(['a'])
+    const result = applyInboxRefreshForToasts(prev, incoming, toasted, true)
+    expect(result.toToast.map((n) => n.id)).toEqual(['b'])
+    expect(toasted.has('b')).toBe(true)
+  })
+})

--- a/clients/web/src/lib/course-files-api.ts
+++ b/clients/web/src/lib/course-files-api.ts
@@ -25,8 +25,14 @@ export type FileItem = {
   updatedAt: string
 }
 
+export type FolderBreadcrumb = {
+  id: string
+  name: string
+}
+
 export type FolderContents = {
   folderId: string | null
+  breadcrumbs?: FolderBreadcrumb[]
   folders: FileFolder[]
   files: FileItem[]
 }

--- a/clients/web/src/lib/notification-toast.ts
+++ b/clients/web/src/lib/notification-toast.ts
@@ -2,12 +2,12 @@ import type { InboxNotification } from '../context/inbox-notifications-context'
 
 const TOAST_EVENT_TYPES = new Set(['canvas_course_imported', 'inbox_message'])
 
-/** sessionStorage key for notification ids that already triggered a toast. */
+/** localStorage key for notification ids that already triggered a toast. */
 export const NOTIFICATION_TOASTED_IDS_KEY = 'lextures:notification-toasted-ids'
 
 export function loadNotificationToastedIds(): Set<string> {
   try {
-    const raw = sessionStorage.getItem(NOTIFICATION_TOASTED_IDS_KEY)
+    const raw = localStorage.getItem(NOTIFICATION_TOASTED_IDS_KEY)
     if (!raw) return new Set()
     const parsed = JSON.parse(raw) as unknown
     if (!Array.isArray(parsed)) return new Set()
@@ -21,10 +21,41 @@ export function rememberNotificationToastedIds(existing: Set<string>, ids: strin
   for (const id of ids) existing.add(id)
   const trimmed = [...existing].slice(-100)
   try {
-    sessionStorage.setItem(NOTIFICATION_TOASTED_IDS_KEY, JSON.stringify(trimmed))
+    localStorage.setItem(NOTIFICATION_TOASTED_IDS_KEY, JSON.stringify(trimmed))
   } catch {
     /* quota / private mode */
   }
+}
+
+export type InboxRefreshToastResult = {
+  next: InboxNotification[]
+  toToast: InboxNotification[]
+  nowHydrated: boolean
+}
+
+/** Applies an inbox poll result and returns notifications that should toast. */
+export function applyInboxRefreshForToasts(
+  prev: readonly InboxNotification[],
+  incoming: readonly InboxNotification[],
+  alreadyToasted: Set<string>,
+  inboxHydrated: boolean,
+): InboxRefreshToastResult {
+  if (!inboxHydrated) {
+    const existingToastableIds = incoming
+      .filter((n) => TOAST_EVENT_TYPES.has(n.eventType))
+      .map((n) => n.id)
+    rememberNotificationToastedIds(alreadyToasted, existingToastableIds)
+    return { next: [...incoming], toToast: [], nowHydrated: true }
+  }
+
+  const toToast = pickNotificationsToToast(prev, incoming, alreadyToasted, true)
+  if (toToast.length > 0) {
+    rememberNotificationToastedIds(
+      alreadyToasted,
+      toToast.map((n) => n.id),
+    )
+  }
+  return { next: [...incoming], toToast, nowHydrated: true }
 }
 
 export function pickNotificationsToToast(

--- a/clients/web/src/pages/lms/course-files-page.tsx
+++ b/clients/web/src/pages/lms/course-files-page.tsx
@@ -75,9 +75,6 @@ export default function CourseFilesPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  // breadcrumbs: list of {id, name} from root to current
-  const [breadcrumbs, setBreadcrumbs] = useState<{ id: string; name: string }[]>([])
-
   const [uploading, setUploading] = useState(false)
   const [uploadProgress, setUploadProgress] = useState<string | null>(null)
   const [cloudImportError, setCloudImportError] = useState<string | null>(null)
@@ -142,6 +139,11 @@ export default function CourseFilesPage() {
     setSelectedItems(new Set())
     setSearchQuery('')
   }, [folderId])
+
+  const breadcrumbs = useMemo(() => {
+    if (!folderId || contents?.folderId !== folderId) return []
+    return contents.breadcrumbs ?? []
+  }, [folderId, contents?.folderId, contents?.breadcrumbs])
 
   const filteredFolders = useMemo(() => {
     if (!contents) return []
@@ -270,29 +272,11 @@ export default function CourseFilesPage() {
     setRenameValue(selected.file.displayName)
   }
 
-  // Keep breadcrumb trail in sync when folderId changes
-  useEffect(() => {
-    if (!folderId) {
-      setBreadcrumbs([])
-      return
-    }
-    // If we navigated into a subfolder, append; otherwise rebuild from contents
-    if (contents?.folderId === folderId) return
-    // On direct navigation (e.g. back/forward) we may not have parent info — just clear
-    setBreadcrumbs([])
-  }, [folderId, contents?.folderId])
-
-  function navigateToFolder(id: string | null, name?: string) {
+  function navigateToFolder(id: string | null) {
     if (!id) {
       setSearchParams({})
-      setBreadcrumbs([])
     } else {
       setSearchParams({ folder: id })
-      setBreadcrumbs(prev => {
-        const existing = prev.findIndex(b => b.id === id)
-        if (existing >= 0) return prev.slice(0, existing + 1)
-        return [...prev, { id, name: name ?? 'Folder' }]
-      })
     }
   }
 
@@ -451,101 +435,107 @@ export default function CourseFilesPage() {
         />
       )}
 
-      {/* Toolbar */}
-      <div className="mb-4 flex flex-wrap items-center gap-2">
-        {/* Breadcrumbs */}
-        <nav className="flex min-w-0 flex-1 items-center gap-1 text-sm">
-          <span
-            onDragOver={(e) => {
-              if (draggingItem && folderId !== undefined) {
-                e.preventDefault()
-                e.dataTransfer.dropEffect = 'move'
-              }
-            }}
-            onDragEnter={() => {
-              if (draggingItem && folderId !== undefined) {
-                setDragOverBreadcrumbId('root')
-              }
-            }}
-            onDragLeave={(e) => {
-              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                setDragOverBreadcrumbId(null)
-              }
-            }}
-            onDrop={() => {
-              if (draggingItem && folderId !== undefined) {
-                void handleMoveItem(draggingItem.kind, draggingItem.id, null)
-              }
+      {/* Breadcrumb trail */}
+      <nav
+        aria-label="Folder path"
+        className="mb-3 flex min-w-0 flex-wrap items-center gap-1 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900/60"
+      >
+        <span
+          onDragOver={(e) => {
+            if (draggingItem && folderId !== undefined) {
+              e.preventDefault()
+              e.dataTransfer.dropEffect = 'move'
+            }
+          }}
+          onDragEnter={() => {
+            if (draggingItem && folderId !== undefined) {
+              setDragOverBreadcrumbId('root')
+            }
+          }}
+          onDragLeave={(e) => {
+            if (!e.currentTarget.contains(e.relatedTarget as Node)) {
               setDragOverBreadcrumbId(null)
-            }}
-            className={`px-1.5 py-0.5 rounded transition-all duration-150 ${
-              draggingItem && folderId !== undefined
-                ? dragOverBreadcrumbId === 'root'
-                  ? 'bg-indigo-100 dark:bg-indigo-900/60 ring-2 ring-indigo-500 text-indigo-700 dark:text-indigo-300 font-semibold'
-                  : 'bg-indigo-50/50 dark:bg-indigo-950/20 border border-dashed border-indigo-300 dark:border-indigo-700'
-                : ''
-            }`}
+            }
+          }}
+          onDrop={() => {
+            if (draggingItem && folderId !== undefined) {
+              void handleMoveItem(draggingItem.kind, draggingItem.id, null)
+            }
+            setDragOverBreadcrumbId(null)
+          }}
+          className={`rounded px-1.5 py-0.5 transition-all duration-150 ${
+            draggingItem && folderId !== undefined
+              ? dragOverBreadcrumbId === 'root'
+                ? 'bg-indigo-100 font-semibold text-indigo-700 ring-2 ring-indigo-500 dark:bg-indigo-900/60 dark:text-indigo-300'
+                : 'border border-dashed border-indigo-300 bg-indigo-50/50 dark:border-indigo-700 dark:bg-indigo-950/20'
+              : ''
+          }`}
+        >
+          <button
+            type="button"
+            onClick={() => navigateToFolder(null)}
+            className="text-indigo-600 hover:underline dark:text-indigo-400"
+            aria-current={!folderId ? 'page' : undefined}
           >
-            <button
-              onClick={() => navigateToFolder(null)}
-              className="text-indigo-600 hover:underline dark:text-indigo-400"
-            >
-              Files
-            </button>
-          </span>
-          {breadcrumbs.map((b, i) => {
-            const isLast = i === breadcrumbs.length - 1
-            const canDropOnCrumb = draggingItem && folderId !== b.id && draggingItem.id !== b.id
-            return (
-              <span key={b.id} className="flex items-center gap-1">
-                <span className="text-slate-400">/</span>
-                <span
-                  onDragOver={(e) => {
-                    if (canDropOnCrumb) {
-                      e.preventDefault()
-                      e.dataTransfer.dropEffect = 'move'
-                    }
-                  }}
-                  onDragEnter={() => {
-                    if (canDropOnCrumb) {
-                      setDragOverBreadcrumbId(b.id)
-                    }
-                  }}
-                  onDragLeave={(e) => {
-                    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                      setDragOverBreadcrumbId(null)
-                    }
-                  }}
-                  onDrop={() => {
-                    if (canDropOnCrumb) {
-                      void handleMoveItem(draggingItem!.kind, draggingItem!.id, b.id)
-                    }
+            Files
+          </button>
+        </span>
+        {breadcrumbs.map((b, i) => {
+          const isLast = i === breadcrumbs.length - 1
+          const canDropOnCrumb = draggingItem && folderId !== b.id && draggingItem.id !== b.id
+          return (
+            <span key={b.id} className="flex min-w-0 items-center gap-1">
+              <span className="text-slate-400 dark:text-neutral-500" aria-hidden>/</span>
+              <span
+                onDragOver={(e) => {
+                  if (canDropOnCrumb) {
+                    e.preventDefault()
+                    e.dataTransfer.dropEffect = 'move'
+                  }
+                }}
+                onDragEnter={() => {
+                  if (canDropOnCrumb) {
+                    setDragOverBreadcrumbId(b.id)
+                  }
+                }}
+                onDragLeave={(e) => {
+                  if (!e.currentTarget.contains(e.relatedTarget as Node)) {
                     setDragOverBreadcrumbId(null)
-                  }}
-                  className={`px-1.5 py-0.5 rounded transition-all duration-150 ${
-                    canDropOnCrumb
-                      ? dragOverBreadcrumbId === b.id
-                        ? 'bg-indigo-100 dark:bg-indigo-900/60 ring-2 ring-indigo-500 text-indigo-700 dark:text-indigo-300 font-semibold'
-                        : 'bg-indigo-50/50 dark:bg-indigo-950/20 border border-dashed border-indigo-300 dark:border-indigo-700'
-                      : ''
-                  }`}
-                >
-                  {!isLast ? (
-                    <button
-                      onClick={() => navigateToFolder(b.id, b.name)}
-                      className="text-indigo-600 hover:underline dark:text-indigo-400"
-                    >
-                      {b.name}
-                    </button>
-                  ) : (
-                    <span className="truncate font-medium text-slate-800 dark:text-neutral-200">{b.name}</span>
-                  )}
-                </span>
+                  }
+                }}
+                onDrop={() => {
+                  if (canDropOnCrumb) {
+                    void handleMoveItem(draggingItem!.kind, draggingItem!.id, b.id)
+                  }
+                  setDragOverBreadcrumbId(null)
+                }}
+                className={`min-w-0 rounded px-1.5 py-0.5 transition-all duration-150 ${
+                  canDropOnCrumb
+                    ? dragOverBreadcrumbId === b.id
+                      ? 'bg-indigo-100 font-semibold text-indigo-700 ring-2 ring-indigo-500 dark:bg-indigo-900/60 dark:text-indigo-300'
+                      : 'border border-dashed border-indigo-300 bg-indigo-50/50 dark:border-indigo-700 dark:bg-indigo-950/20'
+                    : ''
+                }`}
+              >
+                {!isLast ? (
+                  <button
+                    type="button"
+                    onClick={() => navigateToFolder(b.id)}
+                    className="max-w-[12rem] truncate text-indigo-600 hover:underline dark:text-indigo-400"
+                  >
+                    {b.name}
+                  </button>
+                ) : (
+                  <span className="block max-w-[12rem] truncate font-medium text-slate-800 dark:text-neutral-200" aria-current="page">{b.name}</span>
+                )}
               </span>
-            )
-          })}
-        </nav>
+            </span>
+          )
+        })}
+      </nav>
 
+      {/* Toolbar */}
+      <div className="mb-4 flex flex-wrap items-center justify-end gap-2">
         {canManage && (
           <div className="flex shrink-0 items-center gap-2">
             <button
@@ -719,7 +709,7 @@ export default function CourseFilesPage() {
                   renamingFolder={renamingFolder}
                   renameValue={renameValue}
                   setRenameValue={setRenameValue}
-                  onNavigate={() => navigateToFolder(folder.id, folder.name)}
+                  onNavigate={() => navigateToFolder(folder.id)}
                   onRenameStart={() => { setRenamingFolder(folder); setRenameValue(folder.name) }}
                   onRenameSubmit={() => void handleRenameFolder()}
                   onRenameCancel={() => setRenamingFolder(null)}
@@ -777,7 +767,7 @@ export default function CourseFilesPage() {
             <>
               <button
                 className="flex w-full items-center gap-2 px-4 py-2 text-sm hover:bg-slate-50 dark:hover:bg-neutral-800"
-                onClick={() => { navigateToFolder(contextMenu.item.id, (contextMenu.item as FileFolder).name); setContextMenu(null) }}
+                onClick={() => { navigateToFolder(contextMenu.item.id); setContextMenu(null) }}
               >
                 Open
               </button>

--- a/server/internal/httpserver/canvas_import_queue.go
+++ b/server/internal/httpserver/canvas_import_queue.go
@@ -232,9 +232,33 @@ func (d Deps) HandleCanvasImportQueueMessage(ctx context.Context, msg canvasimpo
 	return d.processCanvasImportQueueMessage(ctx, msg, emit)
 }
 
+func canvasImportJobAlreadyTerminal(status canvasimportjobs.Status) bool {
+	return status == canvasimportjobs.StatusCompleted || status == canvasimportjobs.StatusFailed
+}
+
 func (d Deps) processCanvasImportQueueMessage(ctx context.Context, msg canvasimportjobs.QueueMessage, progress func(string) bool) error {
 	if d.Pool == nil {
 		return errors.New("server misconfiguration")
+	}
+	job, err := canvasimportjobs.Load(ctx, d.Pool, msg.JobID)
+	if err != nil {
+		return err
+	}
+	if job == nil {
+		return fmt.Errorf("canvas import job %s not found", msg.JobID)
+	}
+	if canvasImportJobAlreadyTerminal(job.Status) {
+		if job.Status == canvasimportjobs.StatusCompleted && d.CanvasImportHub != nil {
+			d.CanvasImportHub.Broadcast(msg.JobID, canvasimportevents.Message{Type: "complete"})
+		}
+		if job.Status == canvasimportjobs.StatusFailed && d.CanvasImportHub != nil {
+			errMsg := "Canvas import failed."
+			if job.ErrorMessage != nil && *job.ErrorMessage != "" {
+				errMsg = *job.ErrorMessage
+			}
+			d.CanvasImportHub.Broadcast(msg.JobID, canvasimportevents.Message{Type: "error", Message: errMsg})
+		}
+		return nil
 	}
 	if err := canvasimportjobs.MarkProcessing(ctx, d.Pool, msg.JobID); err != nil {
 		return err
@@ -249,15 +273,15 @@ func (d Deps) processCanvasImportQueueMessage(ctx context.Context, msg canvasimp
 		Files:       msg.Include.Files,
 	}.withDefaults()
 
-	err := d.runCanvasImport(ctx, msg.UserID, msg.CourseCode, msg.Mode, msg.CanvasBaseURL, msg.CanvasCourseID, msg.AccessToken, include, progress)
-	if err != nil {
-		if markErr := canvasimportjobs.MarkFailed(ctx, d.Pool, msg.JobID, err.Error(), canvasImportMaxAttempts); markErr != nil {
-			return fmt.Errorf("import failed: %w; mark failed: %v", err, markErr)
+	importErr := d.runCanvasImport(ctx, msg.UserID, msg.CourseCode, msg.Mode, msg.CanvasBaseURL, msg.CanvasCourseID, msg.AccessToken, include, progress)
+	if importErr != nil {
+		if markErr := canvasimportjobs.MarkFailed(ctx, d.Pool, msg.JobID, importErr.Error(), canvasImportMaxAttempts); markErr != nil {
+			return fmt.Errorf("import failed: %w; mark failed: %v", importErr, markErr)
 		}
 		if d.CanvasImportHub != nil {
-			d.CanvasImportHub.Broadcast(msg.JobID, canvasimportevents.Message{Type: "error", Message: err.Error()})
+			d.CanvasImportHub.Broadcast(msg.JobID, canvasimportevents.Message{Type: "error", Message: importErr.Error()})
 		}
-		return err
+		return importErr
 	}
 
 	var courseTitle string
@@ -265,6 +289,7 @@ func (d Deps) processCanvasImportQueueMessage(ctx context.Context, msg canvasimp
 	if markErr := canvasimportjobs.MarkCompleted(ctx, d.Pool, msg.JobID, courseTitle); markErr != nil {
 		return markErr
 	}
+	d.pushNotificationService().EnqueueCanvasCourseImported(ctx, msg.UserID, courseTitle, msg.CourseCode)
 	if d.CanvasImportHub != nil {
 		d.CanvasImportHub.Broadcast(msg.JobID, canvasimportevents.Message{Type: "complete"})
 	}

--- a/server/internal/httpserver/canvas_import_queue_test.go
+++ b/server/internal/httpserver/canvas_import_queue_test.go
@@ -14,6 +14,22 @@ func TestIncludeToRepo(t *testing.T) {
 	}
 }
 
+func TestCanvasImportJobAlreadyTerminal(t *testing.T) {
+	t.Parallel()
+	if canvasImportJobAlreadyTerminal(canvasimportjobs.StatusCompleted) != true {
+		t.Fatal("completed should be terminal")
+	}
+	if canvasImportJobAlreadyTerminal(canvasimportjobs.StatusFailed) != true {
+		t.Fatal("failed should be terminal")
+	}
+	if canvasImportJobAlreadyTerminal(canvasimportjobs.StatusQueued) {
+		t.Fatal("queued should not be terminal")
+	}
+	if canvasImportJobAlreadyTerminal(canvasimportjobs.StatusProcessing) {
+		t.Fatal("processing should not be terminal")
+	}
+}
+
 func TestTerminalWSMessage_Statuses(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/server/internal/httpserver/canvas_import_ws.go
+++ b/server/internal/httpserver/canvas_import_ws.go
@@ -534,15 +534,6 @@ func (d Deps) runCanvasImport(
 		}
 	}
 
-	courseTitle := strAt(course, "name", "")
-	if courseTitle == "" {
-		_ = d.Pool.QueryRow(ctx, `SELECT title FROM course.courses WHERE id = $1`, courseID).Scan(&courseTitle)
-	}
-	if courseTitle == "" {
-		courseTitle = courseCode
-	}
-	d.pushNotificationService().EnqueueCanvasCourseImported(ctx, importerUserID, courseTitle, courseCode)
-
 	return nil
 }
 

--- a/server/internal/httpserver/course_file_manager.go
+++ b/server/internal/httpserver/course_file_manager.go
@@ -98,6 +98,13 @@ func (d Deps) handleGetCourseFilesFolder() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to list folder contents.")
 			return
 		}
+		breadcrumbs, err := filemanager.ListFolderBreadcrumbs(r.Context(), d.Pool, courseID, folderID)
+		if err != nil {
+			log.Printf("course-files-folder-breadcrumbs: course=%q folder=%s err=%v", courseCode, folderID, err)
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to list folder contents.")
+			return
+		}
+		contents.Breadcrumbs = breadcrumbs
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(contents)
 	}

--- a/server/internal/repos/filemanager/folders.go
+++ b/server/internal/repos/filemanager/folders.go
@@ -96,6 +96,38 @@ func listFiles(ctx context.Context, db *pgxpool.Pool, courseID uuid.UUID, folder
 	return out, rows.Err()
 }
 
+// ListFolderBreadcrumbs returns ancestors from the course-files root through the given folder (inclusive).
+func ListFolderBreadcrumbs(ctx context.Context, db *pgxpool.Pool, courseID, folderID uuid.UUID) ([]FolderBreadcrumb, error) {
+	rows, err := db.Query(ctx, `
+		WITH RECURSIVE ancestors AS (
+			SELECT id, parent_id, name, 0 AS depth
+			FROM course.file_folders
+			WHERE id = $1 AND course_id = $2
+			UNION ALL
+			SELECT f.id, f.parent_id, f.name, a.depth + 1
+			FROM course.file_folders f
+			JOIN ancestors a ON f.id = a.parent_id
+		)
+		SELECT id, name FROM ancestors ORDER BY depth DESC
+	`, folderID, courseID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []FolderBreadcrumb
+	for rows.Next() {
+		var crumb FolderBreadcrumb
+		if scanErr := rows.Scan(&crumb.ID, &crumb.Name); scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, crumb)
+	}
+	if out == nil {
+		out = []FolderBreadcrumb{}
+	}
+	return out, rows.Err()
+}
+
 func GetFolder(ctx context.Context, db *pgxpool.Pool, courseID, folderID uuid.UUID) (*Folder, error) {
 	row := db.QueryRow(ctx, `
 		SELECT id, course_id, parent_id, name, created_by, created_at, updated_at

--- a/server/internal/repos/filemanager/models.go
+++ b/server/internal/repos/filemanager/models.go
@@ -31,9 +31,16 @@ type FileItem struct {
 	UpdatedAt        time.Time  `json:"updatedAt"`
 }
 
+// FolderBreadcrumb is one segment of the path from the course-files root to the current folder.
+type FolderBreadcrumb struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+}
+
 // FolderContents is the response for listing a folder (or the root).
 type FolderContents struct {
-	FolderID *uuid.UUID `json:"folderId"`
-	Folders  []Folder   `json:"folders"`
-	Files    []FileItem `json:"files"`
+	FolderID    *uuid.UUID         `json:"folderId"`
+	Breadcrumbs []FolderBreadcrumb `json:"breadcrumbs,omitempty"`
+	Folders     []Folder           `json:"folders"`
+	Files       []FileItem         `json:"files"`
 }

--- a/server/internal/service/officepreview/pptx_anim.go
+++ b/server/internal/service/officepreview/pptx_anim.go
@@ -1,0 +1,171 @@
+package officepreview
+
+import "strings"
+
+// pptxAnimEndState captures slide appearance after all click-sequence animations finish.
+type pptxAnimEndState struct {
+	hiddenIDs map[string]bool
+	offsets   map[string]pptxMotionOffset
+}
+
+type pptxMotionOffset struct {
+	dx, dy int64 // EMU delta applied to shape position
+}
+
+func parsePptxAnimEndState(slideRoot *pptxXMLNode) pptxAnimEndState {
+	state := pptxAnimEndState{
+		hiddenIDs: make(map[string]bool),
+		offsets:   make(map[string]pptxMotionOffset),
+	}
+	timing := slideRoot.child("timing")
+	if timing == nil {
+		return state
+	}
+	visibility := make(map[string]bool)
+	walkPptxTimingNodes(timing, func(n *pptxXMLNode) {
+		switch n.XMLName.Local {
+		case "animEffect":
+			spid := pptxAnimTargetSpID(n)
+			if spid == "" {
+				return
+			}
+			switch n.attr("transition") {
+			case "out":
+				visibility[spid] = false
+			case "in":
+				visibility[spid] = true
+			}
+		case "set":
+			spid := pptxAnimTargetSpID(n)
+			if spid == "" {
+				return
+			}
+			if pptxSetAnimVisibility(n, false) {
+				visibility[spid] = false
+			} else if pptxSetAnimVisibility(n, true) {
+				visibility[spid] = true
+			}
+		case "animMotion":
+			spid := pptxAnimTargetSpID(n)
+			if spid == "" {
+				return
+			}
+			if off := pptxAnimMotionOffset(n); off.dx != 0 || off.dy != 0 {
+				prev := state.offsets[spid]
+				state.offsets[spid] = pptxMotionOffset{
+					dx: prev.dx + off.dx,
+					dy: prev.dy + off.dy,
+				}
+			}
+		}
+	})
+	for spid, visible := range visibility {
+		if !visible {
+			state.hiddenIDs[spid] = true
+		}
+	}
+	return state
+}
+
+func walkPptxTimingNodes(node *pptxXMLNode, fn func(*pptxXMLNode)) {
+	if node == nil {
+		return
+	}
+	fn(node)
+	for i := range node.Children {
+		walkPptxTimingNodes(&node.Children[i], fn)
+	}
+}
+
+func pptxAnimTargetSpID(node *pptxXMLNode) string {
+	spTgt := node.findDeep("spTgt")
+	if spTgt == nil {
+		return ""
+	}
+	return spTgt.attr("spid")
+}
+
+func pptxSetAnimVisibility(node *pptxXMLNode, wantVisible bool) bool {
+	cBhvr := node.child("cBhvr")
+	if cBhvr == nil {
+		return false
+	}
+	attrName := cBhvr.findDeep("attrName")
+	if attrName == nil || attrName.Content == "" {
+		if lst := cBhvr.child("attrNameLst"); lst != nil {
+			for i := range lst.Children {
+				if lst.Children[i].XMLName.Local == "attrName" {
+					attrName = &lst.Children[i]
+					break
+				}
+			}
+		}
+	}
+	name := ""
+	if attrName != nil {
+		name = strings.TrimSpace(attrName.Content)
+		if name == "" {
+			name = attrName.attr("val")
+		}
+	}
+	if name != "style.visibility" && name != "visibility" {
+		return false
+	}
+	to := node.child("to")
+	if to == nil {
+		return false
+	}
+	if strVal := to.child("strVal"); strVal != nil {
+		val := strings.ToLower(strings.TrimSpace(strVal.attr("val")))
+		if wantVisible {
+			return val == "visible"
+		}
+		return val == "hidden" || val == "none"
+	}
+	return false
+}
+
+func pptxAnimMotionOffset(node *pptxXMLNode) pptxMotionOffset {
+	var off pptxMotionOffset
+	if by := node.child("by"); by != nil {
+		if pos := by.child("pos"); pos != nil {
+			off.dx = parseEMU(pos.attr("x"))
+			off.dy = parseEMU(pos.attr("y"))
+			return off
+		}
+	}
+	if to := node.child("to"); to != nil {
+		if pos := to.child("pos"); pos != nil {
+			off.dx = parseEMU(pos.attr("x"))
+			off.dy = parseEMU(pos.attr("y"))
+		}
+	}
+	return off
+}
+
+func applyPptxAnimEndState(layers []pptxVisualLayer, state pptxAnimEndState) []pptxVisualLayer {
+	if len(state.hiddenIDs) == 0 && len(state.offsets) == 0 {
+		return layers
+	}
+	out := make([]pptxVisualLayer, 0, len(layers))
+	for _, layer := range layers {
+		if layer.spID != "" && state.hiddenIDs[layer.spID] {
+			continue
+		}
+		if layer.spID != "" {
+			if off, ok := state.offsets[layer.spID]; ok {
+				layer.left += off.dx
+				layer.top += off.dy
+			}
+		}
+		out = append(out, layer)
+	}
+	return out
+}
+
+func shapeSpID(node *pptxXMLNode) string {
+	if cNvPr := node.findDeep("cNvPr"); cNvPr != nil {
+		return cNvPr.attr("id")
+	}
+	return ""
+}

--- a/server/internal/service/officepreview/pptx_anim_test.go
+++ b/server/internal/service/officepreview/pptx_anim_test.go
@@ -1,0 +1,71 @@
+package officepreview
+
+import "testing"
+
+func TestParsePptxAnimEndStateExitAndMotion(t *testing.T) {
+	slideXML := []byte(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:timing>
+    <p:tnLst>
+      <p:par>
+        <p:cTn>
+          <p:childTnLst>
+            <p:animEffect transition="out">
+              <p:cBhvr>
+                <p:tgtEl><p:spTgt spid="4"/></p:tgtEl>
+              </p:cBhvr>
+            </p:animEffect>
+            <p:animMotion>
+              <p:cBhvr>
+                <p:tgtEl><p:spTgt spid="2"/></p:tgtEl>
+              </p:cBhvr>
+              <p:by><p:pos x="100000" y="200000"/></p:by>
+            </p:animMotion>
+            <p:set>
+              <p:cBhvr>
+                <p:tgtEl><p:spTgt spid="3"/></p:tgtEl>
+                <p:attrNameLst><p:attrName>style.visibility</p:attrName></p:attrNameLst>
+              </p:cBhvr>
+              <p:to><p:strVal val="hidden"/></p:to>
+            </p:set>
+          </p:childTnLst>
+        </p:cTn>
+      </p:par>
+    </p:tnLst>
+  </p:timing>
+</p:sld>`)
+	root, err := parsePptxXML(slideXML)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	state := parsePptxAnimEndState(root)
+	if !state.hiddenIDs["4"] {
+		t.Fatal("expected spid 4 hidden after exit animation")
+	}
+	if !state.hiddenIDs["3"] {
+		t.Fatal("expected spid 3 hidden after visibility set")
+	}
+	off := state.offsets["2"]
+	if off.dx != 100000 || off.dy != 200000 {
+		t.Fatalf("motion offset = %+v, want dx=100000 dy=200000", off)
+	}
+}
+
+func TestApplyPptxAnimEndState(t *testing.T) {
+	layers := []pptxVisualLayer{
+		{spID: "2", left: 10, top: 20, cx: 100, cy: 100, kind: "text"},
+		{spID: "3", left: 0, top: 0, cx: 50, cy: 50, kind: "text"},
+		{spID: "5", left: 0, top: 0, cx: 50, cy: 50, kind: "text"},
+	}
+	state := pptxAnimEndState{
+		hiddenIDs: map[string]bool{"3": true},
+		offsets:   map[string]pptxMotionOffset{"2": {dx: 1000, dy: 2000}},
+	}
+	out := applyPptxAnimEndState(layers, state)
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2", len(out))
+	}
+	if out[0].left != 1010 || out[0].top != 2020 {
+		t.Fatalf("offset layer = %+v", out[0])
+	}
+}

--- a/server/internal/service/officepreview/pptx_theme_test.go
+++ b/server/internal/service/officepreview/pptx_theme_test.go
@@ -1,0 +1,41 @@
+package officepreview
+
+import "testing"
+
+func TestResolveTypefaceFromTheme(t *testing.T) {
+	theme := &pptxTheme{
+		fonts: map[string]string{
+			"+mj-lt": "Calibri Light",
+			"+mn-lt": "Calibri",
+		},
+	}
+	if got := theme.resolveTypeface("+mn-lt"); got != "Calibri" {
+		t.Fatalf("resolveTypeface(+mn-lt) = %q", got)
+	}
+	if got := theme.resolveTypeface("Arial"); got != "Arial" {
+		t.Fatalf("resolveTypeface(Arial) = %q", got)
+	}
+}
+
+func TestResolveShapeLstStyleUsesMasterTitleStyle(t *testing.T) {
+	titleStyle, err := parsePptxXML([]byte(`<p:titleStyle xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <a:lvl1pPr><a:defRPr sz="4400"/></a:lvl1pPr>
+</p:titleStyle>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp, err := parsePptxXML([]byte(`<p:sp xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:nvSpPr><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>
+  <p:txBody><a:p><a:r><a:t>Hello</a:t></a:r></a:p></p:txBody>
+</p:sp>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	txBody := sp.child("txBody")
+	ph := sp.findDeep("ph")
+	phk := &phKey{typ: ph.attr("type"), idx: ph.attr("idx")}
+	lst := resolveShapeLstStyle(sp, txBody, phk, pptxTextStyles{title: titleStyle})
+	if lst == nil || lst.XMLName.Local != "titleStyle" {
+		t.Fatalf("lst style = %#v", lst)
+	}
+}

--- a/server/internal/service/officepreview/pptx_visual.go
+++ b/server/internal/service/officepreview/pptx_visual.go
@@ -40,6 +40,7 @@ type pptxVisualLayer struct {
 	alt     string
 	// shape geometry
 	borderRadiusPx float64
+	spID string // cNvPr id for animation end-state
 }
 
 // readShapeBorderRadiusPx extracts a CSS border-radius for known preset geometries.
@@ -91,12 +92,11 @@ func convertPptxToVisualHTML(data []byte, filename, mimeType string) (string, er
 		return "", fmt.Errorf("no slides")
 	}
 	size := pptxPresentationSize(zr)
-	theme := loadPptxTheme(zr)
 
 	var slides strings.Builder
 	rendered := 0
 	for i, slidePath := range slidePaths {
-		slideHTML, ok := renderPptxVisualSlide(zr, slidePath, i+1, size, theme)
+		slideHTML, ok := renderPptxVisualSlide(zr, slidePath, i+1, size)
 		if !ok {
 			continue
 		}
@@ -133,7 +133,7 @@ func pptxPresentationSize(zr *zip.Reader) pptxSlideSize {
 	return size
 }
 
-func renderPptxVisualSlide(zr *zip.Reader, slidePath string, slideNum int, size pptxSlideSize, theme *pptxTheme) (string, bool) {
+func renderPptxVisualSlide(zr *zip.Reader, slidePath string, slideNum int, size pptxSlideSize) (string, bool) {
 	slideData, err := readZipFile(zr, slidePath)
 	if err != nil {
 		return "", false
@@ -163,6 +163,10 @@ func renderPptxVisualSlide(zr *zip.Reader, slidePath string, slideNum int, size 
 		}
 	}
 
+	theme := loadPptxThemeForMaster(zr, masterPath, masterRels)
+	theme = theme.withSlideClrMapOvr(slideRoot)
+	textStyles := parseMasterTextStyles(masterRoot)
+
 	// Build placeholder geometry + default style map from layout and master.
 	phMap := buildPhMap(masterRoot, layoutRoot, theme)
 
@@ -191,6 +195,8 @@ func renderPptxVisualSlide(zr *zip.Reader, slidePath string, slideNum int, size 
 		}
 	}
 
+	slidePhKeys := collectSlidePhKeys(slideRoot)
+
 	var layers []pptxVisualLayer
 	z := 0
 
@@ -204,7 +210,23 @@ func renderPptxVisualSlide(zr *zip.Reader, slidePath string, slideNum int, size 
 		layers = append(layers, bgLayers...)
 	}
 
-	// 2. Background (non-placeholder) shapes from layout.
+	// 2. Master placeholder content not overridden by the slide or layout.
+	if masterRoot != nil {
+		covered := clonePhKeySet(slidePhKeys)
+		if layoutRoot != nil {
+			for k := range collectSlidePhKeys(layoutRoot) {
+				covered[k] = true
+			}
+		}
+		phLayers := extractInheritedPlaceholderLayers(masterRoot, zr, masterPath, masterRels, theme, phMap, textStyles, covered)
+		for i := range phLayers {
+			phLayers[i].zIndex = z
+			z++
+		}
+		layers = append(layers, phLayers...)
+	}
+
+	// 3. Background (non-placeholder) shapes from layout.
 	if layoutRoot != nil {
 		bgLayers := extractBackgroundLayers(layoutRoot, zr, layoutPath, layoutRels, theme)
 		for i := range bgLayers {
@@ -214,13 +236,26 @@ func renderPptxVisualSlide(zr *zip.Reader, slidePath string, slideNum int, size 
 		layers = append(layers, bgLayers...)
 	}
 
-	// 3. All shapes from the slide, with placeholder position/style inheritance.
-	slideLayers := extractSlideLayers(slideRoot, zr, slidePath, slideRels, size, theme, phMap)
+	// 4. Layout placeholder content not overridden by the slide.
+	if layoutRoot != nil {
+		phLayers := extractInheritedPlaceholderLayers(layoutRoot, zr, layoutPath, layoutRels, theme, phMap, textStyles, slidePhKeys)
+		for i := range phLayers {
+			phLayers[i].zIndex = z
+			z++
+		}
+		layers = append(layers, phLayers...)
+	}
+
+	// 5. All shapes from the slide, with placeholder position/style inheritance.
+	slideLayers := extractSlideLayers(slideRoot, zr, slidePath, slideRels, size, theme, phMap, textStyles)
 	for i := range slideLayers {
 		slideLayers[i].zIndex = z
 		z++
 	}
 	layers = append(layers, slideLayers...)
+
+	animState := parsePptxAnimEndState(slideRoot)
+	layers = applyPptxAnimEndState(layers, animState)
 
 	// Promote a large background image if no explicit background was found.
 	if bgURI == "" && bgColor == "" {
@@ -286,7 +321,7 @@ func extractBackgroundLayers(root *pptxXMLNode, zr *zip.Reader, partPath string,
 		if n.findDeep("ph") != nil {
 			return
 		}
-		layer, ok := extractShapeLayer(local, n, gt, zr, partPath, rels, theme, nil)
+		layer, ok := extractShapeLayer(local, n, gt, zr, partPath, rels, theme, nil, pptxTextStyles{})
 		if ok {
 			layer.zIndex = z
 			z++
@@ -296,13 +331,61 @@ func extractBackgroundLayers(root *pptxXMLNode, zr *zip.Reader, partPath string,
 	return layers
 }
 
+func collectSlidePhKeys(root *pptxXMLNode) map[phKey]bool {
+	if root == nil {
+		return map[phKey]bool{}
+	}
+	out := make(map[phKey]bool)
+	walkPptxShapes(root, identityTransform, func(local string, n *pptxXMLNode, _ pptxGroupTransform) {
+		if local != "sp" {
+			return
+		}
+		if ph := n.findDeep("ph"); ph != nil {
+			out[phKey{typ: ph.attr("type"), idx: ph.attr("idx")}] = true
+		}
+	})
+	return out
+}
+
+func clonePhKeySet(src map[phKey]bool) map[phKey]bool {
+	out := make(map[phKey]bool, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+// extractInheritedPlaceholderLayers renders layout/master placeholder shapes that
+// the slide does not define (template chrome, default prompt text, etc.).
+func extractInheritedPlaceholderLayers(root *pptxXMLNode, zr *zip.Reader, partPath string, rels map[string]packageRel, theme *pptxTheme, phMap map[phKey]phInfo, textStyles pptxTextStyles, covered map[phKey]bool) []pptxVisualLayer {
+	var layers []pptxVisualLayer
+	walkPptxShapes(root, identityTransform, func(local string, n *pptxXMLNode, gt pptxGroupTransform) {
+		if local != "sp" {
+			return
+		}
+		ph := n.findDeep("ph")
+		if ph == nil {
+			return
+		}
+		key := phKey{typ: ph.attr("type"), idx: ph.attr("idx")}
+		if covered[key] {
+			return
+		}
+		layer, ok := extractSpLayer(n, gt, zr, partPath, rels, theme, phMap, textStyles)
+		if ok {
+			layers = append(layers, layer)
+		}
+	})
+	return layers
+}
+
 // extractSlideLayers renders all shapes from the slide. Placeholder shapes look
 // up their position and default style from phMap when not set on the shape itself.
-func extractSlideLayers(root *pptxXMLNode, zr *zip.Reader, slidePath string, rels map[string]packageRel, size pptxSlideSize, theme *pptxTheme, phMap map[phKey]phInfo) []pptxVisualLayer {
+func extractSlideLayers(root *pptxXMLNode, zr *zip.Reader, slidePath string, rels map[string]packageRel, size pptxSlideSize, theme *pptxTheme, phMap map[phKey]phInfo, textStyles pptxTextStyles) []pptxVisualLayer {
 	var layers []pptxVisualLayer
 	z := 0
 	walkPptxShapes(root, identityTransform, func(local string, n *pptxXMLNode, gt pptxGroupTransform) {
-		layer, ok := extractShapeLayer(local, n, gt, zr, slidePath, rels, theme, phMap)
+		layer, ok := extractShapeLayer(local, n, gt, zr, slidePath, rels, theme, phMap, textStyles)
 		if ok {
 			layer.zIndex = z
 			z++
@@ -314,14 +397,16 @@ func extractSlideLayers(root *pptxXMLNode, zr *zip.Reader, slidePath string, rel
 
 // extractShapeLayer extracts a single visual layer from a sp, pic, or cxnSp shape.
 // phMap is nil for master/layout background rendering.
-func extractShapeLayer(local string, n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partPath string, rels map[string]packageRel, theme *pptxTheme, phMap map[phKey]phInfo) (pptxVisualLayer, bool) {
+func extractShapeLayer(local string, n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partPath string, rels map[string]packageRel, theme *pptxTheme, phMap map[phKey]phInfo, textStyles pptxTextStyles) (pptxVisualLayer, bool) {
 	switch local {
 	case "pic":
 		return extractPicLayer(n, gt, zr, partPath, rels)
 	case "sp":
-		return extractSpLayer(n, gt, zr, partPath, rels, theme, phMap)
+		return extractSpLayer(n, gt, zr, partPath, rels, theme, phMap, textStyles)
 	case "cxnSp":
 		return extractCxnSpLayer(n, gt, theme)
+	case "graphicFrame":
+		return extractGraphicFrameLayer(n, gt, zr, partPath, rels)
 	}
 	return pptxVisualLayer{}, false
 }
@@ -404,10 +489,53 @@ func extractPicLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, part
 		left: left, top: top, cx: cx, cy: cy,
 		rotDeg: xfrm.rotDeg, flipH: xfrm.flipH,
 		kind: "image", dataURI: uri, alt: alt,
+		spID: shapeSpID(n),
 	}, true
 }
 
-func extractSpLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partPath string, rels map[string]packageRel, theme *pptxTheme, phMap map[phKey]phInfo) (pptxVisualLayer, bool) {
+func extractGraphicFrameLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partPath string, rels map[string]packageRel) (pptxVisualLayer, bool) {
+	xfrm := readShapeXfrm(n)
+	if xfrm.cx <= 0 || xfrm.cy <= 0 {
+		return pptxVisualLayer{}, false
+	}
+	graphic := n.findDeep("graphic")
+	if graphic == nil {
+		return pptxVisualLayer{}, false
+	}
+	graphicData := graphic.child("graphicData")
+	if graphicData == nil {
+		return pptxVisualLayer{}, false
+	}
+	pic := graphicData.child("pic")
+	if pic == nil {
+		return pptxVisualLayer{}, false
+	}
+	embed := findBlipEmbedInTree(pic)
+	if embed == "" {
+		return pptxVisualLayer{}, false
+	}
+	left, top, cx, cy := gt.apply(xfrm.left, xfrm.top, xfrm.cx, xfrm.cy)
+	uri := resolvePptxEmbed(zr, partPath, rels, embed)
+	if uri == "" {
+		return pptxVisualLayer{}, false
+	}
+	alt := "Slide image"
+	if cNvPr := pic.findDeep("cNvPr"); cNvPr != nil {
+		if a := cNvPr.attr("descr"); a != "" {
+			alt = a
+		} else if a := cNvPr.attr("name"); a != "" {
+			alt = a
+		}
+	}
+	return pptxVisualLayer{
+		left: left, top: top, cx: cx, cy: cy,
+		rotDeg: xfrm.rotDeg, flipH: xfrm.flipH,
+		kind: "image", dataURI: uri, alt: alt,
+		spID: shapeSpID(n),
+	}, true
+}
+
+func extractSpLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partPath string, rels map[string]packageRel, theme *pptxTheme, phMap map[phKey]phInfo, textStyles pptxTextStyles) (pptxVisualLayer, bool) {
 	xfrm := readShapeXfrm(n)
 	left, top, cx, cy := gt.apply(xfrm.left, xfrm.top, xfrm.cx, xfrm.cy)
 
@@ -433,7 +561,7 @@ func extractSpLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partP
 	// If there's no text body but a blip fill, treat as an image.
 	var paraHTML []pptxParaHTML
 	if txBody != nil {
-		paraHTML = extractTxBodyHTML(txBody, theme)
+		paraHTML = extractTxBodyHTML(txBody, theme, resolveShapeLstStyle(n, txBody, phk, textStyles))
 	}
 	if len(paraHTML) == 0 && spPr != nil {
 		if embed := findBlipEmbedInTree(spPr); embed != "" {
@@ -443,6 +571,7 @@ func extractSpLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partP
 					left: left, top: top, cx: cx, cy: cy,
 					rotDeg: xfrm.rotDeg, flipH: xfrm.flipH,
 					kind: "image", dataURI: uri, alt: "Slide graphic",
+					spID: shapeSpID(n),
 				}, true
 			}
 		}
@@ -460,11 +589,30 @@ func extractSpLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partP
 			rotDeg: xfrm.rotDeg, flipH: xfrm.flipH,
 			kind: "text", background: bg, border: border,
 			borderRadiusPx: readShapeBorderRadiusPx(n, cx, cy),
+			spID: shapeSpID(n),
 		}, true
 	}
 
-	// Resolve default text style (own shape → placeholder map → fallback).
+	// Resolve default text style (own shape → placeholder map → master txStyles → p:style).
 	fontPt, color, bold := firstRunStyle(n, theme)
+	lstStyle := resolveShapeLstStyle(n, txBody, phk, textStyles)
+	if fontPt == 0 || color == "" || !bold {
+		lstPt, lstClr, lstBold := defaultRunStyleFromLstStyle(lstStyle, theme)
+		if fontPt == 0 && lstPt > 0 {
+			fontPt = lstPt
+		}
+		if color == "" && lstClr != "" {
+			color = lstClr
+		}
+		if !bold && lstBold {
+			bold = lstBold
+		}
+	}
+	if color == "" {
+		if styleClr := shapeStyleFontColor(n, theme); styleClr != "" {
+			color = styleClr
+		}
+	}
 	if phk != nil && phMap != nil {
 		if info, ok := phMap[*phk]; ok {
 			if fontPt == 0 && info.defaultFontPt > 0 {
@@ -527,6 +675,7 @@ func extractSpLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partP
 		background: bg, border: border, vertAlign: vertAlign,
 		vert: vert, noWrap: noWrap,
 		borderRadiusPx: readShapeBorderRadiusPx(n, cx, cy),
+		spID: shapeSpID(n),
 	}, true
 }
 

--- a/server/internal/service/officepreview/pptx_xml_tree.go
+++ b/server/internal/service/officepreview/pptx_xml_tree.go
@@ -105,14 +105,16 @@ type pptxShapeXfrm struct {
 }
 
 func readShapeXfrm(node *pptxXMLNode) pptxShapeXfrm {
-	spPr := node.child("spPr")
-	if spPr == nil {
-		spPr = node.child("grpSpPr")
+	xfrm := node.child("xfrm")
+	if xfrm == nil {
+		spPr := node.child("spPr")
+		if spPr == nil {
+			spPr = node.child("grpSpPr")
+		}
+		if spPr != nil {
+			xfrm = spPr.child("xfrm")
+		}
 	}
-	if spPr == nil {
-		return pptxShapeXfrm{}
-	}
-	xfrm := spPr.child("xfrm")
 	if xfrm == nil {
 		return pptxShapeXfrm{}
 	}
@@ -534,15 +536,81 @@ type pptxParaHTML struct {
 	style string // full CSS for the <p> element (alignment, line-height, spacing, etc.)
 }
 
+// pptxTextStyles holds slide-master default text styles (title/body/other).
+type pptxTextStyles struct {
+	title *pptxXMLNode
+	body  *pptxXMLNode
+	other *pptxXMLNode
+}
+
+func parseMasterTextStyles(masterRoot *pptxXMLNode) pptxTextStyles {
+	var styles pptxTextStyles
+	if masterRoot == nil {
+		return styles
+	}
+	txStyles := masterRoot.findDeep("txStyles")
+	if txStyles == nil {
+		return styles
+	}
+	styles.title = txStyles.child("titleStyle")
+	styles.body = txStyles.child("bodyStyle")
+	styles.other = txStyles.child("otherStyle")
+	return styles
+}
+
+func resolveShapeLstStyle(sp, txBody *pptxXMLNode, phk *phKey, textStyles pptxTextStyles) *pptxXMLNode {
+	if txBody != nil {
+		if lst := txBody.child("lstStyle"); lst != nil {
+			return lst
+		}
+	}
+	if phk != nil {
+		switch phk.typ {
+		case "title", "ctrTitle", "subTitle":
+			if textStyles.title != nil {
+				return textStyles.title
+			}
+		case "body", "obj", "dtm", "tbl", "chart", "clipArt", "media", "pic":
+			if textStyles.body != nil {
+				return textStyles.body
+			}
+		default:
+			if textStyles.other != nil {
+				return textStyles.other
+			}
+		}
+	}
+	if textStyles.body != nil {
+		return textStyles.body
+	}
+	return nil
+}
+
+// shapeStyleFontColor reads default text color from p:style/a:fontRef.
+func shapeStyleFontColor(sp *pptxXMLNode, theme *pptxTheme) string {
+	styleEl := sp.child("style")
+	if styleEl == nil {
+		return ""
+	}
+	fontRef := styleEl.child("fontRef")
+	if fontRef == nil {
+		return ""
+	}
+	if clr := resolveColorNode(fontRef, theme); clr != "" {
+		return clr
+	}
+	return ""
+}
+
 // extractTxBodyHTML returns per-paragraph HTML with inline styles for each run.
-func extractTxBodyHTML(txBody *pptxXMLNode, theme *pptxTheme) []pptxParaHTML {
+func extractTxBodyHTML(txBody *pptxXMLNode, theme *pptxTheme, lstStyle *pptxXMLNode) []pptxParaHTML {
 	var result []pptxParaHTML
 	for i := range txBody.Children {
 		child := &txBody.Children[i]
 		if child.XMLName.Local != "p" {
 			continue
 		}
-		html, style := extractParagraphHTML(child, theme)
+		html, style := extractParagraphHTML(child, theme, lstStyle, paragraphLevel(child))
 		if strings.TrimSpace(html) != "" {
 			result = append(result, pptxParaHTML{html: html, style: style})
 		}
@@ -550,7 +618,18 @@ func extractTxBodyHTML(txBody *pptxXMLNode, theme *pptxTheme) []pptxParaHTML {
 	return result
 }
 
-func extractParagraphHTML(p *pptxXMLNode, theme *pptxTheme) (string, string) {
+func paragraphLevel(p *pptxXMLNode) int {
+	if pPr := p.child("pPr"); pPr != nil {
+		if lvl := pPr.attr("lvl"); lvl != "" {
+			if v := int(parseEMU(lvl)); v >= 0 {
+				return v + 1
+			}
+		}
+	}
+	return 1
+}
+
+func extractParagraphHTML(p *pptxXMLNode, theme *pptxTheme, lstStyle *pptxXMLNode, lvl int) (string, string) {
 	var styleProps []string
 	marL := int64(0)
 
@@ -596,7 +675,7 @@ func extractParagraphHTML(p *pptxXMLNode, theme *pptxTheme) (string, string) {
 		child := &p.Children[i]
 		switch child.XMLName.Local {
 		case "r":
-			buf.WriteString(extractRunHTML(child, theme))
+			buf.WriteString(extractRunHTML(child, theme, defaultRunStyleForLevel(lstStyle, theme, lvl)))
 		case "br":
 			buf.WriteString("<br/>")
 		case "fld":
@@ -638,7 +717,59 @@ func parseSpcPct(node *pptxXMLNode) float64 {
 	return 0
 }
 
-func extractRunHTML(r *pptxXMLNode, theme *pptxTheme) string {
+type pptxDefaultRunStyle struct {
+	fontPt float64
+	color  string
+	bold   bool
+}
+
+func defaultRunStyleForLevel(lstStyle *pptxXMLNode, theme *pptxTheme, lvl int) pptxDefaultRunStyle {
+	if lstStyle == nil {
+		return pptxDefaultRunStyle{}
+	}
+	if lvl < 1 {
+		lvl = 1
+	}
+	lvlName := fmt.Sprintf("lvl%dpPr", lvl)
+	var lvlNode *pptxXMLNode
+	for i := range lstStyle.Children {
+		if lstStyle.Children[i].XMLName.Local == lvlName {
+			lvlNode = &lstStyle.Children[i]
+			break
+		}
+	}
+	if lvlNode == nil {
+		pt, clr, bold := defaultRunStyleFromLstStyle(lstStyle, theme)
+		return pptxDefaultRunStyle{fontPt: pt, color: clr, bold: bold}
+	}
+	defRPr := lvlNode.child("defRPr")
+	if defRPr == nil {
+		return pptxDefaultRunStyle{}
+	}
+	var out pptxDefaultRunStyle
+	if sz := defRPr.attr("sz"); sz != "" {
+		if v := parseEMU(sz); v > 0 {
+			out.fontPt = float64(v) / 100
+		}
+	}
+	out.bold = defRPr.attr("b") == "1" || strings.EqualFold(defRPr.attr("b"), "true")
+	if fill := defRPr.child("solidFill"); fill != nil {
+		out.color = resolveColorNode(fill, theme)
+	}
+	if out.color == "" {
+		if clrNode := defRPr.findDeep("srgbClr"); clrNode != nil {
+			out.color = "#" + strings.ToUpper(clrNode.attr("val"))
+		} else if clrNode := defRPr.findDeep("schemeClr"); clrNode != nil {
+			out.color = resolveColorNodeDirect(clrNode, theme)
+		}
+	}
+	if latin := defRPr.child("latin"); latin != nil {
+		_ = theme.resolveTypeface(latin.attr("typeface"))
+	}
+	return out
+}
+
+func extractRunHTML(r *pptxXMLNode, theme *pptxTheme, defaults pptxDefaultRunStyle) string {
 	tNode := r.child("t")
 	if tNode == nil {
 		return ""
@@ -691,10 +822,21 @@ func extractRunHTML(r *pptxXMLNode, theme *pptxTheme) string {
 			}
 		}
 		if latin := rPr.child("latin"); latin != nil {
-			if tf := safeFontFamily(latin.attr("typeface")); tf != "" {
+			if tf := safeFontFamily(theme.resolveTypeface(latin.attr("typeface"))); tf != "" {
 				styles = append(styles, "font-family:'"+tf+"'")
 			}
 		}
+	}
+	if len(styles) == 0 || !runStyleHas("font-size", styles) {
+		if defaults.fontPt > 0 {
+			styles = append(styles, fmt.Sprintf("font-size:%.2fpx", ptToPx(defaults.fontPt)))
+		}
+	}
+	if !runStyleHas("color", styles) && defaults.color != "" {
+		styles = append(styles, "color:"+defaults.color)
+	}
+	if !runStyleHas("font-weight", styles) && defaults.bold {
+		styles = append(styles, "font-weight:700")
 	}
 
 	escaped := escapeHTMLText(text)
@@ -702,6 +844,16 @@ func extractRunHTML(r *pptxXMLNode, theme *pptxTheme) string {
 		return escaped
 	}
 	return `<span style="` + strings.Join(styles, ";") + `">` + escaped + `</span>`
+}
+
+func runStyleHas(prop string, styles []string) bool {
+	prefix := prop + ":"
+	for _, s := range styles {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func contains(slice []string, s string) bool {
@@ -767,10 +919,11 @@ func parseSlideBgCSS(cSld *pptxXMLNode, theme *pptxTheme) string {
 // ----- Theme color resolution -----
 
 type pptxTheme struct {
-	colors        map[string]string // scheme name → RRGGBB hex (no #)
-	clrMap        map[string]string // bg1/tx1/bg2/tx2/etc → dk1/lt1/... per slide master clrMap
-	fillStyles    []*pptxXMLNode    // fmtScheme/fillStyleLst entries (1-indexed by fillRef idx)
-	bgFillStyles  []*pptxXMLNode    // fmtScheme/bgFillStyleLst entries (1001+ idx)
+	colors       map[string]string // scheme name → RRGGBB hex (no #)
+	clrMap       map[string]string // bg1/tx1/bg2/tx2/etc → dk1/lt1/... per slide master clrMap
+	fillStyles   []*pptxXMLNode    // fmtScheme/fillStyleLst entries (1-indexed by fillRef idx)
+	bgFillStyles []*pptxXMLNode    // fmtScheme/bgFillStyleLst entries (1001+ idx)
+	fonts        map[string]string // +mj-lt, +mn-lt, etc. → resolved typeface
 }
 
 // defaultClrMap is the standard mapping used when a master doesn't define its own.
@@ -781,21 +934,60 @@ var defaultClrMap = map[string]string{
 	"tx2": "dk2",
 }
 
-func loadPptxTheme(zr *zip.Reader) *pptxTheme {
-	theme := &pptxTheme{colors: make(map[string]string), clrMap: defaultClrMap}
-	for _, name := range []string{"ppt/theme/theme1.xml", "ppt/theme/theme2.xml", "ppt/theme/theme3.xml"} {
-		data, err := readZipFile(zr, name)
-		if err != nil {
-			continue
+func loadPptxThemeForMaster(zr *zip.Reader, masterPath string, masterRels map[string]packageRel) *pptxTheme {
+	theme := &pptxTheme{
+		colors: make(map[string]string),
+		clrMap: defaultClrMap,
+		fonts:  make(map[string]string),
+	}
+
+	themePath := ""
+	if masterPath != "" && masterRels != nil {
+		themePath = pptxRelatedPartPath(masterRels, masterPath, "theme")
+	}
+	if themePath == "" {
+		for _, name := range []string{"ppt/theme/theme1.xml", "ppt/theme/theme2.xml", "ppt/theme/theme3.xml"} {
+			if _, err := readZipFile(zr, name); err == nil {
+				themePath = name
+				break
+			}
 		}
-		root, err := parsePptxXML(data)
-		if err != nil {
-			continue
+	}
+	if themePath != "" {
+		populateThemeFromFile(zr, themePath, theme)
+	}
+
+	if masterPath != "" {
+		if data, err := readZipFile(zr, masterPath); err == nil {
+			if root, err := parsePptxXML(data); err == nil {
+				if cm := root.findDeep("clrMap"); cm != nil {
+					m := make(map[string]string, len(cm.Attrs))
+					for _, a := range cm.Attrs {
+						if a.Value != "" {
+							m[a.Name.Local] = a.Value
+						}
+					}
+					if len(m) > 0 {
+						theme.clrMap = m
+					}
+				}
+			}
 		}
-		clrScheme := root.findDeep("clrScheme")
-		if clrScheme == nil {
-			continue
-		}
+	}
+	return theme
+}
+
+func populateThemeFromFile(zr *zip.Reader, themePath string, theme *pptxTheme) {
+	data, err := readZipFile(zr, themePath)
+	if err != nil {
+		return
+	}
+	root, err := parsePptxXML(data)
+	if err != nil {
+		return
+	}
+	clrScheme := root.findDeep("clrScheme")
+	if clrScheme != nil {
 		colors := make(map[string]string)
 		for _, child := range clrScheme.Children {
 			schemeName := child.XMLName.Local
@@ -805,41 +997,101 @@ func loadPptxTheme(zr *zip.Reader) *pptxTheme {
 			}
 		}
 		theme.colors = colors
-		// Also cache fillStyleLst / bgFillStyleLst entries for fillRef idx resolution.
-		if fmtScheme := root.findDeep("fmtScheme"); fmtScheme != nil {
-			if fsl := fmtScheme.child("fillStyleLst"); fsl != nil {
-				for i := range fsl.Children {
-					c := &fsl.Children[i]
-					theme.fillStyles = append(theme.fillStyles, c)
-				}
-			}
-			if bfsl := fmtScheme.child("bgFillStyleLst"); bfsl != nil {
-				for i := range bfsl.Children {
-					c := &bfsl.Children[i]
-					theme.bgFillStyles = append(theme.bgFillStyles, c)
-				}
+	}
+	if fmtScheme := root.findDeep("fmtScheme"); fmtScheme != nil {
+		if fsl := fmtScheme.child("fillStyleLst"); fsl != nil {
+			for i := range fsl.Children {
+				c := &fsl.Children[i]
+				theme.fillStyles = append(theme.fillStyles, c)
 			}
 		}
-		break
-	}
-	// Read the first slide master's clrMap, if present. Most decks have one master,
-	// and its clrMap can swap the standard bg/tx mappings (e.g., dark-themed templates).
-	if data, err := readZipFile(zr, "ppt/slideMasters/slideMaster1.xml"); err == nil {
-		if root, err := parsePptxXML(data); err == nil {
-			if cm := root.findDeep("clrMap"); cm != nil {
-				m := make(map[string]string, len(cm.Attrs))
-				for _, a := range cm.Attrs {
-					if a.Value != "" {
-						m[a.Name.Local] = a.Value
-					}
-				}
-				if len(m) > 0 {
-					theme.clrMap = m
-				}
+		if bfsl := fmtScheme.child("bgFillStyleLst"); bfsl != nil {
+			for i := range bfsl.Children {
+				c := &bfsl.Children[i]
+				theme.bgFillStyles = append(theme.bgFillStyles, c)
 			}
 		}
 	}
-	return theme
+	theme.fonts = parseFontScheme(root)
+}
+
+func parseFontScheme(root *pptxXMLNode) map[string]string {
+	fonts := make(map[string]string)
+	fontScheme := root.findDeep("fontScheme")
+	if fontScheme == nil {
+		return fonts
+	}
+	for _, entry := range []struct {
+		node *pptxXMLNode
+		pfx  string
+	}{
+		{fontScheme.child("majorFont"), "+mj"},
+		{fontScheme.child("minorFont"), "+mn"},
+	} {
+		if entry.node == nil {
+			continue
+		}
+		for _, script := range []struct {
+			tag    string
+			suffix string
+		}{
+			{"latin", "-lt"},
+			{"ea", "-ea"},
+			{"cs", "-cs"},
+		} {
+			if node := entry.node.child(script.tag); node != nil {
+				if tf := strings.TrimSpace(node.attr("typeface")); tf != "" && !strings.HasPrefix(tf, "+") {
+					fonts[entry.pfx+script.suffix] = tf
+				}
+			}
+		}
+	}
+	return fonts
+}
+
+func (t *pptxTheme) resolveTypeface(typeface string) string {
+	typeface = strings.TrimSpace(typeface)
+	if typeface == "" {
+		return ""
+	}
+	if strings.HasPrefix(typeface, "+") {
+		if resolved, ok := t.fonts[typeface]; ok {
+			return resolved
+		}
+		return ""
+	}
+	return typeface
+}
+
+func (t *pptxTheme) withSlideClrMapOvr(slideRoot *pptxXMLNode) *pptxTheme {
+	if slideRoot == nil {
+		return t
+	}
+	ovr := slideRoot.child("clrMapOvr")
+	if ovr == nil {
+		return t
+	}
+	if ovr.child("masterClrMapping") != nil {
+		return t
+	}
+	ocm := ovr.child("overrideClrMapping")
+	if ocm == nil {
+		return t
+	}
+	clone := *t
+	merged := make(map[string]string, len(t.clrMap)+len(ocm.Attrs))
+	for k, v := range t.clrMap {
+		merged[k] = v
+	}
+	for _, a := range ocm.Attrs {
+		if a.Value != "" {
+			merged[a.Name.Local] = a.Value
+		}
+	}
+	if len(merged) > 0 {
+		clone.clrMap = merged
+	}
+	return &clone
 }
 
 func extractSingleColorHex(node *pptxXMLNode) string {


### PR DESCRIPTION
## Summary

- **Course files**: Folder breadcrumbs are computed server-side (recursive ancestor query) and returned with folder listings, so deep links and browser back/forward show the correct path without client-side trail bookkeeping.
- **Canvas import**: Queue workers skip already-terminal jobs and re-broadcast WebSocket completion/error events; import-complete inbox toasts are enqueued when the job finishes (not mid-import), with dedup persisted in `localStorage`.
- **PPTX preview**: Per-master theme loading, inherited master/layout placeholder content, animation end-state rendering, graphic-frame images, and master text styles for more faithful slide previews.

## Test plan

- [x] `golangci-lint run ./...` (server)
- [x] `go test ./... -count=1 -short -timeout=3m` (server)
- [x] `npm run lint`, `npm run typecheck`, `npm run test` (clients/web)
- [ ] Open course Files, navigate into nested folders, use breadcrumb links and browser back/forward — trail matches actual path
- [ ] Drag a file onto a breadcrumb segment — move succeeds
- [ ] Run a Canvas import to completion — one toast, WebSocket shows complete, reconnecting to a finished job still gets terminal event
- [ ] Preview a PPTX with inherited placeholders, theme colors, and build animations — layout matches PowerPoint more closely