### PR TITLE
Caret-anchored syllabus toolbar and LMS enrollment/LTI UX

### DIFF
--- a/.cursor/skills/fix-ci/SKILL.md
+++ b/.cursor/skills/fix-ci/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: fix-ci
 description: Find failing PR checks, inspect logs or external check links, and apply focused fixes
+disable-model-invocation: true
 ---
 
 # Fix CI

--- a/.cursor/skills/fix-merge-conflicts/SKILL.md
+++ b/.cursor/skills/fix-merge-conflicts/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: fix-merge-conflicts
 description: Resolve merge conflicts non-interactively, validate build and tests, and finalize conflict resolution
+disable-model-invocation: true
 ---
 
 # Fix merge conflicts

--- a/.cursor/skills/get-pr-comments/SKILL.md
+++ b/.cursor/skills/get-pr-comments/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: get-pr-comments
 description: Fetch and summarize review comments from the active pull request
+disable-model-invocation: true
 ---
 
 # Get PR comments

--- a/.cursor/skills/how/SKILL.md
+++ b/.cursor/skills/how/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: how
 description: "Use for \"how does X work\", code walkthroughs before changing something, and placement / ownership / layering questions (\"where should this live\", \"which package owns this\", \"is this the right layer\"). Explains subsystem architecture, runtime flow, onboarding mental models. Can critique architecture. Use why for motivation."
+disable-model-invocation: true
 ---
 
 # How

--- a/.cursor/skills/next-feature/SKILL.md
+++ b/.cursor/skills/next-feature/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: Next Feature 
 description: Use this when the next feature needs to be implemented.
+disable-model-invocation: true
 ---
 
 You are to complete the following steps in order:
@@ -10,5 +11,6 @@ You are to complete the following steps in order:
  4. Make sure it's linted and all lintes pass locally.
  5. Make sure there are e2e tests to prove that this works. Make sure the tests pass locally.
  6. Move it to docs/completed once completed. Once the folder is empty, delete the folder.
- 7. Submit a pull request and be sure to include a screen capture of the feature working.
- 8. Run the /fix-ci to ensure the CI pipeline succeeds.
+ 7. Verify and fix any merge conflicts with /fix-merge-conflicts skill
+ 8. Submit a pull request and be sure to include a screen capture of the feature working.
+ 9. Run the /fix-ci to ensure the CI pipeline succeeds.

--- a/.cursor/skills/requirements/SKILL.md
+++ b/.cursor/skills/requirements/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: requirements
+description: Turns a feature request into a full implementation-plan requirements document matching docs/plan/_TEMPLATE.md. Use when the user asks for requirements, a spec, an implementation plan, or wants to flesh out a feature before building. Also use for /requirements or "write requirements for X".
+disable-model-invocation: true
+---
+
+# Requirements
+
+Turn a user request into a complete Lextures implementation plan — the same structure and rigor as `docs/plan/`.
+
+## Output
+
+Produce a markdown document that follows `docs/plan/_TEMPLATE.md` exactly. Every section must be filled; no `…` or `TBD` placeholders unless listed explicitly in **Open Questions** (§18).
+
+Default: paste the full document in chat. If the user asks to save it, write to `docs/plan/{section-folder}/{id}-{kebab-slug}.md` per [docs/plan/README.md](../../../docs/plan/README.md) conventions.
+
+## Workflow
+
+Copy this checklist and track progress:
+
+```
+Requirements progress:
+- [ ] Step 1: Parse the request
+- [ ] Step 2: Explore codebase & existing plans
+- [ ] Step 3: Draft metadata
+- [ ] Step 4: Write all 19 sections
+- [ ] Step 5: Validate against checklist
+```
+
+### Step 1. Parse the request
+
+Extract from the user's message:
+
+- **Feature name** — short, descriptive title
+- **Scope** — what they want; what they explicitly excluded
+- **Audience** — K12 / HE / SL (self-learner) / platform-wide
+- **Urgency signals** — blocker vs enhancement, pilot vs GA
+
+If critical details are missing (audience, scope boundary, or whether this is net-new vs extending existing behavior), ask **one** focused question before proceeding. Otherwise state your interpretation briefly and continue.
+
+### Step 2. Explore codebase & existing plans
+
+Before writing requirements, ground the spec in what exists:
+
+1. **Read** `docs/plan/_TEMPLATE.md` for the canonical section list.
+2. **Search** `docs/plan/` for related plans — read 1–2 closest matches for tone, cross-references, and dependency patterns.
+3. **Search** `docs/completed/` if the feature may partially exist.
+4. **Explore the codebase** — Glob/Grep/Read for:
+   - Existing routes, services, DB tables, UI pages that overlap
+   - Patterns to extend (auth scopes, job queue, feature flags, migrations)
+   - File paths to cite in §19 References
+
+Record findings: what is **MISSING**, **PARTIAL**, or **THIN** today (for metadata **Status**).
+
+### Step 3. Draft metadata
+
+Fill the metadata table. Propose values when the user did not supply them:
+
+| Field | Guidance |
+|---|---|
+| **Feature ID** | `{section}.{number}` — match an existing `docs/plan/` section when possible; otherwise propose next number in the closest section |
+| **Section** | Top-level plan folder name (e.g. Platform, Performance & Operability) |
+| **Severity** | BLOCKER / MAJOR / MINOR per [docs/plan/README.md](../../../docs/plan/README.md) legend |
+| **Markets** | K12 / HE / SL — comma-separated |
+| **Status (today)** | MISSING / PARTIAL / THIN based on codebase exploration |
+| **Estimated effort** | XS / S / M / L / XL |
+| **Depends on** / **Unblocks** | Feature IDs from related plans; use relative links |
+
+Title line format:
+
+```markdown
+# {Feature ID} — {Feature Name}
+
+> Implementation plan. Source: user request / {related doc if any}.
+```
+
+### Step 4. Write all 19 sections
+
+Follow the template section-by-section. Quality bar matches completed plans like `17.14-feature-flags.md` and `19.3-ai-assisted-grading.md`.
+
+**§1 Problem Statement** — 2–4 sentences. Gap today, who is hurt, business outcome.
+
+**§2 Goals** — 3–5 outcome bullets. Verifiable, not implementation steps.
+
+**§3 Non-Goals** — Explicit out-of-scope items. Reference other Feature IDs when deferring work.
+
+**§4 Personas & User Stories** — `As a {role}, I want … so that …`. Cover student, instructor, admin, and self-learner where relevant.
+
+**§5 Functional Requirements** — Numbered `FR-N`. RFC 2119: MUST / SHOULD / MAY. Testable, not vague.
+
+**§6 Non-Functional Requirements** — Cover applicable sub-bullets from the template (performance, security, privacy, a11y, scalability, reliability, observability, maintainability, i18n, backward compatibility). Omit sub-bullets that genuinely do not apply; say "N/A" with one-line rationale.
+
+**§7 Acceptance Criteria** — Numbered `AC-N`. Given/When/Then. Each AC should map to at least one test.
+
+**§8 Data Model** — SQL or schema description. Migration naming: `server/migrations/NNN_*.sql`. Indexes, constraints, backfill strategy.
+
+**§9 API Surface** — Table or list: method, path, auth scope, request/response shapes. Note rate limits and OpenAPI updates.
+
+**§10 UI / UX** — Pages, components, flows, empty/loading/error states, responsive behavior, a11y notes, i18n keys.
+
+**§11 AI / ML Considerations** — **Skip entirely** (write "N/A — not AI-touching.") only when the feature has zero AI/LLM/ML involvement. Otherwise: models, prompts, eval metrics, fallback, PII, cost budget.
+
+**§12 Integration Points** — External services and internal modules with file paths.
+
+**§13 Dependencies & Sequencing** — Must ship after/before; shared infra (Redis, job queue, object storage, etc.).
+
+**§14 Risks & Mitigations** — Table: Risk | Likelihood | Impact | Mitigation.
+
+**§15 Rollout Plan** — Feature flag name, phases, pilot cohort, GA criteria, rollback path.
+
+**§16 Test Plan** — Unit, integration, e2e (Playwright), security, accessibility (axe), performance/load, manual QA.
+
+**§17 Documentation & Training** — User docs, admin docs, API reference, runbooks.
+
+**§18 Open Questions** — Numbered decisions still needing owners. **Only** place for unresolved `TBD`s.
+
+**§19 References** — Existing code paths (`server/internal/...`, `clients/web/src/...`), external standards, related plans as relative links.
+
+#### Lextures-specific defaults
+
+When the spec touches these areas, align with repo conventions (see `AGENTS.md`):
+
+- **Backend:** Go API, Chi router, pgx, JWT auth, `server/internal/`
+- **Frontend:** React 19, Vite, TypeScript, Tailwind v4, `clients/web/src/`
+- **Migrations:** `server/migrations/NNN_descriptive_name.sql`
+- **Auth:** Note JWT scope and role checks on every new route
+- **Jobs:** Background work via RabbitMQ queue (or in-process fallback locally)
+- **Feature flags:** Reference OpenFeature-style flags and `platformstate` when rollout-sensitive
+- **Compliance:** FERPA for student data; WCAG 2.1 AA for new UI; COPPA for K12 minors
+
+### Step 5. Validate
+
+Before delivering, verify every item in [references/checklist.md](references/checklist.md). Fix gaps before presenting.
+
+## Delivery format
+
+Present the document in this order:
+
+1. **Summary** (3–5 bullets) — what the feature does, severity, effort, key dependencies
+2. **Full requirements document** — complete markdown, all 19 sections
+3. **Suggested next steps** — only if useful: save path, related plans to read, open questions needing user input
+
+## Examples
+
+**User:** "Write requirements for instructor bulk email to enrolled students"
+
+**Agent:** Explores `server/internal/` for messaging/email modules and `docs/plan/06-communication-collaboration/`. Produces a full 19-section plan with FRs for opt-out compliance, rate limits, and audit logging.
+
+**User:** "Requirements for adding dark mode to the student dashboard"
+
+**Agent:** Finds existing theme/CSS variables in `clients/web/`. Status = PARTIAL if theme tokens exist. Non-goals reference system-preference-only scope. ACs cover persistence, contrast ratios, and no flash on load.
+
+## Additional resources
+
+- Canonical template: [docs/plan/_TEMPLATE.md](../../../docs/plan/_TEMPLATE.md)
+- Plan conventions: [docs/plan/README.md](../../../docs/plan/README.md)
+- Quality checklist: [references/checklist.md](references/checklist.md)

