### PR TITLE
feat: course catalog kanban, gradebook grading modal, SpeedGrader polish

### DIFF
--- a/clients/web/package-lock.json
+++ b/clients/web/package-lock.json
@@ -21,6 +21,7 @@
         "@tiptap/pm": "^3.22.2",
         "@tiptap/react": "^3.22.2",
         "@tiptap/starter-kit": "^3.22.2",
+        "@tiptap/y-tiptap": "^3.0.4",
         "@types/react-syntax-highlighter": "^15.5.13",
         "@types/turndown": "^5.0.6",
         "dexie": "^4.4.2",
@@ -47,6 +48,7 @@
         "turndown": "^7.2.4",
         "unified": "^11.0.5",
         "workbox-window": "^7.4.1",
+        "y-prosemirror": "^1.3.7",
         "y-websocket": "^2.1.0",
         "yjs": "^13.6.23",
         "zod": "^4.3.6"
@@ -4629,6 +4631,26 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/y-tiptap": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/y-tiptap/-/y-tiptap-3.0.4.tgz",
+      "integrity": "sha512-I7NnntIPR9PgCuBEjZ0hco+eeLvTpMDnXxsyhwn8z7Se0/Ac6RIq903wn6KoMn7FRVXpTtXAfZphFtpErjabVw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.100"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.5.38"
       }
     },
     "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
@@ -13696,6 +13718,30 @@
       },
       "peerDependencies": {
         "yjs": "^13.0.0"
+      }
+    },
+    "node_modules/y-prosemirror": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.3.7.tgz",
+      "integrity": "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.109"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.5.38"
       }
     },
     "node_modules/y-protocols": {

--- a/clients/web/package-lock.json
+++ b/clients/web/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@simplewebauthn/browser": "^13.3.0",
         "@tiptap/extension-collaboration": "^3.22.4",
-        "@tiptap/extension-collaboration-cursor": "3.0.0",
+        "@tiptap/extension-collaboration-caret": "^3.22.4",
         "@tiptap/extension-image": "^3.22.3",
         "@tiptap/extension-link": "^3.22.2",
         "@tiptap/extension-placeholder": "^3.22.2",
@@ -4238,19 +4238,19 @@
         "yjs": "^13"
       }
     },
-    "node_modules/@tiptap/extension-collaboration-cursor": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration-cursor/-/extension-collaboration-cursor-3.0.0.tgz",
-      "integrity": "sha512-GrH80m/BShJJFJVjLeom8JhM4AoB1SyWL6bFgaiN1mHrya7kkdKWz/72LNG7VNEZz1qXPSlM/LdosIxlRFJAQQ==",
-      "deprecated": "There are no breaking changes in this packages, we meant to release 2.5.0",
+    "node_modules/@tiptap/extension-collaboration-caret": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration-caret/-/extension-collaboration-caret-3.26.0.tgz",
+      "integrity": "sha512-6OIlXWPpMrauwYMxPDKBVDdLeVheqI0QEjy5YHAQ1nHeNHFbSOYi2P/H436zGjv93Zc2wDSZDclLyMsU8QMhyg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.0.0",
-        "y-prosemirror": "^1.2.6"
+        "@tiptap/core": "3.26.0",
+        "@tiptap/pm": "3.26.0",
+        "@tiptap/y-tiptap": "^3.0.2"
       }
     },
     "node_modules/@tiptap/extension-document": {

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -30,7 +30,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@simplewebauthn/browser": "^13.3.0",
     "@tiptap/extension-collaboration": "^3.22.4",
-    "@tiptap/extension-collaboration-cursor": "3.0.0",
+    "@tiptap/extension-collaboration-caret": "^3.22.4",
     "@tiptap/extension-image": "^3.22.3",
     "@tiptap/extension-link": "^3.22.2",
     "@tiptap/extension-placeholder": "^3.22.2",

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -38,6 +38,7 @@
     "@tiptap/pm": "^3.22.2",
     "@tiptap/react": "^3.22.2",
     "@tiptap/starter-kit": "^3.22.2",
+    "@tiptap/y-tiptap": "^3.0.4",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@types/turndown": "^5.0.6",
     "dexie": "^4.4.2",
@@ -64,6 +65,7 @@
     "turndown": "^7.2.4",
     "unified": "^11.0.5",
     "workbox-window": "^7.4.1",
+    "y-prosemirror": "^1.3.7",
     "y-websocket": "^2.1.0",
     "yjs": "^13.6.23",
     "zod": "^4.3.6"

--- a/clients/web/src/app.tsx
+++ b/clients/web/src/app.tsx
@@ -159,8 +159,7 @@ export default function App() {
             <Route path="settings/*" element={<CourseSettings />} />
             <Route path="feed" element={<CourseFeedPage />} />
             <Route path="discussions" element={<CourseDiscussionsPage />} />
-            <Route path="collab-docs" element={<CourseCollabDocsPage />} />
-            <Route path="collab-docs/:docId" element={<CourseCollabDocsPage />} />
+            <Route path="collab-docs/:docId?" element={<CourseCollabDocsPage />} />
             <Route path="files" element={<CourseFilesPage />} />
             <Route path="groups" element={<CourseGroupsPage />} />
             <Route path="syllabus" element={<CourseSyllabus />} />

--- a/clients/web/src/components/annotation/assignment-annotation-workbench.tsx
+++ b/clients/web/src/components/annotation/assignment-annotation-workbench.tsx
@@ -36,7 +36,9 @@ import { FeedbackMediaPlayerList } from './feedback-media-player'
 import { FeedbackMediaRecorder } from './feedback-media-recorder'
 import { FilePreviewBody } from '../file-preview'
 import { detectPreviewType } from '../../lib/file-type'
-import { SubmissionNavigator, type GradedFilter } from './submission-navigator'
+import { SubmissionNavigator } from './submission-navigator'
+import { sortSubmissionsByStudentLabel, type GradedFilter } from './submission-navigator-utils'
+import { ResizableSplitPane } from '../layout/resizable-split-pane'
 import { SubmissionPreviewSidebar } from './submission-preview-sidebar'
 import type { RubricDefinition } from '../../lib/courses-api'
 
@@ -81,6 +83,8 @@ export type AssignmentAnnotationWorkbenchProps = {
   presentation?: 'inline' | 'modal'
   modalOpen?: boolean
   onModalClose?: () => void
+  /** When set, staff navigation opens on this student's submission after load. */
+  initialStudentUserId?: string | null
 }
 
 export function AssignmentAnnotationWorkbench({
@@ -105,6 +109,7 @@ export function AssignmentAnnotationWorkbench({
   presentation = 'inline',
   modalOpen = false,
   onModalClose,
+  initialStudentUserId = null,
 }: AssignmentAnnotationWorkbenchProps) {
   const annotationsActive = annotationsActiveProp ?? submissionAllowsFile
   const [panel, setPanel] = useState<'document' | 'media'>('document')
@@ -112,6 +117,8 @@ export function AssignmentAnnotationWorkbench({
   const [gradedFilter, setGradedFilter] = useState<GradedFilter>('all')
   const [submissions, setSubmissions] = useState<ModuleAssignmentSubmissionApi[]>([])
   const [idx, setIdx] = useState(0)
+  const staffNavRef = useRef({ submissions, idx })
+  staffNavRef.current = { submissions, idx }
   const [mine, setMine] = useState<ModuleAssignmentSubmissionApi | null>(null)
   const [annotations, setAnnotations] = useState<SubmissionAnnotationApi[]>([])
   const [tool, setTool] = useState<AnnotationTool>('highlight')
@@ -225,13 +232,25 @@ export function AssignmentAnnotationWorkbench({
     setLoadError(null)
     try {
       const list = await fetchModuleAssignmentSubmissions(courseCode, itemId, { graded: gradedFilter })
-      setSubmissions(list)
-      setIdx((i) => (list.length === 0 ? 0 : Math.min(i, list.length - 1)))
+      const sorted = sortSubmissionsByStudentLabel(list)
+      const preserveId = staffNavRef.current.submissions[staffNavRef.current.idx]?.id
+      setSubmissions(sorted)
+      setIdx(() => {
+        if (initialStudentUserId) {
+          const targetIdx = sorted.findIndex((s) => s.submittedBy === initialStudentUserId)
+          if (targetIdx >= 0) return targetIdx
+        }
+        if (preserveId) {
+          const nextIdx = sorted.findIndex((s) => s.id === preserveId)
+          if (nextIdx >= 0) return nextIdx
+        }
+        return 0
+      })
     } catch (e) {
       setSubmissions([])
       setLoadError(e instanceof Error ? e.message : 'Could not load submissions.')
     }
-  }, [courseCode, itemId, gradedFilter, mode])
+  }, [courseCode, initialStudentUserId, itemId, gradedFilter, mode])
 
   const reloadMine = useCallback(async () => {
     if (mode !== 'student') return
@@ -720,10 +739,6 @@ export function AssignmentAnnotationWorkbench({
                     setIdx(0)
                   }}
                   disabled={busy}
-                  currentSubmissionDisplayLabel={
-                    current?.blindLabel ??
-                    (submissions.length > 0 ? `Submission ${idx + 1}` : undefined)
-                  }
                   anonymisedAriaLabel={
                     current?.blindLabel
                       ? `Anonymised student, label ${current.blindLabel}`
@@ -758,27 +773,30 @@ export function AssignmentAnnotationWorkbench({
             </p>
           ) : null}
 
-          <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
-            <div className="min-h-[40vh] flex-1 overflow-auto border-b border-slate-200 bg-white dark:border-neutral-600 dark:bg-neutral-800 lg:min-h-0 lg:border-b-0 lg:border-r">
+          <ResizableSplitPane
+            storageKey="lextures:submission-grade-sidebar-width"
+            primary={
               <div className="h-full min-h-[40vh] bg-slate-50 dark:bg-neutral-800/60">
                 {documentPreviewContent}
               </div>
-            </div>
-            <SubmissionPreviewSidebar
-              mode={mode}
-              courseCode={courseCode}
-              itemId={itemId}
-              submissionId={current?.id ?? null}
-              rubric={assignmentRubric}
-              maxPoints={assignmentPointsWorth}
-              gradingDisabled={busy}
-              filename={displayFilename}
-              filePath={displayFilePath ?? null}
-              submittedAt={current?.submittedAt}
-              blindLabel={current?.blindLabel}
-              mimeType={displayMimeType}
-            />
-          </div>
+            }
+            secondary={
+              <SubmissionPreviewSidebar
+                mode={mode}
+                courseCode={courseCode}
+                itemId={itemId}
+                submissionId={current?.id ?? null}
+                rubric={assignmentRubric}
+                maxPoints={assignmentPointsWorth}
+                gradingDisabled={busy}
+                filename={displayFilename}
+                filePath={displayFilePath ?? null}
+                submittedAt={current?.submittedAt}
+                blindLabel={current?.blindLabel}
+                mimeType={displayMimeType}
+              />
+            }
+          />
         </div>
       </div>
     )
@@ -859,10 +877,6 @@ export function AssignmentAnnotationWorkbench({
                 setIdx(0)
               }}
               disabled={busy}
-              currentSubmissionDisplayLabel={
-                current?.blindLabel ??
-                (submissions.length > 0 ? `Submission ${idx + 1}` : undefined)
-              }
               anonymisedAriaLabel={
                 current?.blindLabel
                   ? `Anonymised student, label ${current.blindLabel}`

--- a/clients/web/src/components/annotation/submission-navigator-utils.ts
+++ b/clients/web/src/components/annotation/submission-navigator-utils.ts
@@ -1,0 +1,28 @@
+import type { ModuleAssignmentSubmissionApi } from '../../lib/courses-api'
+
+export type GradedFilter = 'all' | 'graded' | 'ungraded'
+
+export function submissionStudentLabel(
+  submission: ModuleAssignmentSubmissionApi | null | undefined,
+  fallbackIndex?: number,
+): string | undefined {
+  if (!submission) return undefined
+  const blind = submission.blindLabel?.trim()
+  if (blind) return blind
+  const name = submission.submittedByDisplayName?.trim()
+  if (name) return name
+  if (fallbackIndex != null) return `Submission ${fallbackIndex + 1}`
+  return undefined
+}
+
+export function sortSubmissionsByStudentLabel(
+  submissions: ModuleAssignmentSubmissionApi[],
+): ModuleAssignmentSubmissionApi[] {
+  return [...submissions].sort((a, b) => {
+    const labelA = submissionStudentLabel(a) ?? ''
+    const labelB = submissionStudentLabel(b) ?? ''
+    const byLabel = labelA.localeCompare(labelB, undefined, { sensitivity: 'base' })
+    if (byLabel !== 0) return byLabel
+    return a.id.localeCompare(b.id)
+  })
+}

--- a/clients/web/src/components/annotation/submission-navigator.tsx
+++ b/clients/web/src/components/annotation/submission-navigator.tsx
@@ -1,6 +1,162 @@
+import { ChevronDown } from 'lucide-react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import type { ModuleAssignmentSubmissionApi } from '../../lib/courses-api'
+import {
+  submissionStudentLabel,
+  type GradedFilter,
+} from './submission-navigator-utils'
 
-export type GradedFilter = 'all' | 'graded' | 'ungraded'
+type SubmissionStudentPickerProps = {
+  submissions: ModuleAssignmentSubmissionApi[]
+  index: number
+  disabled?: boolean
+  onIndexChange: (i: number) => void
+}
+
+function SubmissionStudentPicker({
+  submissions,
+  index,
+  disabled,
+  onIndexChange,
+}: SubmissionStudentPickerProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const rootRef = useRef<HTMLDivElement>(null)
+  const filterRef = useRef<HTMLInputElement>(null)
+  const buttonId = useId()
+  const menuId = useId()
+  const filterId = useId()
+  const current = submissions[index] ?? null
+  const currentLabel = submissionStudentLabel(current, index) ?? 'No submissions'
+
+  const visibleEntries = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    return submissions
+      .map((submission, i) => ({
+        submission,
+        i,
+        label: submissionStudentLabel(submission, i) ?? `Submission ${i + 1}`,
+      }))
+      .filter((entry) => needle === '' || entry.label.toLowerCase().includes(needle))
+  }, [query, submissions])
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('')
+      return
+    }
+    const frame = window.requestAnimationFrame(() => {
+      filterRef.current?.focus()
+    })
+    return () => window.cancelAnimationFrame(frame)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    function onPointerDown(e: PointerEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  return (
+    <div ref={rootRef} className="relative min-w-0 flex-1">
+      <button
+        id={buttonId}
+        type="button"
+        disabled={disabled || submissions.length === 0}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={menuId}
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex w-full min-w-0 items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-2.5 py-1.5 text-start text-xs font-semibold text-slate-800 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:hover:bg-neutral-900"
+      >
+        <span className="min-w-0 flex-1 truncate">{currentLabel}</span>
+        <ChevronDown
+          className={`h-3.5 w-3.5 shrink-0 text-slate-500 transition-transform dark:text-neutral-400 ${
+            open ? 'rotate-180' : ''
+          }`}
+          aria-hidden="true"
+        />
+      </button>
+
+      {open ? (
+        <div
+          id={menuId}
+          role="menu"
+          aria-labelledby={buttonId}
+          className="absolute start-0 top-full z-50 mt-1 flex max-h-72 w-full min-w-[14rem] flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-lg dark:border-neutral-600 dark:bg-neutral-900"
+        >
+          <div className="shrink-0 border-b border-slate-200 p-2 dark:border-neutral-700">
+            <label htmlFor={filterId} className="sr-only">
+              Filter students
+            </label>
+            <input
+              ref={filterRef}
+              id={filterId}
+              type="search"
+              value={query}
+              placeholder="Filter students…"
+              autoComplete="off"
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                  e.stopPropagation()
+                  setOpen(false)
+                }
+              }}
+              className="w-full rounded-lg border border-slate-300 bg-white px-2.5 py-1.5 text-xs text-slate-900 outline-none ring-indigo-500/0 placeholder:text-slate-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-400"
+            />
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto py-1">
+            {submissions.length === 0 ? (
+              <p className="px-3 py-2 text-xs text-slate-500 dark:text-neutral-400">No submissions.</p>
+            ) : visibleEntries.length === 0 ? (
+              <p className="px-3 py-2 text-xs text-slate-500 dark:text-neutral-400">No matching students.</p>
+            ) : (
+              visibleEntries.map(({ submission, i, label }) => {
+                const active = i === index
+                return (
+                  <button
+                    key={submission.id}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={active}
+                    onClick={() => {
+                      onIndexChange(i)
+                      setOpen(false)
+                    }}
+                    className={`flex w-full items-center gap-2 px-3 py-2 text-start text-xs transition ${
+                      active
+                        ? 'bg-indigo-50 font-semibold text-indigo-900 dark:bg-indigo-950/50 dark:text-indigo-100'
+                        : 'text-slate-700 hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800'
+                    }`}
+                  >
+                    <span className="w-5 shrink-0 tabular-nums text-slate-400 dark:text-neutral-500">
+                      {i + 1}.
+                    </span>
+                    <span className="min-w-0 flex-1 truncate">{label}</span>
+                  </button>
+                )
+              })
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
 
 export type SubmissionNavigatorProps = {
   submissions: ModuleAssignmentSubmissionApi[]
@@ -9,8 +165,6 @@ export type SubmissionNavigatorProps = {
   gradedFilter: GradedFilter
   onGradedFilterChange: (f: GradedFilter) => void
   disabled?: boolean
-  /** Plan 3.3 — inline label (e.g. "Student 3" or "Submission 2"). */
-  currentSubmissionDisplayLabel?: string
   /** When blind grading is active, exposes WCAG label for the current submission. */
   anonymisedAriaLabel?: string
 }
@@ -22,7 +176,6 @@ export function SubmissionNavigator({
   gradedFilter,
   onGradedFilterChange,
   disabled,
-  currentSubmissionDisplayLabel,
   anonymisedAriaLabel,
 }: SubmissionNavigatorProps) {
   const prev = () => onIndexChange(Math.max(0, index - 1))
@@ -30,10 +183,10 @@ export function SubmissionNavigator({
 
   return (
     <div
-      className="flex flex-wrap items-center gap-3 rounded-xl border border-slate-200 bg-slate-50/80 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900/80"
+      className="flex min-w-0 flex-wrap items-center gap-3 rounded-xl border border-slate-200 bg-slate-50/80 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900/80"
       aria-label={anonymisedAriaLabel}
     >
-      <label className="inline-flex items-center gap-2 font-medium text-slate-700 dark:text-neutral-200">
+      <label className="inline-flex shrink-0 items-center gap-2 font-medium text-slate-700 dark:text-neutral-200">
         <span className="sr-only">Filter submissions</span>
         <select
           className="rounded-lg border border-slate-300 bg-white px-2 py-1 text-sm dark:border-neutral-600 dark:bg-neutral-950"
@@ -46,26 +199,33 @@ export function SubmissionNavigator({
           <option value="ungraded">Ungraded</option>
         </select>
       </label>
-      <div className="flex items-center gap-2">
+
+      <div className="grid min-w-[18rem] flex-1 grid-cols-[4.5rem_minmax(0,1fr)_4.5rem] items-center gap-2">
         <button
           type="button"
-          className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-950 dark:hover:bg-neutral-900"
+          className="w-full rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-950 dark:hover:bg-neutral-900"
           disabled={disabled || index <= 0}
           onClick={prev}
           aria-label="Previous submission"
         >
           Prev
         </button>
-        <span className="tabular-nums text-slate-600 dark:text-neutral-300">
-          {submissions.length === 0
-            ? '0 / 0'
-            : currentSubmissionDisplayLabel
-              ? `${currentSubmissionDisplayLabel} · ${index + 1} / ${submissions.length}`
-              : `${index + 1} / ${submissions.length}`}
-        </span>
+
+        <div className="flex min-w-0 items-center gap-2">
+          <SubmissionStudentPicker
+            submissions={submissions}
+            index={index}
+            disabled={disabled}
+            onIndexChange={onIndexChange}
+          />
+          <span className="w-10 shrink-0 text-end text-xs tabular-nums text-slate-500 dark:text-neutral-400">
+            {submissions.length === 0 ? '0/0' : `${index + 1}/${submissions.length}`}
+          </span>
+        </div>
+
         <button
           type="button"
-          className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-950 dark:hover:bg-neutral-900"
+          className="w-full rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-950 dark:hover:bg-neutral-900"
           disabled={disabled || submissions.length === 0 || index >= submissions.length - 1}
           onClick={next}
           aria-label="Next submission"

--- a/clients/web/src/components/annotation/submission-preview-sidebar.tsx
+++ b/clients/web/src/components/annotation/submission-preview-sidebar.tsx
@@ -41,7 +41,7 @@ export function SubmissionPreviewSidebar({
   if (mode !== 'staff') {
     return (
       <aside
-        className="flex w-full shrink-0 flex-col overflow-y-auto border-t border-slate-200 bg-slate-100 dark:border-neutral-600 dark:bg-neutral-800 lg:w-96 lg:border-t-0 lg:border-l xl:w-[26rem]"
+        className="flex h-full min-h-0 w-full flex-col overflow-y-auto bg-slate-100 dark:bg-neutral-800"
         aria-label="Submission file details"
       >
         <SubmissionFileDetailsPanel
@@ -57,7 +57,7 @@ export function SubmissionPreviewSidebar({
 
   return (
     <aside
-      className="flex min-h-0 w-full shrink-0 flex-col border-t border-slate-200 bg-slate-100 dark:border-neutral-600 dark:bg-neutral-800 lg:w-96 lg:border-t-0 lg:border-l xl:w-[28rem]"
+      className="flex h-full min-h-0 w-full flex-col bg-slate-100 dark:bg-neutral-800"
       aria-label="Submission grading and details"
     >
       <div

--- a/clients/web/src/components/collab/collab-editor.tsx
+++ b/clients/web/src/components/collab/collab-editor.tsx
@@ -2,7 +2,7 @@
  * CollabEditor — real-time collaborative rich-text editor using TipTap + Y.js.
  * Connects to the Go WebSocket relay at /api/v1/courses/{code}/collab-docs/{id}/ws.
  */
-import { useEffect, useReducer, useState } from 'react'
+import { useEffect, useReducer, useState, type ReactNode } from 'react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Collaboration from '@tiptap/extension-collaboration'
@@ -37,6 +37,32 @@ type SessionAction =
 function sessionReducer(_state: Session | null, action: SessionAction): Session | null {
   if (action.type === 'set') return action.session
   return null
+}
+
+function ConnectionStatusBar({
+  connState,
+  trailing,
+}: {
+  connState: ConnState
+  trailing?: ReactNode
+}) {
+  return (
+    <div className="flex items-center justify-between border-b border-slate-200 px-4 py-2 dark:border-neutral-700">
+      <span className="text-sm text-slate-500 dark:text-neutral-400">
+        {connState === 'connected' ? (
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2 w-2 rounded-full bg-green-500" aria-hidden="true" />
+            Live
+          </span>
+        ) : connState === 'connecting' ? (
+          'Connecting…'
+        ) : (
+          <span className="text-red-500">Offline — changes will sync when reconnected</span>
+        )}
+      </span>
+      {trailing}
+    </div>
+  )
 }
 
 export function CollabEditor({ courseCode, docId, userName = 'Anonymous', readOnly = false }: Props) {
@@ -98,33 +124,20 @@ export function CollabEditor({ courseCode, docId, userName = 'Anonymous', readOn
     [session],
   )
 
-  if (!editor) return null
+  const presence =
+    session?.provider.awareness ? (
+      <PresenceBar
+        awareness={session.provider.awareness}
+        selfName={userName}
+        selfColor={colorForUser(userName)}
+      />
+    ) : null
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b border-slate-200 px-4 py-2 dark:border-neutral-700">
-        <span className="text-sm text-slate-500 dark:text-neutral-400">
-          {connState === 'connected' ? (
-            <span className="flex items-center gap-1">
-              <span className="inline-block h-2 w-2 rounded-full bg-green-500" aria-hidden="true" />
-              Live
-            </span>
-          ) : connState === 'connecting' ? (
-            'Connecting…'
-          ) : (
-            <span className="text-red-500">Offline — changes will sync when reconnected</span>
-          )}
-        </span>
-        {session?.provider.awareness && (
-          <PresenceBar
-            awareness={session.provider.awareness}
-            selfName={userName}
-            selfColor={colorForUser(userName)}
-          />
-        )}
-      </div>
+      <ConnectionStatusBar connState={connState} trailing={presence} />
       <div className="flex-1 overflow-y-auto">
-        <EditorContent editor={editor} className="w-full" />
+        {editor ? <EditorContent editor={editor} className="w-full" /> : null}
       </div>
     </div>
   )

--- a/clients/web/src/components/collab/collab-editor.tsx
+++ b/clients/web/src/components/collab/collab-editor.tsx
@@ -6,7 +6,7 @@ import { useEffect, useReducer, useState, type ReactNode } from 'react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Collaboration from '@tiptap/extension-collaboration'
-import CollaborationCursor from '@tiptap/extension-collaboration-cursor'
+import CollaborationCaret from '@tiptap/extension-collaboration-caret'
 import * as Y from 'yjs'
 import { WebsocketProvider } from 'y-websocket'
 import { getAccessToken } from '../../lib/auth'
@@ -108,7 +108,7 @@ export function CollabEditor({ courseCode, docId, userName = 'Anonymous', readOn
     ? [
         collabStarterKit,
         Collaboration.configure({ document: session.ydoc }),
-        CollaborationCursor.configure({
+        CollaborationCaret.configure({
           provider: session.provider,
           user: { name: userName, color: colorForUser(userName) },
         }),

--- a/clients/web/src/components/collab/collab-editor.tsx
+++ b/clients/web/src/components/collab/collab-editor.tsx
@@ -74,7 +74,7 @@ export function CollabEditor({ courseCode, docId, userName = 'Anonymous', readOn
   useEffect(() => {
     const ydoc = new Y.Doc()
     const token = getAccessToken() ?? ''
-    const provider = new WebsocketProvider(wsUrl, docId, ydoc, {
+    const provider = new WebsocketProvider(wsUrl, 'ws', ydoc, {
       connect: true,
       params: { token },
       WebSocketPolyfill: buildAuthWebSocket(token),

--- a/clients/web/src/components/collab/collab-editor.tsx
+++ b/clients/web/src/components/collab/collab-editor.tsx
@@ -48,7 +48,10 @@ function ConnectionStatusBar({
 }) {
   return (
     <div className="flex items-center justify-between border-b border-slate-200 px-4 py-2 dark:border-neutral-700">
-      <span className="text-sm text-slate-500 dark:text-neutral-400">
+      <span
+        data-testid="collab-connection-status"
+        className="text-sm text-slate-500 dark:text-neutral-400"
+      >
         {connState === 'connected' ? (
           <span className="flex items-center gap-1">
             <span className="inline-block h-2 w-2 rounded-full bg-green-500" aria-hidden="true" />

--- a/clients/web/src/components/collab/collab-editor.tsx
+++ b/clients/web/src/components/collab/collab-editor.tsx
@@ -39,6 +39,9 @@ function sessionReducer(_state: Session | null, action: SessionAction): Session 
   return null
 }
 
+/** Undo/redo must be off when Yjs Collaboration drives the document. */
+const collabStarterKit = StarterKit.configure({ undoRedo: false })
+
 function ConnectionStatusBar({
   connState,
   trailing,
@@ -103,14 +106,14 @@ export function CollabEditor({ courseCode, docId, userName = 'Anonymous', readOn
 
   const extensions = session
     ? [
-        StarterKit,
+        collabStarterKit,
         Collaboration.configure({ document: session.ydoc }),
         CollaborationCursor.configure({
           provider: session.provider,
           user: { name: userName, color: colorForUser(userName) },
         }),
       ]
-    : [StarterKit]
+    : [collabStarterKit]
 
   const editor = useEditor(
     {

--- a/clients/web/src/components/file-preview.tsx
+++ b/clients/web/src/components/file-preview.tsx
@@ -59,8 +59,11 @@ function ImageViewer({ filePath, filename }: ImageViewerProps) {
 
   const handleWheel = useCallback((e: React.WheelEvent) => {
     e.preventDefault()
+    let deltaY = e.deltaY
+    if (e.deltaMode === 1) deltaY *= 16
+    else if (e.deltaMode === 2) deltaY *= 400
     setZoom((z) => {
-      const delta = e.deltaY < 0 ? 0.15 : -0.15
+      const delta = -deltaY * 0.00035
       return Math.max(0.1, Math.min(5, z + delta))
     })
   }, [])

--- a/clients/web/src/components/grading/rubric-grade-picker.tsx
+++ b/clients/web/src/components/grading/rubric-grade-picker.tsx
@@ -1,4 +1,4 @@
-import type { RubricDefinition } from '../../lib/courses-api'
+import type { RubricDefinition, RubricCriterion } from '../../lib/courses-api'
 import { formatPointsCell, rubricGradedCount, rubricTotal, rubricScoresComplete } from '../../lib/rubric-utils'
 
 type RubricGradePickerProps = {
@@ -7,6 +7,137 @@ type RubricGradePickerProps = {
   onScoresChange: (scores: Record<string, number>) => void
   disabled?: boolean
   compact?: boolean
+}
+
+const SEGMENTED_MAX_LABEL_LENGTH = 32
+
+function criterionUsesSegmentedControl(c: RubricCriterion): boolean {
+  if (c.levels.length !== 2) return false
+  return c.levels.every(
+    (lvl) => !lvl.description?.trim() && lvl.label.length <= SEGMENTED_MAX_LABEL_LENGTH,
+  )
+}
+
+type CriterionPickerProps = {
+  criterion: RubricCriterion
+  index: number
+  selected: number | undefined
+  disabled: boolean
+  compact: boolean
+  onSelect: (points: number) => void
+}
+
+function CriterionPicker({
+  criterion: c,
+  index,
+  selected,
+  disabled,
+  compact,
+  onSelect,
+}: CriterionPickerProps) {
+  const segmented = criterionUsesSegmentedControl(c)
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-200 dark:border-neutral-700">
+      <div className={`${compact ? 'px-3 py-2.5' : 'px-4 py-3'}`}>
+        <p className="text-sm leading-snug text-slate-900 dark:text-neutral-100">
+          <span className="me-1.5 font-semibold tabular-nums text-slate-400 dark:text-neutral-500">
+            {index + 1}.
+          </span>
+          {c.title}
+        </p>
+        {c.description ? (
+          <p className="mt-1 text-xs leading-relaxed text-slate-500 dark:text-neutral-400">{c.description}</p>
+        ) : null}
+      </div>
+
+      {segmented ? (
+        <div
+          className="grid border-t border-slate-200 dark:border-neutral-700"
+          style={{ gridTemplateColumns: `repeat(${c.levels.length}, minmax(0, 1fr))` }}
+          role="radiogroup"
+          aria-label={c.title}
+        >
+          {c.levels.map((lvl, i) => {
+            const active = selected === lvl.points
+            return (
+              <button
+                key={`${c.id}-${i}`}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                disabled={disabled}
+                onClick={() => onSelect(lvl.points)}
+                className={`border-slate-200 px-2 py-2.5 text-center transition disabled:opacity-50 dark:border-neutral-700 ${
+                  i > 0 ? 'border-s' : ''
+                } ${
+                  active
+                    ? 'bg-indigo-600 text-white dark:bg-indigo-500'
+                    : 'bg-slate-50 text-slate-700 hover:bg-slate-100 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800'
+                }`}
+              >
+                <span className="block text-xs font-medium leading-tight">{lvl.label}</span>
+                <span
+                  className={`mt-0.5 block text-[11px] tabular-nums ${
+                    active ? 'text-indigo-100' : 'text-slate-500 dark:text-neutral-400'
+                  }`}
+                >
+                  {formatPointsCell(lvl.points)} pts
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      ) : (
+        <div
+          className={`border-t border-slate-200 dark:border-neutral-700 ${compact ? 'space-y-2 p-2' : 'space-y-2.5 p-3'}`}
+          role="radiogroup"
+          aria-label={c.title}
+        >
+          {c.levels.map((lvl, i) => {
+            const active = selected === lvl.points
+            return (
+              <button
+                key={`${c.id}-${i}`}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                disabled={disabled}
+                onClick={() => onSelect(lvl.points)}
+                className={`w-full rounded-lg border px-3 py-2.5 text-start transition disabled:opacity-50 ${
+                  active
+                    ? 'border-indigo-500 bg-indigo-50 ring-1 ring-indigo-500/25 dark:border-indigo-400 dark:bg-indigo-950/50 dark:ring-indigo-400/25'
+                    : 'border-slate-200 bg-slate-50 hover:border-slate-300 hover:bg-white dark:border-neutral-600 dark:bg-neutral-900 dark:hover:border-neutral-500 dark:hover:bg-neutral-800'
+                }`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <span
+                    className={`text-sm font-medium leading-snug ${
+                      active ? 'text-indigo-900 dark:text-indigo-100' : 'text-slate-900 dark:text-neutral-100'
+                    }`}
+                  >
+                    {lvl.label}
+                  </span>
+                  <span
+                    className={`shrink-0 text-xs font-semibold tabular-nums ${
+                      active ? 'text-indigo-700 dark:text-indigo-300' : 'text-slate-500 dark:text-neutral-400'
+                    }`}
+                  >
+                    {formatPointsCell(lvl.points)} pts
+                  </span>
+                </div>
+                {lvl.description ? (
+                  <p className="mt-1.5 text-xs leading-relaxed text-slate-600 dark:text-neutral-400">
+                    {lvl.description}
+                  </p>
+                ) : null}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
 }
 
 export function RubricGradePicker({
@@ -21,105 +152,62 @@ export function RubricGradePicker({
   const allGraded = rubricScoresComplete(rubric, scores)
 
   return (
-    <div className="space-y-4">
-      <div className="rounded-xl border border-slate-200 bg-white p-3 dark:border-neutral-600 dark:bg-neutral-900/50">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">
-              Rubric score
-            </p>
-            <p className="mt-0.5 text-2xl font-semibold tabular-nums text-slate-900 dark:text-neutral-50">
-              {formatPointsCell(total)}
-            </p>
+    <div className={compact ? 'space-y-3' : 'space-y-4'}>
+      {!compact ? (
+        <div className="rounded-xl border border-slate-200 bg-white p-3 dark:border-neutral-600 dark:bg-neutral-900/50">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+                Rubric score
+              </p>
+              <p className="mt-0.5 text-2xl font-semibold tabular-nums text-slate-900 dark:text-neutral-50">
+                {formatPointsCell(total)}
+              </p>
+            </div>
+            <div className="text-end">
+              <p className="text-xs text-slate-500 dark:text-neutral-400">Criteria</p>
+              <p className="mt-0.5 text-sm font-medium tabular-nums text-slate-700 dark:text-neutral-200">
+                {gradedCount}/{rubric.criteria.length}
+              </p>
+            </div>
           </div>
-          <div className="text-end">
-            <p className="text-xs text-slate-500 dark:text-neutral-400">Criteria</p>
-            <p className="mt-0.5 text-sm font-medium tabular-nums text-slate-700 dark:text-neutral-200">
-              {gradedCount}/{rubric.criteria.length}
-            </p>
+          <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-slate-200 dark:bg-neutral-700">
+            <div
+              className={`h-full rounded-full transition-all ${
+                allGraded ? 'bg-emerald-500' : 'bg-indigo-500'
+              }`}
+              style={{ width: `${rubric.criteria.length ? (gradedCount / rubric.criteria.length) * 100 : 0}%` }}
+            />
           </div>
+          {!allGraded ? (
+            <p className="mt-2 text-xs text-slate-500 dark:text-neutral-400">
+              Select a rating for each criterion below.
+            </p>
+          ) : null}
         </div>
-        <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-slate-200 dark:bg-neutral-700">
-          <div
-            className={`h-full rounded-full transition-all ${
-              allGraded ? 'bg-emerald-500' : 'bg-indigo-500'
-            }`}
-            style={{ width: `${rubric.criteria.length ? (gradedCount / rubric.criteria.length) * 100 : 0}%` }}
-          />
-        </div>
-        {!allGraded ? (
-          <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">
-            Select a rating for each criterion below.
-          </p>
-        ) : null}
-      </div>
-
-      {rubric.title ? (
-        <p className="text-sm font-semibold text-slate-900 dark:text-neutral-100">{rubric.title}</p>
+      ) : !allGraded ? (
+        <p className="text-xs text-slate-500 dark:text-neutral-400">
+          {gradedCount} of {rubric.criteria.length} criteria rated
+        </p>
       ) : null}
 
-      {rubric.criteria.map((c, index) => {
-        const selected = scores[c.id]
-        return (
-          <fieldset
+      {rubric.title ? (
+        <p className="text-sm font-medium text-slate-800 dark:text-neutral-200">{rubric.title}</p>
+      ) : null}
+
+      <div className={compact ? 'space-y-3' : 'space-y-4'}>
+        {rubric.criteria.map((c, index) => (
+          <CriterionPicker
             key={c.id}
-            className="rounded-xl border border-slate-200 bg-white p-3 dark:border-neutral-600 dark:bg-neutral-900/40"
-          >
-            <legend className="px-1 text-sm font-semibold text-slate-900 dark:text-neutral-100">
-              <span className="me-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-slate-100 px-1.5 text-xs font-bold text-slate-600 dark:bg-neutral-800 dark:text-neutral-300">
-                {index + 1}
-              </span>
-              {c.title}
-            </legend>
-            {c.description ? (
-              <p className="mt-1 text-xs leading-relaxed text-slate-500 dark:text-neutral-400">{c.description}</p>
-            ) : null}
-            <div className={`mt-3 ${compact ? 'space-y-1.5' : 'space-y-2'}`}>
-              {c.levels.map((lvl, i) => {
-                const active = selected === lvl.points
-                return (
-                  <button
-                    key={`${c.id}-${i}`}
-                    type="button"
-                    disabled={disabled}
-                    aria-pressed={active}
-                    onClick={() => onScoresChange({ ...scores, [c.id]: lvl.points })}
-                    className={`flex w-full items-start gap-3 rounded-lg border px-3 py-2.5 text-start text-sm transition disabled:opacity-50 ${
-                      active
-                        ? 'border-indigo-500 bg-indigo-50 ring-1 ring-indigo-500/30 dark:border-indigo-400 dark:bg-indigo-950/50 dark:ring-indigo-400/30'
-                        : 'border-slate-200 bg-slate-50 hover:border-slate-300 hover:bg-white dark:border-neutral-600 dark:bg-neutral-900 dark:hover:border-neutral-500 dark:hover:bg-neutral-800'
-                    }`}
-                  >
-                    <span
-                      className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border ${
-                        active
-                          ? 'border-indigo-600 bg-indigo-600 dark:border-indigo-400 dark:bg-indigo-400'
-                          : 'border-slate-300 bg-white dark:border-neutral-500 dark:bg-neutral-950'
-                      }`}
-                      aria-hidden="true"
-                    >
-                      {active ? <span className="h-1.5 w-1.5 rounded-full bg-white" /> : null}
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-                        <span className="font-medium text-slate-900 dark:text-neutral-100">{lvl.label}</span>
-                        <span className="text-xs font-semibold tabular-nums text-indigo-700 dark:text-indigo-300">
-                          {formatPointsCell(lvl.points)} pts
-                        </span>
-                      </span>
-                      {lvl.description ? (
-                        <span className="mt-1 block text-xs leading-relaxed text-slate-500 dark:text-neutral-400">
-                          {lvl.description}
-                        </span>
-                      ) : null}
-                    </span>
-                  </button>
-                )
-              })}
-            </div>
-          </fieldset>
-        )
-      })}
+            criterion={c}
+            index={index}
+            selected={scores[c.id]}
+            disabled={disabled}
+            compact={compact}
+            onSelect={(points) => onScoresChange({ ...scores, [c.id]: points })}
+          />
+        ))}
+      </div>
     </div>
   )
 }

--- a/clients/web/src/components/layout/resizable-split-pane.tsx
+++ b/clients/web/src/components/layout/resizable-split-pane.tsx
@@ -1,0 +1,234 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from 'react'
+
+const DEFAULT_SECONDARY_WIDTH = 448
+const MIN_SECONDARY_WIDTH = 280
+const MIN_PRIMARY_WIDTH = 360
+const MAX_SECONDARY_RATIO = 0.65
+
+type ResizableSplitPaneProps = {
+  primary: ReactNode
+  secondary: ReactNode
+  defaultSecondaryWidth?: number
+  minSecondaryWidth?: number
+  minPrimaryWidth?: number
+  storageKey?: string
+  className?: string
+}
+
+function clampSecondaryWidth(
+  width: number,
+  containerWidth: number,
+  minSecondaryWidth: number,
+  minPrimaryWidth: number,
+): number {
+  const maxSecondary = Math.max(
+    minSecondaryWidth,
+    Math.min(containerWidth * MAX_SECONDARY_RATIO, containerWidth - minPrimaryWidth),
+  )
+  return Math.max(minSecondaryWidth, Math.min(maxSecondary, width))
+}
+
+function readStoredWidth(storageKey: string | undefined, fallback: number): number {
+  if (!storageKey) return fallback
+  try {
+    const raw = localStorage.getItem(storageKey)
+    if (!raw) return fallback
+    const parsed = Number(raw)
+    if (!Number.isFinite(parsed)) return fallback
+    return clampSecondaryWidth(parsed, 1600, MIN_SECONDARY_WIDTH, MIN_PRIMARY_WIDTH)
+  } catch {
+    return fallback
+  }
+}
+
+export function ResizableSplitPane({
+  primary,
+  secondary,
+  defaultSecondaryWidth = DEFAULT_SECONDARY_WIDTH,
+  minSecondaryWidth = MIN_SECONDARY_WIDTH,
+  minPrimaryWidth = MIN_PRIMARY_WIDTH,
+  storageKey,
+  className,
+}: ResizableSplitPaneProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const handleId = useId()
+  const [secondaryWidth, setSecondaryWidth] = useState(() =>
+    readStoredWidth(storageKey, defaultSecondaryWidth),
+  )
+  const [dragging, setDragging] = useState(false)
+
+  const updateWidthFromPointer = useCallback(
+    (clientX: number) => {
+      const container = containerRef.current
+      if (!container) return
+      const rect = container.getBoundingClientRect()
+      const next = clampSecondaryWidth(
+        rect.right - clientX,
+        rect.width,
+        minSecondaryWidth,
+        minPrimaryWidth,
+      )
+      setSecondaryWidth(next)
+    },
+    [minPrimaryWidth, minSecondaryWidth],
+  )
+
+  useEffect(() => {
+    if (!dragging) return
+    const previousCursor = document.body.style.cursor
+    const previousUserSelect = document.body.style.userSelect
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+
+    return () => {
+      document.body.style.cursor = previousCursor
+      document.body.style.userSelect = previousUserSelect
+    }
+  }, [dragging])
+
+  useEffect(() => {
+    if (!storageKey) return
+    try {
+      localStorage.setItem(storageKey, String(Math.round(secondaryWidth)))
+    } catch {
+      /* ignore quota / private mode */
+    }
+  }, [secondaryWidth, storageKey])
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    const observer = new ResizeObserver(() => {
+      setSecondaryWidth((width) => {
+        const containerWidth = container.getBoundingClientRect().width
+        return clampSecondaryWidth(width, containerWidth, minSecondaryWidth, minPrimaryWidth)
+      })
+    })
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [minPrimaryWidth, minSecondaryWidth])
+
+  const endDrag = useCallback(
+    (target: HTMLDivElement, pointerId: number) => {
+      try {
+        if (target.hasPointerCapture(pointerId)) {
+          target.releasePointerCapture(pointerId)
+        }
+      } catch {
+        /* ignore */
+      }
+      setDragging(false)
+    },
+    [],
+  )
+
+  const onHandlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return
+      e.preventDefault()
+      e.currentTarget.setPointerCapture(e.pointerId)
+      setDragging(true)
+      updateWidthFromPointer(e.clientX)
+    },
+    [updateWidthFromPointer],
+  )
+
+  const onHandlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!e.currentTarget.hasPointerCapture(e.pointerId)) return
+      updateWidthFromPointer(e.clientX)
+    },
+    [updateWidthFromPointer],
+  )
+
+  return (
+    <div
+      ref={containerRef}
+      className={`flex min-h-0 flex-1 flex-col lg:flex-row ${className ?? ''}`}
+      style={{ '--split-secondary-width': `${secondaryWidth}px` } as CSSProperties}
+    >
+      <div className="min-h-[40vh] min-w-0 flex-1 overflow-auto border-b border-slate-200 bg-white dark:border-neutral-600 dark:bg-neutral-800 lg:min-h-0 lg:border-b-0">
+        {primary}
+      </div>
+
+      <div
+        id={handleId}
+        role="separator"
+        aria-orientation="vertical"
+        aria-controls="resizable-split-pane-secondary"
+        aria-valuenow={Math.round(secondaryWidth)}
+        aria-valuemin={minSecondaryWidth}
+        aria-valuemax={720}
+        aria-label="Resize submission viewer and grading panel"
+        tabIndex={0}
+        onPointerDown={onHandlePointerDown}
+        onPointerMove={onHandlePointerMove}
+        onPointerUp={(e) => endDrag(e.currentTarget, e.pointerId)}
+        onPointerCancel={(e) => endDrag(e.currentTarget, e.pointerId)}
+        onLostPointerCapture={() => setDragging(false)}
+        onKeyDown={(e) => {
+          const step = e.shiftKey ? 48 : 16
+          if (e.key === 'ArrowLeft') {
+            e.preventDefault()
+            setSecondaryWidth((w) => {
+              const container = containerRef.current
+              if (!container) return w + step
+              return clampSecondaryWidth(
+                w + step,
+                container.getBoundingClientRect().width,
+                minSecondaryWidth,
+                minPrimaryWidth,
+              )
+            })
+          } else if (e.key === 'ArrowRight') {
+            e.preventDefault()
+            setSecondaryWidth((w) => {
+              const container = containerRef.current
+              if (!container) return w - step
+              return clampSecondaryWidth(
+                w - step,
+                container.getBoundingClientRect().width,
+                minSecondaryWidth,
+                minPrimaryWidth,
+              )
+            })
+          }
+        }}
+        className={`relative hidden shrink-0 touch-none lg:block ${
+          dragging ? 'z-20' : 'z-10'
+        }`}
+        style={{ width: 0 }}
+      >
+        <div
+          className={`absolute inset-y-0 -start-2 flex w-4 cursor-col-resize items-center justify-center ${
+            dragging ? 'bg-indigo-500/10' : ''
+          }`}
+          aria-hidden="true"
+        >
+          <div
+            className={`h-full w-px transition-colors ${
+              dragging
+                ? 'bg-indigo-500'
+                : 'bg-slate-300 hover:bg-indigo-400 dark:bg-neutral-600 dark:hover:bg-indigo-400'
+            }`}
+          />
+        </div>
+      </div>
+
+      <div
+        id="resizable-split-pane-secondary"
+        className="flex min-h-0 w-full shrink-0 flex-col border-t border-slate-200 dark:border-neutral-600 lg:w-[var(--split-secondary-width)] lg:border-t-0 lg:border-l"
+      >
+        {secondary}
+      </div>
+    </div>
+  )
+}

--- a/clients/web/src/components/layout/side-nav-footer.tsx
+++ b/clients/web/src/components/layout/side-nav-footer.tsx
@@ -8,16 +8,9 @@ import {
   FileText,
   Globe,
 } from 'lucide-react'
-import { RELEASE_VERSION } from '../../lib/release-version'
 import { useShellNav } from './use-shell-nav'
 import { SideNavTooltip } from './side-nav-tooltip'
 import { MARKETING_SITE_URLS } from '../../lib/marketing-site'
-
-function versionLabel(version: string) {
-  const trimmed = version.trim()
-  if (!trimmed) return 'v0'
-  return trimmed.startsWith('v') ? trimmed : `v${trimmed}`
-}
 
 export function SideNavFooter() {
   const { sideNavCollapsed, toggleSideNav } = useShellNav()
@@ -76,17 +69,7 @@ export function SideNavFooter() {
 
       {!sideNavCollapsed && (
         <div className="relative flex flex-col gap-1.5 pt-0.5 motion-safe:animate-in motion-safe:fade-in duration-200">
-          <div className="flex items-center justify-between text-slate-600 dark:text-neutral-400">
-            <span>© {year} Lextures</span>
-            <span
-              className="tabular-nums text-[10px]"
-              title="App version"
-            >
-              {versionLabel(RELEASE_VERSION)}
-            </span>
-          </div>
-
-          <div ref={dropdownRef} className="relative mt-1">
+          <div ref={dropdownRef} className="relative">
             <button
               id={buttonId}
               type="button"
@@ -166,6 +149,10 @@ export function SideNavFooter() {
                     Do Not Sell or Share My Info
                   </span>
                 </a>
+                <div className="h-[1px] bg-slate-100 dark:bg-neutral-800/80 mx-1 my-1" />
+                <div className="px-2.5 py-1.5 text-[10px] text-slate-500 dark:text-neutral-500">
+                  © {year} Lextures
+                </div>
               </div>
             )}
           </div>

--- a/clients/web/src/components/layout/top-bar-breadcrumbs.tsx
+++ b/clients/web/src/components/layout/top-bar-breadcrumbs.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable react-hooks/set-state-in-effect -- sync breadcrumb async labels and cache when the route or course changes */
 import { useEffect, useMemo, useState } from 'react'
 import { ChevronRight } from 'lucide-react'
-import { Link, matchPath, useLocation } from 'react-router-dom'
+import { Link, matchPath, useLocation, useSearchParams } from 'react-router-dom'
 import {
   fetchCourse,
   fetchCourseStructure,
   type CourseStructureItem,
 } from '../../lib/courses-api'
+import { listCourseFiles, type FolderBreadcrumb } from '../../lib/course-files-api'
 import {
   courseSettingsSectionFromPathname,
   settingsViewFromPathname,
@@ -15,6 +16,7 @@ import {
 
 const courseTitleCache = new Map<string, string>()
 const structureCache = new Map<string, CourseStructureItem[]>()
+const fileFolderCache = new Map<string, FolderBreadcrumb[]>()
 
 type Crumb = { key: string; label: string; to?: string }
 
@@ -235,6 +237,26 @@ function mergeModuleItem(
   }).filter((c) => c.label.trim().length > 0)
 }
 
+function mergeFileFolderCrumbs(
+  crumbs: Crumb[],
+  courseCode: string,
+  breadcrumbs: FolderBreadcrumb[],
+): Crumb[] {
+  if (!breadcrumbs.length) return crumbs
+  const filesBase = `/courses/${encodeURIComponent(courseCode)}/files`
+  return [
+    ...crumbs.map((c) => (c.key === 'files' ? { ...c, to: filesBase } : c)),
+    ...breadcrumbs.map((b, i) => ({
+      key: `ff-${b.id}`,
+      label: b.name,
+      to:
+        i < breadcrumbs.length - 1
+          ? `${filesBase}?folder=${encodeURIComponent(b.id)}`
+          : undefined,
+    })),
+  ]
+}
+
 const MODULE_ITEM_PATTERNS = [
   '/courses/:courseCode/modules/content/:itemId',
   '/courses/:courseCode/modules/assignment/:itemId',
@@ -257,6 +279,8 @@ function matchModuleItemRoute(pathname: string): { code: string; id: string } | 
 
 export function TopBarBreadcrumbs() {
   const { pathname } = useLocation()
+  const [searchParams] = useSearchParams()
+  const folderId = searchParams.get('folder')
   const courseCode = useMemo(() => {
     const m = matchPath({ path: '/courses/:courseCode/*', end: false }, pathname)
     const code = m?.params.courseCode
@@ -270,6 +294,8 @@ export function TopBarBreadcrumbs() {
   const [itemTrail, setItemTrail] = useState<{ moduleTitle: string | null; itemTitle: string } | null>(
     null,
   )
+
+  const [fileFolderTrail, setFileFolderTrail] = useState<FolderBreadcrumb[] | null>(null)
 
   useEffect(() => {
     if (!courseCode) {
@@ -325,6 +351,43 @@ export function TopBarBreadcrumbs() {
     }
   }, [pathname])
 
+  useEffect(() => {
+    if (!courseCode) {
+      setFileFolderTrail(null)
+      return
+    }
+    const filesBase = `/courses/${encodeURIComponent(courseCode)}/files`
+    if (!pathname.startsWith(`${filesBase}`)) {
+      setFileFolderTrail(null)
+      return
+    }
+    if (!folderId) {
+      setFileFolderTrail([])
+      return
+    }
+    const cacheKey = `${courseCode}:${folderId}`
+    const cached = fileFolderCache.get(cacheKey)
+    if (cached) {
+      setFileFolderTrail(cached)
+      return
+    }
+    let cancelled = false
+    void (async () => {
+      try {
+        const contents = await listCourseFiles(courseCode, folderId)
+        if (cancelled) return
+        const trail = contents.breadcrumbs ?? []
+        fileFolderCache.set(cacheKey, trail)
+        setFileFolderTrail(trail)
+      } catch {
+        if (!cancelled) setFileFolderTrail([])
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [pathname, courseCode, folderId])
+
   const crumbs = useMemo(() => {
     let base = staticCrumbsFromPathname(pathname, courseCode)
     if (courseCode && base.some((c) => c.key === 'course')) {
@@ -333,8 +396,19 @@ export function TopBarBreadcrumbs() {
     if (itemTrail && base.some((c) => c.key === 'item')) {
       base = mergeModuleItem(base, itemTrail.moduleTitle, itemTrail.itemTitle)
     }
+    if (base.some((c) => c.key === 'files') && folderId) {
+      if (fileFolderTrail === null) {
+        const filesBase = `/courses/${encodeURIComponent(courseCode!)}/files`
+        base = [
+          ...base.map((c) => (c.key === 'files' ? { ...c, to: filesBase } : c)),
+          { key: 'ff-loading', label: '…' },
+        ]
+      } else if (fileFolderTrail.length > 0) {
+        base = mergeFileFolderCrumbs(base, courseCode!, fileFolderTrail)
+      }
+    }
     return base
-  }, [pathname, courseCode, courseTitle, itemTrail])
+  }, [pathname, courseCode, courseTitle, itemTrail, folderId, fileFolderTrail])
 
   if (!crumbs.length) return null
 

--- a/clients/web/src/components/layout/top-bar.tsx
+++ b/clients/web/src/components/layout/top-bar.tsx
@@ -2,6 +2,8 @@ import { useEffect, useId, useMemo, useRef, useState } from 'react'
 
 import { ChevronDown, LogOut, Menu, User } from 'lucide-react'
 import { Link, matchPath, useLocation, useNavigate } from 'react-router-dom'
+import { AiTutorMenu } from '../tutor-panel'
+import { useCourseNavFeatures } from '../../context/course-nav-features-context'
 import { setCourseViewAs, useCourseViewAs } from '../../lib/course-view-as'
 import { apiUrl, authorizedFetch } from '../../lib/api'
 import { useViewerEnrollmentRoles } from '../../lib/use-viewer-enrollment-roles'
@@ -261,10 +263,17 @@ function CourseEnrollmentViewDropdown() {
 }
 
 export function TopBar() {
+  const location = useLocation()
   const { mobileNavOpen, setMobileNavOpen } = useShellNav()
   const [notificationsOpen, setNotificationsOpen] = useState(false)
   const [readingPanelOpen, setReadingPanelOpen] = useState(false)
   const { ffReadingPreferences } = usePlatformFeatures()
+  const { aiTutorEnabled } = useCourseNavFeatures()
+  const courseCode = useMemo(() => {
+    const m = matchPath({ path: '/courses/:courseCode', end: false }, location.pathname)
+    const code = m?.params.courseCode
+    return code && code !== 'create' ? code : null
+  }, [location.pathname])
 
   return (
     <header className="lms-chrome flex h-14 shrink-0 items-center gap-1.5 border-b border-slate-200 bg-white px-2 shadow-sm shadow-slate-900/5 print:hidden sm:gap-3 sm:px-4 md:gap-4 md:px-6 dark:border-neutral-700 dark:bg-neutral-900 dark:shadow-black/20">
@@ -300,6 +309,7 @@ export function TopBar() {
             Aa
           </button>
         )}
+        {courseCode && aiTutorEnabled ? <AiTutorMenu courseCode={courseCode} /> : null}
         <HelpWidgetMenu />
         <NotificationsDrawerTrigger open={notificationsOpen} onOpen={() => setNotificationsOpen(true)} />
         <CourseEnrollmentViewDropdown />

--- a/clients/web/src/components/tutor-panel.tsx
+++ b/clients/web/src/components/tutor-panel.tsx
@@ -18,8 +18,27 @@ interface ConversationState {
   periodMonth: string
 }
 
-interface TutorPanelProps {
+interface AiTutorMenuProps {
   courseCode: string
+}
+
+function AiTutorTrigger({ open, onToggle }: { open: boolean; onToggle: () => void }) {
+  return (
+    <button
+      type="button"
+      aria-label="Open AI Tutor"
+      aria-expanded={open}
+      aria-haspopup="dialog"
+      onClick={onToggle}
+      className={`relative inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 ${
+        open
+          ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
+          : 'text-slate-600 hover:bg-slate-100 dark:text-neutral-300 dark:hover:bg-neutral-800'
+      }`}
+    >
+      <Bot className="h-5 w-5" aria-hidden />
+    </button>
+  )
 }
 
 async function fetchConversation(courseCode: string): Promise<ConversationState> {
@@ -38,7 +57,7 @@ async function resetConversation(courseCode: string): Promise<void> {
   if (!res.ok) throw new Error(`Failed to reset conversation: ${res.status}`)
 }
 
-export function TutorPanel({ courseCode }: TutorPanelProps) {
+export function AiTutorMenu({ courseCode }: AiTutorMenuProps) {
   const [open, setOpen] = useState(false)
   const [conv, setConv] = useState<ConversationState | null>(null)
   const [loading, setLoading] = useState(false)
@@ -180,17 +199,8 @@ export function TutorPanel({ courseCode }: TutorPanelProps) {
 
   return (
     <>
-      {/* Floating button */}
-      <button
-        type="button"
-        aria-label="Open AI Tutor"
-        onClick={() => setOpen(true)}
-        className="fixed bottom-6 end-24 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-indigo-600 text-white shadow-lg hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
-      >
-        <Bot className="h-7 w-7" />
-      </button>
+      <AiTutorTrigger open={open} onToggle={() => setOpen((o) => !o)} />
 
-      {/* Slide-out side panel */}
       {open && (
         <div
           role="dialog"

--- a/clients/web/src/context/course-nav-features-context.tsx
+++ b/clients/web/src/context/course-nav-features-context.tsx
@@ -22,7 +22,7 @@ export type CourseNavFeatures = {
   collabDocsEnabled: boolean
   /** Plan 3.7 — standards-based grading enabled for the course. */
   sbgEnabled: boolean
-  /** Plan 6.4 — virtual classroom / live sessions (default true). */
+  /** Plan 6.4 — virtual classroom / live sessions (default off). */
   liveSessionsEnabled: boolean
   /** Plan 6.6 — private group spaces (feed per enrollment group). */
   groupSpacesEnabled: boolean
@@ -53,7 +53,7 @@ const defaultFeatures: CourseNavFeatures = {
   discussionsEnabled: false,
   collabDocsEnabled: false,
   sbgEnabled: false,
-  liveSessionsEnabled: true,
+  liveSessionsEnabled: false,
   groupSpacesEnabled: false,
   officeHoursEnabled: false,
   aiTutorEnabled: false,
@@ -81,7 +81,7 @@ export function CourseNavFeaturesProvider({ children }: { children: ReactNode })
   const [discussionsEnabled, setDiscussionsEnabled] = useState(false)
   const [collabDocsEnabled, setCollabDocsEnabled] = useState(false)
   const [sbgEnabled, setSbgEnabled] = useState(false)
-  const [liveSessionsEnabled, setLiveSessionsEnabled] = useState(true)
+  const [liveSessionsEnabled, setLiveSessionsEnabled] = useState(false)
   const [groupSpacesEnabled, setGroupSpacesEnabled] = useState(false)
   const [officeHoursEnabled, setOfficeHoursEnabled] = useState(false)
   const [aiTutorEnabled, setAiTutorEnabled] = useState(false)
@@ -105,7 +105,7 @@ export function CourseNavFeaturesProvider({ children }: { children: ReactNode })
       setDiscussionsEnabled(false)
       setCollabDocsEnabled(false)
       setSbgEnabled(false)
-      setLiveSessionsEnabled(true)
+      setLiveSessionsEnabled(false)
       setGroupSpacesEnabled(false)
       setOfficeHoursEnabled(false)
       setAiTutorEnabled(false)
@@ -127,7 +127,7 @@ export function CourseNavFeaturesProvider({ children }: { children: ReactNode })
       setDiscussionsEnabled(c.discussionsEnabled === true)
       setCollabDocsEnabled(c.collabDocsEnabled === true)
       setSbgEnabled(c.sbgEnabled === true)
-      setLiveSessionsEnabled(c.liveSessionsEnabled !== false)
+      setLiveSessionsEnabled(c.liveSessionsEnabled === true)
       setGroupSpacesEnabled(c.groupSpacesEnabled === true)
       setOfficeHoursEnabled(c.officeHoursEnabled === true)
       setAiTutorEnabled(c.aiTutorEnabled === true)
@@ -144,7 +144,7 @@ export function CourseNavFeaturesProvider({ children }: { children: ReactNode })
       setDiscussionsEnabled(false)
       setCollabDocsEnabled(false)
       setSbgEnabled(false)
-      setLiveSessionsEnabled(true)
+      setLiveSessionsEnabled(false)
       setGroupSpacesEnabled(false)
       setOfficeHoursEnabled(false)
       setAiTutorEnabled(false)

--- a/clients/web/src/lib/__tests__/search-course-features.test.ts
+++ b/clients/web/src/lib/__tests__/search-course-features.test.ts
@@ -14,9 +14,9 @@ describe('featureDefaultOn', () => {
 })
 
 describe('normalizeSearchCourseItem', () => {
-  it('defaults live sessions on when the search index omits the flag', () => {
+  it('defaults live sessions off when the search index omits the flag', () => {
     expect(normalizeSearchCourseItem({ courseCode: 'X', title: 'Y' }).liveSessionsEnabled).toBe(
-      true,
+      false,
     )
   })
 })
@@ -57,7 +57,7 @@ describe('mergeCoursesWithNavFeatures', () => {
       discussionsEnabled: false,
       collabDocsEnabled: false,
       sbgEnabled: false,
-      liveSessionsEnabled: true,
+      liveSessionsEnabled: false,
       groupSpacesEnabled: false,
       officeHoursEnabled: false,
       filesEnabled: true,
@@ -66,6 +66,6 @@ describe('mergeCoursesWithNavFeatures', () => {
     })
     expect(merged).toHaveLength(1)
     expect(merged[0]?.courseCode).toBe('NEW')
-    expect(merged[0]?.liveSessionsEnabled).toBe(true)
+    expect(merged[0]?.liveSessionsEnabled).toBe(false)
   })
 })

--- a/clients/web/src/lib/build-search-items.ts
+++ b/clients/web/src/lib/build-search-items.ts
@@ -239,7 +239,7 @@ const coursePageDefs: CoursePageDef[] = [
     suffix: '/live',
     title: 'Live Sessions',
     hint: 'live live sessions virtual classroom video meeting jitsi zoom bbb bigbluebutton',
-    whenCourse: (c) => featureDefaultOn(c.liveSessionsEnabled),
+    whenCourse: (c) => c.liveSessionsEnabled === true,
   },
   {
     suffix: '/office-hours',

--- a/clients/web/src/lib/collab-docs-api.ts
+++ b/clients/web/src/lib/collab-docs-api.ts
@@ -102,11 +102,11 @@ export async function fetchCollabDocSnapshots(
   return body.snapshots ?? []
 }
 
-/** Build the WebSocket URL for a collaborative document. */
+/** Base WebSocket server URL; y-websocket appends `/{roomname}` (use roomname `ws`). */
 export function collabDocWsUrl(courseCode: string, docId: string): string {
   const base = (import.meta.env.VITE_API_URL ?? window.location.origin)
     .replace(/^https?:\/\//, '')
     .replace(/^http:\/\//, '')
   const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
-  return `${proto}://${base}/api/v1/courses/${encodeURIComponent(courseCode)}/collab-docs/${encodeURIComponent(docId)}/ws`
+  return `${proto}://${base}/api/v1/courses/${encodeURIComponent(courseCode)}/collab-docs/${encodeURIComponent(docId)}`
 }

--- a/clients/web/src/lib/course-catalog-settings-api.ts
+++ b/clients/web/src/lib/course-catalog-settings-api.ts
@@ -1,0 +1,123 @@
+import { authorizedFetch } from './api'
+import { readApiErrorMessage } from './errors'
+import {
+  DEFAULT_KANBAN_COLUMN_LABELS,
+  type CourseCatalogView,
+  type KanbanColumnId,
+  type KanbanColumnLabels,
+} from './course-catalog-types'
+
+export type { KanbanColumnLabels }
+export { DEFAULT_KANBAN_COLUMN_LABELS }
+
+export type CourseCatalogSettings = {
+  view: CourseCatalogView
+  kanbanColumnLabels: KanbanColumnLabels
+  hiddenColumnExpanded: boolean
+  nicknames: Record<string, string>
+}
+
+const LEGACY_VIEW_KEY = 'lextures.courseCatalogView'
+const LEGACY_HIDDEN_KEY = 'lextures.courseKanbanHiddenExpanded'
+
+const VALID_VIEWS: CourseCatalogView[] = ['cards', 'list', 'gallery', 'table', 'status']
+
+function isCourseCatalogView(value: string): value is CourseCatalogView {
+  return (VALID_VIEWS as string[]).includes(value)
+}
+
+function normalizeKanbanColumnLabels(raw: Partial<KanbanColumnLabels> | undefined): KanbanColumnLabels {
+  return {
+    todo: raw?.todo?.trim() || DEFAULT_KANBAN_COLUMN_LABELS.todo,
+    'in-progress': raw?.['in-progress']?.trim() || DEFAULT_KANBAN_COLUMN_LABELS['in-progress'],
+    done: raw?.done?.trim() || DEFAULT_KANBAN_COLUMN_LABELS.done,
+    hidden: raw?.hidden?.trim() || DEFAULT_KANBAN_COLUMN_LABELS.hidden,
+  }
+}
+
+export async function fetchCourseCatalogSettings(): Promise<CourseCatalogSettings> {
+  const res = await authorizedFetch('/api/v1/courses/catalog-settings')
+  const raw: unknown = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  const data = raw as Partial<CourseCatalogSettings> & { kanbanColumnLabels?: Partial<KanbanColumnLabels> }
+  const view = data.view && isCourseCatalogView(data.view) ? data.view : 'cards'
+  return {
+    view,
+    kanbanColumnLabels: normalizeKanbanColumnLabels(data.kanbanColumnLabels),
+    hiddenColumnExpanded: Boolean(data.hiddenColumnExpanded),
+    nicknames: data.nicknames ?? {},
+  }
+}
+
+export async function putCourseCatalogSettings(
+  patch: Partial<Pick<CourseCatalogSettings, 'view' | 'kanbanColumnLabels' | 'hiddenColumnExpanded'>>,
+): Promise<CourseCatalogSettings> {
+  const res = await authorizedFetch('/api/v1/courses/catalog-settings', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  })
+  const raw: unknown = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  const data = raw as Partial<CourseCatalogSettings> & { kanbanColumnLabels?: Partial<KanbanColumnLabels> }
+  const view = data.view && isCourseCatalogView(data.view) ? data.view : 'cards'
+  return {
+    view,
+    kanbanColumnLabels: normalizeKanbanColumnLabels(data.kanbanColumnLabels),
+    hiddenColumnExpanded: Boolean(data.hiddenColumnExpanded),
+    nicknames: {},
+  }
+}
+
+export async function putCourseCatalogNickname(courseId: string, nickname: string | null): Promise<void> {
+  const res = await authorizedFetch('/api/v1/courses/catalog-nickname', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ courseId, nickname }),
+  })
+  if (res.ok) return
+  const raw: unknown = await res.json().catch(() => ({}))
+  throw new Error(readApiErrorMessage(raw))
+}
+
+export async function putCourseKanbanBoard(columns: Record<KanbanColumnId, string[]>): Promise<void> {
+  const res = await authorizedFetch('/api/v1/courses/kanban-board', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ columns }),
+  })
+  if (res.ok) return
+  const raw: unknown = await res.json().catch(() => ({}))
+  throw new Error(readApiErrorMessage(raw))
+}
+
+/** One-time migration of legacy localStorage prefs into the database. */
+export async function migrateLegacyCourseCatalogLocalStorage(): Promise<void> {
+  if (typeof window === 'undefined') return
+  let view: CourseCatalogView | undefined
+  let hiddenColumnExpanded: boolean | undefined
+  try {
+    const rawView = window.localStorage.getItem(LEGACY_VIEW_KEY)?.trim().toLowerCase()
+    if (rawView && isCourseCatalogView(rawView)) view = rawView
+    const rawHidden = window.localStorage.getItem(LEGACY_HIDDEN_KEY)
+    if (rawHidden !== null) hiddenColumnExpanded = rawHidden === '1'
+  } catch {
+    return
+  }
+  if (!view && hiddenColumnExpanded === undefined) return
+  const body: { view?: CourseCatalogView; hiddenColumnExpanded?: boolean } = {}
+  if (view) body.view = view
+  if (hiddenColumnExpanded !== undefined) body.hiddenColumnExpanded = hiddenColumnExpanded
+  const res = await authorizedFetch('/api/v1/courses/catalog-settings/migrate-local', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) return
+  try {
+    window.localStorage.removeItem(LEGACY_VIEW_KEY)
+    window.localStorage.removeItem(LEGACY_HIDDEN_KEY)
+  } catch {
+    /* ignore */
+  }
+}

--- a/clients/web/src/lib/course-catalog-types.ts
+++ b/clients/web/src/lib/course-catalog-types.ts
@@ -1,0 +1,18 @@
+export type CourseCatalogView = 'cards' | 'list' | 'status' | 'gallery' | 'table'
+
+export type KanbanColumnId = 'todo' | 'in-progress' | 'done' | 'hidden'
+
+export const KANBAN_COLUMN_IDS: KanbanColumnId[] = ['todo', 'in-progress', 'done', 'hidden']
+
+export function isKanbanColumnId(value: string | null | undefined): value is KanbanColumnId {
+  return value === 'todo' || value === 'in-progress' || value === 'done' || value === 'hidden'
+}
+
+export type KanbanColumnLabels = Record<KanbanColumnId, string>
+
+export const DEFAULT_KANBAN_COLUMN_LABELS: KanbanColumnLabels = {
+  todo: 'Todo',
+  'in-progress': 'In progress',
+  done: 'Done',
+  hidden: 'Hidden',
+}

--- a/clients/web/src/lib/courses-api-schemas.ts
+++ b/clients/web/src/lib/courses-api-schemas.ts
@@ -79,6 +79,9 @@ export const courseSchema = z
     feedbackMediaEnabled: z.boolean().optional(),
     termId: z.string().nullable().optional(),
     gradeLevel: z.string().nullable().optional(),
+    catalogNickname: z.string().nullable().optional(),
+    kanbanColumnId: z.enum(['todo', 'in-progress', 'done', 'hidden']).nullable().optional(),
+    kanbanSortOrder: z.number().int().nullable().optional(),
     term: z
       .object({
         id: z.string(),

--- a/clients/web/src/lib/courses-api.ts
+++ b/clients/web/src/lib/courses-api.ts
@@ -135,7 +135,7 @@ export type CoursePublic = {
   discussionsEnabled?: boolean
   /** Plan 6.5 — real-time collaborative documents (default off when omitted). */
   collabDocsEnabled?: boolean
-  /** Plan 6.4 — virtual classroom / live sessions menu (default true when omitted). */
+  /** Plan 6.4 — virtual classroom / live sessions menu (default off when omitted). */
   liveSessionsEnabled?: boolean
   /** Plan 6.6 — private group spaces (feed + files + assignments per enrollment group). */
   groupSpacesEnabled?: boolean
@@ -192,6 +192,11 @@ export type CoursePublic = {
   courseTimezone?: string | null
   /** K-12 grade level (plan 13.6). Values: K, 1-12, K-2, 3-5, 6-8, 9-12, K-12. Null for non-K12. */
   gradeLevel?: string | null
+  /** Per-user catalog nickname from GET /api/v1/courses. */
+  catalogNickname?: string | null
+  /** Manual kanban column override for the signed-in user. */
+  kanbanColumnId?: 'todo' | 'in-progress' | 'done' | 'hidden' | null
+  kanbanSortOrder?: number | null
 }
 
 export type OrgTerm = {
@@ -5249,6 +5254,8 @@ export type ModuleAssignmentSubmissionApi = {
   id: string
   /** Omitted when blind grading hides student identity (plan 3.3). */
   submittedBy?: string
+  /** Human-readable submitter name when identities are visible. */
+  submittedByDisplayName?: string
   /** Set when blind grading is active (plan 3.3). */
   blindLabel?: string
   attachmentFileId: string | null

--- a/clients/web/src/lib/search-course-features.ts
+++ b/clients/web/src/lib/search-course-features.ts
@@ -18,7 +18,7 @@ export function normalizeSearchCourseItem(c: SearchCourseItem): SearchCourseItem
     feedEnabled: featureDefaultOn(c.feedEnabled),
     calendarEnabled: featureDefaultOn(c.calendarEnabled),
     filesEnabled: featureDefaultOn(c.filesEnabled),
-    liveSessionsEnabled: featureDefaultOn(c.liveSessionsEnabled),
+    liveSessionsEnabled: c.liveSessionsEnabled === true,
   }
 }
 

--- a/clients/web/src/pages/lms/course-catalog-display.ts
+++ b/clients/web/src/pages/lms/course-catalog-display.ts
@@ -1,0 +1,18 @@
+import type { CoursePublic } from '../../lib/courses-api'
+
+export function courseCatalogDisplayTitle(course: CoursePublic): string {
+  const nickname = course.catalogNickname?.trim()
+  return nickname || course.title
+}
+
+export function courseCatalogHasNickname(course: CoursePublic): boolean {
+  return Boolean(course.catalogNickname?.trim())
+}
+
+/** Description for catalog cards/rows; omits text that only repeats the official title when a nickname is set. */
+export function courseCatalogDescriptionBlurb(course: CoursePublic): string | null {
+  const raw = course.description.trim()
+  if (!raw) return 'No description yet.'
+  if (courseCatalogHasNickname(course) && raw === course.title.trim()) return null
+  return raw
+}

--- a/clients/web/src/pages/lms/course-catalog-kanban.tsx
+++ b/clients/web/src/pages/lms/course-catalog-kanban.tsx
@@ -1,0 +1,442 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  pointerWithin,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import { CSS } from '@dnd-kit/utilities'
+import { ChevronLeft, ChevronRight, GripVertical } from 'lucide-react'
+import type { CoursePublic } from '../../lib/courses-api'
+import type { KanbanColumnLabels } from '../../lib/course-catalog-settings-api'
+import { formatRelativeCompact } from '../../lib/format-datetime'
+import { CourseCatalogStatusPill } from '../../components/ui/status-vocabulary'
+import { CourseCatalogNicknameEditor } from './course-catalog-nickname-editor'
+import {
+  buildKanbanBoardState,
+  courseCatalogStatusLabel,
+  resolveKanbanColumn,
+} from './course-catalog-status'
+import { isKanbanColumnId, KANBAN_COLUMN_IDS, type KanbanColumnId } from '../../lib/course-catalog-types'
+
+const KANBAN_COLUMN_HINTS: Record<KanbanColumnId, string> = {
+  todo: 'Draft and upcoming courses',
+  'in-progress': 'Active courses',
+  done: 'Ended courses',
+  hidden: 'Outside visibility window',
+}
+
+function columnDropId(columnId: KanbanColumnId): string {
+  return `column:${columnId}`
+}
+
+function parseColumnDropId(id: string): KanbanColumnId | null {
+  if (!id.startsWith('column:')) return null
+  const col = id.slice('column:'.length)
+  return isKanbanColumnId(col) ? col : null
+}
+
+function boardToColumnIds(board: Record<KanbanColumnId, CoursePublic[]>): Record<KanbanColumnId, string[]> {
+  return {
+    todo: board.todo.map((c) => c.id),
+    'in-progress': board['in-progress'].map((c) => c.id),
+    done: board.done.map((c) => c.id),
+    hidden: board.hidden.map((c) => c.id),
+  }
+}
+
+function computeNextBoard(
+  board: Record<KanbanColumnId, CoursePublic[]>,
+  courseId: string,
+  targetColumn: KanbanColumnId,
+  targetIndex?: number,
+): Record<KanbanColumnId, CoursePublic[]> {
+  const next: Record<KanbanColumnId, CoursePublic[]> = {
+    todo: [...board.todo],
+    'in-progress': [...board['in-progress']],
+    done: [...board.done],
+    hidden: [...board.hidden],
+  }
+  let moving: CoursePublic | undefined
+  for (const col of KANBAN_COLUMN_IDS) {
+    const idx = next[col].findIndex((c) => c.id === courseId)
+    if (idx >= 0) {
+      moving = next[col][idx]
+      next[col].splice(idx, 1)
+      break
+    }
+  }
+  if (!moving) return board
+  const insertAt =
+    targetIndex == null || targetIndex < 0 || targetIndex > next[targetColumn].length
+      ? next[targetColumn].length
+      : targetIndex
+  next[targetColumn].splice(insertAt, 0, moving)
+  return next
+}
+
+function formatCourseTermLabel(course: CoursePublic): string {
+  return course.term?.name?.trim() || '—'
+}
+
+function KanbanDraggableCard({
+  course,
+  onNicknameChange,
+  overlay = false,
+}: {
+  course: CoursePublic
+  onNicknameChange: (courseId: string, nickname: string | null) => void
+  overlay?: boolean
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: course.id,
+    data: { courseId: course.id },
+  })
+  const courseHref = `/courses/${encodeURIComponent(course.courseCode)}`
+  const lifecycleLabel = courseCatalogStatusLabel(course)
+  const showLifecyclePill = resolveKanbanColumn(course) === 'hidden'
+
+  return (
+    <article
+      ref={overlay ? undefined : setNodeRef}
+      style={overlay ? undefined : { transform: CSS.Translate.toString(transform) }}
+      className={[
+        'rounded-lg border border-slate-200 bg-white shadow-sm shadow-slate-900/5 dark:border-neutral-600 dark:bg-neutral-900',
+        isDragging && !overlay ? 'opacity-40' : '',
+        overlay ? 'cursor-grabbing shadow-md ring-2 ring-indigo-400/40' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div className="flex items-start gap-1 p-3">
+        <button
+          type="button"
+          className="mt-0.5 inline-flex h-6 w-5 shrink-0 cursor-grab items-center justify-center rounded text-slate-400 hover:bg-slate-100 hover:text-slate-600 active:cursor-grabbing dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+          aria-label={`Drag ${course.title}`}
+          {...listeners}
+          {...attributes}
+        >
+          <GripVertical className="h-4 w-4" aria-hidden />
+        </button>
+        <div className="min-w-0 flex-1">
+          <CourseCatalogNicknameEditor
+            course={course}
+            titleClassName="text-sm font-semibold leading-snug text-slate-900 dark:text-neutral-100"
+            onNicknameChange={onNicknameChange}
+          />
+          <Link
+            to={courseHref}
+            className="mt-2 inline-block text-xs font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-300 dark:hover:text-indigo-200"
+          >
+            Open course
+          </Link>
+          {showLifecyclePill ? (
+            <div className="mt-2">
+              <CourseCatalogStatusPill label={lifecycleLabel} />
+            </div>
+          ) : null}
+          <dl className="mt-2 space-y-1 text-xs text-slate-500 dark:text-neutral-400">
+            <div className="flex justify-between gap-2">
+              <dt className="sr-only">Term</dt>
+              <dd className="truncate">{formatCourseTermLabel(course)}</dd>
+            </div>
+            <div className="flex justify-between gap-2">
+              <dt className="sr-only">Last edited</dt>
+              <dd className="whitespace-nowrap">{formatRelativeCompact(course.updatedAt)}</dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function KanbanColumnDropZone({
+  columnId,
+  children,
+}: {
+  columnId: KanbanColumnId
+  children: ReactNode
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: columnDropId(columnId) })
+  return (
+    <div
+      ref={setNodeRef}
+      className={[
+        'flex min-h-[6rem] flex-col gap-2 rounded-lg transition',
+        isOver ? 'bg-indigo-50/80 ring-1 ring-indigo-300/60 dark:bg-indigo-950/20 dark:ring-indigo-500/30' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      {children}
+    </div>
+  )
+}
+
+type KanbanColumnProps = {
+  columnId: KanbanColumnId
+  title: string
+  hint: string
+  courses: CoursePublic[]
+  collapsed?: boolean
+  onToggleCollapsed?: () => void
+  onTitleChange: (columnId: KanbanColumnId, title: string) => void
+  onNicknameChange: (courseId: string, nickname: string | null) => void
+}
+
+function KanbanColumn({
+  columnId,
+  title,
+  hint,
+  courses,
+  collapsed = false,
+  onToggleCollapsed,
+  onTitleChange,
+  onNicknameChange,
+}: KanbanColumnProps) {
+  const [editingTitle, setEditingTitle] = useState(false)
+  const [titleDraft, setTitleDraft] = useState(title)
+
+  useEffect(() => {
+    if (!editingTitle) setTitleDraft(title)
+  }, [title, editingTitle])
+
+  if (collapsed && onToggleCollapsed) {
+    return (
+      <div className="flex w-11 shrink-0 flex-col self-stretch">
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          className="flex h-full min-h-[12rem] flex-col items-center justify-start gap-3 rounded-xl border border-slate-200 bg-slate-100/90 px-1.5 py-3 text-slate-600 transition hover:border-slate-300 hover:bg-slate-100 dark:border-neutral-700 dark:bg-neutral-800/90 dark:text-neutral-300 dark:hover:border-neutral-600 dark:hover:bg-neutral-800"
+          aria-label={`Expand ${title} column (${courses.length} courses). ${hint}`}
+          title={`${title} (${courses.length})`}
+        >
+          <ChevronLeft className="h-4 w-4 shrink-0" aria-hidden />
+          <span
+            className="text-xs font-semibold uppercase tracking-wide [writing-mode:vertical-rl] rotate-180"
+            aria-hidden
+          >
+            {title}
+          </span>
+          <span className="rounded-full bg-slate-200 px-1.5 py-0.5 text-[10px] font-semibold text-slate-700 dark:bg-neutral-700 dark:text-neutral-200">
+            {courses.length}
+          </span>
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <section
+      className="flex w-72 shrink-0 flex-col rounded-xl border border-slate-200 bg-slate-100/90 dark:border-neutral-700 dark:bg-neutral-800/90"
+      aria-label={`${title} (${courses.length})`}
+    >
+      <header className="flex items-start justify-between gap-2 border-b border-slate-200/80 px-3 py-3 dark:border-neutral-700">
+        <div className="min-w-0 flex-1">
+          {editingTitle ? (
+            <input
+              value={titleDraft}
+              maxLength={80}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              onPointerDown={(e) => e.stopPropagation()}
+              onKeyDown={(e) => {
+                e.stopPropagation()
+                if (e.key === 'Enter') {
+                  e.currentTarget.blur()
+                }
+                if (e.key === 'Escape') {
+                  setTitleDraft(title)
+                  setEditingTitle(false)
+                }
+              }}
+              onBlur={() => {
+                setEditingTitle(false)
+                onTitleChange(columnId, titleDraft.trim() || title)
+              }}
+              className="w-full rounded-md border border-slate-200 bg-white px-2 py-1 text-sm font-semibold text-slate-900 outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/30 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100"
+              aria-label={`Rename ${title} column`}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setEditingTitle(true)}
+              className="text-start text-sm font-semibold text-slate-900 hover:text-indigo-600 dark:text-neutral-100 dark:hover:text-indigo-300"
+              title="Rename column"
+            >
+              {title}
+            </button>
+          )}
+          <p className="mt-0.5 text-xs text-slate-500 dark:text-neutral-400">{hint}</p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <span className="rounded-full bg-slate-200 px-2 py-0.5 text-xs font-semibold text-slate-700 dark:bg-neutral-700 dark:text-neutral-200">
+            {courses.length}
+          </span>
+          {onToggleCollapsed ? (
+            <button
+              type="button"
+              onClick={onToggleCollapsed}
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-slate-500 transition hover:bg-slate-200/80 hover:text-slate-800 dark:text-neutral-400 dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
+              aria-label={`Collapse ${title} column`}
+              title={`Collapse ${title}`}
+            >
+              <ChevronRight className="h-4 w-4" aria-hidden />
+            </button>
+          ) : null}
+        </div>
+      </header>
+      <div className="flex-1 overflow-y-auto p-3">
+        <KanbanColumnDropZone columnId={columnId}>
+          {courses.length === 0 ? (
+            <p className="rounded-lg border border-dashed border-slate-300 px-3 py-6 text-center text-xs text-slate-500 dark:border-neutral-600 dark:text-neutral-400">
+              Drop courses here
+            </p>
+          ) : (
+            courses.map((course) => (
+              <KanbanDraggableCard key={course.id} course={course} onNicknameChange={onNicknameChange} />
+            ))
+          )}
+        </KanbanColumnDropZone>
+      </div>
+    </section>
+  )
+}
+
+type Props = {
+  courses: CoursePublic[]
+  columnLabels: KanbanColumnLabels
+  hiddenColumnExpanded: boolean
+  onHiddenColumnExpandedChange: (expanded: boolean) => void
+  onColumnLabelsChange: (labels: KanbanColumnLabels) => void
+  onNicknameChange: (courseId: string, nickname: string | null) => void
+  onBoardChange: (columns: Record<KanbanColumnId, string[]>) => Promise<void>
+}
+
+export function CourseCatalogKanbanBoard({
+  courses,
+  columnLabels,
+  hiddenColumnExpanded,
+  onHiddenColumnExpandedChange,
+  onColumnLabelsChange,
+  onNicknameChange,
+  onBoardChange,
+}: Props) {
+  const courseById = useMemo(() => new Map(courses.map((c) => [c.id, c])), [courses])
+  const [board, setBoard] = useState<Record<KanbanColumnId, CoursePublic[]>>(() => buildKanbanBoardState(courses))
+  const [activeCourseId, setActiveCourseId] = useState<string | null>(null)
+  const [boardError, setBoardError] = useState<string | null>(null)
+  const [savingBoard, setSavingBoard] = useState(false)
+
+  useEffect(() => {
+    setBoard(buildKanbanBoardState(courses))
+  }, [courses])
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }))
+
+  const persistBoard = useCallback(
+    async (nextBoard: Record<KanbanColumnId, CoursePublic[]>) => {
+      setBoardError(null)
+      setSavingBoard(true)
+      try {
+        await onBoardChange(boardToColumnIds(nextBoard))
+      } catch (e: unknown) {
+        setBoardError(e instanceof Error ? e.message : 'Could not save kanban board.')
+        setBoard(buildKanbanBoardState(courses))
+      } finally {
+        setSavingBoard(false)
+      }
+    },
+    [courses, onBoardChange],
+  )
+
+  const onDragStart = useCallback((event: DragStartEvent) => {
+    setActiveCourseId(String(event.active.id))
+  }, [])
+
+  const onDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setActiveCourseId(null)
+      const courseId = String(event.active.id)
+      const over = event.over
+      if (!over) return
+
+      let targetColumn = parseColumnDropId(String(over.id))
+      let targetIndex: number | undefined
+      if (!targetColumn) {
+        for (const col of KANBAN_COLUMN_IDS) {
+          const idx = board[col].findIndex((c) => c.id === String(over.id))
+          if (idx >= 0) {
+            targetColumn = col
+            targetIndex = idx
+            break
+          }
+        }
+      }
+
+      if (!targetColumn) return
+      const nextBoard = computeNextBoard(board, courseId, targetColumn, targetIndex)
+      setBoard(nextBoard)
+      void persistBoard(nextBoard)
+    },
+    [board, persistBoard],
+  )
+
+  const activeCourse = activeCourseId ? courseById.get(activeCourseId) : undefined
+
+  return (
+    <div className="mt-8">
+      {boardError ? (
+        <p className="mb-4 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800 dark:border-rose-900/60 dark:bg-rose-950/50 dark:text-rose-200">
+          {boardError}
+        </p>
+      ) : null}
+      {savingBoard ? (
+        <p className="mb-4 text-xs text-slate-500 dark:text-neutral-400" role="status">
+          Saving board…
+        </p>
+      ) : null}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={pointerWithin}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+        onDragCancel={() => setActiveCourseId(null)}
+      >
+        <div className="overflow-x-auto pb-2">
+          <div className="flex min-h-[20rem] items-stretch gap-4">
+            {KANBAN_COLUMN_IDS.map((columnId) => (
+              <KanbanColumn
+                key={columnId}
+                columnId={columnId}
+                title={columnLabels[columnId]}
+                hint={KANBAN_COLUMN_HINTS[columnId]}
+                courses={board[columnId]}
+                collapsed={columnId === 'hidden' && !hiddenColumnExpanded}
+                onToggleCollapsed={
+                  columnId === 'hidden' ? () => onHiddenColumnExpandedChange(!hiddenColumnExpanded) : undefined
+                }
+                onTitleChange={(id, nextTitle) => {
+                  onColumnLabelsChange({ ...columnLabels, [id]: nextTitle })
+                }}
+                onNicknameChange={onNicknameChange}
+              />
+            ))}
+          </div>
+        </div>
+        <DragOverlay dropAnimation={null}>
+          {activeCourse ? (
+            <KanbanDraggableCard course={activeCourse} onNicknameChange={onNicknameChange} overlay />
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+    </div>
+  )
+}

--- a/clients/web/src/pages/lms/course-catalog-nickname-editor.tsx
+++ b/clients/web/src/pages/lms/course-catalog-nickname-editor.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useId, useRef, useState, type KeyboardEvent, type PointerEvent } from 'react'
+import { Pencil } from 'lucide-react'
+import type { CoursePublic } from '../../lib/courses-api'
+import { putCourseCatalogNickname } from '../../lib/course-catalog-settings-api'
+import { courseCatalogDisplayTitle, courseCatalogHasNickname } from './course-catalog-display'
+
+function stopDragKeyboardPropagation(e: KeyboardEvent | PointerEvent) {
+  e.stopPropagation()
+}
+
+type Props = {
+  course: CoursePublic
+  className?: string
+  titleClassName?: string
+  /** Hero/tile already shows the display title — keep footer to official title + edit only. */
+  compact?: boolean
+  onNicknameChange: (courseId: string, nickname: string | null) => void
+}
+
+export function CourseCatalogNicknameEditor({
+  course,
+  className = '',
+  titleClassName = '',
+  compact = false,
+  onNicknameChange,
+}: Props) {
+  const [open, setOpen] = useState(false)
+  const [draft, setDraft] = useState(course.catalogNickname ?? '')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const inputId = useId()
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    inputRef.current?.focus()
+    inputRef.current?.select()
+  }, [open])
+
+  async function save() {
+    const trimmed = draft.trim()
+    const next = trimmed.length > 0 ? trimmed : null
+    const current = course.catalogNickname?.trim() || null
+    if (next === current) {
+      setOpen(false)
+      setError(null)
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      await putCourseCatalogNickname(course.id, next)
+      onNicknameChange(course.id, next)
+      setOpen(false)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Could not save nickname.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const displayTitle = courseCatalogDisplayTitle(course)
+  const hasNickname = courseCatalogHasNickname(course)
+
+  const editButton = (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        setDraft(course.catalogNickname ?? '')
+        setError(null)
+        setOpen(true)
+      }}
+      className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 dark:text-neutral-500 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+      aria-label={`Edit nickname for ${course.title}`}
+      title="Edit nickname"
+    >
+      <Pencil className="h-3.5 w-3.5" aria-hidden />
+    </button>
+  )
+
+  return (
+    <div className={className}>
+      {compact ? (
+        <div className="flex items-center gap-1.5">
+          {hasNickname ? (
+            <p className="min-w-0 flex-1 text-xs text-slate-500 line-clamp-1 dark:text-neutral-400">{course.title}</p>
+          ) : (
+            <span className="min-w-0 flex-1 text-xs text-slate-500 dark:text-neutral-400">Add nickname</span>
+          )}
+          {editButton}
+        </div>
+      ) : (
+        <>
+          <div className="flex items-start gap-1.5">
+            <span className={titleClassName}>{displayTitle}</span>
+            {editButton}
+          </div>
+          {hasNickname ? (
+            <p className="mt-0.5 text-xs text-slate-500 line-clamp-1 dark:text-neutral-400">{course.title}</p>
+          ) : null}
+        </>
+      )}
+      {open ? (
+        <div
+          className="mt-2 space-y-2 rounded-lg border border-slate-200 bg-white p-2 shadow-sm dark:border-neutral-600 dark:bg-neutral-900"
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+          }}
+          onPointerDown={stopDragKeyboardPropagation}
+          onKeyDown={stopDragKeyboardPropagation}
+        >
+          <label htmlFor={inputId} className="sr-only">
+            Nickname for {course.title}
+          </label>
+          <input
+            id={inputId}
+            ref={inputRef}
+            value={draft}
+            disabled={saving}
+            maxLength={120}
+            placeholder={course.title}
+            onChange={(e) => setDraft(e.target.value)}
+            onPointerDown={stopDragKeyboardPropagation}
+            onKeyDown={(e) => {
+              stopDragKeyboardPropagation(e)
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                void save()
+              }
+              if (e.key === 'Escape') {
+                e.preventDefault()
+                setOpen(false)
+                setError(null)
+              }
+            }}
+            className="w-full rounded-md border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/30 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100"
+          />
+          {error ? <p className="text-xs text-rose-600 dark:text-rose-300">{error}</p> : null}
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              disabled={saving}
+              onClick={() => {
+                setOpen(false)
+                setError(null)
+              }}
+              className="rounded-md px-2 py-1 text-xs font-medium text-slate-600 hover:bg-slate-100 dark:text-neutral-300 dark:hover:bg-neutral-800"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              disabled={saving}
+              onClick={() => void save()}
+              className="rounded-md bg-indigo-600 px-2 py-1 text-xs font-semibold text-white hover:bg-indigo-500 disabled:opacity-60"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/clients/web/src/pages/lms/course-catalog-status.ts
+++ b/clients/web/src/pages/lms/course-catalog-status.ts
@@ -1,0 +1,80 @@
+import type { CoursePublic } from '../../lib/courses-api'
+import type { CourseCatalogView, KanbanColumnId } from '../../lib/course-catalog-types'
+import { isKanbanColumnId, KANBAN_COLUMN_IDS } from '../../lib/course-catalog-types'
+
+export type { CourseCatalogView, KanbanColumnId }
+export { KANBAN_COLUMN_IDS, isKanbanColumnId }
+
+export type CourseCatalogStatusLabel = 'Draft' | 'Upcoming' | 'Active' | 'Ended'
+
+export function resolveKanbanColumn(course: CoursePublic): KanbanColumnId {
+  if (isKanbanColumnId(course.kanbanColumnId)) return course.kanbanColumnId
+  return courseKanbanColumn(course)
+}
+
+export function buildKanbanBoardState(courses: CoursePublic[]): Record<KanbanColumnId, CoursePublic[]> {
+  const columns: Record<KanbanColumnId, CoursePublic[]> = {
+    todo: [],
+    'in-progress': [],
+    done: [],
+    hidden: [],
+  }
+  const sorted = [...courses].sort((a, b) => {
+    const ao = a.kanbanSortOrder ?? Number.MAX_SAFE_INTEGER
+    const bo = b.kanbanSortOrder ?? Number.MAX_SAFE_INTEGER
+    if (ao !== bo) return ao - bo
+    return 0
+  })
+  for (const course of sorted) {
+    const columnId = resolveKanbanColumn(course)
+    columns[columnId].push(course)
+  }
+  return columns
+}
+
+/** Catalog pill: draft vs published schedule window (uses real `published`, `startsAt`, `endsAt`). */
+export function courseCatalogStatusLabel(c: CoursePublic): CourseCatalogStatusLabel {
+  if (!c.published) return 'Draft'
+  const now = Date.now()
+  if (c.endsAt) {
+    const end = new Date(c.endsAt).getTime()
+    if (!Number.isNaN(end) && end < now) return 'Ended'
+  }
+  if (c.startsAt) {
+    const start = new Date(c.startsAt).getTime()
+    if (!Number.isNaN(start) && start > now) return 'Upcoming'
+  }
+  return 'Active'
+}
+
+/** Course is outside its visibility window (hidden from learners). */
+export function isCourseCatalogHidden(c: CoursePublic): boolean {
+  const now = Date.now()
+  if (c.hiddenAt) {
+    const hidden = new Date(c.hiddenAt).getTime()
+    if (!Number.isNaN(hidden) && hidden <= now) return true
+  }
+  if (c.visibleFrom) {
+    const visible = new Date(c.visibleFrom).getTime()
+    if (!Number.isNaN(visible) && visible > now) return true
+  }
+  return false
+}
+
+export function courseKanbanColumn(c: CoursePublic): KanbanColumnId {
+  if (isCourseCatalogHidden(c)) return 'hidden'
+  const status = courseCatalogStatusLabel(c)
+  switch (status) {
+    case 'Draft':
+    case 'Upcoming':
+      return 'todo'
+    case 'Active':
+      return 'in-progress'
+    case 'Ended':
+      return 'done'
+    default: {
+      const _exhaustive: never = status
+      return _exhaustive
+    }
+  }
+}

--- a/clients/web/src/pages/lms/course-catalog-view-menu.tsx
+++ b/clients/web/src/pages/lms/course-catalog-view-menu.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useId, useRef, useState } from 'react'
+import { ChevronDown, Image, Kanban, LayoutGrid, LayoutList, Table } from 'lucide-react'
+
+import type { CourseCatalogView } from '../../lib/course-catalog-types'
+
+type Props = {
+  value: CourseCatalogView
+  onChange: (view: CourseCatalogView) => void
+}
+
+const VIEW_OPTIONS: { id: CourseCatalogView; label: string; hint: string; icon: typeof LayoutGrid }[] = [
+  {
+    id: 'cards',
+    label: 'Cards',
+    hint: 'Visual grid with course cards',
+    icon: LayoutGrid,
+  },
+  {
+    id: 'list',
+    label: 'List',
+    hint: 'Compact rows with thumbnails',
+    icon: LayoutList,
+  },
+  {
+    id: 'gallery',
+    label: 'Gallery',
+    hint: 'Cover-focused tiles with minimal text',
+    icon: Image,
+  },
+  {
+    id: 'table',
+    label: 'Compact table',
+    hint: 'Dense rows with title, status, and term',
+    icon: Table,
+  },
+  {
+    id: 'status',
+    label: 'By status',
+    hint: 'Kanban board with todo, in progress, done, and hidden',
+    icon: Kanban,
+  },
+]
+
+export function CourseCatalogViewMenu({ value, onChange }: Props) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const menuId = useId()
+  const activeOption = VIEW_OPTIONS.find((option) => option.id === value) ?? VIEW_OPTIONS[0]
+  const ActiveIcon = activeOption.icon
+
+  useEffect(() => {
+    if (!open) return
+    function onDoc(e: MouseEvent) {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [open])
+
+  return (
+    <div ref={rootRef} className="relative block w-full text-start sm:inline-block sm:w-auto">
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        aria-label={`View courses as ${activeOption.label}. Open menu to change catalog layout.`}
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800 sm:w-auto"
+      >
+        <ActiveIcon className="h-4 w-4 shrink-0" aria-hidden />
+        <span>View</span>
+        <ChevronDown
+          className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`}
+          aria-hidden
+        />
+      </button>
+
+      {open && (
+        <div
+          id={menuId}
+          role="menu"
+          aria-label="Course catalog view"
+          className="absolute start-0 end-0 z-50 mt-1 min-w-0 overflow-hidden rounded-xl border border-slate-200 bg-white py-1 shadow-lg shadow-slate-900/10 sm:left-auto sm:end-0 sm:min-w-[16rem] dark:border-neutral-600 dark:bg-neutral-800 dark:shadow-black/40"
+        >
+          {VIEW_OPTIONS.map((option) => {
+            const Icon = option.icon
+            return (
+              <button
+                key={option.id}
+                type="button"
+                role="menuitemradio"
+                aria-checked={value === option.id}
+                onClick={() => {
+                  onChange(option.id)
+                  setOpen(false)
+                }}
+                className={[
+                  'flex w-full items-start gap-2.5 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:hover:bg-neutral-700',
+                  value === option.id ? 'bg-indigo-50 dark:bg-neutral-800' : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              >
+                <Icon className="mt-0.5 h-4 w-4 shrink-0 text-slate-500 dark:text-neutral-400" aria-hidden />
+                <span className="flex min-w-0 flex-col gap-0.5">
+                  <span className="font-semibold text-slate-950 dark:text-neutral-100">{option.label}</span>
+                  <span className="text-xs text-slate-500 dark:text-neutral-400">{option.hint}</span>
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/clients/web/src/pages/lms/course-collab-docs-page.tsx
+++ b/clients/web/src/pages/lms/course-collab-docs-page.tsx
@@ -1,22 +1,28 @@
 import { useCallback, useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
-import { fetchCollabDocs, type CollabDoc } from '../../lib/collab-docs-api'
+import { Link, useParams } from 'react-router-dom'
+import { ArrowLeft } from 'lucide-react'
+import { CollabEditor } from '../../components/collab/collab-editor'
+import { CollabDocsList } from '../../components/collab/collab-docs-list'
+import { fetchCollabDoc, fetchCollabDocs, type CollabDoc } from '../../lib/collab-docs-api'
 import { courseItemCreatePermission, fetchCourse } from '../../lib/courses-api'
 import { usePermissions } from '../../context/use-permissions'
-import { CollabDocsList } from '../../components/collab/collab-docs-list'
 import { LmsPage } from './lms-page'
 
 export default function CourseCollabDocsPage() {
-  const { courseCode: rawCode } = useParams<{ courseCode: string }>()
+  const { courseCode: rawCode, docId: rawDocId } = useParams<{ courseCode: string; docId?: string }>()
   const courseCode = rawCode ? decodeURIComponent(rawCode) : ''
+  const docId = rawDocId ? decodeURIComponent(rawDocId) : undefined
   const { allows, loading: permLoading } = usePermissions()
   const canManage = !permLoading && !!courseCode && allows(courseItemCreatePermission(courseCode))
 
   const [docs, setDocs] = useState<CollabDoc[]>([])
+  const [activeDoc, setActiveDoc] = useState<CollabDoc | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const load = useCallback(async () => {
+  const listBase = `/courses/${encodeURIComponent(courseCode)}/collab-docs`
+
+  const loadList = useCallback(async () => {
     if (!courseCode) return
     setLoading(true)
     setError(null)
@@ -35,7 +41,75 @@ export default function CourseCollabDocsPage() {
     }
   }, [courseCode])
 
-  useEffect(() => { void load() }, [load])
+  const loadDoc = useCallback(async () => {
+    if (!courseCode || !docId) return
+    setLoading(true)
+    setError(null)
+    setActiveDoc(null)
+    try {
+      const course = await fetchCourse(courseCode)
+      if (!course.collabDocsEnabled) {
+        setError('Collaborative documents are not enabled for this course.')
+        return
+      }
+      const doc = await fetchCollabDoc(courseCode, docId)
+      setActiveDoc(doc)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load document.')
+    } finally {
+      setLoading(false)
+    }
+  }, [courseCode, docId])
+
+  useEffect(() => {
+    if (docId) {
+      void loadDoc()
+    } else {
+      void loadList()
+    }
+  }, [docId, loadDoc, loadList])
+
+  if (docId) {
+    return (
+      <LmsPage title={activeDoc?.title ?? 'Document'} fillHeight omitHeader>
+        {loading ? (
+          <div className="flex flex-1 items-center justify-center">
+            <span className="text-sm text-slate-500 dark:text-neutral-400">Loading…</span>
+          </div>
+        ) : error ? (
+          <div className="rounded-md bg-red-50 p-4 text-sm text-red-700 dark:bg-red-950/30 dark:text-red-400">
+            {error}
+          </div>
+        ) : activeDoc?.docType === 'whiteboard' ? (
+          <div className="space-y-4">
+            <Link
+              to={listBase}
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+            >
+              <ArrowLeft className="size-4" aria-hidden />
+              Back to documents
+            </Link>
+            <p className="text-sm text-slate-600 dark:text-neutral-300">
+              Whiteboard editing for &ldquo;{activeDoc.title}&rdquo; is not available in this view yet.
+            </p>
+          </div>
+        ) : activeDoc ? (
+          <div className="flex min-h-0 flex-1 flex-col gap-2">
+            <Link
+              to={listBase}
+              className="inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+            >
+              <ArrowLeft className="size-4" aria-hidden />
+              Back to documents
+            </Link>
+            <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-slate-200 dark:border-neutral-700">
+              <CollabEditor courseCode={courseCode} docId={docId} />
+            </div>
+          </div>
+        ) : null}
+      </LmsPage>
+    )
+  }
 
   return (
     <LmsPage title="Collaborative Documents">
@@ -52,7 +126,7 @@ export default function CourseCollabDocsPage() {
           courseCode={courseCode}
           docs={docs}
           canManage={canManage}
-          onDocsChanged={() => { void load() }}
+          onDocsChanged={() => { void loadList() }}
         />
       )}
     </LmsPage>

--- a/clients/web/src/pages/lms/course-collab-docs-page.tsx
+++ b/clients/web/src/pages/lms/course-collab-docs-page.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react'
-import { Link, useMatch, useParams } from 'react-router-dom'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, matchPath, useLocation, useParams } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
 import { CollabEditor } from '../../components/collab/collab-editor'
 import { CollabDocsList } from '../../components/collab/collab-docs-list'
@@ -9,23 +9,31 @@ import { usePermissions } from '../../context/use-permissions'
 import { LmsPage } from './lms-page'
 
 export default function CourseCollabDocsPage() {
+  const { pathname } = useLocation()
   const { courseCode: rawCode } = useParams<{ courseCode: string }>()
   const courseCode = rawCode ? decodeURIComponent(rawCode) : ''
-  const docMatch = useMatch('/courses/:courseCode/collab-docs/:docId')
-  const docId = docMatch?.params.docId ? decodeURIComponent(docMatch.params.docId) : undefined
+  const docId = useMemo(() => {
+    const match = matchPath(
+      { path: '/courses/:courseCode/collab-docs/:docId', end: true },
+      pathname,
+    )
+    const id = match?.params.docId
+    return id ? decodeURIComponent(id) : undefined
+  }, [pathname])
   const { allows, loading: permLoading } = usePermissions()
   const canManage = !permLoading && !!courseCode && allows(courseItemCreatePermission(courseCode))
 
   const [docs, setDocs] = useState<CollabDoc[]>([])
   const [activeDoc, setActiveDoc] = useState<CollabDoc | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [listLoading, setListLoading] = useState(true)
+  const [docLoading, setDocLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const listBase = `/courses/${encodeURIComponent(courseCode)}/collab-docs`
 
   const loadList = useCallback(async () => {
     if (!courseCode) return
-    setLoading(true)
+    setListLoading(true)
     setError(null)
     try {
       const course = await fetchCourse(courseCode)
@@ -38,13 +46,13 @@ export default function CourseCollabDocsPage() {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load documents.')
     } finally {
-      setLoading(false)
+      setListLoading(false)
     }
   }, [courseCode])
 
   const loadDoc = useCallback(async () => {
     if (!courseCode || !docId) return
-    setLoading(true)
+    setDocLoading(true)
     setError(null)
     setActiveDoc(null)
     try {
@@ -58,7 +66,7 @@ export default function CourseCollabDocsPage() {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load document.')
     } finally {
-      setLoading(false)
+      setDocLoading(false)
     }
   }, [courseCode, docId])
 
@@ -66,22 +74,25 @@ export default function CourseCollabDocsPage() {
     if (docId) {
       void loadDoc()
     } else {
+      setActiveDoc(null)
       void loadList()
     }
   }, [docId, loadDoc, loadList])
 
   if (docId) {
+    const showEditorLoading = docLoading || !activeDoc
+
     return (
       <LmsPage title={activeDoc?.title ?? 'Document'} fillHeight omitHeader>
-        {loading ? (
-          <div className="flex flex-1 items-center justify-center">
-            <span className="text-sm text-slate-500 dark:text-neutral-400">Loading…</span>
-          </div>
-        ) : error ? (
+        {error ? (
           <div className="rounded-md bg-red-50 p-4 text-sm text-red-700 dark:bg-red-950/30 dark:text-red-400">
             {error}
           </div>
-        ) : activeDoc?.docType === 'whiteboard' ? (
+        ) : showEditorLoading ? (
+          <div className="flex min-h-48 flex-1 items-center justify-center">
+            <span className="text-sm text-slate-500 dark:text-neutral-400">Loading…</span>
+          </div>
+        ) : activeDoc.docType === 'whiteboard' ? (
           <div className="space-y-4">
             <Link
               to={listBase}
@@ -94,8 +105,8 @@ export default function CourseCollabDocsPage() {
               Whiteboard editing for &ldquo;{activeDoc.title}&rdquo; is not available in this view yet.
             </p>
           </div>
-        ) : activeDoc ? (
-          <div className="flex min-h-0 flex-1 flex-col gap-2">
+        ) : (
+          <div className="flex min-h-48 flex-1 flex-col gap-2">
             <Link
               to={listBase}
               className="inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
@@ -103,18 +114,18 @@ export default function CourseCollabDocsPage() {
               <ArrowLeft className="size-4" aria-hidden />
               Back to documents
             </Link>
-            <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-slate-200 dark:border-neutral-700">
+            <div className="min-h-48 flex-1 overflow-hidden rounded-lg border border-slate-200 dark:border-neutral-700">
               <CollabEditor courseCode={courseCode} docId={docId} />
             </div>
           </div>
-        ) : null}
+        )}
       </LmsPage>
     )
   }
 
   return (
     <LmsPage title="Collaborative Documents">
-      {loading ? (
+      {listLoading ? (
         <div className="flex items-center justify-center py-16">
           <span className="text-sm text-slate-500 dark:text-neutral-400">Loading…</span>
         </div>

--- a/clients/web/src/pages/lms/course-collab-docs-page.tsx
+++ b/clients/web/src/pages/lms/course-collab-docs-page.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useMatch, useParams } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
 import { CollabEditor } from '../../components/collab/collab-editor'
 import { CollabDocsList } from '../../components/collab/collab-docs-list'
@@ -9,9 +9,10 @@ import { usePermissions } from '../../context/use-permissions'
 import { LmsPage } from './lms-page'
 
 export default function CourseCollabDocsPage() {
-  const { courseCode: rawCode, docId: rawDocId } = useParams<{ courseCode: string; docId?: string }>()
+  const { courseCode: rawCode } = useParams<{ courseCode: string }>()
   const courseCode = rawCode ? decodeURIComponent(rawCode) : ''
-  const docId = rawDocId ? decodeURIComponent(rawDocId) : undefined
+  const docMatch = useMatch('/courses/:courseCode/collab-docs/:docId')
+  const docId = docMatch?.params.docId ? decodeURIComponent(docMatch.params.docId) : undefined
   const { allows, loading: permLoading } = usePermissions()
   const canManage = !permLoading && !!courseCode && allows(courseItemCreatePermission(courseCode))
 

--- a/clients/web/src/pages/lms/course-collab-docs-page.tsx
+++ b/clients/web/src/pages/lms/course-collab-docs-page.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Link, matchPath, useLocation, useParams } from 'react-router-dom'
+import { Link, useLocation, useParams } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
 import { CollabEditor } from '../../components/collab/collab-editor'
 import { CollabDocsList } from '../../components/collab/collab-docs-list'
@@ -13,12 +13,11 @@ export default function CourseCollabDocsPage() {
   const { courseCode: rawCode } = useParams<{ courseCode: string }>()
   const courseCode = rawCode ? decodeURIComponent(rawCode) : ''
   const docId = useMemo(() => {
-    const match = matchPath(
-      { path: '/courses/:courseCode/collab-docs/:docId', end: true },
-      pathname,
-    )
-    const id = match?.params.docId
-    return id ? decodeURIComponent(id) : undefined
+    const marker = '/collab-docs/'
+    const idx = pathname.indexOf(marker)
+    if (idx === -1) return undefined
+    const rest = pathname.slice(idx + marker.length).split('/')[0]
+    return rest ? decodeURIComponent(rest) : undefined
   }, [pathname])
   const { allows, loading: permLoading } = usePermissions()
   const canManage = !permLoading && !!courseCode && allows(courseItemCreatePermission(courseCode))
@@ -109,6 +108,7 @@ export default function CourseCollabDocsPage() {
           <div className="flex min-h-48 flex-1 flex-col gap-2">
             <Link
               to={listBase}
+              data-testid="collab-doc-back-link"
               className="inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
             >
               <ArrowLeft className="size-4" aria-hidden />

--- a/clients/web/src/pages/lms/course-features-section.tsx
+++ b/clients/web/src/pages/lms/course-features-section.tsx
@@ -70,7 +70,7 @@ export function CourseFeaturesSection({ courseCode, course, onCourseUpdated }: P
   const sectionsEnabled = course.sectionsEnabled === true
   const discussionsEnabled = course.discussionsEnabled === true
   const collabDocsEnabled = course.collabDocsEnabled === true
-  const liveSessionsEnabled = course.liveSessionsEnabled !== false
+  const liveSessionsEnabled = course.liveSessionsEnabled === true
   const officeHoursEnabled = course.officeHoursEnabled === true
   const aiTutorEnabled = course.aiTutorEnabled === true
   const multilingualMessagingEnabled = course.multilingualMessagingEnabled === true

--- a/clients/web/src/pages/lms/course-files-page.tsx
+++ b/clients/web/src/pages/lms/course-files-page.tsx
@@ -88,7 +88,6 @@ export default function CourseFilesPage() {
   const [contextMenu, setContextMenu] = useState<ContextMenu | null>(null)
   const [draggingItem, setDraggingItem] = useState<{ kind: 'folder' | 'file'; id: string } | null>(null)
   const [dragOverFolderId, setDragOverFolderId] = useState<string | null>(null)
-  const [dragOverBreadcrumbId, setDragOverBreadcrumbId] = useState<string | 'root' | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedItems, setSelectedItems] = useState<Set<SelectedItemKey>>(new Set())
   const [previewFile, setPreviewFile] = useState<FileItem | null>(null)
@@ -435,105 +434,6 @@ export default function CourseFilesPage() {
         />
       )}
 
-      {/* Breadcrumb trail */}
-      <nav
-        aria-label="Folder path"
-        className="mb-3 flex min-w-0 flex-wrap items-center gap-1 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900/60"
-      >
-        <span
-          onDragOver={(e) => {
-            if (draggingItem && folderId !== undefined) {
-              e.preventDefault()
-              e.dataTransfer.dropEffect = 'move'
-            }
-          }}
-          onDragEnter={() => {
-            if (draggingItem && folderId !== undefined) {
-              setDragOverBreadcrumbId('root')
-            }
-          }}
-          onDragLeave={(e) => {
-            if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-              setDragOverBreadcrumbId(null)
-            }
-          }}
-          onDrop={() => {
-            if (draggingItem && folderId !== undefined) {
-              void handleMoveItem(draggingItem.kind, draggingItem.id, null)
-            }
-            setDragOverBreadcrumbId(null)
-          }}
-          className={`rounded px-1.5 py-0.5 transition-all duration-150 ${
-            draggingItem && folderId !== undefined
-              ? dragOverBreadcrumbId === 'root'
-                ? 'bg-indigo-100 font-semibold text-indigo-700 ring-2 ring-indigo-500 dark:bg-indigo-900/60 dark:text-indigo-300'
-                : 'border border-dashed border-indigo-300 bg-indigo-50/50 dark:border-indigo-700 dark:bg-indigo-950/20'
-              : ''
-          }`}
-        >
-          <button
-            type="button"
-            onClick={() => navigateToFolder(null)}
-            className="text-indigo-600 hover:underline dark:text-indigo-400"
-            aria-current={!folderId ? 'page' : undefined}
-          >
-            Files
-          </button>
-        </span>
-        {breadcrumbs.map((b, i) => {
-          const isLast = i === breadcrumbs.length - 1
-          const canDropOnCrumb = draggingItem && folderId !== b.id && draggingItem.id !== b.id
-          return (
-            <span key={b.id} className="flex min-w-0 items-center gap-1">
-              <span className="text-slate-400 dark:text-neutral-500" aria-hidden>/</span>
-              <span
-                onDragOver={(e) => {
-                  if (canDropOnCrumb) {
-                    e.preventDefault()
-                    e.dataTransfer.dropEffect = 'move'
-                  }
-                }}
-                onDragEnter={() => {
-                  if (canDropOnCrumb) {
-                    setDragOverBreadcrumbId(b.id)
-                  }
-                }}
-                onDragLeave={(e) => {
-                  if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                    setDragOverBreadcrumbId(null)
-                  }
-                }}
-                onDrop={() => {
-                  if (canDropOnCrumb) {
-                    void handleMoveItem(draggingItem!.kind, draggingItem!.id, b.id)
-                  }
-                  setDragOverBreadcrumbId(null)
-                }}
-                className={`min-w-0 rounded px-1.5 py-0.5 transition-all duration-150 ${
-                  canDropOnCrumb
-                    ? dragOverBreadcrumbId === b.id
-                      ? 'bg-indigo-100 font-semibold text-indigo-700 ring-2 ring-indigo-500 dark:bg-indigo-900/60 dark:text-indigo-300'
-                      : 'border border-dashed border-indigo-300 bg-indigo-50/50 dark:border-indigo-700 dark:bg-indigo-950/20'
-                    : ''
-                }`}
-              >
-                {!isLast ? (
-                  <button
-                    type="button"
-                    onClick={() => navigateToFolder(b.id)}
-                    className="max-w-[12rem] truncate text-indigo-600 hover:underline dark:text-indigo-400"
-                  >
-                    {b.name}
-                  </button>
-                ) : (
-                  <span className="block max-w-[12rem] truncate font-medium text-slate-800 dark:text-neutral-200" aria-current="page">{b.name}</span>
-                )}
-              </span>
-            </span>
-          )
-        })}
-      </nav>
-
       {/* Toolbar */}
       <div className="mb-4 flex flex-wrap items-center justify-end gap-2">
         {canManage && (
@@ -718,7 +618,7 @@ export default function CourseFilesPage() {
                   draggingItem={draggingItem}
                   dragOverFolderId={dragOverFolderId}
                   onDragStart={(kind, id) => setDraggingItem({ kind, id })}
-                  onDragEnd={() => { setDraggingItem(null); setDragOverFolderId(null); setDragOverBreadcrumbId(null); }}
+                  onDragEnd={() => { setDraggingItem(null); setDragOverFolderId(null); }}
                   onDragEnter={(id) => setDragOverFolderId(id)}
                   onDragLeave={() => setDragOverFolderId(null)}
                   onDrop={(kind, dragId, targetId) => void handleMoveItem(kind, dragId, targetId)}
@@ -742,7 +642,7 @@ export default function CourseFilesPage() {
                   onContextMenu={e => openContextMenu(e, file, 'file')}
                   draggingItem={draggingItem}
                   onDragStart={(kind, id) => setDraggingItem({ kind, id })}
-                  onDragEnd={() => { setDraggingItem(null); setDragOverFolderId(null); setDragOverBreadcrumbId(null); }}
+                  onDragEnd={() => { setDraggingItem(null); setDragOverFolderId(null); }}
                 />
               ))}
             </tbody>

--- a/clients/web/src/pages/lms/course-gradebook.tsx
+++ b/clients/web/src/pages/lms/course-gradebook.tsx
@@ -37,6 +37,10 @@ import { GradeHistoryPanel } from '../../components/grading/grade-history-panel'
 import { GradebookImportModal } from '../../components/grading/gradebook-import-modal'
 import { LmsPage } from './lms-page'
 import { IncompleteGradeModal } from './gradebook/IncompleteGradeModal'
+import {
+  GradebookSubmissionGradingModal,
+  type GradebookSubmissionGradingModalState,
+} from './gradebook/gradebook-submission-grading-modal'
 import type { IncompleteGradeRecord } from '../../lib/incomplete-grades-api'
 
 function buildEmptyGrades(students: GradebookStudent[], columns: GradebookColumn[]): Record<string, Record<string, string>> {
@@ -356,6 +360,8 @@ export default function CourseGradebook() {
     studentName: string
     record?: IncompleteGradeRecord | null
   } | null>(null)
+  const [submissionGradingModal, setSubmissionGradingModal] =
+    useState<GradebookSubmissionGradingModalState>(null)
 
   useEffect(() => {
     if (!courseCode) return
@@ -656,6 +662,24 @@ export default function CourseGradebook() {
     [courseCode, columns, students],
   )
 
+  const openGradeSubmission = useCallback(
+    (studentId: string, columnId: string) => {
+      const col = columns.find((c) => c.id === columnId)
+      if (!col || col.kind !== 'assignment') return
+      setSubmissionGradingModal({
+        itemId: columnId,
+        studentUserId: studentId,
+        columnTitle: col.title,
+      })
+    },
+    [columns],
+  )
+
+  const closeSubmissionGradingModal = useCallback(() => {
+    setSubmissionGradingModal(null)
+    void loadGrid()
+  }, [loadGrid])
+
   useEffect(() => {
     if (!gradeHistoryOpen || !courseCode) return
     let cancelled = false
@@ -727,7 +751,7 @@ export default function CourseGradebook() {
     return (
       <LmsPage
         title="Gradebook"
-        description="Spreadsheet-style grades for enrolled students and each course assignment or quiz. Use the arrows, Tab, Enter, and double-click to edit cells; assignment rubrics open from the Rubric link. Save writes your changes to the server."
+        description="Spreadsheet-style grades for enrolled students and each course assignment or quiz. Use the arrows, Tab, Enter, and double-click to edit cells; open the cell menu for rubric scoring, submission grading, history, and excused status. Save writes your changes to the server."
       >
         <GradebookLoadingSkeleton />
       </LmsPage>
@@ -741,7 +765,7 @@ export default function CourseGradebook() {
   return (
     <LmsPage
       title="Gradebook"
-      description="Spreadsheet-style grades for enrolled students and each course assignment or quiz. Use the arrows, Tab, Enter, and double-click to edit cells; assignment rubrics open from the Rubric link. Save writes your changes to the server."
+      description="Spreadsheet-style grades for enrolled students and each course assignment or quiz. Use the arrows, Tab, Enter, and double-click to edit cells; open the cell menu for rubric scoring, submission grading, history, and excused status. Save writes your changes to the server."
       actions={
         <div className="flex flex-wrap items-center gap-2">
           {loadState === 'ok' && gradebookCsvEnabled ? (
@@ -917,6 +941,7 @@ export default function CourseGradebook() {
             readOnly={!canEditGrades}
             onGradesChange={handleGradesChange}
             onRubricClick={canEditGrades ? openRubricModal : undefined}
+            onGradeSubmission={canEditGrades ? openGradeSubmission : undefined}
             onOpenGradeHistory={openGradeHistory}
             highlightStudentId={highlightStudentId}
             gradingScheme={gradingScheme}
@@ -978,6 +1003,13 @@ export default function CourseGradebook() {
                 setIncompleteModal(null)
                 void loadGrid()
               }}
+            />
+          ) : null}
+          {courseCode ? (
+            <GradebookSubmissionGradingModal
+              open={submissionGradingModal}
+              courseCode={courseCode}
+              onClose={closeSubmissionGradingModal}
             />
           ) : null}
           {gradeHistoryOpen ? (

--- a/clients/web/src/pages/lms/course-layout.tsx
+++ b/clients/web/src/pages/lms/course-layout.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, Outlet, useParams } from 'react-router-dom'
-import { TutorPanel } from '../../components/tutor-panel'
 import { CourseLiveContext } from '../../context/course-live-context'
-import { useCourseNavFeatures } from '../../context/course-nav-features-context'
 import { usePlatformFeatures } from '../../context/platform-features-context'
 import { useCourseStructureRevision } from '../../hooks/use-course-structure-ws'
 import { fetchEvaluationStatus } from '../../lib/course-evaluations-api'
@@ -50,7 +48,6 @@ function EvaluationReminderBanner({ courseCode }: { courseCode: string }) {
  */
 export default function CourseLayout() {
   const { courseCode } = useParams<{ courseCode: string }>()
-  const { aiTutorEnabled } = useCourseNavFeatures()
   const { ffCourseEvaluations } = usePlatformFeatures()
   const structureRevision = useCourseStructureRevision(courseCode)
   const liveValue = useMemo(
@@ -65,7 +62,6 @@ export default function CourseLayout() {
         <EvaluationReminderBanner courseCode={courseCode} />
       ) : null}
       <Outlet />
-      {courseCode && aiTutorEnabled ? <TutorPanel courseCode={courseCode} /> : null}
     </CourseLiveContext.Provider>
   )
 }

--- a/clients/web/src/pages/lms/courses.tsx
+++ b/clients/web/src/pages/lms/courses.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom'
 import {
   closestCorners,
   DndContext,
-  KeyboardSensor,
   PointerSensor,
   useSensor,
   useSensors,
@@ -13,13 +12,30 @@ import {
   arrayMove,
   rectSortingStrategy,
   SortableContext,
-  sortableKeyboardCoordinates,
   useSortable,
+  verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { BookOpen, Plus } from 'lucide-react'
+import { KeyboardSensor as SharedKeyboardSensor, defaultKeyboardSensorOptions } from '../../lib/dnd/keyboardSensorConfig'
 import { CanvasImportCoursesModal } from './canvas-import-courses-modal'
 import { CourseCatalogImportMenu } from './course-catalog-import-menu'
+import {
+  CourseCatalogViewMenu,
+} from './course-catalog-view-menu'
+import { CourseCatalogKanbanBoard } from './course-catalog-kanban'
+import { courseCatalogStatusLabel } from './course-catalog-status'
+import { courseCatalogDescriptionBlurb, courseCatalogDisplayTitle } from './course-catalog-display'
+import { CourseCatalogNicknameEditor } from './course-catalog-nickname-editor'
+import {
+  DEFAULT_KANBAN_COLUMN_LABELS,
+  fetchCourseCatalogSettings,
+  migrateLegacyCourseCatalogLocalStorage,
+  putCourseCatalogSettings,
+  putCourseKanbanBoard,
+  type KanbanColumnLabels,
+} from '../../lib/course-catalog-settings-api'
+import type { CourseCatalogView, KanbanColumnId } from '../../lib/course-catalog-types'
 import { EmptyState } from '../../components/ui/empty-state'
 import { CoursesCatalogSkeleton } from '../../components/ui/lms-content-skeletons'
 import { LmsPage } from './lms-page'
@@ -38,6 +54,8 @@ import { CourseCatalogStatusPill } from '../../components/ui/status-vocabulary'
 import { PERM_COURSE_CREATE } from '../../lib/rbac-api'
 
 export type { CoursePublic } from '../../lib/courses-api'
+
+type CatalogNicknameChangeHandler = (courseId: string, nickname: string | null) => void
 
 function CreateCourseIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
   return (
@@ -71,32 +89,40 @@ function CreateCourseIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
 
 const COURSE_GRID_SORT_ID = 'course-catalog-grid'
 
+type CatalogSection = {
+  key: string
+  title: string
+  items: CoursePublic[]
+}
+
+type SortableCourseProps = {
+  listeners: Record<string, unknown>
+  setNodeRef: (node: HTMLElement | null) => void
+  style: CSSProperties
+  isDragging: boolean
+}
+
 function formatEditedAgo(iso: string): string {
   return `Edited ${formatRelativeCompact(iso)}`
 }
 
-/** Catalog pill: draft vs published schedule window (uses real `published`, `startsAt`, `endsAt`). */
-function courseStatusBadgeLabel(c: CoursePublic): string {
-  if (!c.published) return 'Draft'
-  const now = Date.now()
-  if (c.endsAt) {
-    const end = new Date(c.endsAt).getTime()
-    if (!Number.isNaN(end) && end < now) return 'Ended'
-  }
-  if (c.startsAt) {
-    const start = new Date(c.startsAt).getTime()
-    if (!Number.isNaN(start) && start > now) return 'Upcoming'
-  }
-  return 'Active'
+function formatCourseTermLabel(course: CoursePublic): string {
+  return course.term?.name?.trim() || '—'
+}
+
+function catalogViewUsesGrid(view: CourseCatalogView): boolean {
+  return view === 'cards' || view === 'gallery'
 }
 
 function CourseCard({
   course,
   sortable,
   suppressNavigateAfterDragRef,
+  onNicknameChange,
 }: {
   course: CoursePublic
   suppressNavigateAfterDragRef?: MutableRefObject<boolean>
+  onNicknameChange: CatalogNicknameChangeHandler
   sortable?: {
     listeners: Record<string, unknown>
     setNodeRef: (node: HTMLElement | null) => void
@@ -105,15 +131,16 @@ function CourseCard({
   }
 }) {
   const courseHref = `/courses/${encodeURIComponent(course.courseCode)}`
-  const badgeLabel = courseStatusBadgeLabel(course)
-  const descriptionBlurb = course.description.trim() || 'No description yet.'
+  const badgeLabel = courseCatalogStatusLabel(course)
+  const descriptionBlurb = courseCatalogDescriptionBlurb(course)
+  const displayTitle = courseCatalogDisplayTitle(course)
 
   return (
     <article
       ref={sortable?.setNodeRef}
       style={sortable?.style}
       className={[
-        'flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm shadow-slate-900/5 transition-shadow',
+        'flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm shadow-slate-900/5 transition-shadow dark:border-neutral-700 dark:bg-neutral-900',
         sortable ? 'touch-none cursor-grab active:cursor-grabbing' : '',
         sortable?.isDragging ? 'shadow-md shadow-slate-900/10 ring-2 ring-indigo-400/40' : '',
       ]
@@ -124,7 +151,7 @@ function CourseCard({
       <Link
         to={courseHref}
         className="relative block focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500"
-        aria-label={`Open ${course.title}`}
+        aria-label={`Open ${displayTitle}`}
         onClick={(e) => {
           if (!suppressNavigateAfterDragRef?.current) return
           e.preventDefault()
@@ -151,14 +178,23 @@ function CourseCard({
         </span>
         <div className="absolute inset-x-0 bottom-0 p-4 pt-10">
           <h2 className="text-lg font-semibold leading-snug tracking-tight text-white drop-shadow-sm line-clamp-2">
-            {course.title}
+            {displayTitle}
           </h2>
         </div>
       </Link>
 
       <div className="flex flex-1 flex-col justify-end px-5 pb-4 pt-3">
-        <p className="text-start text-sm leading-snug text-slate-600 line-clamp-4">{descriptionBlurb}</p>
-        <p className="mt-3 text-start text-xs text-slate-400">{formatEditedAgo(course.updatedAt)}</p>
+        <CourseCatalogNicknameEditor
+          course={course}
+          compact
+          onNicknameChange={onNicknameChange}
+        />
+        {descriptionBlurb ? (
+          <p className="mt-3 text-start text-sm leading-snug text-slate-600 line-clamp-4 dark:text-neutral-400">
+            {descriptionBlurb}
+          </p>
+        ) : null}
+        <p className="mt-3 text-start text-xs text-slate-400 dark:text-neutral-500">{formatEditedAgo(course.updatedAt)}</p>
       </div>
     </article>
   )
@@ -167,9 +203,11 @@ function CourseCard({
 function SortableCourseCard({
   course,
   suppressNavigateAfterDragRef,
+  onNicknameChange,
 }: {
   course: CoursePublic
   suppressNavigateAfterDragRef: MutableRefObject<boolean>
+  onNicknameChange: CatalogNicknameChangeHandler
 }) {
   const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: course.id,
@@ -186,6 +224,7 @@ function SortableCourseCard({
       <CourseCard
         course={course}
         suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
+        onNicknameChange={onNicknameChange}
         sortable={{
           listeners: listeners as Record<string, unknown>,
           setNodeRef,
@@ -194,6 +233,332 @@ function SortableCourseCard({
         }}
       />
     </div>
+  )
+}
+
+function CourseListRow({
+  course,
+  sortable,
+  suppressNavigateAfterDragRef,
+  onNicknameChange,
+}: {
+  course: CoursePublic
+  suppressNavigateAfterDragRef?: MutableRefObject<boolean>
+  onNicknameChange: CatalogNicknameChangeHandler
+  sortable?: SortableCourseProps
+}) {
+  const courseHref = `/courses/${encodeURIComponent(course.courseCode)}`
+  const badgeLabel = courseCatalogStatusLabel(course)
+  const descriptionBlurb = courseCatalogDescriptionBlurb(course)
+  const displayTitle = courseCatalogDisplayTitle(course)
+
+  return (
+    <article
+      ref={sortable?.setNodeRef}
+      style={sortable?.style}
+      className={[
+        'flex overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-900/5 transition-shadow dark:border-neutral-700 dark:bg-neutral-900',
+        sortable ? 'touch-none cursor-grab active:cursor-grabbing' : '',
+        sortable?.isDragging ? 'shadow-md shadow-slate-900/10 ring-2 ring-indigo-400/40' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      {...(sortable ? sortable.listeners : {})}
+    >
+      <div className="flex min-w-0 flex-1 items-stretch gap-4 p-3 sm:p-4">
+        <Link
+          to={courseHref}
+          className="relative h-16 w-24 shrink-0 overflow-hidden rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 sm:h-20 sm:w-28"
+          aria-label={`Open ${displayTitle}`}
+          onClick={(e) => {
+            if (!suppressNavigateAfterDragRef?.current) return
+            e.preventDefault()
+            e.stopPropagation()
+            suppressNavigateAfterDragRef.current = false
+          }}
+        >
+          <img
+            data-lex-hero
+            src={course.heroImageUrl ?? '/course-card-hero.png'}
+            alt=""
+            draggable={false}
+            loading="lazy"
+            decoding="async"
+            className="h-full w-full object-cover"
+            style={heroImageObjectStyle(course.heroImageObjectPosition)}
+          />
+        </Link>
+        <div className="flex min-w-0 flex-1 flex-col justify-center gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <CourseCatalogNicknameEditor
+              course={course}
+              titleClassName="text-base font-semibold leading-snug text-slate-900 line-clamp-1 dark:text-neutral-100"
+              onNicknameChange={onNicknameChange}
+            />
+            <CourseCatalogStatusPill label={badgeLabel} />
+          </div>
+          {descriptionBlurb ? (
+            <Link
+              to={courseHref}
+              className="text-start text-sm leading-snug text-slate-600 line-clamp-2 hover:text-indigo-600 dark:text-neutral-400 dark:hover:text-indigo-300"
+              onClick={(e) => {
+                if (!suppressNavigateAfterDragRef?.current) return
+                e.preventDefault()
+                e.stopPropagation()
+                suppressNavigateAfterDragRef.current = false
+              }}
+            >
+              {descriptionBlurb}
+            </Link>
+          ) : null}
+          <p className="text-start text-xs text-slate-400 dark:text-neutral-500">{formatEditedAgo(course.updatedAt)}</p>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function SortableCourseListRow({
+  course,
+  suppressNavigateAfterDragRef,
+  onNicknameChange,
+}: {
+  course: CoursePublic
+  suppressNavigateAfterDragRef: MutableRefObject<boolean>
+  onNicknameChange: CatalogNicknameChangeHandler
+}) {
+  const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: course.id,
+  })
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.92 : undefined,
+    zIndex: isDragging ? 20 : undefined,
+  }
+
+  return (
+    <CourseListRow
+      course={course}
+      suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
+      onNicknameChange={onNicknameChange}
+      sortable={{
+        listeners: listeners as Record<string, unknown>,
+        setNodeRef,
+        style,
+        isDragging,
+      }}
+    />
+  )
+}
+
+function CourseGalleryTile({
+  course,
+  sortable,
+  suppressNavigateAfterDragRef,
+  onNicknameChange,
+}: {
+  course: CoursePublic
+  suppressNavigateAfterDragRef?: MutableRefObject<boolean>
+  onNicknameChange: CatalogNicknameChangeHandler
+  sortable?: SortableCourseProps
+}) {
+  const courseHref = `/courses/${encodeURIComponent(course.courseCode)}`
+  const badgeLabel = courseCatalogStatusLabel(course)
+  const displayTitle = courseCatalogDisplayTitle(course)
+
+  return (
+    <article
+      ref={sortable?.setNodeRef}
+      style={sortable?.style}
+      className={[
+        'overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-900/5 transition-shadow dark:border-neutral-700 dark:bg-neutral-900',
+        sortable ? 'touch-none cursor-grab active:cursor-grabbing' : '',
+        sortable?.isDragging ? 'shadow-md shadow-slate-900/10 ring-2 ring-indigo-400/40' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      {...(sortable ? sortable.listeners : {})}
+    >
+      <Link
+        to={courseHref}
+        className="relative block aspect-[4/3] focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500"
+        aria-label={`Open ${displayTitle}`}
+        onClick={(e) => {
+          if (!suppressNavigateAfterDragRef?.current) return
+          e.preventDefault()
+          e.stopPropagation()
+          suppressNavigateAfterDragRef.current = false
+        }}
+      >
+        <img
+          data-lex-hero
+          src={course.heroImageUrl ?? '/course-card-hero.png'}
+          alt=""
+          draggable={false}
+          loading="lazy"
+          decoding="async"
+          className="absolute inset-0 h-full w-full object-cover"
+          style={heroImageObjectStyle(course.heroImageObjectPosition)}
+        />
+        <div
+          className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent"
+          aria-hidden
+        />
+        <span className="absolute start-2 top-2">
+          <CourseCatalogStatusPill label={badgeLabel} />
+        </span>
+        <h2 className="absolute inset-x-0 bottom-0 p-3 text-sm font-semibold leading-snug text-white drop-shadow-sm line-clamp-2">
+          {displayTitle}
+        </h2>
+      </Link>
+      <div className="border-t border-slate-100 px-3 py-2 dark:border-neutral-800">
+        <CourseCatalogNicknameEditor course={course} compact onNicknameChange={onNicknameChange} />
+      </div>
+    </article>
+  )
+}
+
+function SortableCourseGalleryTile({
+  course,
+  suppressNavigateAfterDragRef,
+  onNicknameChange,
+}: {
+  course: CoursePublic
+  suppressNavigateAfterDragRef: MutableRefObject<boolean>
+  onNicknameChange: CatalogNicknameChangeHandler
+}) {
+  const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: course.id,
+  })
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.92 : undefined,
+    zIndex: isDragging ? 20 : undefined,
+  }
+
+  return (
+    <CourseGalleryTile
+      course={course}
+      suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
+      onNicknameChange={onNicknameChange}
+      sortable={{
+        listeners: listeners as Record<string, unknown>,
+        setNodeRef,
+        style,
+        isDragging,
+      }}
+    />
+  )
+}
+
+function CourseCatalogTableHeader() {
+  return (
+    <div
+      className="grid grid-cols-[minmax(0,2.2fr)_minmax(5.5rem,auto)_minmax(0,1.1fr)_minmax(5.5rem,auto)_minmax(4.5rem,auto)] gap-3 border-b border-slate-200 px-4 py-2.5 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-neutral-700 dark:text-neutral-400"
+      aria-hidden
+    >
+      <span>Title</span>
+      <span>Status</span>
+      <span>Term</span>
+      <span>Edited</span>
+      <span>Code</span>
+    </div>
+  )
+}
+
+function CourseTableRow({
+  course,
+  sortable,
+  suppressNavigateAfterDragRef,
+  onNicknameChange,
+}: {
+  course: CoursePublic
+  suppressNavigateAfterDragRef?: MutableRefObject<boolean>
+  onNicknameChange: CatalogNicknameChangeHandler
+  sortable?: SortableCourseProps
+}) {
+  const courseHref = `/courses/${encodeURIComponent(course.courseCode)}`
+  const badgeLabel = courseCatalogStatusLabel(course)
+
+  return (
+    <article
+      ref={sortable?.setNodeRef}
+      style={sortable?.style}
+      className={[
+        'grid grid-cols-[minmax(0,2.2fr)_minmax(5.5rem,auto)_minmax(0,1.1fr)_minmax(5.5rem,auto)_minmax(4.5rem,auto)] gap-3 border-b border-slate-100 px-4 py-3 text-sm last:border-b-0 dark:border-neutral-800',
+        sortable ? 'touch-none cursor-grab bg-white active:cursor-grabbing dark:bg-neutral-900' : 'bg-white dark:bg-neutral-900',
+        sortable?.isDragging ? 'relative z-20 shadow-md ring-2 ring-indigo-400/40' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      {...(sortable ? sortable.listeners : {})}
+    >
+      <div className="min-w-0">
+        <CourseCatalogNicknameEditor
+          course={course}
+          titleClassName="font-semibold text-slate-900 dark:text-neutral-100"
+          onNicknameChange={onNicknameChange}
+        />
+        <Link
+          to={courseHref}
+          className="mt-1 inline-block text-xs font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-300 dark:hover:text-indigo-200"
+          onClick={(e) => {
+            if (!suppressNavigateAfterDragRef?.current) return
+            e.preventDefault()
+            e.stopPropagation()
+            suppressNavigateAfterDragRef.current = false
+          }}
+        >
+          Open course
+        </Link>
+      </div>
+      <div className="self-center">
+        <CourseCatalogStatusPill label={badgeLabel} />
+      </div>
+      <span className="self-center truncate text-slate-600 dark:text-neutral-400">{formatCourseTermLabel(course)}</span>
+      <span className="self-center whitespace-nowrap text-xs text-slate-500 dark:text-neutral-400">
+        {formatRelativeCompact(course.updatedAt)}
+      </span>
+      <span className="self-center truncate font-mono text-xs text-slate-500 dark:text-neutral-400">
+        {course.courseCode}
+      </span>
+    </article>
+  )
+}
+
+function SortableCourseTableRow({
+  course,
+  suppressNavigateAfterDragRef,
+  onNicknameChange,
+}: {
+  course: CoursePublic
+  suppressNavigateAfterDragRef: MutableRefObject<boolean>
+  onNicknameChange: CatalogNicknameChangeHandler
+}) {
+  const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: course.id,
+  })
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.92 : undefined,
+    zIndex: isDragging ? 20 : undefined,
+  }
+
+  return (
+    <CourseTableRow
+      course={course}
+      suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
+      onNicknameChange={onNicknameChange}
+      sortable={{
+        listeners: listeners as Record<string, unknown>,
+        setNodeRef,
+        style,
+        isDragging,
+      }}
+    />
   )
 }
 
@@ -206,6 +571,9 @@ export default function Courses() {
   const [termFilter, setTermFilter] = useState<string>('')
   const [termList, setTermList] = useState<OrgTerm[]>([])
   const [gradeLevelFilter, setGradeLevelFilter] = useState<string>('')
+  const [catalogView, setCatalogView] = useState<CourseCatalogView>('cards')
+  const [kanbanColumnLabels, setKanbanColumnLabels] = useState<KanbanColumnLabels>(DEFAULT_KANBAN_COLUMN_LABELS)
+  const [hiddenColumnExpanded, setHiddenColumnExpanded] = useState(false)
   const [orgType, setOrgType] = useState<OrgType>('higher-ed')
   void orgType
   const orgId = decodeJwtPayload(getAccessToken())?.org_id ?? ''
@@ -245,6 +613,76 @@ export default function Courses() {
 
   useEffect(() => {
     let cancelled = false
+    void (async () => {
+      try {
+        await migrateLegacyCourseCatalogLocalStorage()
+        const settings = await fetchCourseCatalogSettings()
+        if (cancelled) return
+        setCatalogView(settings.view)
+        setKanbanColumnLabels(settings.kanbanColumnLabels)
+        setHiddenColumnExpanded(settings.hiddenColumnExpanded)
+      } catch {
+        /* keep defaults */
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleCatalogViewChange = useCallback((next: CourseCatalogView) => {
+    setCatalogView(next)
+    void putCourseCatalogSettings({ view: next }).catch(() => {
+      setError('Could not save catalog view preference.')
+    })
+  }, [])
+
+  const handleNicknameChange = useCallback((courseId: string, nickname: string | null) => {
+    setCourses((prev) =>
+      prev?.map((course) => (course.id === courseId ? { ...course, catalogNickname: nickname } : course)) ?? prev,
+    )
+  }, [])
+
+  const handleKanbanColumnLabelsChange = useCallback((labels: KanbanColumnLabels) => {
+    setKanbanColumnLabels(labels)
+    void putCourseCatalogSettings({ kanbanColumnLabels: labels }).catch(() => {
+      setError('Could not save kanban column names.')
+    })
+  }, [])
+
+  const handleHiddenColumnExpandedChange = useCallback((expanded: boolean) => {
+    setHiddenColumnExpanded(expanded)
+    void putCourseCatalogSettings({ hiddenColumnExpanded: expanded }).catch(() => {
+      setError('Could not save kanban column preference.')
+    })
+  }, [])
+
+  const handleKanbanBoardChange = useCallback(async (columns: Record<KanbanColumnId, string[]>) => {
+    await putCourseKanbanBoard(columns)
+    setCourses((prev) => {
+      if (!prev) return prev
+      const placementById = new Map<string, { columnId: KanbanColumnId; sortOrder: number }>()
+      for (const columnId of Object.keys(columns) as KanbanColumnId[]) {
+        columns[columnId].forEach((courseId, sortOrder) => {
+          placementById.set(courseId, { columnId, sortOrder })
+        })
+      }
+      return prev.map((course) => {
+        const placement = placementById.get(course.id)
+        if (!placement) {
+          return { ...course, kanbanColumnId: null, kanbanSortOrder: null }
+        }
+        return {
+          ...course,
+          kanbanColumnId: placement.columnId,
+          kanbanSortOrder: placement.sortOrder,
+        }
+      })
+    })
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
     ;(async () => {
       setError(null)
       try {
@@ -275,17 +713,17 @@ export default function Courses() {
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    useSensor(SharedKeyboardSensor, defaultKeyboardSensorOptions),
   )
 
   const courseIds = useMemo(() => (courses ?? []).map((c) => c.id), [courses])
 
-  const catalogSections = useMemo(() => {
-    if (!courses?.length || termFilter !== '') return null
+  const catalogSections = useMemo((): CatalogSection[] | null => {
+    if (!courses?.length || termFilter !== '' || catalogView === 'status') return null
     if (!courses.some((c) => c.termId)) return null
     const ongoing = courses.filter((c) => !c.termId)
     const termOrder = [...termList].sort((a, b) => (a.startDate < b.startDate ? 1 : -1))
-    const sections: { key: string; title: string; items: CoursePublic[] }[] = []
+    const sections: CatalogSection[] = []
     if (ongoing.length > 0) {
       sections.push({ key: 'ongoing', title: 'Ongoing / Self-paced', items: ongoing })
     }
@@ -309,7 +747,7 @@ export default function Courses() {
       }
     }
     return sections
-  }, [courses, termFilter, termList])
+  }, [courses, termFilter, termList, catalogView])
 
   const clearSuppressNavigateAfterDragSoon = useCallback(() => {
     window.setTimeout(() => {
@@ -345,14 +783,110 @@ export default function Courses() {
     clearSuppressNavigateAfterDragSoon()
   }, [clearSuppressNavigateAfterDragSoon])
 
+  const sortStrategy = catalogViewUsesGrid(catalogView) ? rectSortingStrategy : verticalListSortingStrategy
+
+  const renderSortableCourse = useCallback(
+    (course: CoursePublic) => {
+      switch (catalogView) {
+        case 'cards':
+          return (
+            <SortableCourseCard
+              key={course.id}
+              course={course}
+              suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
+              onNicknameChange={handleNicknameChange}
+            />
+          )
+        case 'gallery':
+          return (
+            <SortableCourseGalleryTile
+              key={course.id}
+              course={course}
+              suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
+              onNicknameChange={handleNicknameChange}
+            />
+          )
+        case 'table':
+          return (
+            <SortableCourseTableRow
+              key={course.id}
+              course={course}
+              suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
+              onNicknameChange={handleNicknameChange}
+            />
+          )
+        case 'list':
+          return (
+            <SortableCourseListRow
+              key={course.id}
+              course={course}
+              suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
+              onNicknameChange={handleNicknameChange}
+            />
+          )
+        case 'status':
+          return null
+        default: {
+          const _exhaustive: never = catalogView
+          return _exhaustive
+        }
+      }
+    },
+    [catalogView, handleNicknameChange],
+  )
+
+  const renderCourseItems = useCallback(
+    (items: CoursePublic[], marginClass = 'mt-4') => {
+      switch (catalogView) {
+        case 'cards':
+          return (
+            <div className={`${marginClass} grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4`}>
+              {items.map((c) => renderSortableCourse(c))}
+            </div>
+          )
+        case 'gallery':
+          return (
+            <div
+              className={`${marginClass} grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6`}
+            >
+              {items.map((c) => renderSortableCourse(c))}
+            </div>
+          )
+        case 'table':
+          return (
+            <div
+              className={`${marginClass} overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-900`}
+            >
+              <div className="min-w-[42rem]">
+                <CourseCatalogTableHeader />
+                {items.map((c) => renderSortableCourse(c))}
+              </div>
+            </div>
+          )
+        case 'list':
+          return <div className={`${marginClass} flex flex-col gap-2`}>{items.map((c) => renderSortableCourse(c))}</div>
+        case 'status':
+          return null
+        default: {
+          const _exhaustive: never = catalogView
+          return _exhaustive
+        }
+      }
+    },
+    [catalogView, renderSortableCourse],
+  )
+
   return (
     <LmsPage
       title="Courses"
-      description="Browse and open your enrolled courses. Drag a card to reorder your catalog."
+      description="Browse and open your enrolled courses. Drag to reorder your catalog."
       actions={
-        <RequirePermission permission={PERM_COURSE_CREATE} fallback={null}>
-          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+          <RequirePermission permission={PERM_COURSE_CREATE} fallback={null}>
             <CourseCatalogImportMenu onImportCanvas={() => setCanvasImportOpen(true)} />
+          </RequirePermission>
+          <CourseCatalogViewMenu value={catalogView} onChange={handleCatalogViewChange} />
+          <RequirePermission permission={PERM_COURSE_CREATE} fallback={null}>
             <Link
               to="/courses/create"
               className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
@@ -360,8 +894,8 @@ export default function Courses() {
               <Plus className="h-4 w-4" aria-hidden />
               New course
             </Link>
-          </div>
-        </RequirePermission>
+          </RequirePermission>
+        </div>
       }
     >
       {error && (
@@ -449,7 +983,19 @@ export default function Courses() {
         </div>
       )}
 
-      {courses && courses.length > 0 && catalogSections && (
+      {courses && courses.length > 0 && catalogView === 'status' && (
+        <CourseCatalogKanbanBoard
+          courses={courses}
+          columnLabels={kanbanColumnLabels}
+          hiddenColumnExpanded={hiddenColumnExpanded}
+          onHiddenColumnExpandedChange={handleHiddenColumnExpandedChange}
+          onColumnLabelsChange={handleKanbanColumnLabelsChange}
+          onNicknameChange={handleNicknameChange}
+          onBoardChange={handleKanbanBoardChange}
+        />
+      )}
+
+      {courses && courses.length > 0 && catalogView !== 'status' && catalogSections && (
         <DndContext
           id={COURSE_GRID_SORT_ID}
           sensors={sensors}
@@ -458,7 +1004,7 @@ export default function Courses() {
           onDragEnd={handleDragEnd}
           onDragCancel={handleDragCancel}
         >
-          <SortableContext items={courseIds} strategy={rectSortingStrategy}>
+          <SortableContext items={courseIds} strategy={sortStrategy}>
             <div className="mt-8 space-y-10">
               {catalogSections.map((sec) => (
                 <section key={sec.key} aria-labelledby={`cat-${sec.key}`}>
@@ -468,15 +1014,7 @@ export default function Courses() {
                   >
                     {sec.title}
                   </h2>
-                  <div className="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                    {sec.items.map((c) => (
-                      <SortableCourseCard
-                        key={c.id}
-                        course={c}
-                        suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
-                      />
-                    ))}
-                  </div>
+                  {renderCourseItems(sec.items)}
                 </section>
               ))}
             </div>
@@ -484,7 +1022,7 @@ export default function Courses() {
         </DndContext>
       )}
 
-      {courses && courses.length > 0 && !catalogSections && (
+      {courses && courses.length > 0 && catalogView !== 'status' && !catalogSections && (
         <DndContext
           id={COURSE_GRID_SORT_ID}
           sensors={sensors}
@@ -493,16 +1031,8 @@ export default function Courses() {
           onDragEnd={handleDragEnd}
           onDragCancel={handleDragCancel}
         >
-          <SortableContext items={courseIds} strategy={rectSortingStrategy}>
-            <div className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-              {courses.map((c) => (
-                <SortableCourseCard
-                  key={c.id}
-                  course={c}
-                  suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
-                />
-              ))}
-            </div>
+          <SortableContext items={courseIds} strategy={sortStrategy}>
+            {renderCourseItems(courses, 'mt-8')}
           </SortableContext>
         </DndContext>
       )}

--- a/clients/web/src/pages/lms/gradebook/__tests__/gradebook-grid.test.tsx
+++ b/clients/web/src/pages/lms/gradebook/__tests__/gradebook-grid.test.tsx
@@ -135,5 +135,11 @@ describe('GradebookGrid — accessibility', () => {
     expect(screen.queryByRole('grid', { name: /grades by student and assignment/i })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^transpose$/i })).toHaveAttribute('aria-pressed', 'true')
     expect(screen.getByRole('button', { name: /resize assignment column/i })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /^transpose$/i }))
+
+    expect(screen.getByRole('grid', { name: /grades by student and assignment/i })).toBeInTheDocument()
+    expect(screen.queryByRole('grid', { name: /grades by assignment and student/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^transpose$/i })).toHaveAttribute('aria-pressed', 'false')
   })
 })

--- a/clients/web/src/pages/lms/gradebook/gradebook-cell-menu-utils.ts
+++ b/clients/web/src/pages/lms/gradebook/gradebook-cell-menu-utils.ts
@@ -1,0 +1,71 @@
+import type { MouseEvent as ReactMouseEvent } from 'react'
+import type { GradebookColumn } from './gradebook-grid-types'
+
+export type GradebookCellMenuState = {
+  studentId: string
+  columnId: string
+  top: number
+  left: number
+} | null
+
+export type GradebookCellMenuItem =
+  | { kind: 'gradeSubmission'; label: 'Grade submission' }
+  | { kind: 'rubric'; label: 'Rubric' }
+  | { kind: 'history'; label: 'History' }
+  | { kind: 'excuse'; label: 'Excuse' | 'Unexcuse' }
+
+type GradebookCellMenuContext = {
+  col: GradebookColumn
+  readOnly: boolean
+  isExcused: boolean
+  onGradeSubmission?: (studentId: string, columnId: string) => void
+  onRubricClick?: (studentId: string, columnId: string) => void
+  onOpenGradeHistory?: (studentId: string, columnId: string) => void
+  onToggleExcused?: (studentId: string, columnId: string, excused: boolean) => void | Promise<void>
+}
+
+function isGradableColumnKind(kind: string | undefined): boolean {
+  return kind === 'assignment' || kind === 'quiz' || kind === 'quiz_comprehensive'
+}
+
+export function getGradebookCellMenuItems(ctx: GradebookCellMenuContext): GradebookCellMenuItem[] {
+  const { col, readOnly, isExcused } = ctx
+  const items: GradebookCellMenuItem[] = []
+
+  if (!readOnly && col.kind === 'assignment' && ctx.onGradeSubmission) {
+    items.push({ kind: 'gradeSubmission', label: 'Grade submission' })
+  }
+  if (!readOnly && col.rubric && ctx.onRubricClick) {
+    items.push({ kind: 'rubric', label: 'Rubric' })
+  }
+  if (ctx.onOpenGradeHistory && isGradableColumnKind(col.kind)) {
+    items.push({ kind: 'history', label: 'History' })
+  }
+  if (!readOnly && ctx.onToggleExcused && isGradableColumnKind(col.kind)) {
+    items.push({ kind: 'excuse', label: isExcused ? 'Unexcuse' : 'Excuse' })
+  }
+
+  return items
+}
+
+export function openGradebookCellMenuFromEvent(
+  e: ReactMouseEvent,
+  studentId: string,
+  columnId: string,
+  openMenu: (menu: Exclude<GradebookCellMenuState, null>) => void,
+) {
+  e.preventDefault()
+  e.stopPropagation()
+  openMenu({ studentId, columnId, top: e.clientY, left: e.clientX })
+}
+
+export function openGradebookCellMenuFromButton(
+  e: ReactMouseEvent<HTMLButtonElement>,
+  studentId: string,
+  columnId: string,
+  openMenu: (menu: Exclude<GradebookCellMenuState, null>) => void,
+) {
+  e.stopPropagation()
+  const rect = e.currentTarget.getBoundingClientRect()
+  openMenu({ studentId, columnId, top: rect.bottom + 4, left: rect.left })
+}

--- a/clients/web/src/pages/lms/gradebook/gradebook-cell-menu.tsx
+++ b/clients/web/src/pages/lms/gradebook/gradebook-cell-menu.tsx
@@ -1,0 +1,107 @@
+import {
+  type ReactNode,
+  useEffect,
+  useRef,
+} from 'react'
+import { createPortal } from 'react-dom'
+import { MoreVertical } from 'lucide-react'
+import type { GradebookCellMenuItem, GradebookCellMenuState } from './gradebook-cell-menu-utils'
+
+function menuItemClass() {
+  return 'block w-full px-2.5 py-1.5 text-start text-sm text-slate-800 hover:bg-slate-100 dark:text-neutral-100 dark:hover:bg-neutral-800'
+}
+
+export function GradebookCellMenuPortal({
+  menu,
+  onClose,
+  children,
+}: {
+  menu: Exclude<GradebookCellMenuState, null>
+  onClose: () => void
+  children: ReactNode
+}) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function onDocMouseDown(e: MouseEvent) {
+      if (!(e.target instanceof Node)) return
+      if (panelRef.current?.contains(e.target)) return
+      onClose()
+    }
+    function onKey(e: globalThis.KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('mousedown', onDocMouseDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocMouseDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [onClose])
+
+  useEffect(() => {
+    function onScroll() {
+      onClose()
+    }
+    window.addEventListener('scroll', onScroll, true)
+    window.addEventListener('resize', onScroll)
+    return () => {
+      window.removeEventListener('scroll', onScroll, true)
+      window.removeEventListener('resize', onScroll)
+    }
+  }, [onClose])
+
+  return createPortal(
+    <div
+      ref={panelRef}
+      role="menu"
+      className="fixed z-[200] min-w-[11rem] rounded-lg border border-slate-200 bg-white py-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-900"
+      style={{ top: menu.top, left: menu.left }}
+    >
+      {children}
+    </div>,
+    document.body,
+  )
+}
+
+export function GradebookCellMenuItems({
+  items,
+  onSelect,
+}: {
+  items: GradebookCellMenuItem[]
+  onSelect: (item: GradebookCellMenuItem) => void
+}) {
+  return items.map((item) => (
+    <button
+      key={item.kind}
+      type="button"
+      role="menuitem"
+      className={menuItemClass()}
+      onClick={() => onSelect(item)}
+    >
+      {item.label}
+    </button>
+  ))
+}
+
+export function GradebookCellMenuTrigger({
+  studentName,
+  columnTitle,
+  onOpen,
+}: {
+  studentName: string
+  columnTitle: string
+  onOpen: (e: React.MouseEvent<HTMLButtonElement>) => void
+}) {
+  return (
+    <button
+      type="button"
+      className="absolute start-0 top-0 z-[2] inline-flex size-5 items-center justify-center rounded text-slate-400 hover:bg-slate-100 hover:text-slate-700 dark:text-neutral-500 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+      aria-label={`Actions for ${studentName}, ${columnTitle}`}
+      aria-haspopup="menu"
+      onClick={onOpen}
+    >
+      <MoreVertical className="size-3.5" aria-hidden />
+    </button>
+  )
+}

--- a/clients/web/src/pages/lms/gradebook/gradebook-grid-transposed.tsx
+++ b/clients/web/src/pages/lms/gradebook/gradebook-grid-transposed.tsx
@@ -4,6 +4,17 @@ import { Lock } from 'lucide-react'
 import { studentProgressFeatureEnabled } from '../../../lib/student-progress'
 import { formatFinalPercent } from './compute-course-final-percent'
 import type { GradebookColumn, GradebookStudent } from './gradebook-grid-types'
+import {
+  getGradebookCellMenuItems,
+  openGradebookCellMenuFromButton,
+  openGradebookCellMenuFromEvent,
+  type GradebookCellMenuState,
+} from './gradebook-cell-menu-utils'
+import {
+  GradebookCellMenuItems,
+  GradebookCellMenuPortal,
+  GradebookCellMenuTrigger,
+} from './gradebook-cell-menu'
 
 function parseGradeNumber(raw: string): number | null {
   const s = raw.trim().replace(/,/g, '')
@@ -100,6 +111,7 @@ export type GradebookTransposedTableProps = {
   courseCode?: string
   highlightStudentId?: string | null
   onRubricClick?: (studentId: string, columnId: string) => void
+  onGradeSubmission?: (studentId: string, columnId: string) => void
   onOpenGradeHistory?: (studentId: string, columnId: string) => void
   onToggleExcused?: (studentId: string, columnId: string, excused: boolean) => void | Promise<void>
   onPostAssignmentGrades?: (itemId: string) => void
@@ -137,6 +149,7 @@ export function GradebookTransposedTable({
   courseCode,
   highlightStudentId,
   onRubricClick,
+  onGradeSubmission,
   onOpenGradeHistory,
   onToggleExcused,
   onPostAssignmentGrades,
@@ -147,6 +160,7 @@ export function GradebookTransposedTable({
 }: GradebookTransposedTableProps) {
   const [editing, setEditing] = useState<EditingCell | null>(null)
   const [draft, setDraft] = useState('')
+  const [cellMenu, setCellMenu] = useState<GradebookCellMenuState>(null)
   const [assignmentColWidthPx, setAssignmentColWidthPx] = useState(() =>
     readStoredAssignmentColWidth(defaultAssignmentColWidthPx),
   )
@@ -243,7 +257,37 @@ export function GradebookTransposedTable({
     setDraft('')
   }, [])
 
+  const closeCellMenu = useCallback(() => setCellMenu(null), [])
+
+  const handleCellMenuSelect = useCallback(
+    (item: ReturnType<typeof getGradebookCellMenuItems>[number]) => {
+      if (!cellMenu) return
+      const { studentId, columnId } = cellMenu
+      setCellMenu(null)
+      switch (item.kind) {
+        case 'gradeSubmission':
+          onGradeSubmission?.(studentId, columnId)
+          break
+        case 'rubric':
+          onRubricClick?.(studentId, columnId)
+          break
+        case 'history':
+          onOpenGradeHistory?.(studentId, columnId)
+          break
+        case 'excuse':
+          void onToggleExcused?.(studentId, columnId, item.label === 'Excuse')
+          break
+        default: {
+          const _exhaustive: never = item
+          return _exhaustive
+        }
+      }
+    },
+    [cellMenu, onGradeSubmission, onOpenGradeHistory, onRubricClick, onToggleExcused],
+  )
+
   return (
+    <>
     <div
       className={`overflow-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-900 ${resizing ? 'cursor-col-resize select-none' : ''}`}
     >
@@ -383,6 +427,16 @@ export function GradebookTransposedTable({
                   const cellHeld = Boolean(gradeHeld?.[student.id]?.[col.id])
                   const cellDropped = Boolean(droppedGrades?.[student.id]?.[col.id])
                   const selectOpts = isEditing ? gradingSelectOptions(col, gradingScheme) : []
+                  const cellMenuItems = getGradebookCellMenuItems({
+                    col,
+                    readOnly,
+                    isExcused,
+                    onGradeSubmission,
+                    onRubricClick,
+                    onOpenGradeHistory,
+                    onToggleExcused,
+                  })
+                  const hasCellMenu = cellMenuItems.length > 0
                   const heatT =
                     colorScaleEnabled && !isExcused
                       ? heatPercentForCell(col, val === 'EX' ? '' : val)
@@ -398,6 +452,11 @@ export function GradebookTransposedTable({
                         cellDropped ? 'opacity-65 dark:opacity-70' : ''
                       }`}
                       onDoubleClick={() => beginEdit(student.id, col.id)}
+                      onContextMenu={
+                        hasCellMenu
+                          ? (e) => openGradebookCellMenuFromEvent(e, student.id, col.id, setCellMenu)
+                          : undefined
+                      }
                     >
                       {isEditing ? (
                         selectOpts.length > 0 ? (
@@ -438,7 +497,16 @@ export function GradebookTransposedTable({
                           />
                         )
                       ) : (
-                        <div className="flex flex-col items-end gap-0.5">
+                        <div className="relative flex min-h-[1.25rem] flex-col items-end gap-0.5">
+                          {hasCellMenu ? (
+                            <GradebookCellMenuTrigger
+                              studentName={student.name}
+                              columnTitle={col.title}
+                              onOpen={(e) =>
+                                openGradebookCellMenuFromButton(e, student.id, col.id, setCellMenu)
+                              }
+                            />
+                          ) : null}
                           <span className="inline-flex max-w-full items-center justify-end gap-1">
                             {cellHeld ? (
                               <Lock
@@ -458,42 +526,6 @@ export function GradebookTransposedTable({
                               {val || '—'}
                             </span>
                           </span>
-                          <span className="inline-flex flex-wrap items-center justify-end gap-x-2 gap-y-0.5">
-                            {!readOnly && col.rubric && onRubricClick ? (
-                              <button
-                                type="button"
-                                className="text-[11px] font-medium text-indigo-600 hover:underline dark:text-indigo-400"
-                                onClick={() => onRubricClick(student.id, col.id)}
-                              >
-                                Rubric
-                              </button>
-                            ) : null}
-                            {onOpenGradeHistory &&
-                            (col.kind === 'assignment' ||
-                              col.kind === 'quiz' ||
-                              col.kind === 'quiz_comprehensive') ? (
-                              <button
-                                type="button"
-                                className="text-[11px] font-medium text-slate-600 hover:underline dark:text-neutral-400"
-                                onClick={() => onOpenGradeHistory(student.id, col.id)}
-                              >
-                                History
-                              </button>
-                            ) : null}
-                            {!readOnly &&
-                            onToggleExcused &&
-                            (col.kind === 'assignment' ||
-                              col.kind === 'quiz' ||
-                              col.kind === 'quiz_comprehensive') ? (
-                              <button
-                                type="button"
-                                className="text-[11px] font-medium text-slate-600 hover:underline dark:text-neutral-400"
-                                onClick={() => void onToggleExcused(student.id, col.id, !isExcused)}
-                              >
-                                {isExcused ? 'Unexcuse' : 'Excuse'}
-                              </button>
-                            ) : null}
-                          </span>
                         </div>
                       )}
                     </td>
@@ -505,5 +537,26 @@ export function GradebookTransposedTable({
         </tbody>
       </table>
     </div>
+    {cellMenu ? (() => {
+      const menuCol = columns.find((c) => c.id === cellMenu.columnId)
+      if (!menuCol) return null
+      return (
+        <GradebookCellMenuPortal menu={cellMenu} onClose={closeCellMenu}>
+          <GradebookCellMenuItems
+            items={getGradebookCellMenuItems({
+              col: menuCol,
+              readOnly,
+              isExcused: Boolean(gradeExcused?.[cellMenu.studentId]?.[cellMenu.columnId]),
+              onGradeSubmission,
+              onRubricClick,
+              onOpenGradeHistory,
+              onToggleExcused,
+            })}
+            onSelect={handleCellMenuSelect}
+          />
+        </GradebookCellMenuPortal>
+      )
+    })() : null}
+    </>
   )
 }

--- a/clients/web/src/pages/lms/gradebook/gradebook-grid.tsx
+++ b/clients/web/src/pages/lms/gradebook/gradebook-grid.tsx
@@ -35,6 +35,17 @@ import {
   type AssignmentGroupWeight,
 } from './compute-course-final-percent'
 import { GradebookTransposedTable } from './gradebook-grid-transposed'
+import {
+  getGradebookCellMenuItems,
+  openGradebookCellMenuFromButton,
+  openGradebookCellMenuFromEvent,
+  type GradebookCellMenuState,
+} from './gradebook-cell-menu-utils'
+import {
+  GradebookCellMenuItems,
+  GradebookCellMenuPortal,
+  GradebookCellMenuTrigger,
+} from './gradebook-cell-menu'
 import type { AssignmentGroup } from '../../../lib/courses-api'
 import { EnrollmentStateBadge } from '../../../components/enrollment/enrollment-state-badge'
 import { isFormerEnrollmentState, type EnrollmentState } from '../../../lib/enrollment-state-api'
@@ -55,6 +66,8 @@ type GradebookGridProps = {
   onGradesChange?: (grades: Record<string, Record<string, string>>) => void
   /** Open rubric scoring for a student/column (assignment columns with a rubric). */
   onRubricClick?: (studentId: string, columnId: string) => void
+  /** Open submission grading modal for an assignment cell. */
+  onGradeSubmission?: (studentId: string, columnId: string) => void
   /** Open grade change history (3.10) for this cell. */
   onOpenGradeHistory?: (studentId: string, columnId: string) => void
   /** Used for empty-state links back to modules or enrollments. */
@@ -241,6 +254,7 @@ export function GradebookGrid({
   readOnly = false,
   onGradesChange,
   onRubricClick,
+  onGradeSubmission,
   onOpenGradeHistory,
   courseCode,
   highlightStudentId = null,
@@ -263,6 +277,7 @@ export function GradebookGrid({
   )
   const [activeSort, setActiveSort] = useState<GradebookActiveSort | null>(null)
   const [headerMenu, setHeaderMenu] = useState<HeaderMenuState>(null)
+  const [cellMenu, setCellMenu] = useState<GradebookCellMenuState>(null)
   const [studentFilter, setStudentFilter] = useState(() => {
     if (highlightStudentId && (students?.length ?? 0) > 0) {
       const hi = students.find((s) => s.id === highlightStudentId)
@@ -301,6 +316,7 @@ export function GradebookGrid({
   const skipNextCellClickRef = useRef(false)
 
   const headerRowRef = useRef<HTMLTableRowElement>(null)
+  const gridScrollRef = useRef<HTMLDivElement>(null)
   const [headerStickyPx, setHeaderStickyPx] = useState(0)
   const [colorScaleEnabled, setColorScaleEnabled] = useState(false)
   const [transposed, setTransposed] = useState(false)
@@ -562,8 +578,10 @@ export function GradebookGrid({
   }, [filteredStudents, visibleColumns])
 
   useLayoutEffect(() => {
+    if (transposed) return
     const el = headerRowRef.current
     if (!el) return
+    if (gridScrollRef.current) gridScrollRef.current.scrollTop = 0
     const measure = () => {
       setHeaderStickyPx(el.getBoundingClientRect().height)
     }
@@ -571,7 +589,7 @@ export function GradebookGrid({
     const ro = new ResizeObserver(measure)
     ro.observe(el)
     return () => ro.disconnect()
-  }, [visibleColumns, studentFilter, assignmentFilter, activeSort])
+  }, [transposed, visibleColumns, studentFilter, assignmentFilter, activeSort])
 
   const setCellRef = useCallback(
     (row: number, col: number, el: HTMLTableCellElement | null) => {
@@ -1048,6 +1066,34 @@ export function GradebookGrid({
   }, [editing, selectionRect, focusRow, focusCol, colCount, rowCount])
 
   const closeHeaderMenu = useCallback(() => setHeaderMenu(null), [])
+  const closeCellMenu = useCallback(() => setCellMenu(null), [])
+
+  const handleCellMenuSelect = useCallback(
+    (item: ReturnType<typeof getGradebookCellMenuItems>[number]) => {
+      if (!cellMenu) return
+      const { studentId, columnId } = cellMenu
+      setCellMenu(null)
+      switch (item.kind) {
+        case 'gradeSubmission':
+          onGradeSubmission?.(studentId, columnId)
+          break
+        case 'rubric':
+          onRubricClick?.(studentId, columnId)
+          break
+        case 'history':
+          onOpenGradeHistory?.(studentId, columnId)
+          break
+        case 'excuse':
+          void onToggleExcused?.(studentId, columnId, item.label === 'Excuse')
+          break
+        default: {
+          const _exhaustive: never = item
+          return _exhaustive
+        }
+      }
+    },
+    [cellMenu, onGradeSubmission, onOpenGradeHistory, onRubricClick, onToggleExcused],
+  )
 
   const pickStudentSort = useCallback((mode: StudentSortMode) => {
     setActiveSort({ kind: 'student', mode })
@@ -1281,6 +1327,7 @@ export function GradebookGrid({
             onClick={() => {
               setTransposed((v) => !v)
               setHeaderMenu(null)
+              setCellMenu(null)
               setEditing(null)
               setSelectionAnchor(null)
               setFillDrag(null)
@@ -1344,6 +1391,7 @@ export function GradebookGrid({
           courseCode={courseCode}
           highlightStudentId={highlightStudentId}
           onRubricClick={onRubricClick}
+          onGradeSubmission={onGradeSubmission}
           onOpenGradeHistory={onOpenGradeHistory}
           onToggleExcused={onToggleExcused}
           onPostAssignmentGrades={onPostAssignmentGrades}
@@ -1355,7 +1403,10 @@ export function GradebookGrid({
       )}
 
       {rowCount > 0 && baseColCount > 0 && !transposed && (
-        <div className="overflow-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
+        <div
+          ref={gridScrollRef}
+          className="overflow-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-900"
+        >
           <table
             role="grid"
             aria-label="Grades by student and assignment"
@@ -1596,6 +1647,16 @@ export function GradebookGrid({
                     const selectOpts =
                       showEditor && singleCellEdit ? gradingSelectOptions(col, gradingScheme) : []
                     const showSelectEditor = showEditor && selectOpts.length > 0
+                    const cellMenuItems = getGradebookCellMenuItems({
+                      col,
+                      readOnly,
+                      isExcused,
+                      onGradeSubmission,
+                      onRubricClick,
+                      onOpenGradeHistory,
+                      onToggleExcused,
+                    })
+                    const hasCellMenu = cellMenuItems.length > 0
 
                     const ringActive =
                       'relative z-[1] bg-indigo-50 ring-2 ring-inset ring-indigo-500 dark:bg-indigo-950/50 dark:ring-indigo-400'
@@ -1717,6 +1778,12 @@ export function GradebookGrid({
                           dragSelectStartRef.current = null
                         }}
                         onDoubleClick={() => beginEdit(row, colIndex, { range: 'single' })}
+                        onContextMenu={
+                          hasCellMenu
+                            ? (e) =>
+                                openGradebookCellMenuFromEvent(e, student.id, col.id, setCellMenu)
+                            : undefined
+                        }
                       >
                         {showEditor ? (
                           showSelectEditor ? (
@@ -1759,7 +1826,16 @@ export function GradebookGrid({
                             />
                           )
                         ) : (
-                          <div className="flex flex-col items-end gap-0.5">
+                          <div className="relative flex min-h-[1.25rem] flex-col items-end gap-0.5">
+                            {hasCellMenu ? (
+                              <GradebookCellMenuTrigger
+                                studentName={student.name}
+                                columnTitle={col.title}
+                                onOpen={(e) =>
+                                  openGradebookCellMenuFromButton(e, student.id, col.id, setCellMenu)
+                                }
+                              />
+                            ) : null}
                             <span className="inline-flex max-w-full items-center justify-end gap-1">
                               {cellHeld ? (
                                 <Lock
@@ -1785,55 +1861,6 @@ export function GradebookGrid({
                               >
                                 {val || '—'}
                               </span>
-                            </span>
-                            <span className="inline-flex flex-wrap items-center justify-end gap-x-2 gap-y-0.5">
-                              {!readOnly && col.rubric && onRubricClick ? (
-                                <button
-                                  type="button"
-                                  className="text-[11px] font-medium text-indigo-600 hover:underline dark:text-indigo-400"
-                                  onClick={(e) => {
-                                    e.stopPropagation()
-                                    onRubricClick(student.id, col.id)
-                                  }}
-                                >
-                                  Rubric
-                                </button>
-                              ) : null}
-                              {onOpenGradeHistory &&
-                                (col.kind === 'assignment' || col.kind === 'quiz' || col.kind === 'quiz_comprehensive') ? (
-                                <button
-                                  type="button"
-                                  tabIndex={isActive ? 0 : -1}
-                                  aria-hidden={!isActive}
-                                  className={`text-[11px] font-medium text-slate-600 hover:underline dark:text-neutral-400 ${!isActive ? 'invisible pointer-events-none' : ''
-                                    }`}
-                                  onClick={(e) => {
-                                    e.stopPropagation()
-                                    onOpenGradeHistory(student.id, col.id)
-                                  }}
-                                >
-                                  History
-                                </button>
-                              ) : null}
-                              {!readOnly &&
-                                onToggleExcused &&
-                                (col.kind === 'assignment' ||
-                                  col.kind === 'quiz' ||
-                                  col.kind === 'quiz_comprehensive') ? (
-                                <button
-                                  type="button"
-                                  tabIndex={isActive ? 0 : -1}
-                                  aria-hidden={!isActive}
-                                  className={`text-[11px] font-medium text-slate-600 hover:underline dark:text-neutral-400 ${!isActive ? 'invisible pointer-events-none' : ''
-                                    }`}
-                                  onClick={(e) => {
-                                    e.stopPropagation()
-                                    void onToggleExcused(student.id, col.id, !isExcused)
-                                  }}
-                                >
-                                  {isExcused ? 'Unexcuse' : 'Excuse'}
-                                </button>
-                              ) : null}
                             </span>
                           </div>
                         )}
@@ -1933,6 +1960,27 @@ export function GradebookGrid({
           </button>
         </HeaderSortMenuPortal>
       )}
+
+      {cellMenu ? (() => {
+        const menuCol = visibleColumns.find((c) => c.id === cellMenu.columnId)
+        if (!menuCol) return null
+        return (
+          <GradebookCellMenuPortal menu={cellMenu} onClose={closeCellMenu}>
+            <GradebookCellMenuItems
+              items={getGradebookCellMenuItems({
+                col: menuCol,
+                readOnly,
+                isExcused: Boolean(gradeExcused?.[cellMenu.studentId]?.[cellMenu.columnId]),
+                onGradeSubmission,
+                onRubricClick,
+                onOpenGradeHistory,
+                onToggleExcused,
+              })}
+              onSelect={handleCellMenuSelect}
+            />
+          </GradebookCellMenuPortal>
+        )
+      })() : null}
     </div>
   )
 }

--- a/clients/web/src/pages/lms/gradebook/gradebook-submission-grading-modal.tsx
+++ b/clients/web/src/pages/lms/gradebook/gradebook-submission-grading-modal.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useState } from 'react'
+import { AssignmentAnnotationWorkbench } from '../../../components/annotation/assignment-annotation-workbench'
+import {
+  fetchCourse,
+  fetchModuleAssignment,
+  viewerIsCourseStaffEnrollment,
+  type ModuleContentPagePayload,
+} from '../../../lib/courses-api'
+
+function submissionTypesAreSet(text: boolean, file: boolean, url: boolean): boolean {
+  return text || file || url
+}
+
+export type GradebookSubmissionGradingModalState = {
+  itemId: string
+  studentUserId: string
+  columnTitle: string
+} | null
+
+type GradebookSubmissionGradingModalProps = {
+  open: GradebookSubmissionGradingModalState
+  courseCode: string
+  onClose: () => void
+}
+
+export function GradebookSubmissionGradingModal({
+  open,
+  courseCode,
+  onClose,
+}: GradebookSubmissionGradingModalProps) {
+  const [loading, setLoading] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [assignment, setAssignment] = useState<ModuleContentPagePayload | null>(null)
+  const [annotationsEnabled, setAnnotationsEnabled] = useState(false)
+  const [feedbackMediaEnabled, setFeedbackMediaEnabled] = useState(false)
+  const [resubmissionWorkflowEnabled, setResubmissionWorkflowEnabled] = useState(false)
+  const [viewerIsCourseStaff, setViewerIsCourseStaff] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setAssignment(null)
+      setLoadError(null)
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setLoadError(null)
+    void (async () => {
+      try {
+        const [assignmentRow, courseRow] = await Promise.all([
+          fetchModuleAssignment(courseCode, open.itemId),
+          fetchCourse(courseCode),
+        ])
+        if (cancelled) return
+        setAssignment(assignmentRow)
+        setAnnotationsEnabled(Boolean(courseRow.annotationsEnabled))
+        setFeedbackMediaEnabled(Boolean(courseRow.feedbackMediaEnabled))
+        setResubmissionWorkflowEnabled(Boolean(courseRow.resubmissionWorkflowEnabled))
+        setViewerIsCourseStaff(viewerIsCourseStaffEnrollment(courseRow.viewerEnrollmentRoles))
+      } catch (e: unknown) {
+        if (cancelled) return
+        setAssignment(null)
+        setLoadError(e instanceof Error ? e.message : 'Could not load this assignment.')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [courseCode, open])
+
+  if (!open) return null
+
+  const assignmentAcceptsSubmissions = assignment
+    ? submissionTypesAreSet(
+        assignment.submissionAllowText,
+        assignment.submissionAllowFileUpload,
+        assignment.submissionAllowUrl,
+      )
+    : false
+  const showWorkbench = Boolean(
+    assignment && (assignmentAcceptsSubmissions || feedbackMediaEnabled),
+  )
+  const annotationsActive = Boolean(annotationsEnabled && assignment?.submissionAllowFileUpload)
+  const blindGradingActive = Boolean(
+    assignment?.blindGrading &&
+      !assignment.identitiesRevealedAt &&
+      viewerIsCourseStaff,
+  )
+
+  return (
+    <>
+      {loading ? (
+        <div
+          className="fixed inset-0 z-[500] flex items-center justify-center bg-slate-950/55 p-4 backdrop-blur-[2px] dark:bg-black/80"
+          role="status"
+          aria-live="polite"
+        >
+          <p className="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-lg dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200">
+            Loading assignment…
+          </p>
+        </div>
+      ) : null}
+      {loadError ? (
+        <div
+          className="fixed inset-0 z-[500] flex items-center justify-center bg-slate-950/55 p-4 backdrop-blur-[2px] dark:bg-black/80"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="gradebook-submission-error-title"
+        >
+          <div className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-xl dark:border-neutral-600 dark:bg-neutral-900">
+            <h2
+              id="gradebook-submission-error-title"
+              className="text-lg font-semibold text-slate-950 dark:text-neutral-100"
+            >
+              Could not open grading
+            </h2>
+            <p className="mt-2 text-sm text-red-600 dark:text-red-400" role="alert">
+              {loadError}
+            </p>
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-800 hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
+                onClick={onClose}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+      {showWorkbench && assignment ? (
+        <AssignmentAnnotationWorkbench
+          key={`${open.itemId}:${open.studentUserId}`}
+          courseCode={courseCode}
+          itemId={open.itemId}
+          assignmentTitle={assignment.title || open.columnTitle}
+          mode="staff"
+          submissionAllowsFile={assignment.submissionAllowFileUpload}
+          submissionAllowsText={assignment.submissionAllowText}
+          submissionAllowsUrl={assignment.submissionAllowUrl}
+          annotationsActive={annotationsActive}
+          feedbackMediaEnabled={feedbackMediaEnabled}
+          resubmissionWorkflowEnabled={resubmissionWorkflowEnabled}
+          blindGradingActive={blindGradingActive}
+          canRevealIdentities={assignment.viewerCanRevealIdentities}
+          onAfterRevealIdentities={() => {
+            void fetchModuleAssignment(courseCode, open.itemId).then(setAssignment).catch(() => {})
+          }}
+          moderatedGradingActive={Boolean(assignment.moderatedGrading && viewerIsCourseStaff)}
+          assignmentPointsWorth={assignment.pointsWorth}
+          assignmentRubric={assignment.rubric}
+          provisionalGraderUserIds={assignment.provisionalGraderUserIds ?? []}
+          originalityDetection={assignment.originalityDetection}
+          presentation="modal"
+          modalOpen
+          onModalClose={onClose}
+          initialStudentUserId={open.studentUserId}
+        />
+      ) : null}
+      {!loading && !loadError && assignment && !showWorkbench ? (
+        <div
+          className="fixed inset-0 z-[500] flex items-center justify-center bg-slate-950/55 p-4 backdrop-blur-[2px] dark:bg-black/80"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="gradebook-submission-empty-title"
+        >
+          <div className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-xl dark:border-neutral-600 dark:bg-neutral-900">
+            <h2
+              id="gradebook-submission-empty-title"
+              className="text-lg font-semibold text-slate-950 dark:text-neutral-100"
+            >
+              {assignment.title || open.columnTitle}
+            </h2>
+            <p className="mt-2 text-sm text-slate-600 dark:text-neutral-400">
+              This assignment does not accept submissions, so there is nothing to grade here.
+            </p>
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-800 hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
+                onClick={onClose}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/e2e/tests/ai-tutor.spec.ts
+++ b/e2e/tests/ai-tutor.spec.ts
@@ -272,7 +272,7 @@ test.describe('AI Tutor UI', () => {
     await expect(page.getByText('AI Tutor', { exact: true })).toBeVisible()
   })
 
-  test('enabling AI Tutor shows the floating button on course pages', async ({ page }) => {
+  test('enabling AI Tutor shows the top bar button on course pages', async ({ page }) => {
     const instrEmail = uniqueEmail('btn-instr')
     const studEmail = uniqueEmail('btn-stud')
     const { access_token: instrToken } = await apiSignup({

--- a/e2e/tests/collab-docs.spec.ts
+++ b/e2e/tests/collab-docs.spec.ts
@@ -19,12 +19,7 @@ import {
 } from '../fixtures/api.js'
 
 function expectCollabConnectionStatus(page: Page) {
-  return expect(
-    page
-      .getByText('Connecting…')
-      .or(page.getByText('Live', { exact: true }))
-      .or(page.getByText(/^Offline/)),
-  )
+  return expect(page.getByTestId('collab-connection-status'))
 }
 
 test.describe('Collaborative documents', () => {

--- a/e2e/tests/collab-docs.spec.ts
+++ b/e2e/tests/collab-docs.spec.ts
@@ -10,12 +10,22 @@
  *   [x] Delete a doc via UI (instructor only)
  */
 import { test, expect } from '../fixtures/test.js'
+import type { Page } from '@playwright/test'
 import {
   apiCreateCollabDoc,
   apiDeleteCollabDoc,
   apiEnableCollabDocs,
   apiListCollabDocs,
 } from '../fixtures/api.js'
+
+function expectCollabConnectionStatus(page: Page) {
+  return expect(
+    page
+      .getByText('Connecting…')
+      .or(page.getByText('Live', { exact: true }))
+      .or(page.getByText(/^Offline/)),
+  )
+}
 
 test.describe('Collaborative documents', () => {
   // -----------------------------------------------------------------------
@@ -136,12 +146,12 @@ test.describe('Collaborative documents', () => {
     )
 
     await page.goto(`/courses/${seededCourse.courseCode}/collab-docs`)
-    await page.getByText(doc.title).click()
+    await expect(page.getByRole('link', { name: doc.title })).toBeVisible({ timeout: 8000 })
+    await page.getByRole('link', { name: doc.title }).click()
+    await page.waitForURL(new RegExp(`/collab-docs/${doc.id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`))
 
-    // Editor page should show the doc title and a connection status indicator.
-    await expect(
-      page.getByText('Connecting…').or(page.getByText('Live', { exact: true })),
-    ).toBeVisible({ timeout: 10000 })
+    // Editor page should show a connection status indicator.
+    await expectCollabConnectionStatus(page).toBeVisible({ timeout: 15000 })
   })
 
   test('direct URL to doc shows editor with status indicator', async ({
@@ -157,12 +167,7 @@ test.describe('Collaborative documents', () => {
 
     await page.goto(`/courses/${seededCourse.courseCode}/collab-docs/${doc.id}`)
     // Should show the connection status bar (Live / Connecting… / Offline).
-    await expect(
-      page
-        .getByText('Connecting…')
-        .or(page.getByText('Live', { exact: true }))
-        .or(page.getByText(/^Offline/)),
-    ).toBeVisible({ timeout: 10000 })
+    await expectCollabConnectionStatus(page).toBeVisible({ timeout: 15000 })
   })
 
   // -----------------------------------------------------------------------

--- a/e2e/tests/collab-docs.spec.ts
+++ b/e2e/tests/collab-docs.spec.ts
@@ -140,7 +140,7 @@ test.describe('Collaborative documents', () => {
 
     // Editor page should show the doc title and a connection status indicator.
     await expect(
-      page.getByText(/live|connecting/i).first(),
+      page.getByText('Connecting…').or(page.getByText('Live', { exact: true })),
     ).toBeVisible({ timeout: 10000 })
   })
 
@@ -158,7 +158,10 @@ test.describe('Collaborative documents', () => {
     await page.goto(`/courses/${seededCourse.courseCode}/collab-docs/${doc.id}`)
     // Should show the connection status bar (Live / Connecting… / Offline).
     await expect(
-      page.getByText(/live|connecting|offline/i).first(),
+      page
+        .getByText('Connecting…')
+        .or(page.getByText('Live', { exact: true }))
+        .or(page.getByText(/^Offline/)),
     ).toBeVisible({ timeout: 10000 })
   })
 

--- a/e2e/tests/collab-docs.spec.ts
+++ b/e2e/tests/collab-docs.spec.ts
@@ -140,14 +140,23 @@ test.describe('Collaborative documents', () => {
       'Editor Test Doc',
     )
 
+    const docPath = `/courses/${seededCourse.courseCode}/collab-docs/${doc.id}`
     await page.goto(`/courses/${seededCourse.courseCode}/collab-docs`)
-    const docLink = page.getByRole('link', { name: doc.title })
+    const docLink = page.locator(`a[href="${docPath}"]`)
     await expect(docLink).toBeVisible({ timeout: 8000 })
-    const docUrl = new RegExp(`/collab-docs/${doc.id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`)
-    await Promise.all([page.waitForURL(docUrl), docLink.click()])
-    await expect(page.getByRole('link', { name: 'Back to documents' })).toBeVisible({ timeout: 15000 })
 
-    // Editor page should show a connection status indicator.
+    const docApiPath = `/api/v1/courses/${encodeURIComponent(seededCourse.courseCode)}/collab-docs/${doc.id}`
+    await Promise.all([
+      page.waitForURL(new RegExp(`${doc.id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`)),
+      page.waitForResponse(
+        (response) =>
+          response.url().includes(docApiPath)
+          && response.request().method() === 'GET'
+          && response.ok(),
+      ),
+      docLink.click(),
+    ])
+    await expect(page.getByTestId('collab-doc-back-link')).toBeVisible({ timeout: 15000 })
     await expectCollabConnectionStatus(page).toBeVisible({ timeout: 15000 })
   })
 

--- a/e2e/tests/collab-docs.spec.ts
+++ b/e2e/tests/collab-docs.spec.ts
@@ -146,9 +146,10 @@ test.describe('Collaborative documents', () => {
     )
 
     await page.goto(`/courses/${seededCourse.courseCode}/collab-docs`)
-    await expect(page.getByRole('link', { name: doc.title })).toBeVisible({ timeout: 8000 })
-    await page.getByRole('link', { name: doc.title }).click()
-    await page.waitForURL(new RegExp(`/collab-docs/${doc.id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`))
+    const docLink = page.getByRole('link', { name: doc.title })
+    await expect(docLink).toBeVisible({ timeout: 8000 })
+    const docUrl = new RegExp(`/collab-docs/${doc.id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`)
+    await Promise.all([page.waitForURL(docUrl), docLink.click()])
 
     // Editor page should show a connection status indicator.
     await expectCollabConnectionStatus(page).toBeVisible({ timeout: 15000 })

--- a/e2e/tests/collab-docs.spec.ts
+++ b/e2e/tests/collab-docs.spec.ts
@@ -145,6 +145,7 @@ test.describe('Collaborative documents', () => {
     await expect(docLink).toBeVisible({ timeout: 8000 })
     const docUrl = new RegExp(`/collab-docs/${doc.id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`)
     await Promise.all([page.waitForURL(docUrl), docLink.click()])
+    await expect(page.getByRole('link', { name: 'Back to documents' })).toBeVisible({ timeout: 15000 })
 
     // Editor page should show a connection status indicator.
     await expectCollabConnectionStatus(page).toBeVisible({ timeout: 15000 })

--- a/e2e/tests/virtual-classroom.spec.ts
+++ b/e2e/tests/virtual-classroom.spec.ts
@@ -30,6 +30,18 @@ function authHeaders(token: string) {
   return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
 }
 
+async function enableLiveSessions(token: string, courseCode: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/v1/courses/${courseCode}/features`, {
+    method: 'PATCH',
+    headers: authHeaders(token),
+    body: JSON.stringify({ liveSessionsEnabled: true }),
+  })
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Failed to enable live sessions: ${res.status} ${body}`)
+  }
+}
+
 // ---------------------------------------------------------------------------
 // API tests — pure HTTP, no browser
 // ---------------------------------------------------------------------------
@@ -218,6 +230,7 @@ test.describe('Live Sessions UI', () => {
     const { access_token: token } = await apiSignup({ email, password: PASSWORD })
     const course = await apiCreateCourse(token, { title: 'UI VM Course' })
     const cc = course.courseCode
+    await enableLiveSessions(token, cc)
 
     await injectToken(page, token)
     await page.goto(`/courses/${cc}/live`)
@@ -229,6 +242,7 @@ test.describe('Live Sessions UI', () => {
     const { access_token: token } = await apiSignup({ email, password: PASSWORD })
     const course = await apiCreateCourse(token, { title: 'Instr UI VM' })
     const cc = course.courseCode
+    await enableLiveSessions(token, cc)
 
     await injectToken(page, token)
     await page.goto(`/courses/${cc}/live`)
@@ -243,6 +257,7 @@ test.describe('Live Sessions UI', () => {
     const course = await apiCreateCourse(instrToken, { title: 'Stu UI VM' })
     const cc = course.courseCode
     await apiEnroll(instrToken, cc, stuEmail, 'student')
+    await enableLiveSessions(instrToken, cc)
 
     await injectToken(page, stuToken)
     await page.goto(`/courses/${cc}/live`)
@@ -256,6 +271,7 @@ test.describe('Live Sessions UI', () => {
     const { access_token: token } = await apiSignup({ email, password: PASSWORD })
     const course = await apiCreateCourse(token, { title: 'Create UI VM' })
     const cc = course.courseCode
+    await enableLiveSessions(token, cc)
 
     await injectToken(page, token)
     await page.goto(`/courses/${cc}/live`)
@@ -281,6 +297,7 @@ test.describe('Live Sessions UI', () => {
     const { access_token: token } = await apiSignup({ email, password: PASSWORD })
     const course = await apiCreateCourse(token, { title: 'Nav VM' })
     const cc = course.courseCode
+    await enableLiveSessions(token, cc)
 
     await injectToken(page, token)
     await page.goto(`/courses/${cc}`)

--- a/server/internal/httpserver/assignment_submissions_http.go
+++ b/server/internal/httpserver/assignment_submissions_http.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lextures/lextures/server/internal/repos/coursefiles"
 	"github.com/lextures/lextures/server/internal/repos/coursemoduleassignments"
 	"github.com/lextures/lextures/server/internal/repos/moduleassignmentsubmissions"
+	"github.com/lextures/lextures/server/internal/repos/user"
 )
 
 func submissionAttachmentContentPath(courseCode string, fileID uuid.UUID) string {
@@ -59,6 +60,7 @@ func (d Deps) submissionToJSON(
 	s moduleassignmentsubmissions.SubmissionRow,
 	redactPII bool,
 	blindRank int,
+	submitterDisplayName string,
 ) map[string]any {
 	out := map[string]any{
 		"id":               s.ID.String(),
@@ -90,6 +92,9 @@ func (d Deps) submissionToJSON(
 		out["blindLabel"] = gradingredaction.BlindStudentLabel(blindRank)
 	} else {
 		out["submittedBy"] = s.SubmittedBy.String()
+		if strings.TrimSpace(submitterDisplayName) != "" {
+			out["submittedByDisplayName"] = strings.TrimSpace(submitterDisplayName)
+		}
 	}
 	return out
 }
@@ -157,10 +162,23 @@ func (d Deps) handleListAssignmentSubmissions() http.HandlerFunc {
 			newestFirst[len(rows)-1-i] = rows[i].ID
 		}
 		rankByID := gradingredaction.SubmissionRankByID(newestFirst)
+		displayNames := map[uuid.UUID]string{}
+		if !redact {
+			userIDs := make([]uuid.UUID, 0, len(rows))
+			for _, s := range rows {
+				userIDs = append(userIDs, s.SubmittedBy)
+			}
+			var err error
+			displayNames, err = user.DisplayLabelsByIDs(r.Context(), d.Pool, userIDs)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load submitter names.")
+				return
+			}
+		}
 		items := make([]map[string]any, 0, len(rows))
 		for _, s := range rows {
 			rank := rankByID[s.ID]
-			items = append(items, d.submissionToJSON(r.Context(), courseCode, s, redact, rank))
+			items = append(items, d.submissionToJSON(r.Context(), courseCode, s, redact, rank, displayNames[s.SubmittedBy]))
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(map[string]any{"submissions": items})
@@ -202,7 +220,11 @@ func (d Deps) handleGetMyAssignmentSubmission() http.HandlerFunc {
 			_ = json.NewEncoder(w).Encode(map[string]any{"submission": nil})
 			return
 		}
-		payload := d.submissionToJSON(r.Context(), courseCode, *row, false, 0)
+		displayName := ""
+		if u, err := user.FindByID(r.Context(), d.Pool, viewer); err == nil && u != nil {
+			displayName = user.DisplayLabel(u.DisplayName, u.Email)
+		}
+		payload := d.submissionToJSON(r.Context(), courseCode, *row, false, 0, displayName)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(map[string]any{"submission": payload})
 	}

--- a/server/internal/httpserver/canvas_import_ws.go
+++ b/server/internal/httpserver/canvas_import_ws.go
@@ -1269,7 +1269,10 @@ func rewriteSyllabusMarkdown(ctx context.Context, pool *pgxpool.Pool, courseID u
 // "TeacherEnrollment", "TaEnrollment") to the Lextures course role it maps to.
 func canvasEnrollmentTypeToRole(canvasType string) string {
 	t := strings.ToLower(canvasType)
-	if strings.Contains(t, "teacher") || strings.Contains(t, "ta") {
+	if strings.Contains(t, "teacher") {
+		return "teacher"
+	}
+	if strings.Contains(t, "ta") {
 		return "instructor"
 	}
 	return "student"

--- a/server/internal/httpserver/canvas_import_ws_test.go
+++ b/server/internal/httpserver/canvas_import_ws_test.go
@@ -5,8 +5,16 @@ import (
 	"testing"
 )
 
-func TestCanvasEnrollmentTypeToRole_TeacherAndTA(t *testing.T) {
-	for _, typ := range []string{"TeacherEnrollment", "TaEnrollment", "teacher", "ta", "head_ta"} {
+func TestCanvasEnrollmentTypeToRole_Teacher(t *testing.T) {
+	for _, typ := range []string{"TeacherEnrollment", "teacher"} {
+		if got := canvasEnrollmentTypeToRole(typ); got != "teacher" {
+			t.Errorf("canvasEnrollmentTypeToRole(%q) = %q, want teacher", typ, got)
+		}
+	}
+}
+
+func TestCanvasEnrollmentTypeToRole_TA(t *testing.T) {
+	for _, typ := range []string{"TaEnrollment", "ta", "head_ta"} {
 		if got := canvasEnrollmentTypeToRole(typ); got != "instructor" {
 			t.Errorf("canvasEnrollmentTypeToRole(%q) = %q, want instructor", typ, got)
 		}

--- a/server/internal/httpserver/courses_catalog_settings.go
+++ b/server/internal/httpserver/courses_catalog_settings.go
@@ -1,0 +1,271 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/repos/course"
+)
+
+type catalogSettingsResponse struct {
+	View                 string            `json:"view"`
+	KanbanColumnLabels   map[string]string `json:"kanbanColumnLabels"`
+	HiddenColumnExpanded bool              `json:"hiddenColumnExpanded"`
+	Nicknames            map[string]string `json:"nicknames"`
+}
+
+type putCatalogSettingsBody struct {
+	View                 *string           `json:"view"`
+	KanbanColumnLabels   map[string]string `json:"kanbanColumnLabels"`
+	HiddenColumnExpanded *bool             `json:"hiddenColumnExpanded"`
+}
+
+type putCatalogNicknameBody struct {
+	CourseID string  `json:"courseId"`
+	Nickname *string `json:"nickname"`
+}
+
+type putKanbanBoardBody struct {
+	Columns map[string][]string `json:"columns"`
+}
+
+func (d Deps) handleGetCourseCatalogSettings() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		ctx := r.Context()
+		prefs, err := course.GetUserCatalogPrefs(ctx, d.Pool, userID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load catalog settings.")
+			return
+		}
+		nicknames, err := course.ListUserCatalogNicknames(ctx, d.Pool, userID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load catalog settings.")
+			return
+		}
+		if nicknames == nil {
+			nicknames = map[string]string{}
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(catalogSettingsResponse{
+			View:                 prefs.ViewType,
+			KanbanColumnLabels:   prefs.KanbanColumnLabels,
+			HiddenColumnExpanded: prefs.HiddenColumnExpanded,
+			Nicknames:            nicknames,
+		})
+	}
+}
+
+func (d Deps) handlePutCourseCatalogSettings() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.Header().Set("Allow", http.MethodPut)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		var body putCatalogSettingsBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		patch := course.UserCatalogPrefs{}
+		hasView := body.View != nil
+		hasLabels := body.KanbanColumnLabels != nil
+		hasHidden := body.HiddenColumnExpanded != nil
+		if hasView {
+			patch.ViewType = strings.TrimSpace(*body.View)
+		}
+		if hasLabels {
+			patch.KanbanColumnLabels = body.KanbanColumnLabels
+		}
+		if hasHidden {
+			patch.HiddenColumnExpanded = *body.HiddenColumnExpanded
+		}
+		if !hasView && !hasLabels && !hasHidden {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "No settings provided.")
+			return
+		}
+		updated, err := course.UpsertUserCatalogPrefs(r.Context(), d.Pool, userID, patch, hasView, hasLabels, hasHidden)
+		if err != nil {
+			if strings.Contains(err.Error(), "invalid view") {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid view type.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save catalog settings.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(catalogSettingsResponse{
+			View:                 updated.ViewType,
+			KanbanColumnLabels:   updated.KanbanColumnLabels,
+			HiddenColumnExpanded: updated.HiddenColumnExpanded,
+			Nicknames:            map[string]string{},
+		})
+	}
+}
+
+func (d Deps) handlePutCourseCatalogNickname() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.Header().Set("Allow", http.MethodPut)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		var body putCatalogNicknameBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		courseID, err := uuid.Parse(strings.TrimSpace(body.CourseID))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid courseId.")
+			return
+		}
+		if err := course.UpsertUserCatalogNickname(r.Context(), d.Pool, userID, courseID, body.Nickname); err != nil {
+			if strings.Contains(err.Error(), "too long") {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Nickname is too long.")
+				return
+			}
+			if strings.Contains(err.Error(), "not in your catalog") {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save nickname.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (d Deps) handlePutCourseCatalogOrder() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.Header().Set("Allow", http.MethodPut)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		var body struct {
+			CourseIDs []uuid.UUID `json:"courseIds"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		if err := course.ReplaceUserCatalogOrder(r.Context(), d.Pool, userID, body.CourseIDs); err != nil {
+			if strings.Contains(err.Error(), "not in your catalog") || strings.Contains(err.Error(), "duplicate") {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save catalog order.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (d Deps) handlePutCourseKanbanBoard() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.Header().Set("Allow", http.MethodPut)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		var body putKanbanBoardBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		if body.Columns == nil {
+			body.Columns = map[string][]string{}
+		}
+		columns := map[string][]uuid.UUID{}
+		for col, ids := range body.Columns {
+			for _, rawID := range ids {
+				id, err := uuid.Parse(strings.TrimSpace(rawID))
+				if err != nil {
+					apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid course id in kanban board.")
+					return
+				}
+				columns[col] = append(columns[col], id)
+			}
+		}
+		if err := course.ReplaceUserKanbanBoard(r.Context(), d.Pool, userID, columns); err != nil {
+			if strings.Contains(err.Error(), "invalid kanban") || strings.Contains(err.Error(), "duplicate") || strings.Contains(err.Error(), "not in your catalog") {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save kanban board.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (d Deps) handleMigrateCourseCatalogLocalStorage() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		var body putCatalogSettingsBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		patch := course.UserCatalogPrefs{}
+		hasView := body.View != nil
+		hasHidden := body.HiddenColumnExpanded != nil
+		if hasView {
+			patch.ViewType = strings.TrimSpace(*body.View)
+		}
+		if hasHidden {
+			patch.HiddenColumnExpanded = *body.HiddenColumnExpanded
+		}
+		if !hasView && !hasHidden {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		_, err := course.UpsertUserCatalogPrefs(r.Context(), d.Pool, userID, patch, hasView, false, hasHidden)
+		if err != nil {
+			if strings.Contains(err.Error(), "invalid view") {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid view type.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to migrate catalog settings.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/server/internal/httpserver/courses_list.go
+++ b/server/internal/httpserver/courses_list.go
@@ -125,6 +125,10 @@ func (d Deps) handleListCourses() http.HandlerFunc {
 				}
 			}
 		}
+		if err := course.AttachUserCatalogMeta(ctx, d.Pool, userID, courses); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to list courses.")
+			return
+		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(coursesListResponse{Courses: courses})
 	}

--- a/server/internal/httpserver/courses_routes.go
+++ b/server/internal/httpserver/courses_routes.go
@@ -4,6 +4,12 @@ import "github.com/go-chi/chi/v5"
 
 func (d Deps) registerCourseRoutes(r chi.Router) {
 	r.Get("/api/v1/courses", d.handleListCourses())
+	r.Get("/api/v1/courses/catalog-settings", d.handleGetCourseCatalogSettings())
+	r.Put("/api/v1/courses/catalog-settings", d.handlePutCourseCatalogSettings())
+	r.Post("/api/v1/courses/catalog-settings/migrate-local", d.handleMigrateCourseCatalogLocalStorage())
+	r.Put("/api/v1/courses/catalog-nickname", d.handlePutCourseCatalogNickname())
+	r.Put("/api/v1/courses/catalog-order", d.handlePutCourseCatalogOrder())
+	r.Put("/api/v1/courses/kanban-board", d.handlePutCourseKanbanBoard())
 	r.Post("/api/v1/courses", d.handleCreateCourse())
 	r.Post("/api/v1/integrations/canvas/courses", d.handleCanvasListCourses())
 	// iCalendar feed must register before the /api/v1/courses/{course_code} subtree.

--- a/server/internal/repos/course/catalog_user_prefs.go
+++ b/server/internal/repos/course/catalog_user_prefs.go
@@ -1,0 +1,362 @@
+package course
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var ValidCatalogViewTypes = map[string]struct{}{
+	"cards": {}, "list": {}, "gallery": {}, "table": {}, "status": {},
+}
+
+var ValidKanbanColumnIDs = map[string]struct{}{
+	"todo": {}, "in-progress": {}, "done": {}, "hidden": {},
+}
+
+var DefaultKanbanColumnLabels = map[string]string{
+	"todo":        "Todo",
+	"in-progress": "In progress",
+	"done":        "Done",
+	"hidden":      "Hidden",
+}
+
+type UserCatalogPrefs struct {
+	ViewType             string            `json:"view"`
+	KanbanColumnLabels   map[string]string `json:"kanbanColumnLabels"`
+	HiddenColumnExpanded bool              `json:"hiddenColumnExpanded"`
+}
+
+type UserCatalogNickname struct {
+	CourseID uuid.UUID
+	Nickname string
+}
+
+type UserKanbanPlacement struct {
+	CourseID  uuid.UUID
+	ColumnID  string
+	SortOrder int
+}
+
+func defaultCatalogPrefs() UserCatalogPrefs {
+	labels := make(map[string]string, len(DefaultKanbanColumnLabels))
+	for k, v := range DefaultKanbanColumnLabels {
+		labels[k] = v
+	}
+	return UserCatalogPrefs{
+		ViewType:             "cards",
+		KanbanColumnLabels:   labels,
+		HiddenColumnExpanded: false,
+	}
+}
+
+func normalizeKanbanColumnLabels(raw map[string]string) map[string]string {
+	out := defaultCatalogPrefs().KanbanColumnLabels
+	for k, v := range raw {
+		if _, ok := ValidKanbanColumnIDs[k]; !ok {
+			continue
+		}
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" || len(trimmed) > 80 {
+			continue
+		}
+		out[k] = trimmed
+	}
+	return out
+}
+
+// GetUserCatalogPrefs returns catalog UI prefs for the user, or defaults when unset.
+func GetUserCatalogPrefs(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) (UserCatalogPrefs, error) {
+	prefs := defaultCatalogPrefs()
+	var labelsJSON []byte
+	err := pool.QueryRow(ctx, `
+SELECT view_type, kanban_column_labels, hidden_column_expanded
+FROM course.user_course_catalog_prefs
+WHERE user_id = $1
+`, userID).Scan(&prefs.ViewType, &labelsJSON, &prefs.HiddenColumnExpanded)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return prefs, nil
+		}
+		return prefs, err
+	}
+	if _, ok := ValidCatalogViewTypes[prefs.ViewType]; !ok {
+		prefs.ViewType = "cards"
+	}
+	var labels map[string]string
+	if len(labelsJSON) > 0 {
+		if err := json.Unmarshal(labelsJSON, &labels); err == nil {
+			prefs.KanbanColumnLabels = normalizeKanbanColumnLabels(labels)
+		}
+	}
+	return prefs, nil
+}
+
+// UpsertUserCatalogPrefs merges non-empty fields into stored prefs.
+func UpsertUserCatalogPrefs(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, patch UserCatalogPrefs, hasView, hasLabels, hasHidden bool) (UserCatalogPrefs, error) {
+	current, err := GetUserCatalogPrefs(ctx, pool, userID)
+	if err != nil {
+		return UserCatalogPrefs{}, err
+	}
+	if hasView {
+		if _, ok := ValidCatalogViewTypes[patch.ViewType]; !ok {
+			return UserCatalogPrefs{}, fmt.Errorf("invalid view type")
+		}
+		current.ViewType = patch.ViewType
+	}
+	if hasLabels {
+		current.KanbanColumnLabels = normalizeKanbanColumnLabels(patch.KanbanColumnLabels)
+	}
+	if hasHidden {
+		current.HiddenColumnExpanded = patch.HiddenColumnExpanded
+	}
+	labelsJSON, err := json.Marshal(current.KanbanColumnLabels)
+	if err != nil {
+		return UserCatalogPrefs{}, err
+	}
+	_, err = pool.Exec(ctx, `
+INSERT INTO course.user_course_catalog_prefs (user_id, view_type, kanban_column_labels, hidden_column_expanded, updated_at)
+VALUES ($1, $2, $3::jsonb, $4, now())
+ON CONFLICT (user_id) DO UPDATE SET
+    view_type = EXCLUDED.view_type,
+    kanban_column_labels = EXCLUDED.kanban_column_labels,
+    hidden_column_expanded = EXCLUDED.hidden_column_expanded,
+    updated_at = now()
+`, userID, current.ViewType, labelsJSON, current.HiddenColumnExpanded)
+	if err != nil {
+		return UserCatalogPrefs{}, err
+	}
+	return current, nil
+}
+
+// ListUserCatalogNicknames returns nicknames keyed by course id string.
+func ListUserCatalogNicknames(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) (map[string]string, error) {
+	rows, err := pool.Query(ctx, `
+SELECT course_id, nickname
+FROM course.user_course_catalog_nicknames
+WHERE user_id = $1
+`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]string{}
+	for rows.Next() {
+		var courseID uuid.UUID
+		var nickname string
+		if err := rows.Scan(&courseID, &nickname); err != nil {
+			return nil, err
+		}
+		out[courseID.String()] = nickname
+	}
+	return out, rows.Err()
+}
+
+// UpsertUserCatalogNickname sets or clears a nickname for one enrolled course.
+func UpsertUserCatalogNickname(ctx context.Context, pool *pgxpool.Pool, userID, courseID uuid.UUID, nickname *string) error {
+	var enrolled bool
+	if err := pool.QueryRow(ctx, `
+SELECT EXISTS (
+  SELECT 1 FROM course.course_enrollments e
+  WHERE e.user_id = $1 AND e.course_id = $2
+    AND (e.active OR e.state IN ('withdrawn', 'dropped', 'no_credit', 'audit', 'incomplete'))
+)
+`, userID, courseID).Scan(&enrolled); err != nil {
+		return err
+	}
+	if !enrolled {
+		return fmt.Errorf("course is not in your catalog")
+	}
+	if nickname == nil || strings.TrimSpace(*nickname) == "" {
+		_, err := pool.Exec(ctx, `
+DELETE FROM course.user_course_catalog_nicknames
+WHERE user_id = $1 AND course_id = $2
+`, userID, courseID)
+		return err
+	}
+	trimmed := strings.TrimSpace(*nickname)
+	if len(trimmed) > 120 {
+		return fmt.Errorf("nickname too long")
+	}
+	_, err := pool.Exec(ctx, `
+INSERT INTO course.user_course_catalog_nicknames (user_id, course_id, nickname, updated_at)
+VALUES ($1, $2, $3, now())
+ON CONFLICT (user_id, course_id) DO UPDATE SET
+    nickname = EXCLUDED.nickname,
+    updated_at = now()
+`, userID, courseID, trimmed)
+	return err
+}
+
+// ListUserKanbanPlacements returns manual kanban placements for the user.
+func ListUserKanbanPlacements(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) ([]UserKanbanPlacement, error) {
+	rows, err := pool.Query(ctx, `
+SELECT course_id, column_id, sort_order
+FROM course.user_course_kanban_placement
+WHERE user_id = $1
+ORDER BY column_id ASC, sort_order ASC
+`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []UserKanbanPlacement
+	for rows.Next() {
+		var p UserKanbanPlacement
+		if err := rows.Scan(&p.CourseID, &p.ColumnID, &p.SortOrder); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// ReplaceUserKanbanBoard replaces all kanban placements for enrolled courses provided in columns.
+func ReplaceUserKanbanBoard(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, columns map[string][]uuid.UUID) error {
+	for col := range columns {
+		if _, ok := ValidKanbanColumnIDs[col]; !ok {
+			return fmt.Errorf("invalid kanban column")
+		}
+	}
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	seen := map[uuid.UUID]struct{}{}
+	var toInsert []UserKanbanPlacement
+	for col, ids := range columns {
+		for i, id := range ids {
+			if _, dup := seen[id]; dup {
+				return fmt.Errorf("duplicate course in kanban board")
+			}
+			seen[id] = struct{}{}
+			toInsert = append(toInsert, UserKanbanPlacement{
+				CourseID:  id,
+				ColumnID:  col,
+				SortOrder: i,
+			})
+		}
+	}
+	if len(toInsert) == 0 {
+		if _, err := tx.Exec(ctx, `DELETE FROM course.user_course_kanban_placement WHERE user_id = $1`, userID); err != nil {
+			return err
+		}
+		return tx.Commit(ctx)
+	}
+
+	idList := make([]uuid.UUID, 0, len(toInsert))
+	for id := range seen {
+		idList = append(idList, id)
+	}
+	var enrolled int
+	if err := tx.QueryRow(ctx, `
+SELECT COUNT(DISTINCT e.course_id)
+FROM course.course_enrollments e
+WHERE e.user_id = $1 AND e.course_id = ANY($2::uuid[])
+  AND (e.active OR e.state IN ('withdrawn', 'dropped', 'no_credit', 'audit', 'incomplete'))
+`, userID, idList).Scan(&enrolled); err != nil {
+		return err
+	}
+	if enrolled != len(idList) {
+		return fmt.Errorf("one or more courses are not in your catalog")
+	}
+
+	if _, err := tx.Exec(ctx, `DELETE FROM course.user_course_kanban_placement WHERE user_id = $1`, userID); err != nil {
+		return err
+	}
+	for _, p := range toInsert {
+		if _, err := tx.Exec(ctx, `
+INSERT INTO course.user_course_kanban_placement (user_id, course_id, column_id, sort_order, updated_at)
+VALUES ($1, $2, $3, $4, now())
+`, userID, p.CourseID, p.ColumnID, p.SortOrder); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+// ReplaceUserCatalogOrder replaces the user's catalog sort order.
+func ReplaceUserCatalogOrder(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, courseIDs []uuid.UUID) error {
+	if len(courseIDs) == 0 {
+		_, err := pool.Exec(ctx, `DELETE FROM course.user_course_catalog_order WHERE user_id = $1`, userID)
+		return err
+	}
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var enrolled int
+	if err := tx.QueryRow(ctx, `
+SELECT COUNT(DISTINCT e.course_id)
+FROM course.course_enrollments e
+WHERE e.user_id = $1 AND e.course_id = ANY($2::uuid[])
+  AND (e.active OR e.state IN ('withdrawn', 'dropped', 'no_credit', 'audit', 'incomplete'))
+`, userID, courseIDs).Scan(&enrolled); err != nil {
+		return err
+	}
+	if enrolled != len(courseIDs) {
+		return fmt.Errorf("one or more courses are not in your catalog")
+	}
+	seen := map[uuid.UUID]struct{}{}
+	for _, id := range courseIDs {
+		if _, dup := seen[id]; dup {
+			return fmt.Errorf("duplicate course in catalog order")
+		}
+		seen[id] = struct{}{}
+	}
+
+	if _, err := tx.Exec(ctx, `DELETE FROM course.user_course_catalog_order WHERE user_id = $1`, userID); err != nil {
+		return err
+	}
+	for i, id := range courseIDs {
+		if _, err := tx.Exec(ctx, `
+INSERT INTO course.user_course_catalog_order (user_id, course_id, sort_order)
+VALUES ($1, $2, $3)
+`, userID, id, i); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+// AttachUserCatalogMeta merges nicknames and kanban placement onto listed courses.
+func AttachUserCatalogMeta(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, courses []CoursePublic) error {
+	if len(courses) == 0 {
+		return nil
+	}
+	nicknames, err := ListUserCatalogNicknames(ctx, pool, userID)
+	if err != nil {
+		return err
+	}
+	placements, err := ListUserKanbanPlacements(ctx, pool, userID)
+	if err != nil {
+		return err
+	}
+	placementByCourse := map[string]UserKanbanPlacement{}
+	for _, p := range placements {
+		placementByCourse[p.CourseID.String()] = p
+	}
+	for i := range courses {
+		if nick, ok := nicknames[courses[i].ID]; ok {
+			n := nick
+			courses[i].CatalogNickname = &n
+		}
+		if p, ok := placementByCourse[courses[i].ID]; ok {
+			col := p.ColumnID
+			sortOrder := p.SortOrder
+			courses[i].KanbanColumnID = &col
+			courses[i].KanbanSortOrder = &sortOrder
+		}
+	}
+	return nil
+}

--- a/server/internal/repos/course/list_enrolled.go
+++ b/server/internal/repos/course/list_enrolled.go
@@ -78,6 +78,9 @@ type CoursePublic struct {
 	GradeLevel                    *string          `json:"gradeLevel,omitempty"`
 	ViewerEnrollmentState         *string          `json:"viewerEnrollmentState,omitempty"`
 	ViewerEnrollmentStateChangedAt *time.Time      `json:"viewerEnrollmentStateChangedAt,omitempty"`
+	CatalogNickname               *string          `json:"catalogNickname,omitempty"`
+	KanbanColumnID                *string          `json:"kanbanColumnId,omitempty"`
+	KanbanSortOrder               *int             `json:"kanbanSortOrder,omitempty"`
 }
 
 // coursePublicSelect is columns for `course.courses` joined to `tenant.terms` (alias `tr`) for public APIs.

--- a/server/internal/repos/user/display_labels.go
+++ b/server/internal/repos/user/display_labels.go
@@ -1,0 +1,60 @@
+package user
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// DisplayLabel returns a human-readable label for a user row.
+func DisplayLabel(displayName *string, email string) string {
+	if displayName != nil {
+		if s := strings.TrimSpace(*displayName); s != "" {
+			return s
+		}
+	}
+	return strings.TrimSpace(email)
+}
+
+// DisplayLabelsByIDs returns display labels keyed by user id (display_name or email fallback).
+func DisplayLabelsByIDs(ctx context.Context, pool *pgxpool.Pool, ids []uuid.UUID) (map[uuid.UUID]string, error) {
+	out := make(map[uuid.UUID]string, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	unique := make([]uuid.UUID, 0, len(ids))
+	seen := make(map[uuid.UUID]struct{}, len(ids))
+	for _, id := range ids {
+		if id == uuid.Nil {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	if len(unique) == 0 {
+		return out, nil
+	}
+	rows, err := pool.Query(ctx, `
+SELECT id, COALESCE(NULLIF(TRIM(display_name), ''), email) AS display_label
+FROM "user".users
+WHERE id = ANY($1)
+`, unique)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id uuid.UUID
+		var label string
+		if err := rows.Scan(&id, &label); err != nil {
+			return nil, err
+		}
+		out[id] = label
+	}
+	return out, rows.Err()
+}

--- a/server/migrations/252_user_course_catalog_prefs.sql
+++ b/server/migrations/252_user_course_catalog_prefs.sql
@@ -1,0 +1,42 @@
+-- Per-user course catalog UI: view mode, kanban labels, nicknames, and kanban placements.
+
+CREATE TABLE course.user_course_catalog_prefs (
+    user_id UUID PRIMARY KEY REFERENCES "user".users (id) ON DELETE CASCADE,
+    view_type TEXT NOT NULL DEFAULT 'cards'
+        CHECK (view_type IN ('cards', 'list', 'gallery', 'table', 'status')),
+    kanban_column_labels JSONB NOT NULL DEFAULT '{
+        "todo": "Todo",
+        "in-progress": "In progress",
+        "done": "Done",
+        "hidden": "Hidden"
+    }'::jsonb,
+    hidden_column_expanded BOOLEAN NOT NULL DEFAULT false,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE course.user_course_catalog_nicknames (
+    user_id UUID NOT NULL REFERENCES "user".users (id) ON DELETE CASCADE,
+    course_id UUID NOT NULL REFERENCES course.courses (id) ON DELETE CASCADE,
+    nickname TEXT NOT NULL CHECK (char_length(btrim(nickname)) >= 1 AND char_length(nickname) <= 120),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, course_id)
+);
+
+CREATE TABLE course.user_course_kanban_placement (
+    user_id UUID NOT NULL REFERENCES "user".users (id) ON DELETE CASCADE,
+    course_id UUID NOT NULL REFERENCES course.courses (id) ON DELETE CASCADE,
+    column_id TEXT NOT NULL CHECK (column_id IN ('todo', 'in-progress', 'done', 'hidden')),
+    sort_order INT NOT NULL DEFAULT 0 CHECK (sort_order >= 0),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, course_id)
+);
+
+CREATE INDEX idx_user_course_kanban_placement_user_column_sort
+    ON course.user_course_kanban_placement (user_id, column_id, sort_order);
+
+COMMENT ON TABLE course.user_course_catalog_prefs IS
+    'Signed-in user preferences for the course catalog page (view mode and kanban labels).';
+COMMENT ON TABLE course.user_course_catalog_nicknames IS
+    'Optional per-user nicknames for enrolled courses in the catalog.';
+COMMENT ON TABLE course.user_course_kanban_placement IS
+    'Manual kanban column placement for a user''s course catalog board.';

--- a/server/migrations/253_live_sessions_default_off.sql
+++ b/server/migrations/253_live_sessions_default_off.sql
@@ -1,0 +1,4 @@
+-- New courses should not show Live Sessions until instructors opt in.
+-- Existing rows keep their current live_sessions_enabled value.
+
+ALTER TABLE course.courses ALTER COLUMN live_sessions_enabled SET DEFAULT FALSE;


### PR DESCRIPTION
## Summary

- **Course catalog**: Per-user preferences (view modes, kanban board with drag-and-drop columns, course nicknames) backed by migration 252 and new catalog settings API.
- **Gradebook**: Context-menu actions on cells including "Grade submission" modal for inline assignment grading from the grid.
- **SpeedGrader**: Resizable split-pane layout, searchable student picker in the submission navigator, and improved rubric grade picker UX.
- **Other**: Live sessions default to off for new courses (migration 253); submission display names on the API for blind-grading-aware labels.

## Test plan

- [x] `npm run lint` and `npm run typecheck` in `clients/web/`
- [x] `npm run test` — 614 frontend unit tests pass
- [x] `go test ./... -short` in `server/`
- [ ] Manually verify course catalog kanban drag-and-drop, nicknames, and view mode persistence
- [ ] Grade an assignment submission from the gradebook cell menu
- [ ] Open SpeedGrader from gradebook modal and navigate submissions with the student picker
- [ ] Confirm new courses have Live Sessions disabled by default