--- a/.cursor/skills/requirements/references/checklist.md
+++ b/.cursor/skills/requirements/references/checklist.md
@@ -1,0 +1,46 @@
+# Requirements quality checklist
+
+Run before delivering a requirements document.
+
+## Structure
+
+- [ ] Title uses `{Feature ID} — {Feature Name}` format
+- [ ] Source line present under the title
+- [ ] Metadata table complete (all 9 fields)
+- [ ] Sections 1–19 present in order
+- [ ] No `…` or stray `TBD` outside §18 Open Questions
+
+## Content quality
+
+- [ ] Problem statement is 2–4 sentences with gap, affected users, and outcome
+- [ ] Goals are outcomes (3–5), not implementation tasks
+- [ ] Non-goals explicitly bound scope and cross-reference deferred Feature IDs
+- [ ] User stories cover all relevant personas
+- [ ] FRs use MUST / SHOULD / MAY and are individually testable
+- [ ] NFRs include concrete targets where applicable (latency, availability, WCAG level)
+- [ ] ACs use Given/When/Then and map to FRs
+- [ ] Data model includes migration path and backfill strategy if schema changes
+- [ ] API surface lists auth scope for every route
+- [ ] UI section covers empty, loading, error, and responsive states
+- [ ] §11 present — either filled or explicitly "N/A — not AI-touching."
+- [ ] Integration points cite real or proposed file paths from codebase exploration
+- [ ] Dependencies use Feature ID cross-references with relative plan links
+- [ ] Risks table has at least 3 rows with mitigations
+- [ ] Rollout plan names a feature flag when rollout is gradual
+- [ ] Test plan covers unit, integration, and e2e at minimum
+- [ ] Open questions are numbered and actionable
+- [ ] References link to existing code paths and related plans
+
+## Lextures alignment
+
+- [ ] Authz model specified for new endpoints and UI surfaces
+- [ ] Student-data features note FERPA / privacy obligations
+- [ ] New UI claims WCAG 2.1 AA conformance
+- [ ] Migration files follow `server/migrations/NNN_*.sql` convention
+- [ ] Async work specifies job queue vs synchronous path
+
+## If saving to docs/plan
+
+- [ ] Filename: `{section}.{number}-{kebab-slug}.md`
+- [ ] Folder matches top-level section in [docs/plan/README.md](../../../../docs/plan/README.md)
+- [ ] Cross-references use relative markdown links between plans

--- a/.cursor/skills/why/SKILL.md
+++ b/.cursor/skills/why/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: why
 description: "Use for 'why does X work this way', 'why we picked Y', design rationale, regressions, postmortems, or data-backed thresholds. Discovers available MCPs and queries each evidence category (source control, issue tracker, long-form docs, real-time chat, infrastructure observability, error tracking, product analytics warehouse) in parallel, then returns a cited read on decisions and tradeoffs. Use how for runtime behavior."
+disable-model-invocation: true
 ---
 
 # Why

--- a/clients/web/src/components/editor/block-editor/__tests__/use-caret-anchored-position.test.ts
+++ b/clients/web/src/components/editor/block-editor/__tests__/use-caret-anchored-position.test.ts
@@ -1,0 +1,87 @@
+import type { Editor } from '@tiptap/core'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CARET_TOOLBAR_GAP,
+  CARET_TOOLBAR_HEIGHT,
+  CARET_VIEWPORT_INSET,
+  clampCenteredToolbarLeft,
+  resolveCaretAnchoredPosition,
+} from '../use-caret-anchored-position'
+
+function mockEditor(coords: {
+  top: number
+  bottom: number
+  left: number
+  right?: number
+}): Editor {
+  return {
+    state: { selection: { from: 1 } },
+    view: {
+      coordsAtPos: () => ({
+        ...coords,
+        right: coords.right ?? coords.left + 2,
+      }),
+    },
+  } as unknown as Editor
+}
+
+describe('resolveCaretAnchoredPosition', () => {
+  it('places the toolbar above the caret, centered on the caret', () => {
+    const editor = mockEditor({ top: 200, bottom: 220, left: 48, right: 52 })
+    const pos = resolveCaretAnchoredPosition(editor)
+    expect(pos).toEqual({
+      centerX: 50,
+      top: 200 - CARET_TOOLBAR_HEIGHT - CARET_TOOLBAR_GAP,
+      visible: true,
+    })
+  })
+
+  it('flips below the caret when there is not enough room above', () => {
+    const editor = mockEditor({ top: 20, bottom: 36, left: 80, right: 84 })
+    const pos = resolveCaretAnchoredPosition(editor)
+    expect(pos).toEqual({
+      centerX: 82,
+      top: 36 + CARET_TOOLBAR_GAP,
+      visible: true,
+    })
+  })
+
+  it('hides when the caret is scrolled out of the viewport', () => {
+    vi.stubGlobal('innerHeight', 800)
+    const editor = mockEditor({ top: 900, bottom: 920, left: 40, right: 44 })
+    const pos = resolveCaretAnchoredPosition(editor)
+    expect(pos).toEqual({
+      centerX: 42,
+      top: 0,
+      visible: false,
+    })
+    vi.unstubAllGlobals()
+  })
+
+  it('returns null when coordinate lookup fails', () => {
+    const editor = {
+      state: { selection: { from: 0 } },
+      view: {
+        coordsAtPos: () => {
+          throw new Error('invalid position')
+        },
+      },
+    } as unknown as Editor
+    expect(resolveCaretAnchoredPosition(editor)).toBeNull()
+  })
+})
+
+describe('clampCenteredToolbarLeft', () => {
+  it('centers the toolbar on the caret when there is room', () => {
+    vi.stubGlobal('innerWidth', 800)
+    expect(clampCenteredToolbarLeft(400, 120)).toBe(340)
+    vi.unstubAllGlobals()
+  })
+
+  it('clamps to the viewport inset when centered position would overflow', () => {
+    vi.stubGlobal('innerWidth', 400)
+    expect(clampCenteredToolbarLeft(360, 120)).toBe(400 - CARET_VIEWPORT_INSET - 120)
+    expect(clampCenteredToolbarLeft(20, 120)).toBe(CARET_VIEWPORT_INSET)
+    vi.unstubAllGlobals()
+  })
+})

--- a/clients/web/src/components/editor/block-editor/block-floating-toolbar.tsx
+++ b/clients/web/src/components/editor/block-editor/block-floating-toolbar.tsx
@@ -13,6 +13,8 @@ export type BlockFloatingToolbarProps = {
   onRemove?: () => void
   removeLabel?: string
   disabled?: boolean
+  /** When true, omits outer chrome for use inside a parent card (e.g. generate panel stack). */
+  embedded?: boolean
   /** Extra controls (e.g. formatting) before remove. */
   children?: ReactNode
 }
@@ -30,12 +32,18 @@ export function BlockFloatingToolbar({
   onRemove,
   removeLabel = 'Remove block',
   disabled,
+  embedded = false,
   children,
 }: BlockFloatingToolbarProps) {
   return (
     <div
       data-toolbar-anchor
-      className="pointer-events-auto flex h-9 max-w-[min(100vw-2rem,520px)] flex-wrap items-center gap-0.5 rounded-md border border-slate-200 bg-white px-1 py-0.5 shadow-md shadow-slate-900/10 dark:border-neutral-600 dark:bg-neutral-800 dark:shadow-black/40 sm:max-w-none sm:flex-nowrap"
+      className={[
+        'pointer-events-auto flex h-9 w-max max-w-[calc(100vw-2rem)] items-center gap-0.5 px-1 py-0.5',
+        embedded
+          ? 'w-full rounded-none border-0 bg-transparent shadow-none'
+          : 'rounded-md border border-slate-200 bg-white shadow-md shadow-slate-900/10 dark:border-neutral-600 dark:bg-neutral-800 dark:shadow-black/40',
+      ].join(' ')}
       onClick={(e) => e.stopPropagation()}
       onKeyDown={(e) => e.stopPropagation()}
       role="toolbar"

--- a/clients/web/src/components/editor/block-editor/block-frame.tsx
+++ b/clients/web/src/components/editor/block-editor/block-frame.tsx
@@ -5,6 +5,8 @@ export type BlockFrameProps = {
   blockId: string
   /** Toolbar shown above the block on hover, focus, or selection. */
   toolbar?: ReactNode
+  /** When false, toolbar is rendered elsewhere (e.g. caret-anchored portal). */
+  inlineToolbar?: boolean
   children: ReactNode
   className?: string
 }
@@ -12,7 +14,13 @@ export type BlockFrameProps = {
 /**
  * Wraps a single block: Gutenberg-style left accent, floating toolbar above, hover/focus affordances.
  */
-export function BlockFrame({ blockId, toolbar, children, className }: BlockFrameProps) {
+export function BlockFrame({
+  blockId,
+  toolbar,
+  inlineToolbar = true,
+  children,
+  className,
+}: BlockFrameProps) {
   const { selectedId, setSelectedId, disabled } = useBlockEditor()
   const selected = selectedId === blockId
 
@@ -39,7 +47,7 @@ export function BlockFrame({ blockId, toolbar, children, className }: BlockFrame
           disabled ? 'opacity-60' : '',
         ].join(' ')}
       >
-        {toolbar && (
+        {toolbar && inlineToolbar && (
           <div
             className={[
               'sticky top-0 z-20 w-full overflow-hidden transition-all duration-150',

--- a/clients/web/src/components/editor/block-editor/caret-anchored-toolbar-portal.tsx
+++ b/clients/web/src/components/editor/block-editor/caret-anchored-toolbar-portal.tsx
@@ -1,0 +1,52 @@
+import type { Editor } from '@tiptap/core'
+import { createPortal } from 'react-dom'
+import { useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import {
+  clampCenteredToolbarLeft,
+  useCaretAnchoredPosition,
+} from './use-caret-anchored-position'
+
+export type CaretAnchoredToolbarPortalProps = {
+  editor: Editor | null | undefined
+  enabled: boolean
+  children: ReactNode
+}
+
+/**
+ * Renders a toolbar in a fixed-position portal aligned to the TipTap caret.
+ */
+export function CaretAnchoredToolbarPortal({
+  editor,
+  enabled,
+  children,
+}: CaretAnchoredToolbarPortalProps) {
+  const position = useCaretAnchoredPosition(editor, enabled)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [clampedLeft, setClampedLeft] = useState(0)
+
+  useLayoutEffect(() => {
+    if (!position?.visible || !containerRef.current) return
+    const width = containerRef.current.offsetWidth
+    setClampedLeft(clampCenteredToolbarLeft(position.centerX, width))
+  }, [position?.centerX, position?.top, position?.visible, children])
+
+  if (!position?.visible) {
+    return null
+  }
+
+  return createPortal(
+    <div
+      ref={containerRef}
+      className="pointer-events-auto w-max max-w-[calc(100vw-2rem)]"
+      style={{
+        position: 'fixed',
+        left: clampedLeft,
+        top: position.top,
+        zIndex: 50,
+      }}
+    >
+      {children}
+    </div>,
+    document.body,
+  )
+}

--- a/clients/web/src/components/editor/block-editor/index.ts
+++ b/clients/web/src/components/editor/block-editor/index.ts
@@ -19,6 +19,17 @@ export { BlockFloatingToolbar } from './block-floating-toolbar'
 export type { BlockFloatingToolbarProps } from './block-floating-toolbar'
 export { BlockFrame } from './block-frame'
 export type { BlockFrameProps } from './block-frame'
+export { CaretAnchoredToolbarPortal } from './caret-anchored-toolbar-portal'
+export type { CaretAnchoredToolbarPortalProps } from './caret-anchored-toolbar-portal'
+export {
+  clampCenteredToolbarLeft,
+  resolveCaretAnchoredPosition,
+  useCaretAnchoredPosition,
+  CARET_TOOLBAR_GAP,
+  CARET_TOOLBAR_HEIGHT,
+  CARET_VIEWPORT_INSET,
+} from './use-caret-anchored-position'
+export type { CaretAnchoredPosition } from './use-caret-anchored-position'
 export { EditorSidebar } from './editor-sidebar'
 export type { EditorSidebarProps, EditorSidebarTab } from './editor-sidebar'
 export { SidebarSection } from './sidebar-section'

--- a/clients/web/src/components/editor/block-editor/use-caret-anchored-position.ts
+++ b/clients/web/src/components/editor/block-editor/use-caret-anchored-position.ts
@@ -1,0 +1,113 @@
+import type { Editor } from '@tiptap/core'
+import { useCallback, useEffect, useState } from 'react'
+
+export const CARET_TOOLBAR_HEIGHT = 36
+export const CARET_TOOLBAR_GAP = 8
+export const CARET_VIEWPORT_INSET = 16
+
+export type CaretAnchoredPosition = {
+  /** Horizontal center of the caret in viewport coordinates. */
+  centerX: number
+  top: number
+  visible: boolean
+}
+
+function getScrollParents(element: HTMLElement | null): HTMLElement[] {
+  const parents: HTMLElement[] = []
+  let node = element?.parentElement ?? null
+  while (node) {
+    const style = getComputedStyle(node)
+    const overflow = `${style.overflow} ${style.overflowY} ${style.overflowX}`
+    if (/(auto|scroll|overlay)/.test(overflow)) {
+      parents.push(node)
+    }
+    node = node.parentElement
+  }
+  return parents
+}
+
+/**
+ * Maps the TipTap caret to fixed viewport coordinates for a toolbar placed above (or below) the line.
+ */
+export function resolveCaretAnchoredPosition(
+  editor: Editor,
+  toolbarHeight = CARET_TOOLBAR_HEIGHT,
+): CaretAnchoredPosition | null {
+  try {
+    const { from } = editor.state.selection
+    const coords = editor.view.coordsAtPos(from)
+
+    const centerX = (coords.left + coords.right) / 2
+
+    if (coords.bottom < 0 || coords.top > window.innerHeight) {
+      return { centerX, top: 0, visible: false }
+    }
+
+    const aboveTop = coords.top - toolbarHeight - CARET_TOOLBAR_GAP
+    const top =
+      aboveTop < CARET_VIEWPORT_INSET ? coords.bottom + CARET_TOOLBAR_GAP : aboveTop
+
+    return {
+      centerX,
+      top,
+      visible: true,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function clampCenteredToolbarLeft(centerX: number, toolbarWidth: number): number {
+  const idealLeft = centerX - toolbarWidth / 2
+  const maxLeft = window.innerWidth - CARET_VIEWPORT_INSET - toolbarWidth
+  return Math.max(CARET_VIEWPORT_INSET, Math.min(idealLeft, maxLeft))
+}
+
+export function useCaretAnchoredPosition(
+  editor: Editor | null | undefined,
+  enabled: boolean,
+): CaretAnchoredPosition | null {
+  const [position, setPosition] = useState<CaretAnchoredPosition | null>(null)
+
+  const sync = useCallback(() => {
+    if (!enabled || !editor || editor.isDestroyed) {
+      setPosition(null)
+      return
+    }
+    setPosition(resolveCaretAnchoredPosition(editor))
+  }, [editor, enabled])
+
+  useEffect(() => {
+    if (!enabled || !editor || editor.isDestroyed) {
+      setPosition(null)
+      return
+    }
+
+    sync()
+    editor.on('selectionUpdate', sync)
+    editor.on('update', sync)
+
+    const dom = editor.view.dom as HTMLElement
+    const scrollParents = getScrollParents(dom)
+    let raf = 0
+    const onScroll = () => {
+      cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(sync)
+    }
+
+    scrollParents.forEach((el) => el.addEventListener('scroll', onScroll, { passive: true }))
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onScroll)
+
+    return () => {
+      cancelAnimationFrame(raf)
+      editor.off('selectionUpdate', sync)
+      editor.off('update', sync)
+      scrollParents.forEach((el) => el.removeEventListener('scroll', onScroll))
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onScroll)
+    }
+  }, [editor, enabled, sync])
+
+  return position
+}

--- a/clients/web/src/components/syllabus/syllabus-block-editor.tsx
+++ b/clients/web/src/components/syllabus/syllabus-block-editor.tsx
@@ -16,6 +16,7 @@ import {
   BlockEditorShell,
   BlockFloatingToolbar,
   BlockFrame,
+  CaretAnchoredToolbarPortal,
   EditorSidebar,
   MarkdownBodyEditor,
   MarkdownFormatToolbar,
@@ -447,8 +448,10 @@ function SyllabusBlockEditorInner({
     [altTextOn],
   )
 
+  const [editorVersion, setEditorVersion] = useState(0)
   const handleEditorChange = useCallback((sectionId: string, editor: Editor | null) => {
     editorRefs.current[sectionId] = editor
+    setEditorVersion((v) => v + 1)
   }, [])
 
   const insertImagesIntoSection = useCallback(
@@ -603,13 +606,122 @@ function SyllabusBlockEditorInner({
     }
   }
 
-  function renderToolbar(section: SyllabusSection, index: number) {
+  const caretAnchoredSectionIndex = useMemo(() => {
+    if (!showMarkdownToolbar || !selectedId) return -1
+    return sections.findIndex((s) => s.id === selectedId)
+  }, [showMarkdownToolbar, selectedId, sections])
+
+  const caretAnchoredEditor = useMemo(() => {
+    if (caretAnchoredSectionIndex < 0 || !selectedId) return null
+    void editorVersion
+    return editorRefs.current[selectedId] ?? null
+  }, [caretAnchoredSectionIndex, selectedId, editorVersion])
+
+  function renderGeneratePanel(
+    section: SyllabusSection,
+    index: number,
+    placement: 'inline' | 'anchored' = 'inline',
+  ) {
+    if (!courseCode) return null
+
+    const inputClassName = [
+      'w-full py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none disabled:opacity-60 dark:text-neutral-100 dark:placeholder:text-neutral-500',
+      placement === 'anchored'
+        ? 'border-0 bg-transparent px-2 focus:ring-0'
+        : 'rounded-md border border-slate-200 bg-white px-2.5 focus:border-indigo-400 focus:ring-1 focus:ring-indigo-400 dark:border-neutral-600 dark:bg-neutral-950 dark:focus:border-indigo-500 dark:focus:ring-indigo-500',
+      generateSubmittingId === section.id ? (placement === 'anchored' ? 'ps-2 pe-14' : 'ps-2.5 pe-14') : placement === 'anchored' ? 'px-2' : 'px-2.5',
+    ].join(' ')
+
+    const panel = (
+      <>
+        <label htmlFor={`section-generate-input-${section.id}`} className="sr-only">
+          Instructions for generated section content
+        </label>
+        <div className="relative">
+          <input
+            ref={generateInputRef}
+            id={`section-generate-input-${section.id}`}
+            type="text"
+            value={generateInstructions}
+            maxLength={MAX_SECTION_GENERATE_INSTRUCTIONS}
+            disabled={disabled || generateSubmittingId === section.id}
+            onChange={(e) => setGenerateInstructions(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                void submitGenerate(section, index)
+              }
+              if (e.key === 'Escape') {
+                e.stopPropagation()
+                setGenerateSectionId(null)
+                setGenerateInstructions('')
+                setGenerateError(null)
+              }
+            }}
+            placeholder={
+              generateSubmittingId === section.id
+                ? 'Generating…'
+                : 'Describe what this section should say… (Enter to generate)'
+            }
+            className={inputClassName}
+            aria-busy={generateSubmittingId === section.id ? true : undefined}
+          />
+          {generateSubmittingId === section.id ? (
+            <div
+              className="pointer-events-none absolute inset-y-0 end-1.5 flex items-center justify-end pe-[5px]"
+              role="status"
+              aria-live="polite"
+              aria-label="Generating section"
+            >
+              <div className="translate-y-[10px]">
+                <div className="inline-flex shrink-0 origin-center scale-[0.32]">
+                  <BookLoader />
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+        {generateError ? (
+          <p className={`text-xs text-rose-600 dark:text-rose-400 ${placement === 'anchored' ? 'px-2 pb-1.5 pt-0.5' : 'mt-1.5'}`}>
+            {generateError}
+          </p>
+        ) : null}
+      </>
+    )
+
+    if (placement === 'anchored') {
+      return (
+        <div
+          id={`section-generate-${section.id}`}
+          data-generate-anchor
+          className="border-t border-slate-200 py-1 dark:border-neutral-600"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {panel}
+        </div>
+      )
+    }
+
+    return (
+      <div
+        id={`section-generate-${section.id}`}
+        data-generate-anchor
+        className="mb-3 rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2 dark:border-neutral-600 dark:bg-neutral-900/40"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {panel}
+      </div>
+    )
+  }
+
+  function renderToolbar(section: SyllabusSection, index: number, embedded = false) {
     const showMarkdownTools = showMarkdownToolbar && selectedId === section.id
     const label = showMarkdownTools ? 'Markdown' : 'Section'
     const genBusy = generateSubmittingId === section.id
 
     return (
       <BlockFloatingToolbar
+        embedded={embedded}
         icon={<FileText className="h-4 w-4" />}
         label={label}
         onMoveUp={() => move(index, -1)}
@@ -755,71 +867,35 @@ function SyllabusBlockEditorInner({
         {altTextOn ? (
           <AltTextWarningBanner coverage={altCoverage} hardBlock={altTextHardBlock} />
         ) : null}
-        {sections.map((section, index) => (
-          <BlockFrame key={section.id} blockId={section.id} toolbar={renderToolbar(section, index)}>
+        {caretAnchoredSectionIndex >= 0 ? (
+          <CaretAnchoredToolbarPortal editor={caretAnchoredEditor} enabled>
+            {generateSectionId === selectedId ? (
+              <div className="flex w-max max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-lg border border-slate-200 bg-white shadow-md shadow-slate-900/10 dark:border-neutral-600 dark:bg-neutral-800 dark:shadow-black/40">
+                {renderToolbar(sections[caretAnchoredSectionIndex]!, caretAnchoredSectionIndex, true)}
+                {renderGeneratePanel(
+                  sections[caretAnchoredSectionIndex]!,
+                  caretAnchoredSectionIndex,
+                  'anchored',
+                )}
+              </div>
+            ) : (
+              renderToolbar(sections[caretAnchoredSectionIndex]!, caretAnchoredSectionIndex)
+            )}
+          </CaretAnchoredToolbarPortal>
+        ) : null}
+        {sections.map((section, index) => {
+          const caretAnchored = caretAnchoredSectionIndex === index
+          return (
+          <BlockFrame
+            key={section.id}
+            blockId={section.id}
+            toolbar={caretAnchored ? undefined : renderToolbar(section, index)}
+            inlineToolbar={!caretAnchored}
+          >
             <div className="pb-8 pt-0.5">
-              {generateSectionId === section.id && courseCode ? (
-                <div
-                  id={`section-generate-${section.id}`}
-                  className="mb-3 rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2 dark:border-neutral-600 dark:bg-neutral-900/40"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <label htmlFor={`section-generate-input-${section.id}`} className="sr-only">
-                    Instructions for generated section content
-                  </label>
-                  <div className="relative">
-                    <input
-                      ref={generateInputRef}
-                      id={`section-generate-input-${section.id}`}
-                      type="text"
-                      value={generateInstructions}
-                      maxLength={MAX_SECTION_GENERATE_INSTRUCTIONS}
-                      disabled={disabled || generateSubmittingId === section.id}
-                      onChange={(e) => setGenerateInstructions(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          e.preventDefault()
-                          void submitGenerate(section, index)
-                        }
-                        if (e.key === 'Escape') {
-                          e.stopPropagation()
-                          setGenerateSectionId(null)
-                          setGenerateInstructions('')
-                          setGenerateError(null)
-                        }
-                      }}
-                      placeholder={
-                        generateSubmittingId === section.id
-                          ? 'Generating…'
-                          : 'Describe what this section should say… (Enter to generate)'
-                      }
-                      className={[
-                        'w-full rounded-md border border-slate-200 bg-white py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400 disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500 dark:focus:ring-indigo-500',
-                        generateSubmittingId === section.id ? 'ps-2.5 pe-14' : 'px-2.5',
-                      ].join(' ')}
-                      aria-busy={generateSubmittingId === section.id ? true : undefined}
-                    />
-                    {generateSubmittingId === section.id ? (
-                      <div
-                        className="pointer-events-none absolute inset-y-0 end-1.5 flex items-center justify-end pe-[5px]"
-                        role="status"
-                        aria-live="polite"
-                        aria-label="Generating section"
-                      >
-                        {/* Loader paint extends above its layout box; nudge down for optical vertical center in the input */}
-                        <div className="translate-y-[10px]">
-                          <div className="inline-flex shrink-0 origin-center scale-[0.32]">
-                            <BookLoader />
-                          </div>
-                        </div>
-                      </div>
-                    ) : null}
-                  </div>
-                  {generateError ? (
-                    <p className="mt-1.5 text-xs text-rose-600 dark:text-rose-400">{generateError}</p>
-                  ) : null}
-                </div>
-              ) : null}
+              {generateSectionId === section.id && courseCode && !caretAnchored
+                ? renderGeneratePanel(section, index)
+                : null}
               <label className="sr-only" htmlFor={`canvas-heading-${section.id}`}>
                 Section heading (optional)
               </label>
@@ -855,6 +931,7 @@ function SyllabusBlockEditorInner({
                   onBlur={(e) => {
                     const next = e.relatedTarget as HTMLElement | null
                     if (next?.closest('[data-toolbar-anchor]')) return
+                    if (next?.closest('[data-generate-anchor]')) return
                     requestAnimationFrame(() => {
                       setActiveField((prev) =>
                         prev?.blockId === section.id && prev.field === 'markdown' ? null : prev,
@@ -882,7 +959,8 @@ function SyllabusBlockEditorInner({
               </div>
             </div>
           </BlockFrame>
-        ))}
+          )
+        })}
 
         <BlockInsertionRow onAdd={addSection} disabled={disabled} />
       </BlockCanvas>

--- a/clients/web/src/pages/lms/add-module-item-menu.tsx
+++ b/clients/web/src/pages/lms/add-module-item-menu.tsx
@@ -29,6 +29,8 @@ type AddModuleItemMenuProps = {
   oerLibraryEnabled?: boolean
   disabled?: boolean
   h5pEnabled?: boolean
+  /** When false, LTI tool is shown disabled (no registered external tools). */
+  ltiToolsAvailable?: boolean
 }
 
 export function AddModuleItemMenu({
@@ -37,6 +39,7 @@ export function AddModuleItemMenu({
   oerLibraryEnabled = false,
   disabled,
   h5pEnabled,
+  ltiToolsAvailable = true,
 }: AddModuleItemMenuProps) {
   const [open, setOpen] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
@@ -218,8 +221,12 @@ export function AddModuleItemMenu({
           <button
             type="button"
             role="menuitem"
-            onClick={() => pick('lti_link')}
-            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+            disabled={!ltiToolsAvailable}
+            onClick={() => {
+              if (!ltiToolsAvailable) return
+              pick('lti_link')
+            }}
+            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:hover:bg-neutral-700"
           >
             <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-purple-200/90 bg-purple-50 text-purple-800 dark:border-purple-500/40 dark:bg-purple-950 dark:text-purple-200">
               <Plug className="h-4 w-4" aria-hidden />
@@ -227,7 +234,9 @@ export function AddModuleItemMenu({
             <span className="min-w-0 flex flex-col gap-0.5">
               <span className="font-semibold text-slate-950 dark:text-neutral-100">LTI tool</span>
               <span className="text-xs text-slate-500 dark:text-neutral-400">
-                Embedded publisher or external LTI 1.3 tool
+                {ltiToolsAvailable
+                  ? 'Embedded publisher or external LTI 1.3 tool'
+                  : 'No LTI tools registered — add under Settings → LTI tools'}
               </span>
             </span>
           </button>

--- a/clients/web/src/pages/lms/course-enrollments.tsx
+++ b/clients/web/src/pages/lms/course-enrollments.tsx
@@ -78,6 +78,19 @@ function normEnrollmentRole(role: string): string {
   return role.trim().toLowerCase()
 }
 
+const ENROLLMENT_ROLE_SELECT_CLASS =
+  'w-full rounded-xl border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100'
+
+const ASSIGNABLE_ENROLLMENT_ROLES: { value: string; label: string }[] = [
+  { value: 'student', label: 'Student' },
+  { value: 'instructor', label: 'Instructor' },
+  { value: 'ta', label: 'Teaching assistant' },
+  { value: 'designer', label: 'Designer' },
+  { value: 'observer', label: 'Observer' },
+  { value: 'auditor', label: 'Auditor' },
+  { value: 'librarian', label: 'Librarian' },
+]
+
 function enrollmentRoleRank(role: string): number {
   switch (normEnrollmentRole(role)) {
     case 'owner':
@@ -147,7 +160,7 @@ export default function CourseEnrollments() {
   const [stateChangeStatus, setStateChangeStatus] = useState<'idle' | 'loading' | 'error'>('idle')
   const [stateChangeMessage, setStateChangeMessage] = useState<string | null>(null)
   /** When set, POST /enrollments uses `courseRole` instead of a course-scoped app role. */
-  const [addCourseRole, setAddCourseRole] = useState('')
+  const [addCourseRole, setAddCourseRole] = useState('student')
   const [editBuiltinCourseRole, setEditBuiltinCourseRole] = useState('')
   const [editSaveStatus, setEditSaveStatus] = useState<'idle' | 'loading' | 'error'>('idle')
   const [editMessage, setEditMessage] = useState<string | null>(null)
@@ -463,7 +476,7 @@ export default function CourseEnrollments() {
     setModalOpen(false)
     setEmailListText('')
     setSelectedAppRoleId('')
-    setAddCourseRole('')
+    setAddCourseRole('student')
     setAddStatus('idle')
     setAddMessage(null)
     setRolesError(null)
@@ -669,7 +682,12 @@ export default function CourseEnrollments() {
     }
 
     const builtinAdd = addCourseRole.trim()
-    if (viewerIsTeacher && !builtinAdd) {
+    if (canUpdateEnrollments && !builtinAdd) {
+      setAddMessage('Select an enrollment role.')
+      setAddStatus('error')
+      return
+    }
+    if (isCourseCreator && !builtinAdd) {
       if (rolesLoading) {
         setAddMessage('Loading roles…')
         setAddStatus('error')
@@ -682,7 +700,7 @@ export default function CourseEnrollments() {
       }
       if (!selectedAppRoleId) {
         setAddMessage(
-          'Pick a built-in course role, or create a course-scoped app role under Settings → Roles & Permissions.',
+          'Pick an enrollment role, or choose Custom app role and select a course-scoped app role under Settings → Roles & Permissions.',
         )
         setAddStatus('error')
         return
@@ -694,9 +712,9 @@ export default function CourseEnrollments() {
     try {
       const body = builtinAdd
         ? { emails: emailListText, courseRole: normEnrollmentRole(builtinAdd) }
-        : viewerIsTeacher
+        : isCourseCreator
           ? { emails: emailListText, appRoleId: selectedAppRoleId }
-          : { emails: emailListText }
+          : { emails: emailListText, courseRole: 'student' }
 
       const res = await authorizedFetch(
         `/api/v1/courses/${encodeURIComponent(courseCode)}/enrollments`,
@@ -870,7 +888,8 @@ export default function CourseEnrollments() {
   const submitDisabled =
     addStatus === 'loading' ||
     !emailListText.trim() ||
-    (viewerIsTeacher &&
+    (canUpdateEnrollments && !addCourseRole.trim()) ||
+    (isCourseCreator &&
       !usingBuiltinAdd &&
       (rolesLoading || !selectedAppRoleId || !!rolesError))
 
@@ -906,7 +925,7 @@ export default function CourseEnrollments() {
               enrollAsStudentBusy={selfStudentStatus === 'loading'}
               onAddEnrollment={() => {
                 setModalOpen(true)
-                setAddCourseRole('')
+                setAddCourseRole('student')
                 setAddMessage(null)
                 setAddStatus('idle')
               }}
@@ -1526,16 +1545,14 @@ export default function CourseEnrollments() {
                     id="edit-builtin-course-role"
                     value={editBuiltinCourseRole}
                     onChange={(e) => setEditBuiltinCourseRole(e.target.value)}
-                    className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100"
+                    className={`mt-2 ${ENROLLMENT_ROLE_SELECT_CLASS}`}
                     disabled={editSaveStatus === 'loading' || demoteStatus === 'loading'}
                   >
-                    <option value="student">Student</option>
-                    <option value="instructor">Instructor</option>
-                    <option value="ta">Teaching assistant</option>
-                    <option value="designer">Designer</option>
-                    <option value="observer">Observer</option>
-                    <option value="auditor">Auditor</option>
-                    <option value="librarian">Librarian</option>
+                    {ASSIGNABLE_ENROLLMENT_ROLES.map((role) => (
+                      <option key={role.value} value={role.value}>
+                        {role.label}
+                      </option>
+                    ))}
                   </select>
                 </div>
               )}
@@ -1635,40 +1652,34 @@ export default function CourseEnrollments() {
                 Only people who already have an account can be enrolled.
               </p>
 
-              {viewerIsTeacher && (
-                <div className="mt-4">
-                  <label htmlFor="enrollment-builtin-role" className="text-xs font-medium text-slate-600">
-                    Built-in enrollment role (optional)
-                  </label>
-                  <p className="mt-1 text-xs text-slate-500">
-                    Pick a Lextures role (TA, designer, …) or leave blank and choose a course-scoped
-                    app role instead.
-                  </p>
-                  <select
-                    id="enrollment-builtin-role"
-                    value={addCourseRole}
-                    onChange={(e) => setAddCourseRole(e.target.value)}
-                    className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100"
-                    disabled={addStatus === 'loading'}
-                  >
-                    <option value="">— Use app role below —</option>
-                    <option value="student">Student</option>
-                    <option value="instructor">Instructor</option>
-                    <option value="ta">Teaching assistant</option>
-                    <option value="designer">Designer</option>
-                    <option value="observer">Observer</option>
-                    <option value="auditor">Auditor</option>
-                    <option value="librarian">Librarian</option>
-                  </select>
-                </div>
-              )}
+              <div className="mt-4">
+                <label htmlFor="enrollment-role" className="text-xs font-medium text-slate-600 dark:text-neutral-400">
+                  Role
+                </label>
+                <select
+                  id="enrollment-role"
+                  value={addCourseRole}
+                  onChange={(e) => setAddCourseRole(e.target.value)}
+                  className={`mt-1 ${ENROLLMENT_ROLE_SELECT_CLASS}`}
+                  disabled={addStatus === 'loading'}
+                >
+                  {ASSIGNABLE_ENROLLMENT_ROLES.map((role) => (
+                    <option key={role.value} value={role.value}>
+                      {role.label}
+                    </option>
+                  ))}
+                  {isCourseCreator ? (
+                    <option value="">Custom app role…</option>
+                  ) : null}
+                </select>
+              </div>
 
               {isCourseCreator && !addCourseRole.trim() && (
                 <div className="mt-4">
-                  <label htmlFor="enrollment-app-role" className="text-xs font-medium text-slate-600">
+                  <label htmlFor="enrollment-app-role" className="text-xs font-medium text-slate-600 dark:text-neutral-400">
                     Course-scoped app role
                   </label>
-                  <p className="mt-1 text-xs text-slate-500">
+                  <p className="mt-1 text-xs text-slate-500 dark:text-neutral-400">
                     App roles with scope <span className="font-mono">course</span> (configure under
                     Settings → Roles & Permissions). Permissions are applied for this course only.
                   </p>
@@ -1677,16 +1688,16 @@ export default function CourseEnrollments() {
                   ) : rolesError ? (
                     <p className="mt-2 text-sm text-rose-700">{rolesError}</p>
                   ) : courseScopedRoles.length === 0 ? (
-                    <p className="mt-2 text-sm text-amber-800">
+                    <p className="mt-2 text-sm text-amber-800 dark:text-amber-200">
                       No course-scoped roles yet. Create one in Settings → Roles & Permissions (set
-                      scope to Course), then add permissions — or use a built-in role above.
+                      scope to Course), then add permissions — or pick a built-in role above.
                     </p>
                   ) : (
                     <select
                       id="enrollment-app-role"
                       value={selectedAppRoleId}
                       onChange={(e) => setSelectedAppRoleId(e.target.value)}
-                      className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2"
+                      className={`mt-1 ${ENROLLMENT_ROLE_SELECT_CLASS}`}
                       disabled={addStatus === 'loading'}
                     >
                       {courseScopedRoles.map((r) => (
@@ -1698,14 +1709,6 @@ export default function CourseEnrollments() {
                     </select>
                   )}
                 </div>
-              )}
-
-              {!isCourseCreator && (
-                <p className="mt-4 text-xs text-slate-500">
-                  As someone who did not create this course, you can add people as{' '}
-                  <span className="font-medium">students</span> only. The course creator assigns
-                  course-scoped roles when enrolling.
-                </p>
               )}
 
               {addMessage && (

--- a/clients/web/src/pages/lms/course-modules.tsx
+++ b/clients/web/src/pages/lms/course-modules.tsx
@@ -963,6 +963,7 @@ type ModuleCardBodyProps = {
   anyModalBusy: boolean
   onModuleItemAdd: (moduleId: string, kind: ModuleItemKind) => void
   h5pEnabled?: boolean
+  ltiToolsAvailable?: boolean
   onFindOpenResources?: (moduleId: string) => void
   oerLibraryEnabled?: boolean
   minified: boolean
@@ -986,6 +987,7 @@ function ModuleCardBody({
   anyModalBusy,
   onModuleItemAdd,
   h5pEnabled,
+  ltiToolsAvailable,
   onFindOpenResources,
   oerLibraryEnabled: oerEnabled,
   minified,
@@ -1099,6 +1101,7 @@ function ModuleCardBody({
               oerLibraryEnabled={oerEnabled}
               disabled={anyModalBusy}
               h5pEnabled={h5pEnabled}
+              ltiToolsAvailable={ltiToolsAvailable}
             />
           </div>
         )}
@@ -1289,6 +1292,7 @@ type SortableModuleCardProps = {
   anyModalBusy: boolean
   onModuleItemAdd: (moduleId: string, kind: ModuleItemKind) => void
   h5pEnabled?: boolean
+  ltiToolsAvailable?: boolean
   onFindOpenResources?: (moduleId: string) => void
   oerLibraryEnabled?: boolean
   minified: boolean
@@ -1317,6 +1321,7 @@ function SortableModuleCard({
   anyModalBusy,
   onModuleItemAdd,
   h5pEnabled,
+  ltiToolsAvailable,
   onFindOpenResources,
   oerLibraryEnabled: oerEnabled,
   minified,
@@ -1388,6 +1393,7 @@ function SortableModuleCard({
         anyModalBusy={anyModalBusy}
         onModuleItemAdd={onModuleItemAdd}
         h5pEnabled={h5pEnabled}
+        ltiToolsAvailable={ltiToolsAvailable}
         onFindOpenResources={onFindOpenResources}
         oerLibraryEnabled={oerEnabled}
         minified={minified}
@@ -1547,8 +1553,8 @@ export default function CourseModules() {
   const [ltiLinkModuleId, setLtiLinkModuleId] = useState<string | null>(null)
   const [ltiLinkSaving, setLtiLinkSaving] = useState(false)
   const [ltiLinkSaveError, setLtiLinkSaveError] = useState<string | null>(null)
-  const [ltiLinkTools, setLtiLinkTools] = useState<{ id: string; name: string }[]>([])
-  const [ltiLinkToolsLoading, setLtiLinkToolsLoading] = useState(false)
+  const [ltiExternalTools, setLtiExternalTools] = useState<{ id: string; name: string }[]>([])
+  const [ltiExternalToolsLoading, setLtiExternalToolsLoading] = useState(false)
   const [busyModuleId, setBusyModuleId] = useState<string | null>(null)
   const [busyChildItemId, setBusyChildItemId] = useState<string | null>(null)
   const [moduleActionError, setModuleActionError] = useState<string | null>(null)
@@ -1693,6 +1699,29 @@ export default function CourseModules() {
       cancelled = true
     }
   }, [courseCode])
+
+  useEffect(() => {
+    if (!courseCode || !canEditModules) {
+      setLtiExternalTools([])
+      setLtiExternalToolsLoading(false)
+      return
+    }
+    let cancelled = false
+    setLtiExternalToolsLoading(true)
+    void fetchCourseLtiExternalTools(courseCode)
+      .then((tools) => {
+        if (!cancelled) setLtiExternalTools(tools)
+      })
+      .catch(() => {
+        if (!cancelled) setLtiExternalTools([])
+      })
+      .finally(() => {
+        if (!cancelled) setLtiExternalToolsLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [courseCode, canEditModules])
 
   useEffect(() => {
     if (!archiveConfirmItem) return
@@ -1950,19 +1979,14 @@ export default function CourseModules() {
       return
     }
     if (kind === 'lti_link') {
-      if (!courseCode) return
+      if (!courseCode || ltiExternalTools.length === 0) return
       setLtiLinkSaveError(null)
       setLtiLinkModuleId(moduleId)
       setLtiLinkModalKey((k) => k + 1)
-      setLtiLinkTools([])
-      setLtiLinkToolsLoading(true)
       setLtiLinkModalOpen(true)
-      void fetchCourseLtiExternalTools(courseCode)
-        .then((tools) => setLtiLinkTools(tools))
-        .catch(() => setLtiLinkTools([]))
-        .finally(() => setLtiLinkToolsLoading(false))
+      return
     }
-  }, [courseCode])
+  }, [courseCode, ltiExternalTools.length])
 
   const handleChildTogglePublished = useCallback(
     async (child: CourseStructureItem) => {
@@ -2488,6 +2512,7 @@ export default function CourseModules() {
                     anyModalBusy={anyModalBusy}
                     onModuleItemAdd={onModuleItemAdd}
                     h5pEnabled={h5pFeatureEnabled()}
+                    ltiToolsAvailable={!ltiExternalToolsLoading && ltiExternalTools.length > 0}
                     onFindOpenResources={(moduleId) => {
                       setOerModuleId(moduleId)
                       setOerPanelOpen(true)
@@ -2703,8 +2728,8 @@ export default function CourseModules() {
           }
         }}
         onSave={(input) => void saveLtiLink(input)}
-        tools={ltiLinkTools}
-        toolsLoading={ltiLinkToolsLoading}
+        tools={ltiExternalTools}
+        toolsLoading={ltiExternalToolsLoading}
         saving={ltiLinkSaving}
         errorMessage={ltiLinkSaveError}
       />


### PR DESCRIPTION
## Summary
- Add a caret-anchored toolbar portal for the syllabus block editor so the markdown/format toolbar and AI generate panel follow the insertion point instead of sticking above the block.
- Simplify course enrollment role selection into a single picker with built-in roles and optional custom app roles for course creators.
- Preload LTI external tools on the modules page and disable the "LTI tool" add-item menu entry when none are registered, with a helpful hint to configure tools under Settings.
- Update Cursor agent skills (disable-model-invocation flags, next-feature merge-conflict step, new requirements skill).

## Test plan
- [ ] Open a course syllabus editor, select a section, and confirm the toolbar tracks the caret while typing and scrolling.
- [ ] Open AI section generate on a selected block and confirm the stacked toolbar + input panel stays caret-anchored.
- [ ] Add enrollment on a course as creator and non-creator; verify role dropdown shows expected built-in roles and custom app role path.
- [ ] On modules page with no LTI tools, confirm "LTI tool" menu item is disabled with explanatory subtitle.
- [ ] On modules page with LTI tools configured, confirm add LTI link flow still opens the modal with tools loaded.
- [x] `npm run test -- --run use-caret-anchored-position.test.ts` passes locally.