### PR TITLE
feat: quiz submission and grading, dedicated attempt page, and richer DOCX/PPTX preview

### DIFF
--- a/clients/web/src/app.tsx
+++ b/clients/web/src/app.tsx
@@ -29,6 +29,7 @@ import CourseModuleH5PPage from './pages/lms/course-module-h5p-page'
 import CourseModuleLtiPage from './pages/lms/course-module-lti-page'
 import CourseModuleVibeActivityPage from './pages/lms/course-module-vibe-activity-page'
 import CourseModuleQuizPage from './pages/lms/course-module-quiz-page'
+import CourseModuleQuizAttemptPage from './pages/lms/course-module-quiz-attempt-page'
 import CourseDiagnosticPage from './pages/lms/course-diagnostic-page'
 import { CourseQuestionBankPage } from './pages/lms/course-question-bank-page'
 import CourseMisconceptionReportPage from './pages/lms/course-misconception-report-page'
@@ -169,6 +170,7 @@ export default function App() {
               path="modules/assignment/:itemId/moderation"
               element={<ModerationDashboard />}
             />
+            <Route path="modules/quiz/:itemId/attempt" element={<CourseModuleQuizAttemptPage />} />
             <Route path="modules/quiz/:itemId" element={<CourseModuleQuizPage />} />
             <Route path="diagnostic" element={<CourseDiagnosticPage />} />
             <Route path="modules/external-link/:itemId" element={<CourseModuleExternalLinkPage />} />

--- a/clients/web/src/components/layout/quiz-shell-focus-provider.tsx
+++ b/clients/web/src/components/layout/quiz-shell-focus-provider.tsx
@@ -1,10 +1,25 @@
 import { useCallback, useMemo, useState } from 'react'
 import { QuizShellFocusContext, type QuizShellFocusMode, type QuizShellFocusProviderProps } from './quiz-shell-focus-context'
 
+function quizShellFocusEqual(a: QuizShellFocusMode | null, b: QuizShellFocusMode | null): boolean {
+  if (a === b) return true
+  if (a === null || b === null) return false
+  return (
+    a.quizTitle === b.quizTitle &&
+    a.timeRemainingLabel === b.timeRemainingLabel &&
+    a.timeUrgent === b.timeUrgent &&
+    a.questionProgress === b.questionProgress &&
+    a.saveStatusText === b.saveStatusText &&
+    a.lockdownAccent === b.lockdownAccent &&
+    a.flaggedForCurrent === b.flaggedForCurrent &&
+    a.onToggleFlagForReview === b.onToggleFlagForReview
+  )
+}
+
 export function QuizShellFocusProvider({ children }: QuizShellFocusProviderProps) {
   const [focus, setFocus] = useState<QuizShellFocusMode | null>(null)
   const setQuizShellFocus = useCallback((next: QuizShellFocusMode | null) => {
-    setFocus(next)
+    setFocus((prev) => (quizShellFocusEqual(prev, next) ? prev : next))
   }, [])
   const value = useMemo(() => ({ focus, setQuizShellFocus }), [focus, setQuizShellFocus])
   return <QuizShellFocusContext.Provider value={value}>{children}</QuizShellFocusContext.Provider>

--- a/clients/web/src/components/layout/top-bar-breadcrumbs.tsx
+++ b/clients/web/src/components/layout/top-bar-breadcrumbs.tsx
@@ -268,8 +268,9 @@ const MODULE_ITEM_PATTERNS = [
 ] as const
 
 function matchModuleItemRoute(pathname: string): { code: string; id: string } | null {
+  const normalized = pathname.replace(/\/attempt\/?$/, '')
   for (const p of MODULE_ITEM_PATTERNS) {
-    const m = matchPath({ path: p, end: true }, pathname)
+    const m = matchPath({ path: p, end: true }, normalized)
     if (m?.params.itemId && m.params.courseCode) {
       return { code: m.params.courseCode, id: m.params.itemId }
     }

--- a/clients/web/src/components/quiz/__tests__/quiz-student-take-panel.test.tsx
+++ b/clients/web/src/components/quiz/__tests__/quiz-student-take-panel.test.tsx
@@ -1,6 +1,8 @@
+import { type ComponentProps } from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
+import { BrowserRouter } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
 import {
   defaultQuizAdvancedSettings,
@@ -69,21 +71,44 @@ function minimalQuiz(overrides: Partial<ModuleQuizPayload> = {}): ModuleQuizPayl
 }
 
 describe('QuizStudentTakePanel', () => {
+  function renderPanel(props: ComponentProps<typeof QuizStudentTakePanel>) {
+    return render(
+      <BrowserRouter>
+        <QuizStudentTakePanel {...props} />
+      </BrowserRouter>,
+    )
+  }
+
   it('renders nothing when closed', () => {
     const onClose = () => {}
-    const { container } = render(
-      <QuizStudentTakePanel
-        open={false}
-        onClose={onClose}
-        courseCode="C-TEST"
-        itemId="item-1"
-        quiz={minimalQuiz()}
-        advanced={defaultQuizAdvancedSettings()}
-        oneQuestionAtATime={false}
-        allowBackNavigation
-      />,
-    )
+    const { container } = renderPanel({
+      open: false,
+      onClose,
+      courseCode: 'C-TEST',
+      itemId: 'item-1',
+      quiz: minimalQuiz(),
+      advanced: defaultQuizAdvancedSettings(),
+      oneQuestionAtATime: false,
+      allowBackNavigation: true,
+    })
     expect(container.firstChild).toBeNull()
+  })
+
+  it('renders page layout when mounted on the attempt route', () => {
+    const onClose = () => {}
+    renderPanel({
+      layout: 'page',
+      open: true,
+      onClose,
+      courseCode: 'C-TEST',
+      itemId: 'item-1',
+      quiz: minimalQuiz(),
+      advanced: defaultQuizAdvancedSettings(),
+      oneQuestionAtATime: false,
+      allowBackNavigation: true,
+    })
+    expect(screen.getByRole('heading', { name: /begin quiz/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Begin' })).toBeInTheDocument()
   })
 
   it('starts a standard attempt and shows the first question', async () => {
@@ -170,18 +195,16 @@ describe('QuizStudentTakePanel', () => {
     )
 
     const onClose = () => {}
-    render(
-      <QuizStudentTakePanel
-        open
-        onClose={onClose}
-        courseCode="C-TEST"
-        itemId="item-1"
-        quiz={minimalQuiz()}
-        advanced={defaultQuizAdvancedSettings()}
-        oneQuestionAtATime={false}
-        allowBackNavigation
-      />,
-    )
+    renderPanel({
+      open: true,
+      onClose,
+      courseCode: 'C-TEST',
+      itemId: 'item-1',
+      quiz: minimalQuiz(),
+      advanced: defaultQuizAdvancedSettings(),
+      oneQuestionAtATime: false,
+      allowBackNavigation: true,
+    })
 
     await user.click(screen.getByRole('button', { name: /^Begin$/i }))
 

--- a/clients/web/src/components/quiz/__tests__/quiz-take-utils.test.ts
+++ b/clients/web/src/components/quiz/__tests__/quiz-take-utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { type QuizQuestion } from '../../../lib/courses-api'
+import { prepareStaticQuestions, visibleChoices } from '../quiz-take-utils'
+import { defaultQuizAdvancedSettings } from '../../../lib/courses-api'
+
+function baseQuestion(overrides: Partial<QuizQuestion> = {}): QuizQuestion {
+  return {
+    id: 'q1',
+    prompt: 'Pick one',
+    questionType: 'multiple_choice',
+    choices: ['A', 'B'],
+    correctChoiceIndex: 0,
+    multipleAnswer: false,
+    answerWithImage: false,
+    required: true,
+    points: 1,
+    estimatedMinutes: 1,
+    ...overrides,
+  }
+}
+
+describe('visibleChoices', () => {
+  it('returns trimmed non-empty choices', () => {
+    expect(visibleChoices(baseQuestion({ choices: [' A ', '', 'B'] }))).toEqual(['A', 'B'])
+  })
+
+  it('treats null choices as empty', () => {
+    expect(visibleChoices(baseQuestion({ choices: null as unknown as string[] }))).toEqual([])
+  })
+})
+
+describe('prepareStaticQuestions', () => {
+  it('does not throw when choices is null and shuffleChoices is enabled', () => {
+    const advanced = { ...defaultQuizAdvancedSettings(), shuffleChoices: true }
+    const questions = [baseQuestion({ choices: null as unknown as string[] })]
+    expect(() => prepareStaticQuestions(questions, advanced)).not.toThrow()
+  })
+})

--- a/clients/web/src/components/quiz/quiz-analytics-modal.tsx
+++ b/clients/web/src/components/quiz/quiz-analytics-modal.tsx
@@ -3,6 +3,7 @@ import { RefreshCw, X } from 'lucide-react'
 import {
   fetchQuizAnalytics,
   type QuizAnalyticsReport,
+  type QuizFocusAttemptStat,
   type QuizQuestionStat,
   type QuizScoreBucket,
 } from '../../lib/quiz-analytics-api'
@@ -106,6 +107,7 @@ export function QuizAnalyticsModal({ open, onClose, courseCode, itemId, quizTitl
             <div className="space-y-8">
               <AnalyticsSummary report={report} />
               <ScoreDistributionChart buckets={report.scoreBuckets} nAttempts={report.nAttempts} />
+              <FocusLossSection attempts={report.focusAttempts} />
               <QuestionPerformanceSection questions={report.questionStats} />
               <QuizItemAnalysisPanel courseCode={courseCode} itemId={itemId} />
             </div>
@@ -240,6 +242,59 @@ function ScoreDistributionChart({
             <tr key={bucket.label} className="border-b border-slate-100 dark:border-neutral-800">
               <td className="py-1 pe-3">{bucket.label}</td>
               <td className="py-1 text-end tabular-nums">{bucket.count}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  )
+}
+
+function FocusLossSection({ attempts }: { attempts: QuizFocusAttemptStat[] }) {
+  const headingId = useId()
+
+  if (attempts.length === 0) {
+    return (
+      <section aria-labelledby={headingId}>
+        <h3 id={headingId} className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+          Focus-loss events
+        </h3>
+        <p className="mt-3 text-sm text-slate-500 dark:text-neutral-400">
+          No focus-loss events recorded on submitted attempts.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section aria-labelledby={headingId}>
+      <h3 id={headingId} className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+        Focus-loss events
+      </h3>
+      <p className="mt-1 text-xs text-slate-500 dark:text-neutral-400">
+        Tab switches and window blur events logged while learners had a quiz in progress.
+      </p>
+      <table className="mt-4 w-full text-sm">
+        <caption className="sr-only">Focus-loss events by attempt</caption>
+        <thead>
+          <tr className="border-b border-slate-200 dark:border-neutral-700">
+            <th scope="col" className="py-1 pe-3 text-start font-medium">
+              Attempt
+            </th>
+            <th scope="col" className="py-1 pe-3 text-end font-medium">
+              Events
+            </th>
+            <th scope="col" className="py-1 text-end font-medium">
+              Flagged
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {attempts.map((a) => (
+            <tr key={a.attemptId} className="border-b border-slate-100 dark:border-neutral-800">
+              <td className="py-1.5 pe-3 tabular-nums">#{a.attemptNumber}</td>
+              <td className="py-1.5 pe-3 text-end tabular-nums">{a.eventCount}</td>
+              <td className="py-1.5 text-end">{a.academicIntegrityFlag ? 'Yes' : '—'}</td>
             </tr>
           ))}
         </tbody>

--- a/clients/web/src/components/quiz/quiz-student-preview-modal.tsx
+++ b/clients/web/src/components/quiz/quiz-student-preview-modal.tsx
@@ -34,7 +34,8 @@ export type QuizStudentPreviewModalProps = {
 }
 
 function visibleChoices(q: QuizQuestion): string[] {
-  return q.choices.map((c) => c.trim()).filter((c) => c.length > 0)
+  const choices = Array.isArray(q.choices) ? q.choices : []
+  return choices.map((c) => String(c).trim()).filter((c) => c.length > 0)
 }
 
 /** Apply shuffle choices to a copy of the question. */
@@ -598,7 +599,9 @@ function StaticQuizPreview({
       qs = shuffleArray(qs).slice(0, pool)
     }
     if (advanced.shuffleChoices) {
-      qs = qs.map((q) => withShuffledChoices({ ...q, choices: [...q.choices] }))
+      qs = qs.map((q) =>
+        withShuffledChoices({ ...q, choices: [...(Array.isArray(q.choices) ? q.choices : [])] }),
+      )
     }
     return qs
   }, [questions, advanced.shuffleQuestions, advanced.shuffleChoices, advanced.randomQuestionPoolCount])

--- a/clients/web/src/components/quiz/quiz-student-take-panel.tsx
+++ b/clients/web/src/components/quiz/quiz-student-take-panel.tsx
@@ -7,6 +7,7 @@ import {
   type Dispatch,
   type SetStateAction,
 } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { ChevronDown, ChevronUp, Clock, X } from 'lucide-react'
 import { useOptionalQuizShellFocus } from '../layout/quiz-shell-focus-context'
 import type { QuizShellFocusMode, QuizShellLockdownAccent } from '../layout/quiz-shell-focus-context'
@@ -76,6 +77,8 @@ export type QuizStudentTakePanelProps = {
   advanced: QuizAdvancedSettings
   oneQuestionAtATime: boolean
   allowBackNavigation: boolean
+  /** Full-page route (`/attempt`) vs modal overlay on the quiz module page. */
+  layout?: 'overlay' | 'page'
 }
 
 type QuizAnswerState = {
@@ -103,7 +106,10 @@ export function QuizStudentTakePanel({
   advanced,
   oneQuestionAtATime,
   allowBackNavigation,
+  layout = 'overlay',
 }: QuizStudentTakePanelProps) {
+  const pageLayout = layout === 'page'
+  const isActive = pageLayout || open
   const [accessCode, setAccessCode] = useState('')
   const [uiPhase, setUiPhase] = useState<UiPhase>({ kind: 'idle' })
   const [postSubmitResults, setPostSubmitResults] = useState<QuizResultsPayload | null>(null)
@@ -114,6 +120,10 @@ export function QuizStudentTakePanel({
   const [serverLockdown, setServerLockdown] = useState(false)
   const [fullscreenWarning, setFullscreenWarning] = useState<string | null>(null)
   const [focusLossBanner, setFocusLossBanner] = useState<string | null>(null)
+  const [leaveConfirmOpen, setLeaveConfirmOpen] = useState(false)
+  const [leavingBusy, setLeavingBusy] = useState(false)
+  const pendingNavRef = useRef<string | null>(null)
+  const navigate = useNavigate()
   const [srvQuestion, setSrvQuestion] = useState<QuizQuestion | null>(null)
   const [srvIdx, setSrvIdx] = useState(0)
   const [srvTotal, setSrvTotal] = useState(0)
@@ -207,36 +217,117 @@ export function QuizStudentTakePanel({
     setFlaggedQuestionIds(new Set())
     setPostSubmitResults(null)
     setUnderstandingCheckDismissed(false)
+    setLeaveConfirmOpen(false)
+    setLeavingBusy(false)
     timeoutSubmitStartedRef.current = false
     tenMinuteWarningRef.current = false
     oneMinuteWarningRef.current = false
   }, [])
 
-  useEffect(() => {
-    if (!open) reset()
-  }, [open, reset])
+  const takeInProgress =
+    uiPhase.kind === 'starting' || (uiPhase.kind === 'static' && attemptId != null)
+
+  const requestClose = useCallback(() => {
+    if (takeInProgress) {
+      setLeaveConfirmOpen(true)
+      return
+    }
+    onClose()
+  }, [takeInProgress, onClose])
+
+  const confirmLeave = useCallback(async () => {
+    setLeaveConfirmOpen(false)
+    if (takeInProgress && attemptId) {
+      setLeavingBusy(true)
+      try {
+        if (quiz.isAdaptive) {
+          await postQuizSubmit(courseCode, itemId, { attemptId, adaptiveHistory: adHistory })
+        } else {
+          await submitStaticRef.current()
+        }
+      } catch {
+        /* close even if auto-submit fails */
+      } finally {
+        setLeavingBusy(false)
+      }
+    }
+    const pending = pendingNavRef.current
+    pendingNavRef.current = null
+    onClose()
+    if (pending) navigate(pending)
+  }, [takeInProgress, attemptId, onClose, quiz.isAdaptive, courseCode, itemId, adHistory, navigate])
+
+  const cancelLeave = useCallback(() => {
+    setLeaveConfirmOpen(false)
+    pendingNavRef.current = null
+  }, [])
 
   useEffect(() => {
-    if (!open) return
+    if (!takeInProgress || leaveConfirmOpen) return
+    const onClick = (e: MouseEvent) => {
+      const anchor = (e.target as Element).closest('a[href]') as HTMLAnchorElement | null
+      if (!anchor) return
+      if (anchor.target === '_blank' || anchor.hasAttribute('download')) return
+      const href = anchor.getAttribute('href')
+      if (!href || href.startsWith('#') || href.startsWith('mailto:') || href.startsWith('tel:')) return
+      let url: URL
+      try {
+        url = new URL(href, window.location.origin)
+      } catch {
+        return
+      }
+      if (url.origin !== window.location.origin) return
+      const dest = url.pathname + url.search + url.hash
+      const here = window.location.pathname + window.location.search + window.location.hash
+      if (dest === here) return
+      e.preventDefault()
+      e.stopPropagation()
+      pendingNavRef.current = dest
+      setLeaveConfirmOpen(true)
+    }
+    document.addEventListener('click', onClick, true)
+    return () => document.removeEventListener('click', onClick, true)
+  }, [takeInProgress, leaveConfirmOpen])
+
+  useEffect(() => {
+    if (!takeInProgress) return
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', onBeforeUnload)
+    return () => window.removeEventListener('beforeunload', onBeforeUnload)
+  }, [takeInProgress])
+
+  useEffect(() => {
+    if (!pageLayout && !open) reset()
+    return () => {
+      if (pageLayout) reset()
+    }
+  }, [open, reset, pageLayout])
+
+  useEffect(() => {
+    if (!isActive) return
     function onKey(e: KeyboardEvent) {
       if (e.key !== 'Escape') return
+      if (takeInProgress) return
       e.preventDefault()
-      onClose()
+      requestClose()
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [open, onClose])
+  }, [isActive, takeInProgress, requestClose])
 
   useEffect(() => {
-    if (!open) return
+    if (!isActive) return
     requestAnimationFrame(() => {
       const el = panelRef.current?.querySelector<HTMLElement>('button:not([disabled])')
       el?.focus()
     })
-  }, [open])
+  }, [isActive])
 
   useEffect(() => {
-    if (!open || !startMeta?.deadlineAt || uiPhase.kind !== 'static') {
+    if (!isActive || !startMeta?.deadlineAt || uiPhase.kind !== 'static') {
       setTimeLeftSec(null)
       return
     }
@@ -254,7 +345,7 @@ export function QuizStudentTakePanel({
   }, [open, startMeta?.deadlineAt, uiPhase.kind])
 
   useEffect(() => {
-    if (!open || !serverLockdown || startMeta?.lockdownMode !== 'kiosk' || !attemptId) return
+    if (!open || !attemptId || uiPhase.kind !== 'static') return
     const aid = attemptId
     kioskVisSkipRef.current = true
     function onVis() {
@@ -283,7 +374,7 @@ export function QuizStudentTakePanel({
       document.removeEventListener('visibilitychange', onVis)
       window.removeEventListener('blur', onBlur)
     }
-  }, [open, serverLockdown, startMeta?.lockdownMode, attemptId, courseCode, itemId])
+  }, [open, attemptId, uiPhase.kind, courseCode, itemId])
 
   async function beginAttempt() {
     setError(null)
@@ -661,9 +752,8 @@ export function QuizStudentTakePanel({
   }
 
   const optionalShell = useOptionalQuizShellFocus()
-  const timedConfigured = (advanced.timeLimitMinutes ?? 0) > 0
-  const shellFocusSession =
-    open && (timedConfigured || needsLockdownWarning) && uiPhase.kind !== 'done'
+  const setQuizShellFocus = optionalShell?.setQuizShellFocus
+  const shellFocusSession = isActive && takeInProgress
 
   const currentAdaptiveHeadless = open ? (adPending[0] ?? null) : null
 
@@ -757,9 +847,9 @@ export function QuizStudentTakePanel({
   }, [lockdownModalOpen, uiPhase.kind, quiz.isAdaptive, serverLockdown, advanceBusy, srvCompleted])
 
   useEffect(() => {
-    if (!optionalShell) return
+    if (!setQuizShellFocus) return
     if (!shellFocusSession) {
-      optionalShell.setQuizShellFocus(null)
+      setQuizShellFocus(null)
       return
     }
     const model: QuizShellFocusMode = {
@@ -772,12 +862,12 @@ export function QuizStudentTakePanel({
       flaggedForCurrent,
       onToggleFlagForReview: currentFlagQuestionId ? toggleFlagForReview : null,
     }
-    optionalShell.setQuizShellFocus(model)
+    setQuizShellFocus(model)
     return () => {
-      optionalShell.setQuizShellFocus(null)
+      setQuizShellFocus(null)
     }
   }, [
-    optionalShell,
+    setQuizShellFocus,
     shellFocusSession,
     quiz.title,
     timeLabelForShell,
@@ -790,11 +880,12 @@ export function QuizStudentTakePanel({
     toggleFlagForReview,
   ])
 
-  if (!open) return null
+  if (!pageLayout && !open) return null
 
   const currentAdaptive = adPending[0] ?? null
   const reducedTake = Boolean(startMeta?.reducedDistractionMode)
-  const immersiveChrome = shellFocusSession
+  const immersiveChrome = pageLayout || open
+  const showPanelHeader = !pageLayout || !shellFocusSession
 
   const timeLabel =
     timeLeftSec != null
@@ -806,68 +897,87 @@ export function QuizStudentTakePanel({
   return (
     <div
       ref={panelRef}
-      className={`fixed inset-0 z-[70] flex justify-center bg-slate-900/40 p-4 sm:items-center ${
-        immersiveChrome ? 'items-stretch bg-slate-950 p-0 sm:items-stretch' : 'items-end'
-      }`}
-      role="dialog"
-      aria-modal="true"
+      className={
+        pageLayout
+          ? `flex min-h-0 flex-1 flex-col ${reducedTake ? 'lex-quiz-reduced-distract' : ''}`
+          : `fixed inset-0 z-[70] flex justify-center bg-slate-900/40 p-4 sm:items-center ${
+              immersiveChrome ? 'relative items-stretch bg-slate-950 p-0 sm:items-stretch' : 'items-end'
+            }`
+      }
+      role={pageLayout ? undefined : 'dialog'}
+      aria-modal={pageLayout ? undefined : true}
       aria-labelledby="quiz-take-title"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose()
-      }}
+      onClick={
+        pageLayout
+          ? undefined
+          : (e) => {
+              if (e.target === e.currentTarget && !takeInProgress) requestClose()
+            }
+      }
     >
       <div
         className={`flex w-full flex-col overflow-hidden border border-slate-200 bg-white shadow-xl dark:border-neutral-600 dark:bg-neutral-900 ${
-          immersiveChrome
-            ? `h-dvh max-h-dvh max-w-none rounded-none border-0 shadow-none sm:max-h-dvh ${
-                reducedTake ? 'lex-quiz-reduced-distract' : ''
-              }`
-            : `h-[90vh] rounded-2xl ${reducedTake ? 'lex-quiz-reduced-distract max-w-2xl' : 'max-w-3xl'}`
+          pageLayout
+            ? `min-h-0 flex-1 border-0 shadow-none ${reducedTake ? 'lex-quiz-reduced-distract' : ''}`
+            : immersiveChrome
+              ? `h-dvh max-h-dvh max-w-none rounded-none border-0 shadow-none sm:max-h-dvh ${
+                  reducedTake ? 'lex-quiz-reduced-distract' : ''
+                }`
+              : `h-[90vh] rounded-2xl ${reducedTake ? 'lex-quiz-reduced-distract max-w-2xl' : 'max-w-3xl'}`
         } ${highContrastQuiz && reducedTake ? 'ring-2 ring-slate-900 dark:ring-neutral-100' : ''}`}
       >
-        <div
-          className={`flex shrink-0 items-start justify-between gap-3 border-b border-slate-200 px-4 py-3 dark:border-neutral-600 ${
-            immersiveChrome ? 'py-2' : ''
-          }`}
-        >
-          <div className="min-w-0">
-            {immersiveChrome ? (
-              <h2 id="quiz-take-title" className="sr-only">
-                {reducedTake ? 'Quiz' : 'Take quiz'} — {quiz.title || 'Quiz'}
-              </h2>
-            ) : (
-              <>
-                <h2 id="quiz-take-title" className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
-                  {reducedTake ? 'Quiz' : 'Take quiz'}
+        {showPanelHeader ? (
+          <div
+            className={`flex shrink-0 items-start justify-between gap-3 border-b border-slate-200 px-4 py-3 dark:border-neutral-600 ${
+              immersiveChrome ? 'py-2' : ''
+            }`}
+          >
+            <div className="min-w-0">
+              {immersiveChrome && !pageLayout ? (
+                <h2 id="quiz-take-title" className="sr-only">
+                  {reducedTake ? 'Quiz' : 'Take quiz'} — {quiz.title || 'Quiz'}
                 </h2>
-                {!reducedTake ? (
-                  <p className="mt-0.5 truncate text-xs text-slate-500 dark:text-neutral-400" title={quiz.title}>
-                    {quiz.title || 'Quiz'}
-                  </p>
-                ) : null}
-              </>
-            )}
+              ) : (
+                <>
+                  <h2 id="quiz-take-title" className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+                    {reducedTake ? 'Quiz' : pageLayout && uiPhase.kind === 'idle' ? 'Begin quiz' : 'Take quiz'}
+                  </h2>
+                  {!reducedTake ? (
+                    <p className="mt-0.5 truncate text-xs text-slate-500 dark:text-neutral-400" title={quiz.title}>
+                      {quiz.title || 'Quiz'}
+                    </p>
+                  ) : null}
+                </>
+              )}
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              {reducedTake ? (
+                <button
+                  type="button"
+                  onClick={() => setHighContrastQuiz((v) => !v)}
+                  className="rounded-lg border border-slate-200 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                >
+                  {highContrastQuiz ? 'Contrast: on' : 'Contrast: off'}
+                </button>
+              ) : null}
+              {!pageLayout ? (
+                <button
+                  type="button"
+                  onClick={requestClose}
+                  disabled={leavingBusy}
+                  className="shrink-0 rounded-lg p-1.5 text-slate-500 hover:bg-slate-100 hover:text-slate-800 disabled:opacity-50 dark:hover:bg-neutral-800"
+                  aria-label={takeInProgress ? 'Leave quiz' : 'Close'}
+                >
+                  <X className="h-5 w-5" aria-hidden />
+                </button>
+              ) : null}
+            </div>
           </div>
-          <div className="flex shrink-0 items-center gap-2">
-            {reducedTake ? (
-              <button
-                type="button"
-                onClick={() => setHighContrastQuiz((v) => !v)}
-                className="rounded-lg border border-slate-200 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
-              >
-                {highContrastQuiz ? 'Contrast: on' : 'Contrast: off'}
-              </button>
-            ) : null}
-            <button
-              type="button"
-              onClick={onClose}
-              className="shrink-0 rounded-lg p-1.5 text-slate-500 hover:bg-slate-100 hover:text-slate-800 dark:hover:bg-neutral-800"
-              aria-label="Close"
-            >
-              <X className="h-5 w-5" aria-hidden />
-            </button>
-          </div>
-        </div>
+        ) : (
+          <h2 id="quiz-take-title" className="sr-only">
+            {quiz.title || 'Quiz'}
+          </h2>
+        )}
 
         <div className="min-h-0 flex-1 overflow-y-auto bg-slate-50/60 p-4 dark:bg-neutral-950/80">
           {lockdownModalOpen && (
@@ -1002,6 +1112,10 @@ export function QuizStudentTakePanel({
                 {quiz.isAdaptive
                   ? 'You will answer up to the configured number of AI-generated questions. Your attempt is saved when you finish.'
                   : 'Answer each question, then submit. Your score is recorded for this course.'}
+              </p>
+              <p className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-100">
+                Leaving this tab or switching apps during the quiz is logged for your instructor. If you
+                navigate away, your attempt will be submitted automatically.
               </p>
               {advanced.requiresQuizAccessCode ? (
                 <div>
@@ -1239,15 +1353,51 @@ export function QuizStudentTakePanel({
               )}
               <button
                 type="button"
-                onClick={onClose}
+                onClick={requestClose}
                 className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-800 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200"
               >
-                Close
+                {pageLayout ? 'Return to quiz' : 'Close'}
               </button>
             </div>
           )}
         </div>
       </div>
+
+      {leaveConfirmOpen ? (
+        <div
+          className="absolute inset-0 z-10 flex items-center justify-center bg-slate-950/60 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="quiz-leave-title"
+        >
+          <div className="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-5 shadow-xl dark:border-neutral-600 dark:bg-neutral-900">
+            <h3 id="quiz-leave-title" className="text-base font-semibold text-slate-900 dark:text-neutral-100">
+              Leave this quiz?
+            </h3>
+            <p className="mt-2 text-sm text-slate-600 dark:text-neutral-300">
+              Your attempt is in progress. Leaving now will submit whatever you have answered so far.
+            </p>
+            <div className="mt-4 flex flex-wrap justify-end gap-2">
+              <button
+                type="button"
+                onClick={cancelLeave}
+                disabled={leavingBusy}
+                className="rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 dark:border-neutral-600 dark:text-neutral-200"
+              >
+                Stay on quiz
+              </button>
+              <button
+                type="button"
+                onClick={() => void confirmLeave()}
+                disabled={leavingBusy}
+                className="rounded-lg bg-rose-600 px-3 py-2 text-sm font-semibold text-white hover:bg-rose-500 disabled:opacity-50"
+              >
+                {leavingBusy ? 'Submitting…' : 'Leave and submit'}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/clients/web/src/components/quiz/quiz-take-utils.ts
+++ b/clients/web/src/components/quiz/quiz-take-utils.ts
@@ -2,7 +2,8 @@ import { type QuizAdvancedSettings, type QuizQuestion } from '../../lib/courses-
 import { shuffleArray, shuffledIndices } from '../../lib/shuffle'
 
 export function visibleChoices(q: QuizQuestion): string[] {
-  return q.choices.map((c) => c.trim()).filter((c) => c.length > 0)
+  const choices = Array.isArray(q.choices) ? q.choices : []
+  return choices.map((c) => String(c).trim()).filter((c) => c.length > 0)
 }
 
 export function orderingItemsForQuestion(q: QuizQuestion): string[] {
@@ -96,7 +97,9 @@ export function prepareStaticQuestions(
     qs = shuffleArray(qs).slice(0, pool)
   }
   if (advanced.shuffleChoices) {
-    qs = qs.map((q) => withShuffledChoices({ ...q, choices: [...q.choices] }))
+    qs = qs.map((q) =>
+      withShuffledChoices({ ...q, choices: [...(Array.isArray(q.choices) ? q.choices : [])] }),
+    )
   }
   return qs
 }

--- a/clients/web/src/components/settings/org-units-panel.tsx
+++ b/clients/web/src/components/settings/org-units-panel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type FormEvent } from 'react'
 import { ChevronRight, FolderTree, Plus, RefreshCw } from 'lucide-react'
 import { authorizedFetch } from '../../lib/api'
+import { fetchOrgType, type OrgType } from '../../lib/courses-api'
 import { getAccessToken } from '../../lib/auth'
 import { decodeJwtPayload } from '../../lib/jwt-payload'
 import { PERM_RBAC_MANAGE, PERM_TENANT_ORG_UNITS_ADMIN } from '../../lib/rbac-api'
@@ -8,7 +9,7 @@ import { readApiErrorMessage } from '../../lib/errors'
 import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
 import { usePermissions } from '../../context/use-permissions'
 
-export type OrgType = 'higher-ed' | 'k-12'
+export type { OrgType } from '../../lib/courses-api'
 
 type OrgRow = {
   id: string
@@ -162,14 +163,11 @@ export function OrgUnitsPanel() {
   }, [orgId, canUnits, loadTree])
 
   useEffect(() => {
-    if (!orgId) return
-    void authorizedFetch(`/api/v1/orgs/${encodeURIComponent(orgId)}/settings/org-type`)
-      .then((r) => r.json())
-      .then((data: { orgType?: OrgType }) => {
-        if (data.orgType === 'k-12' || data.orgType === 'higher-ed') setOrgType(data.orgType)
-      })
+    if (!orgId || (!canUnits && !canRbac)) return
+    void fetchOrgType(orgId)
+      .then((t) => setOrgType(t))
       .catch(() => {})
-  }, [orgId])
+  }, [orgId, canUnits, canRbac])
 
   async function createRoot(e: FormEvent) {
     e.preventDefault()

--- a/clients/web/src/lib/courses-api-schemas.ts
+++ b/clients/web/src/lib/courses-api-schemas.ts
@@ -467,6 +467,11 @@ export const courseGradingSchemeEnvelopeSchema = z.object({
     .optional(),
 })
 
+const quizQuestionChoicesSchema = z.preprocess(
+  (v) => (Array.isArray(v) ? v : []),
+  z.array(z.string()),
+)
+
 export const quizQuestionSchema = z.object({
   id: z.string(),
   prompt: z.string(),
@@ -486,7 +491,7 @@ export const quizQuestionSchema = z.object({
     'audio_response',
     'video_response',
   ]),
-  choices: z.array(z.string()),
+  choices: quizQuestionChoicesSchema,
   typeConfig: z.record(z.string(), z.unknown()).optional(),
   correctChoiceIndex: z.number().nullable(),
   multipleAnswer: z.boolean(),
@@ -504,7 +509,7 @@ const adaptiveQuizGeneratedQuestionSchema = z.object({
   questionId: z.string().uuid().optional(),
   prompt: z.string(),
   questionType: z.string(),
-  choices: z.array(z.string()),
+  choices: quizQuestionChoicesSchema,
   choiceWeights: z.array(z.number()),
   multipleAnswer: z.boolean(),
   answerWithImage: z.boolean(),

--- a/clients/web/src/lib/courses-api.ts
+++ b/clients/web/src/lib/courses-api.ts
@@ -211,6 +211,17 @@ export type OrgTerm = {
   updatedAt: string
 }
 
+export type OrgType = 'higher-ed' | 'k-12'
+
+export async function fetchOrgType(orgId: string): Promise<OrgType> {
+  const res = await authorizedFetch(`/api/v1/orgs/${encodeURIComponent(orgId)}/settings/org-type`)
+  const raw: unknown = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  const data = raw as { orgType?: string }
+  if (data.orgType === 'k-12' || data.orgType === 'higher-ed') return data.orgType
+  return 'higher-ed'
+}
+
 export async function fetchOrgTerms(orgId: string): Promise<OrgTerm[]> {
   const res = await authorizedFetch(`/api/v1/orgs/${encodeURIComponent(orgId)}/terms`)
   const raw: unknown = await res.json().catch(() => ({}))
@@ -335,6 +346,13 @@ export function learnerCourseItemHref(courseCode: string, item: { kind: string; 
     default:
       return `/courses/${cc}/modules`
   }
+}
+
+/** Full-page student quiz attempt route (begin + take). */
+export function courseModuleQuizAttemptHref(courseCode: string, itemId: string): string {
+  const cc = encodeURIComponent(courseCode)
+  const id = encodeURIComponent(itemId)
+  return `/courses/${cc}/modules/quiz/${id}/attempt`
 }
 
 /** Server `course::GRADING_SCALES` — keep in sync for labels and validation. */
@@ -2840,6 +2858,28 @@ export function quizAdvancedSettingsFromPayload(data: ModuleQuizPayload): QuizAd
 }
 
 /** Backward-compatible defaults when older API responses omit new fields. */
+export function normalizeQuizQuestion(raw: unknown): QuizQuestion {
+  const q = raw as Partial<QuizQuestion> & Record<string, unknown>
+  return {
+    id: String(q.id ?? ''),
+    prompt: String(q.prompt ?? ''),
+    questionType: (q.questionType as QuizQuestion['questionType']) ?? 'multiple_choice',
+    choices: Array.isArray(q.choices) ? q.choices.map((c) => String(c)) : [],
+    choiceIds: Array.isArray(q.choiceIds) ? q.choiceIds.map(String) : undefined,
+    typeConfig:
+      q.typeConfig && typeof q.typeConfig === 'object' && !Array.isArray(q.typeConfig)
+        ? (q.typeConfig as Record<string, unknown>)
+        : undefined,
+    correctChoiceIndex: typeof q.correctChoiceIndex === 'number' ? q.correctChoiceIndex : null,
+    multipleAnswer: Boolean(q.multipleAnswer),
+    answerWithImage: Boolean(q.answerWithImage),
+    required: q.required !== false,
+    points: typeof q.points === 'number' ? q.points : 0,
+    estimatedMinutes: typeof q.estimatedMinutes === 'number' ? q.estimatedMinutes : 0,
+  }
+}
+
+/** Backward-compatible defaults when older API responses omit new fields. */
 export function normalizeModuleQuizPayload(raw: unknown): ModuleQuizPayload {
   const r = raw as Partial<ModuleQuizPayload> & Record<string, unknown>
   return {
@@ -2881,7 +2921,7 @@ export function normalizeModuleQuizPayload(raw: unknown): ModuleQuizPayload {
     adaptiveStopRule: (r.adaptiveStopRule as AdaptiveStopRule) ?? 'fixed_count',
     randomQuestionPoolCount:
       typeof r.randomQuestionPoolCount === 'number' ? r.randomQuestionPoolCount : null,
-    questions: Array.isArray(r.questions) ? (r.questions as QuizQuestion[]) : [],
+    questions: Array.isArray(r.questions) ? r.questions.map(normalizeQuizQuestion) : [],
     usesServerQuestionSampling: Boolean(r.usesServerQuestionSampling),
     updatedAt: String(r.updatedAt ?? ''),
     isAdaptive: Boolean(r.isAdaptive),

--- a/clients/web/src/lib/quiz-analytics-api.ts
+++ b/clients/web/src/lib/quiz-analytics-api.ts
@@ -21,6 +21,14 @@ export type QuizAnalyticsReport = {
   meanScore: number | null
   scoreBuckets: QuizScoreBucket[]
   questionStats: QuizQuestionStat[]
+  focusAttempts: QuizFocusAttemptStat[]
+}
+
+export type QuizFocusAttemptStat = {
+  attemptId: string
+  attemptNumber: number
+  eventCount: number
+  academicIntegrityFlag: boolean
 }
 
 /** GET `/api/v1/courses/:code/quizzes/:id/analytics` — instructor only. */
@@ -40,5 +48,6 @@ export async function fetchQuizAnalytics(
     meanScore: (raw.meanScore as number | null | undefined) ?? null,
     scoreBuckets: (raw.scoreBuckets as QuizScoreBucket[]) ?? [],
     questionStats: (raw.questionStats as QuizQuestionStat[]) ?? [],
+    focusAttempts: (raw.focusAttempts as QuizFocusAttemptStat[]) ?? [],
   }
 }

--- a/clients/web/src/pages/lms/course-files-page.tsx
+++ b/clients/web/src/pages/lms/course-files-page.tsx
@@ -58,6 +58,13 @@ function matchesSearchQuery(name: string, query: string): boolean {
   return name.toLowerCase().includes(query.trim().toLowerCase())
 }
 
+function isExternalFileDragEvent(
+  e: React.DragEvent | DragEvent,
+  draggingItem: { kind: 'folder' | 'file'; id: string } | null,
+): boolean {
+  return draggingItem === null && (e.dataTransfer?.types.includes('Files') ?? false)
+}
+
 const CHECKBOX_COLUMN_CLASS = 'w-11 px-4 py-2.5 align-middle text-left'
 const CHECKBOX_INPUT_CLASS =
   'block h-4 w-4 shrink-0 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-neutral-600 dark:bg-neutral-900'
@@ -88,6 +95,8 @@ export default function CourseFilesPage() {
   const [contextMenu, setContextMenu] = useState<ContextMenu | null>(null)
   const [draggingItem, setDraggingItem] = useState<{ kind: 'folder' | 'file'; id: string } | null>(null)
   const [dragOverFolderId, setDragOverFolderId] = useState<string | null>(null)
+  const [externalFileDragActive, setExternalFileDragActive] = useState(false)
+  const externalDragDepthRef = useRef(0)
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedItems, setSelectedItems] = useState<Set<SelectedItemKey>>(new Set())
   const [previewFile, setPreviewFile] = useState<FileItem | null>(null)
@@ -138,6 +147,41 @@ export default function CourseFilesPage() {
     setSelectedItems(new Set())
     setSearchQuery('')
   }, [folderId])
+
+  useEffect(() => {
+    if (!canManage) return
+
+    function resetExternalDrag() {
+      externalDragDepthRef.current = 0
+      setExternalFileDragActive(false)
+      setDragOverFolderId(null)
+    }
+
+    function onDragEnter(e: DragEvent) {
+      if (!isExternalFileDragEvent(e, draggingItem)) return
+      externalDragDepthRef.current++
+      setExternalFileDragActive(true)
+    }
+
+    function onDragLeave(e: DragEvent) {
+      if (!isExternalFileDragEvent(e, draggingItem)) return
+      externalDragDepthRef.current--
+      if (externalDragDepthRef.current <= 0) {
+        resetExternalDrag()
+      }
+    }
+
+    window.addEventListener('dragenter', onDragEnter)
+    window.addEventListener('dragleave', onDragLeave)
+    window.addEventListener('drop', resetExternalDrag)
+    window.addEventListener('dragend', resetExternalDrag)
+    return () => {
+      window.removeEventListener('dragenter', onDragEnter)
+      window.removeEventListener('dragleave', onDragLeave)
+      window.removeEventListener('drop', resetExternalDrag)
+      window.removeEventListener('dragend', resetExternalDrag)
+    }
+  }, [canManage, draggingItem])
 
   const breadcrumbs = useMemo(() => {
     if (!folderId || contents?.folderId !== folderId) return []
@@ -371,9 +415,9 @@ export default function CourseFilesPage() {
     }
   }
 
-  async function uploadSingleFile(file: File) {
+  async function uploadSingleFile(file: File, targetFolderId: string | null) {
     setUploadProgress(`Uploading ${file.name}…`)
-    const result = await initiateFileUpload(courseCode, file, folderId ?? null)
+    const result = await initiateFileUpload(courseCode, file, targetFolderId)
     if ('presigned' in result) {
       await uploadToPresignedUrl(result.presigned.presignedPutUrl!, file)
       await confirmFileUpload(
@@ -382,19 +426,20 @@ export default function CourseFilesPage() {
         file.name,
         file.type || 'application/octet-stream',
         file.size,
-        folderId ?? null,
+        targetFolderId,
       )
     }
   }
 
-  async function handleFilesSelected(files: FileList | null) {
+  async function handleFilesSelected(files: FileList | null, targetFolderId?: string | null) {
     if (!files || files.length === 0) return
+    const destinationFolderId = targetFolderId ?? folderId ?? null
     setUploading(true)
     setCloudImportError(null)
     for (let i = 0; i < files.length; i++) {
       const file = files[i]
       try {
-        await uploadSingleFile(file)
+        await uploadSingleFile(file, destinationFolderId)
       } catch (err) {
         alert(`Failed to upload ${file.name}: ${err instanceof Error ? err.message : 'Unknown error'}`)
       }
@@ -404,11 +449,23 @@ export default function CourseFilesPage() {
     void load()
   }
 
+  async function handleExternalFileDrop(e: React.DragEvent, targetFolderId: string | null) {
+    if (!canManage) return
+    e.preventDefault()
+    e.stopPropagation()
+    externalDragDepthRef.current = 0
+    setExternalFileDragActive(false)
+    setDragOverFolderId(null)
+    const files = e.dataTransfer.files
+    if (files.length === 0) return
+    await handleFilesSelected(files, targetFolderId)
+  }
+
   async function handleCloudImport(file: File) {
     setUploading(true)
     setCloudImportError(null)
     try {
-      await uploadSingleFile(file)
+      await uploadSingleFile(file, folderId ?? null)
       void load()
     } catch (err) {
       setCloudImportError(err instanceof Error ? err.message : 'Could not import file from cloud storage.')
@@ -560,7 +617,12 @@ export default function CourseFilesPage() {
           {error}
         </div>
       ) : !contents || (contents.folders.length === 0 && contents.files.length === 0) ? (
-        <EmptyState canManage={canManage} onUpload={() => fileInputRef.current?.click()} />
+        <EmptyState
+          canManage={canManage}
+          externalFileDragActive={externalFileDragActive}
+          onUpload={() => fileInputRef.current?.click()}
+          onExternalFileDrop={e => void handleExternalFileDrop(e, folderId ?? null)}
+        />
       ) : filteredFolders.length === 0 && filteredFiles.length === 0 ? (
         <div className="flex flex-col items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-center dark:border-neutral-800 dark:bg-neutral-950">
           <Search className="mb-3 h-10 w-10 text-slate-300 dark:text-neutral-600" aria-hidden />
@@ -570,7 +632,25 @@ export default function CourseFilesPage() {
           </p>
         </div>
       ) : (
-        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-950">
+        <div
+          className={`overflow-hidden rounded-xl border bg-white dark:bg-neutral-950 ${
+            externalFileDragActive && dragOverFolderId === null
+              ? 'border-indigo-400 ring-2 ring-indigo-500/20 dark:border-indigo-600'
+              : 'border-slate-200 dark:border-neutral-800'
+          }`}
+          onDragOver={e => {
+            if (canManage && isExternalFileDragEvent(e, draggingItem)) {
+              e.preventDefault()
+              e.dataTransfer.dropEffect = 'copy'
+              setDragOverFolderId(null)
+            }
+          }}
+          onDrop={e => {
+            if (canManage && isExternalFileDragEvent(e, draggingItem)) {
+              void handleExternalFileDrop(e, folderId ?? null)
+            }
+          }}
+        >
           <table className="min-w-full table-fixed divide-y divide-slate-100 text-sm dark:divide-neutral-800">
             {canManage && (
               <colgroup>
@@ -616,12 +696,14 @@ export default function CourseFilesPage() {
                   onDelete={() => void handleDeleteFolder(folder)}
                   onContextMenu={e => openContextMenu(e, folder, 'folder')}
                   draggingItem={draggingItem}
+                  externalFileDragActive={externalFileDragActive}
                   dragOverFolderId={dragOverFolderId}
                   onDragStart={(kind, id) => setDraggingItem({ kind, id })}
                   onDragEnd={() => { setDraggingItem(null); setDragOverFolderId(null); }}
                   onDragEnter={(id) => setDragOverFolderId(id)}
                   onDragLeave={() => setDragOverFolderId(null)}
                   onDrop={(kind, dragId, targetId) => void handleMoveItem(kind, dragId, targetId)}
+                  onExternalFileDrop={e => void handleExternalFileDrop(e, folder.id)}
                 />
               ))}
               {filteredFiles.map(file => (
@@ -900,13 +982,38 @@ function SelectionActionsMenu({
   )
 }
 
-function EmptyState({ canManage, onUpload }: { canManage: boolean; onUpload: () => void }) {
+function EmptyState({
+  canManage,
+  externalFileDragActive,
+  onUpload,
+  onExternalFileDrop,
+}: {
+  canManage: boolean
+  externalFileDragActive: boolean
+  onUpload: () => void
+  onExternalFileDrop: (e: React.DragEvent) => void
+}) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-xl border-2 border-dashed border-slate-200 py-16 text-center dark:border-neutral-700">
+    <div
+      className={`flex flex-col items-center justify-center rounded-xl border-2 border-dashed py-16 text-center ${
+        externalFileDragActive
+          ? 'border-indigo-400 bg-indigo-50/50 dark:border-indigo-600 dark:bg-indigo-950/30'
+          : 'border-slate-200 dark:border-neutral-700'
+      }`}
+      onDragOver={e => {
+        if (canManage) {
+          e.preventDefault()
+          e.dataTransfer.dropEffect = 'copy'
+        }
+      }}
+      onDrop={e => {
+        if (canManage) onExternalFileDrop(e)
+      }}
+    >
       <FolderOpen className="mb-3 h-12 w-12 text-slate-300 dark:text-neutral-600" aria-hidden />
       <p className="text-sm font-medium text-slate-700 dark:text-neutral-200">No files yet</p>
       <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
-        {canManage ? 'Upload files or create folders to organize course materials.' : 'No files have been uploaded to this course yet.'}
+        {canManage ? 'Upload files, drag and drop them here, or create folders to organize course materials.' : 'No files have been uploaded to this course yet.'}
       </p>
       {canManage && (
         <button
@@ -936,26 +1043,30 @@ type FolderRowProps = {
   onDelete: () => void
   onContextMenu: (e: React.MouseEvent) => void
   draggingItem: { kind: 'folder' | 'file'; id: string } | null
+  externalFileDragActive: boolean
   dragOverFolderId: string | null
   onDragStart: (kind: 'folder' | 'file', id: string) => void
   onDragEnd: () => void
   onDragEnter: (id: string) => void
   onDragLeave: () => void
   onDrop: (kind: 'folder' | 'file', dragId: string, targetId: string) => void
+  onExternalFileDrop: (e: React.DragEvent) => void
 }
 
 function FolderRow({
   folder, canManage, selected, onToggleSelect, renamingFolder, renameValue, setRenameValue,
   onNavigate, onRenameStart, onRenameSubmit, onRenameCancel, onDelete, onContextMenu,
-  draggingItem, dragOverFolderId, onDragStart, onDragEnd, onDragEnter, onDragLeave, onDrop,
+  draggingItem, externalFileDragActive, dragOverFolderId, onDragStart, onDragEnd, onDragEnter, onDragLeave, onDrop,
+  onExternalFileDrop,
 }: FolderRowProps) {
   const isRenaming = renamingFolder?.id === folder.id
-  const isDraggingActive = draggingItem !== null
+  const isInternalDragActive = draggingItem !== null
+  const isDropTargetMode = isInternalDragActive || externalFileDragActive
   const isSelf = draggingItem?.id === folder.id && draggingItem?.kind === 'folder'
   const isDragOver = dragOverFolderId === folder.id
 
   let dragClass = 'group cursor-pointer hover:bg-slate-50 dark:hover:bg-neutral-900/50 transition-colors'
-  if (isDraggingActive) {
+  if (isDropTargetMode) {
     if (isSelf) {
       dragClass = 'opacity-40 select-none pointer-events-none'
     } else {
@@ -981,13 +1092,24 @@ function FolderRow({
       }}
       onDragEnd={onDragEnd}
       onDragOver={(e) => {
-        if (isDraggingActive && !isSelf) {
+        if (canManage && isExternalFileDragEvent(e, draggingItem) && !isSelf) {
+          e.preventDefault()
+          e.stopPropagation()
+          e.dataTransfer.dropEffect = 'copy'
+          return
+        }
+        if (isInternalDragActive && !isSelf) {
           e.preventDefault()
           e.dataTransfer.dropEffect = 'move'
         }
       }}
-      onDragEnter={() => {
-        if (isDraggingActive && !isSelf) {
+      onDragEnter={(e) => {
+        if (canManage && isExternalFileDragEvent(e, draggingItem) && !isSelf) {
+          e.stopPropagation()
+          onDragEnter(folder.id)
+          return
+        }
+        if (isInternalDragActive && !isSelf) {
           onDragEnter(folder.id)
         }
       }}
@@ -998,7 +1120,11 @@ function FolderRow({
         }
       }}
       onDrop={(e) => {
-        if (isDraggingActive && !isSelf) {
+        if (canManage && isExternalFileDragEvent(e, draggingItem) && !isSelf) {
+          onExternalFileDrop(e)
+          return
+        }
+        if (isInternalDragActive && !isSelf) {
           e.preventDefault()
           onDrop(draggingItem.kind, draggingItem.id, folder.id)
         }

--- a/clients/web/src/pages/lms/course-module-assignment-page.tsx
+++ b/clients/web/src/pages/lms/course-module-assignment-page.tsx
@@ -8,6 +8,7 @@ import { markdownToSectionsForEditor, sectionsToMarkdown } from '../../component
 import { usePermissions } from '../../context/use-permissions'
 import {
   fetchCourse,
+  courseGradebookViewPermission,
   fetchCourseEnrollmentsList,
   fetchCourseGradingSettings,
   fetchModuleAssignment,
@@ -317,12 +318,16 @@ export default function CourseModuleAssignmentPage() {
       setDraftNeverDrop(nd)
       setDraftReplaceWithFinal(rwf)
       setAssignmentGroupPatchError(null)
-      try {
-        const grading = await fetchCourseGradingSettings(courseCode)
-        setGradingGroups(
-          grading.assignmentGroups.filter((g) => g.id.trim()).map((g) => ({ id: g.id, name: g.name })),
-        )
-      } catch {
+      if (!permLoading && allows(courseGradebookViewPermission(courseCode))) {
+        try {
+          const grading = await fetchCourseGradingSettings(courseCode)
+          setGradingGroups(
+            grading.assignmentGroups.filter((g) => g.id.trim()).map((g) => ({ id: g.id, name: g.name })),
+          )
+        } catch {
+          setGradingGroups([])
+        }
+      } else if (!permLoading) {
         setGradingGroups([])
       }
       if (allows(permCourseItemCreate(courseCode))) {
@@ -393,7 +398,7 @@ export default function CourseModuleAssignmentPage() {
     } finally {
       setLoading(false)
     }
-  }, [allows, courseCode, itemId, loadMarkups])
+  }, [allows, courseCode, itemId, loadMarkups, permLoading])
 
   useEffect(() => {
     void load()

--- a/clients/web/src/pages/lms/course-module-quiz-attempt-page.tsx
+++ b/clients/web/src/pages/lms/course-module-quiz-attempt-page.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Loader2 } from 'lucide-react'
+import { QuizStudentTakePanel } from '../../components/quiz/quiz-student-take-panel'
+import {
+  fetchModuleQuiz,
+  learnerCourseItemHref,
+  quizAdvancedSettingsFromPayload,
+  type ModuleQuizPayload,
+  type QuizAdvancedSettings,
+} from '../../lib/courses-api'
+import { recordLastVisitedModuleItem } from '../../lib/last-visited-module-item'
+
+export default function CourseModuleQuizAttemptPage() {
+  const { courseCode, itemId } = useParams<{ courseCode: string; itemId: string }>()
+  const navigate = useNavigate()
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [quiz, setQuiz] = useState<ModuleQuizPayload | null>(null)
+  const [advanced, setAdvanced] = useState<QuizAdvancedSettings | null>(null)
+  const [oneQuestionAtATime, setOneQuestionAtATime] = useState(false)
+
+  const quizHref =
+    courseCode && itemId
+      ? learnerCourseItemHref(courseCode, { kind: 'quiz', id: itemId })
+      : '/courses'
+
+  const load = useCallback(async () => {
+    if (!courseCode || !itemId) return
+    setLoading(true)
+    setLoadError(null)
+    try {
+      const data = await fetchModuleQuiz(courseCode, itemId)
+      setQuiz(data)
+      setAdvanced(quizAdvancedSettingsFromPayload(data))
+      setOneQuestionAtATime(Boolean(data.oneQuestionAtATime))
+      recordLastVisitedModuleItem(courseCode, {
+        itemId,
+        kind: 'quiz',
+        title: data.title,
+      })
+    } catch (e) {
+      setQuiz(null)
+      setAdvanced(null)
+      setLoadError(e instanceof Error ? e.message : 'Could not load this quiz.')
+    } finally {
+      setLoading(false)
+    }
+  }, [courseCode, itemId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  if (!courseCode || !itemId) {
+    return (
+      <div className="px-4 py-8 text-sm text-slate-600 dark:text-neutral-400">
+        Missing course or quiz.
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-4 py-16 text-sm text-slate-600 dark:text-neutral-400">
+        <Loader2 className="h-6 w-6 animate-spin text-indigo-600 dark:text-indigo-400" aria-hidden />
+        Loading quiz…
+      </div>
+    )
+  }
+
+  if (loadError || !quiz || !advanced) {
+    return (
+      <div className="px-4 py-8 sm:px-6 md:px-8">
+        <p className="text-sm text-red-700 dark:text-red-400">{loadError ?? 'Could not load this quiz.'}</p>
+        <Link
+          to={quizHref}
+          className="mt-4 inline-block text-sm font-medium text-indigo-700 hover:text-indigo-900 dark:text-indigo-300 dark:hover:text-indigo-200"
+        >
+          Back to quiz
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <QuizStudentTakePanel
+        layout="page"
+        open
+        onClose={() => navigate(quizHref)}
+        courseCode={courseCode}
+        itemId={itemId}
+        quiz={quiz}
+        advanced={advanced}
+        oneQuestionAtATime={oneQuestionAtATime}
+        allowBackNavigation={advanced.allowBackNavigation}
+      />
+    </div>
+  )
+}

--- a/clients/web/src/pages/lms/course-module-quiz-page.tsx
+++ b/clients/web/src/pages/lms/course-module-quiz-page.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { formatDateTime } from '../../lib/format'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { Check, CheckCircle, ChevronDown, Download, Eye, Loader2, BarChart3, Pencil, Plus, Sparkles, Trash2, WifiOff, X } from 'lucide-react'
 import { useOnlineStatus } from '../../hooks/use-online-status'
 import { useOfflineContent } from '../../hooks/use-offline-content'
@@ -14,12 +14,14 @@ import {
   fetchCourseQuestions,
   defaultQuizAdvancedSettings,
   fetchCourse,
+  courseGradebookViewPermission,
   fetchCourseGradingSettings,
   fetchCourseStructure,
   fetchModuleQuiz,
   fetchQuizFocusLossEvents,
   fetchReaderMarkups,
   generateModuleQuizQuestions,
+  courseModuleQuizAttemptHref,
   patchCourseStructureItemAssignmentGroup,
   patchModuleQuiz,
   quizAdvancedSettingsFromPayload,
@@ -27,7 +29,6 @@ import {
   type CourseStructureItem,
   type BankQuestionRow,
   type LockdownMode,
-  type ModuleQuizPayload,
   type QuizAdvancedSettings,
   type QuizQuestion,
   type SyllabusSection,
@@ -38,7 +39,6 @@ import { CourseItemPromptEditor } from '../../components/course-item-prompt-edit
 import { expandQuizPromptWithRefs } from '../../lib/course-item-ref-tokens'
 import { QuizPageSettingsPanel } from '../../components/quiz/quiz-page-settings-panel'
 import { QuizStudentPreviewModal } from '../../components/quiz/quiz-student-preview-modal'
-import { QuizStudentTakePanel } from '../../components/quiz/quiz-student-take-panel'
 import { AuthoringSaveFootprint } from '../../components/authoring-save-footprint'
 import { FeatureHelpTrigger } from '../../components/feature-help/feature-help-trigger'
 import {
@@ -244,6 +244,7 @@ function QuizEditorMoreMenu({
 
 export default function CourseModuleQuizPage() {
   const { courseCode, itemId } = useParams<{ courseCode: string; itemId: string }>()
+  const navigate = useNavigate()
   const { allows, loading: permLoading } = usePermissions()
   const canEdit = Boolean(courseCode && itemId && !permLoading && allows(permCourseItemCreate(courseCode)))
   const canEditQuizItems = Boolean(
@@ -332,8 +333,6 @@ export default function CourseModuleQuizPage() {
   const [generateError, setGenerateError] = useState<string | null>(null)
   const [previewOpen, setPreviewOpen] = useState(false)
   const [analyticsOpen, setAnalyticsOpen] = useState(false)
-  const [studentQuizPayload, setStudentQuizPayload] = useState<ModuleQuizPayload | null>(null)
-  const [studentTakeOpen, setStudentTakeOpen] = useState(false)
   const [studentQuizBanner, setStudentQuizBanner] = useState<{ kind: 'success' | 'error'; text: string } | null>(null)
   const [proctoringConfig, setProctoringConfig] = useState<ProctoringConfig | null | undefined>(undefined)
   const [proctoringChecklistOpen, setProctoringChecklistOpen] = useState(false)
@@ -371,12 +370,16 @@ export default function CourseModuleQuizPage() {
       setDraftNeverDrop(nd)
       setDraftReplaceWithFinal(rwf)
       setAssignmentGroupPatchError(null)
-      try {
-        const grading = await fetchCourseGradingSettings(courseCode)
-        setGradingGroups(
-          grading.assignmentGroups.filter((g) => g.id.trim()).map((g) => ({ id: g.id, name: g.name })),
-        )
-      } catch {
+      if (!permLoading && allows(courseGradebookViewPermission(courseCode))) {
+        try {
+          const grading = await fetchCourseGradingSettings(courseCode)
+          setGradingGroups(
+            grading.assignmentGroups.filter((g) => g.id.trim()).map((g) => ({ id: g.id, name: g.name })),
+          )
+        } catch {
+          setGradingGroups([])
+        }
+      } else if (!permLoading) {
         setGradingGroups([])
       }
       setTitle(data.title)
@@ -400,7 +403,6 @@ export default function CourseModuleQuizPage() {
         typeof data.adaptiveQuestionCount === 'number' ? data.adaptiveQuestionCount : 5,
       )
       setAdaptiveDeliveryMode(data.adaptiveDeliveryMode === 'cat' ? 'cat' : 'ai')
-      setStudentQuizPayload(data)
       setCourseQuestionBankEnabled(courseRow.questionBankEnabled === true)
       setCourseLockdownEnabled(courseRow.lockdownModeEnabled === true)
       setLockdownMode(data.lockdownMode)
@@ -442,7 +444,6 @@ export default function CourseModuleQuizPage() {
       setDraftNeverDrop(false)
       setDraftReplaceWithFinal(false)
       setMarkups([])
-      setStudentQuizPayload(null)
       setCourseLockdownEnabled(false)
       setLockdownMode('standard')
       setDraftLockdownMode('standard')
@@ -451,7 +452,7 @@ export default function CourseModuleQuizPage() {
     } finally {
       setLoading(false)
     }
-  }, [courseCode, itemId, loadMarkups])
+  }, [allows, courseCode, itemId, loadMarkups, permLoading])
 
   useEffect(() => {
     void load()
@@ -530,81 +531,8 @@ export default function CourseModuleQuizPage() {
   }, [importQuestionsOpen])
 
   const quizActionsRef = useRef<HTMLDivElement>(null)
-  const quizSummaryAsideRef = useRef<HTMLElement>(null)
   const importDropdownRef = useRef<HTMLDivElement>(null)
   const importButtonRef = useRef<HTMLButtonElement>(null)
-
-  useLayoutEffect(() => {
-    if (editingContent || loading || loadError) return
-
-    const asideEl = quizSummaryAsideRef.current
-    const mq = window.matchMedia('(min-width: 1024px)')
-    let deferredRaf = 0
-    let mountRaf = 0
-
-    function alignSummaryAside() {
-      const aside = quizSummaryAsideRef.current
-      const actions = quizActionsRef.current
-      if (!aside || !actions) {
-        if (aside) aside.style.marginTop = ''
-        return
-      }
-      if (!mq.matches) {
-        aside.style.marginTop = ''
-        return
-      }
-      const delta =
-        actions.getBoundingClientRect().top - aside.getBoundingClientRect().top
-      aside.style.marginTop = `${Math.round(delta)}px`
-    }
-
-    /** Header + flex row reflow after viewport changes is not always done in the same frame as `resize`. */
-    function scheduleAlignAfterLayout() {
-      cancelAnimationFrame(deferredRaf)
-      deferredRaf = requestAnimationFrame(() => {
-        deferredRaf = requestAnimationFrame(() => {
-          deferredRaf = 0
-          alignSummaryAside()
-        })
-      })
-    }
-
-    alignSummaryAside()
-    mountRaf = requestAnimationFrame(() => alignSummaryAside())
-
-    mq.addEventListener('change', scheduleAlignAfterLayout)
-    window.addEventListener('resize', scheduleAlignAfterLayout)
-    const vv = window.visualViewport
-    vv?.addEventListener('resize', scheduleAlignAfterLayout)
-    return () => {
-      cancelAnimationFrame(mountRaf)
-      cancelAnimationFrame(deferredRaf)
-      mq.removeEventListener('change', scheduleAlignAfterLayout)
-      window.removeEventListener('resize', scheduleAlignAfterLayout)
-      vv?.removeEventListener('resize', scheduleAlignAfterLayout)
-      if (asideEl) asideEl.style.marginTop = ''
-    }
-  }, [
-    editingContent,
-    loading,
-    loadError,
-    title,
-    markdown,
-    questions.length,
-    isAdaptive,
-    dueAt,
-    availableFromAt,
-    availableUntilAt,
-    unlimitedAttempts,
-    oneQuestionAtATime,
-    lockdownMode,
-    focusLossThreshold,
-    courseLockdownEnabled,
-    pointsWorth,
-    assignmentGroupId,
-    gradingGroups,
-    updatedAt,
-  ])
 
   function beginEditContent() {
     setSaveError(null)
@@ -868,7 +796,6 @@ export default function CourseModuleQuizPage() {
         const thAdaptive = data.focusLossThreshold
         setFocusLossThreshold(typeof thAdaptive === 'number' ? thAdaptive : null)
         setDraftFocusLossThreshold(typeof thAdaptive === 'number' ? thAdaptive : null)
-        setStudentQuizPayload(data)
         setPointsWorth(data.pointsWorth ?? null)
         setDraftPointsWorth(data.pointsWorth ?? null)
         setAssignmentGroupId(data.assignmentGroupId ?? null)
@@ -908,7 +835,6 @@ export default function CourseModuleQuizPage() {
         const thStatic = data.focusLossThreshold
         setFocusLossThreshold(typeof thStatic === 'number' ? thStatic : null)
         setDraftFocusLossThreshold(typeof thStatic === 'number' ? thStatic : null)
-        setStudentQuizPayload(data)
         setPointsWorth(data.pointsWorth ?? null)
         setDraftPointsWorth(data.pointsWorth ?? null)
         setAssignmentGroupId(data.assignmentGroupId ?? null)
@@ -975,6 +901,11 @@ export default function CourseModuleQuizPage() {
     }
   }
 
+  function goToQuizAttempt() {
+    if (!courseCode || !itemId) return
+    navigate(courseModuleQuizAttemptHref(courseCode, itemId))
+  }
+
   async function handleStudentStartQuiz() {
     if (!courseCode || !itemId) return
     setStudentQuizBanner(null)
@@ -995,7 +926,7 @@ export default function CourseModuleQuizPage() {
         return
       }
     }
-    setStudentTakeOpen(true)
+    goToQuizAttempt()
   }
 
   async function handleSaveQuizForOffline() {
@@ -1077,65 +1008,30 @@ export default function CourseModuleQuizPage() {
               {saving ? 'Saving…' : 'Save'}
             </button>
           </div>
-        ) : (
+        ) : canEdit ? (
           <div className="flex flex-wrap items-center justify-end gap-2">
-            {canEdit ? (
-              canEditQuizItems ? (
-                <>
-                  <FeatureHelpTrigger topic="quiz-authoring" />
-                  <QuizEditorMoreMenu
-                    disabled={loading}
-                    onPreview={() => setPreviewOpen(true)}
-                    onEditIntro={beginEditContent}
-                    onGenerate={openGenerateModal}
-                    onAnalytics={() => setAnalyticsOpen(true)}
-                  />
-                  <button
-                    type="button"
-                    onClick={openQuestionsEditor}
-                    disabled={loading}
-                    className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    Edit questions
-                  </button>
-                </>
-              ) : null
-            ) : (
-              <div className="flex items-center gap-2">
-                <ReadAloudControls />
-                {isOnline && (
-                  <button
-                    type="button"
-                    onClick={() => void handleSaveQuizForOffline()}
-                    disabled={offlineStatus === 'saving'}
-                    aria-label={offlineStatus === 'cached' ? 'Quiz saved for offline' : 'Save quiz for offline'}
-                    title={offlineStatus === 'cached' ? 'Quiz saved for offline access' : 'Save quiz intro for offline access'}
-                    className="inline-flex items-center gap-1.5 rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    {offlineStatus === 'saving' ? (
-                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-                    ) : offlineStatus === 'cached' ? (
-                      <CheckCircle className="h-4 w-4 text-emerald-600" aria-hidden />
-                    ) : (
-                      <Download className="h-4 w-4" aria-hidden />
-                    )}
-                  </button>
-                )}
+            {canEditQuizItems ? (
+              <>
+                <FeatureHelpTrigger topic="quiz-authoring" />
+                <QuizEditorMoreMenu
+                  disabled={loading}
+                  onPreview={() => setPreviewOpen(true)}
+                  onEditIntro={beginEditContent}
+                  onGenerate={openGenerateModal}
+                  onAnalytics={() => setAnalyticsOpen(true)}
+                />
                 <button
                   type="button"
-                  onClick={() => handleStudentStartQuiz()}
-                  disabled={loading || !isOnline}
-                  aria-disabled={!isOnline}
-                  title={!isOnline ? 'Available when online' : undefined}
+                  onClick={openQuestionsEditor}
+                  disabled={loading}
                   className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
                 >
-                  {!isOnline && <WifiOff className="h-4 w-4" aria-hidden />}
-                  Start Quiz
+                  Edit questions
                 </button>
-              </div>
-            )}
+              </>
+            ) : null}
           </div>
-        )
+        ) : undefined
       }
     >
       <p className="mt-2 text-start text-sm">
@@ -1206,10 +1102,47 @@ export default function CourseModuleQuizPage() {
               />
             </div>
             <aside
-              ref={quizSummaryAsideRef}
-              className="shrink-0 lg:sticky lg:top-6 lg:w-72 lg:max-w-[min(100%,18rem)] xl:w-80 xl:max-w-[min(100%,20rem)]"
+              className="order-first shrink-0 lg:sticky lg:top-6 lg:order-none lg:w-72 lg:max-w-[min(100%,18rem)] lg:self-start xl:w-80 xl:max-w-[min(100%,20rem)]"
               aria-label="Quiz summary"
             >
+              {!canEdit ? (
+                <div className="mb-4 flex flex-wrap items-center justify-end gap-2">
+                  <ReadAloudControls />
+                  {isOnline ? (
+                    <button
+                      type="button"
+                      onClick={() => void handleSaveQuizForOffline()}
+                      disabled={offlineStatus === 'saving'}
+                      aria-label={offlineStatus === 'cached' ? 'Quiz saved for offline' : 'Save quiz for offline'}
+                      title={
+                        offlineStatus === 'cached'
+                          ? 'Quiz saved for offline access'
+                          : 'Save quiz intro for offline access'
+                      }
+                      className="inline-flex items-center gap-1.5 rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                    >
+                      {offlineStatus === 'saving' ? (
+                        <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                      ) : offlineStatus === 'cached' ? (
+                        <CheckCircle className="h-4 w-4 text-emerald-600" aria-hidden />
+                      ) : (
+                        <Download className="h-4 w-4" aria-hidden />
+                      )}
+                    </button>
+                  ) : null}
+                  <button
+                    type="button"
+                    onClick={() => handleStudentStartQuiz()}
+                    disabled={loading || !isOnline}
+                    aria-disabled={!isOnline}
+                    title={!isOnline ? 'Available when online' : undefined}
+                    className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {!isOnline && <WifiOff className="h-4 w-4" aria-hidden />}
+                    Start Quiz
+                  </button>
+                </div>
+              ) : null}
               <div className="rounded-2xl border border-slate-200/90 bg-slate-50/70 p-4 dark:border-neutral-600 dark:bg-neutral-900/90">
                 <p className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
                   {isAdaptive
@@ -1615,24 +1548,11 @@ export default function CourseModuleQuizPage() {
           required={proctoringConfig.required}
           onProceed={() => {
             setProctoringChecklistOpen(false)
-            setStudentTakeOpen(true)
+            goToQuizAttempt()
           }}
           onClose={() => setProctoringChecklistOpen(false)}
         />
       )}
-
-      {studentQuizPayload && courseCode && itemId ? (
-        <QuizStudentTakePanel
-          open={studentTakeOpen}
-          onClose={() => setStudentTakeOpen(false)}
-          courseCode={courseCode}
-          itemId={itemId}
-          quiz={studentQuizPayload}
-          advanced={quizAdvanced}
-          oneQuestionAtATime={oneQuestionAtATime}
-          allowBackNavigation={quizAdvanced.allowBackNavigation}
-        />
-      ) : null}
 
       {questionsOpen && (
         <div

--- a/clients/web/src/pages/lms/courses.tsx
+++ b/clients/web/src/pages/lms/courses.tsx
@@ -43,8 +43,7 @@ import { RequirePermission } from '../../components/require-permission'
 import { usePermissions } from '../../context/use-permissions'
 import { useCoursesRevision } from '../../context/use-inbox-unread'
 import { authorizedFetch } from '../../lib/api'
-import { putCourseCatalogOrder, type CoursePublic, fetchOrgTerms, type OrgTerm } from '../../lib/courses-api'
-import { type OrgType } from '../../components/settings/org-units-panel'
+import { putCourseCatalogOrder, type CoursePublic, fetchOrgTerms, fetchOrgType, type OrgTerm, type OrgType } from '../../lib/courses-api'
 import { decodeJwtPayload } from '../../lib/jwt-payload'
 import { getAccessToken } from '../../lib/auth'
 import { readApiErrorMessage } from '../../lib/errors'
@@ -575,7 +574,6 @@ export default function Courses() {
   const [kanbanColumnLabels, setKanbanColumnLabels] = useState<KanbanColumnLabels>(DEFAULT_KANBAN_COLUMN_LABELS)
   const [hiddenColumnExpanded, setHiddenColumnExpanded] = useState(false)
   const [orgType, setOrgType] = useState<OrgType>('higher-ed')
-  void orgType
   const orgId = decodeJwtPayload(getAccessToken())?.org_id ?? ''
 
   useEffect(() => {
@@ -596,12 +594,9 @@ export default function Courses() {
   useEffect(() => {
     if (!orgId) return
     let cancelled = false
-    void authorizedFetch(`/api/v1/orgs/${encodeURIComponent(orgId)}/settings/org-type`)
-      .then((r) => r.json())
-      .then((data: { orgType?: OrgType }) => {
-        if (!cancelled && (data.orgType === 'k-12' || data.orgType === 'higher-ed')) {
-          setOrgType(data.orgType)
-        }
+    void fetchOrgType(orgId)
+      .then((t) => {
+        if (!cancelled) setOrgType(t)
       })
       .catch(() => {})
     return () => {

--- a/server/internal/httpserver/admin_org_units.go
+++ b/server/internal/httpserver/admin_org_units.go
@@ -58,6 +58,33 @@ func (d Deps) adminOrgOrUnitAccess(w http.ResponseWriter, r *http.Request, orgID
 	return actorID, false, true
 }
 
+// orgReadAccess allows global RBAC admin or any member of orgID to read org-scoped data.
+func (d Deps) orgReadAccess(w http.ResponseWriter, r *http.Request, orgID uuid.UUID) (actorID uuid.UUID, ok bool) {
+	actorID, ok = d.meUserID(w, r)
+	if !ok {
+		return uuid.UUID{}, false
+	}
+	ctx := r.Context()
+	ga, err := rbac.UserHasPermission(ctx, d.Pool, actorID, permGlobalRBACManage)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")
+		return uuid.UUID{}, false
+	}
+	if ga {
+		return actorID, true
+	}
+	uOrg, err := organization.OrgIDForUser(ctx, d.Pool, actorID)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify organization.")
+		return uuid.UUID{}, false
+	}
+	if uOrg != orgID {
+		apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have access to this organization.")
+		return uuid.UUID{}, false
+	}
+	return actorID, true
+}
+
 func (d Deps) unitAdminAllowedSubtree(ctx context.Context, userID, orgID uuid.UUID) ([]uuid.UUID, error) {
 	return orgunit.ListSubtreeIDsForUserOrgUnitAdmin(ctx, d.Pool, userID, orgID)
 }

--- a/server/internal/httpserver/canvas_quiz_import.go
+++ b/server/internal/httpserver/canvas_quiz_import.go
@@ -312,7 +312,7 @@ func canvasQuestionToQuizQuestion(q map[string]any) (coursemodulequiz.QuizQuesti
 		}, true
 
 	case "matching_question":
-		pairs := canvasMatchingPairsJSON(answers)
+		pairs := canvasMatchingPairsJSON(q, answers)
 		return coursemodulequiz.QuizQuestion{
 			ID:                 fmt.Sprintf("canvas-%d", id),
 			Prompt:             prompt,
@@ -402,25 +402,88 @@ func trueFalseCorrectChoiceIndex(answers []map[string]any) *uint {
 	return nil
 }
 
-func canvasMatchingPairsJSON(answers []map[string]any) json.RawMessage {
+func canvasMatchTextByID(q map[string]any) map[int64]string {
+	out := make(map[int64]string)
+	for _, m := range canvasMatchMaps(q) {
+		id := int64At(m, "match_id")
+		if id <= 0 {
+			id = int64At(m, "id")
+		}
+		text := strings.TrimSpace(strAt(m, "text", ""))
+		if text == "" {
+			text = strings.TrimSpace(canvasAnswerText(m))
+		}
+		if id > 0 && text != "" {
+			out[id] = text
+		}
+	}
+	return out
+}
+
+func canvasMatchMaps(q map[string]any) []map[string]any {
+	raw, ok := q["matches"]
+	if !ok || raw == nil {
+		return nil
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(arr))
+	for _, v := range arr {
+		if m, ok := v.(map[string]any); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func canvasMatchingLeftText(a map[string]any) string {
+	for _, k := range []string{"answer_match_left", "left", "text"} {
+		if s := strings.TrimSpace(strAt(a, k, "")); s != "" {
+			return markdownFromHTML(s)
+		}
+	}
+	if s := strings.TrimSpace(strAt(a, "left_html", "")); s != "" {
+		return markdownFromHTML(s)
+	}
+	return strings.TrimSpace(canvasAnswerText(a))
+}
+
+func canvasMatchingRightText(a map[string]any, matchByID map[int64]string) string {
+	for _, k := range []string{"answer_match_right", "right"} {
+		if s := strings.TrimSpace(strAt(a, k, "")); s != "" {
+			return markdownFromHTML(s)
+		}
+	}
+	if matchID := int64At(a, "match_id"); matchID > 0 {
+		if s := strings.TrimSpace(matchByID[matchID]); s != "" {
+			return markdownFromHTML(s)
+		}
+	}
+	return ""
+}
+
+func canvasMatchingPairsJSON(q map[string]any, answers []map[string]any) json.RawMessage {
 	type pair struct {
 		LeftID  string `json:"leftId"`
 		RightID string `json:"rightId"`
 		Left    string `json:"left"`
 		Right   string `json:"right"`
 	}
+	matchByID := canvasMatchTextByID(q)
 	ps := make([]pair, 0, len(answers))
 	for i, a := range answers {
-		left := strings.TrimSpace(strAt(a, "answer_match_left", ""))
-		right := strings.TrimSpace(strAt(a, "answer_match_right", ""))
+		left := canvasMatchingLeftText(a)
+		right := canvasMatchingRightText(a, matchByID)
 		if left == "" && right == "" {
 			continue
 		}
 		ps = append(ps, pair{
 			LeftID:  fmt.Sprintf("l%d", i),
 			RightID: fmt.Sprintf("r%d", i),
-			Left:    markdownFromHTML(left),
-			Right:   markdownFromHTML(right),
+			Left:    left,
+			Right:   right,
 		})
 	}
 	if len(ps) == 0 {

--- a/server/internal/httpserver/canvas_quiz_import_test.go
+++ b/server/internal/httpserver/canvas_quiz_import_test.go
@@ -61,23 +61,94 @@ func TestCanvasQuestionToQuizQuestion_TrueFalseSecondAnswerCorrect(t *testing.T)
 }
 
 func TestCanvasMatchingPairsJSON(t *testing.T) {
-	answers := []map[string]any{
-		{"answer_match_left": "A", "answer_match_right": "1", "weight": float64(100)},
+	t.Run("create API fields", func(t *testing.T) {
+		answers := []map[string]any{
+			{"answer_match_left": "A", "answer_match_right": "1", "weight": float64(100)},
+		}
+		raw := canvasMatchingPairsJSON(nil, answers)
+		var wrap struct {
+			Pairs []struct {
+				LeftID  string `json:"leftId"`
+				RightID string `json:"rightId"`
+				Left    string `json:"left"`
+				Right   string `json:"right"`
+			} `json:"pairs"`
+		}
+		if err := json.Unmarshal(raw, &wrap); err != nil {
+			t.Fatal(err)
+		}
+		if len(wrap.Pairs) != 1 || wrap.Pairs[0].LeftID != "l0" || wrap.Pairs[0].RightID != "r0" {
+			t.Fatalf("%+v", wrap)
+		}
+		if wrap.Pairs[0].Left != "A" || wrap.Pairs[0].Right != "1" {
+			t.Fatalf("unexpected pair text: %+v", wrap.Pairs[0])
+		}
+	})
+
+	t.Run("stored Canvas question_data fields", func(t *testing.T) {
+		q := map[string]any{
+			"matches": []any{
+				map[string]any{"match_id": float64(10), "text": "Utah"},
+				map[string]any{"match_id": float64(11), "text": "Nevada"},
+			},
+		}
+		answers := []map[string]any{
+			{"id": float64(1), "left": "Salt Lake City", "right": "Utah", "match_id": float64(10)},
+			{"id": float64(2), "text": "Las Vegas", "match_id": float64(11)},
+		}
+		raw := canvasMatchingPairsJSON(q, answers)
+		var wrap struct {
+			Pairs []struct {
+				Left  string `json:"left"`
+				Right string `json:"right"`
+			} `json:"pairs"`
+		}
+		if err := json.Unmarshal(raw, &wrap); err != nil {
+			t.Fatal(err)
+		}
+		if len(wrap.Pairs) != 2 {
+			t.Fatalf("expected 2 pairs, got %+v", wrap)
+		}
+		if wrap.Pairs[0].Left != "Salt Lake City" || wrap.Pairs[0].Right != "Utah" {
+			t.Fatalf("pair 0: %+v", wrap.Pairs[0])
+		}
+		if wrap.Pairs[1].Left != "Las Vegas" || wrap.Pairs[1].Right != "Nevada" {
+			t.Fatalf("pair 1: %+v", wrap.Pairs[1])
+		}
+	})
+}
+
+func TestCanvasQuestionToQuizQuestion_Matching(t *testing.T) {
+	q := map[string]any{
+		"id":            float64(99),
+		"question_type": "matching_question",
+		"question_text": "<p>Match cities to states</p>",
+		"points_possible": float64(2),
+		"matches": []any{
+			map[string]any{"match_id": float64(10), "text": "Utah"},
+		},
+		"answers": []any{
+			map[string]any{"id": float64(1), "left": "Salt Lake City", "right": "Utah", "match_id": float64(10)},
+		},
 	}
-	raw := canvasMatchingPairsJSON(answers)
-	var wrap struct {
+	qq, ok := canvasQuestionToQuizQuestion(q)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if qq.QuestionType != "matching" {
+		t.Fatalf("unexpected type: %s", qq.QuestionType)
+	}
+	var cfg struct {
 		Pairs []struct {
-			LeftID  string `json:"leftId"`
-			RightID string `json:"rightId"`
-			Left    string `json:"left"`
-			Right   string `json:"right"`
+			Left  string `json:"left"`
+			Right string `json:"right"`
 		} `json:"pairs"`
 	}
-	if err := json.Unmarshal(raw, &wrap); err != nil {
+	if err := json.Unmarshal(qq.TypeConfig, &cfg); err != nil {
 		t.Fatal(err)
 	}
-	if len(wrap.Pairs) != 1 || wrap.Pairs[0].LeftID != "l0" || wrap.Pairs[0].RightID != "r0" {
-		t.Fatalf("%+v", wrap)
+	if len(cfg.Pairs) != 1 || cfg.Pairs[0].Left != "Salt Lake City" || cfg.Pairs[0].Right != "Utah" {
+		t.Fatalf("unexpected typeConfig: %+v", cfg)
 	}
 }
 

--- a/server/internal/httpserver/communication.go
+++ b/server/internal/httpserver/communication.go
@@ -51,6 +51,20 @@ func (d Deps) notifyCourses(userID uuid.UUID) {
 	d.Comm.Broadcast(userID, coursesUpdateJSON)
 }
 
+func (d Deps) notifyCoursesForUsers(userIDs ...uuid.UUID) {
+	if d.Comm == nil || len(userIDs) == 0 {
+		return
+	}
+	seen := make(map[uuid.UUID]struct{}, len(userIDs))
+	for _, uid := range userIDs {
+		if _, ok := seen[uid]; ok {
+			continue
+		}
+		seen[uid] = struct{}{}
+		d.notifyCourses(uid)
+	}
+}
+
 // handleCommMessagesList is GET /api/v1/communication/messages?folder&...
 func (d Deps) handleCommMessagesList() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/httpserver/course_enrollments_http.go
+++ b/server/internal/httpserver/course_enrollments_http.go
@@ -127,6 +127,7 @@ func (d Deps) handleCourseEnrollmentsPost() http.HandlerFunc {
 		}
 		ctx := r.Context()
 		var added, already, notFound []string
+		var addedUserIDs []uuid.UUID
 		tx, err := d.Pool.BeginTx(ctx, pgx.TxOptions{})
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to start transaction.")
@@ -190,6 +191,7 @@ ON CONFLICT (course_id, user_id, role) DO NOTHING
 					already = append(already, em)
 				} else {
 					added = append(added, em)
+					addedUserIDs = append(addedUserIDs, uid)
 				}
 				if err := courseroles.RefreshManagedGrantsForCourseUser(ctx, tx, uid, *cid, courseCode); err != nil {
 					apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to sync course permissions.")
@@ -240,6 +242,7 @@ ON CONFLICT (course_id, user_id, role) DO NOTHING
 					already = append(already, em)
 				} else {
 					added = append(added, em)
+					addedUserIDs = append(addedUserIDs, uid)
 				}
 				if _, err := tx.Exec(ctx, `
 INSERT INTO "user".user_app_roles (user_id, role_id)
@@ -284,6 +287,7 @@ ON CONFLICT (course_id, user_id, role) DO NOTHING
 					already = append(already, em)
 				} else {
 					added = append(added, em)
+					addedUserIDs = append(addedUserIDs, uid)
 				}
 				if err := courseroles.RefreshManagedGrantsForCourseUser(ctx, tx, uid, *cid, courseCode); err != nil {
 					apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to sync course permissions.")
@@ -295,6 +299,7 @@ ON CONFLICT (course_id, user_id, role) DO NOTHING
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save enrollments.")
 			return
 		}
+		d.notifyCoursesForUsers(addedUserIDs...)
 		learningevents.EmitEnrollmentAsync(d.Pool, d.effectiveConfig(), orgID, *cid, courseCode, added)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(modelenrollment.AddEnrollmentsResponse{
@@ -361,6 +366,9 @@ ON CONFLICT (course_id, user_id, role) DO NOTHING
 		if err := tx.Commit(ctx); err != nil {
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save enrollment.")
 			return
+		}
+		if tag.RowsAffected() > 0 {
+			d.notifyCourses(viewer)
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(modelenrollment.EnrollSelfAsStudentResponse{Created: tag.RowsAffected() > 0})
@@ -554,6 +562,7 @@ WHERE ce.id = $1 AND c.course_code = $2 AND ce.active
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save.")
 			return
 		}
+		d.notifyCourses(uid)
 		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/server/internal/httpserver/org_type_http.go
+++ b/server/internal/httpserver/org_type_http.go
@@ -20,13 +20,13 @@ func (d Deps) handleOrgTypeItem() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid organization id.")
 			return
 		}
-		if _, _, ok := d.adminOrgOrUnitAccess(w, r, orgID); !ok {
-			return
-		}
 		ctx := r.Context()
 
 		switch r.Method {
 		case http.MethodGet:
+			if _, ok := d.orgReadAccess(w, r, orgID); !ok {
+				return
+			}
 			var orgType string
 			err := d.Pool.QueryRow(ctx, `SELECT org_type FROM tenant.organizations WHERE id = $1 AND status <> 'deleted'`, orgID).Scan(&orgType)
 			if err != nil {
@@ -36,6 +36,9 @@ func (d Deps) handleOrgTypeItem() http.HandlerFunc {
 			_ = json.NewEncoder(w).Encode(map[string]any{"orgId": orgID.String(), "orgType": orgType})
 
 		case http.MethodPut:
+			if _, _, ok := d.adminOrgOrUnitAccess(w, r, orgID); !ok {
+				return
+			}
 			var body struct {
 				OrgType string `json:"orgType"`
 			}

--- a/server/internal/httpserver/quiz_analytics.go
+++ b/server/internal/httpserver/quiz_analytics.go
@@ -6,15 +6,17 @@ import (
 
 	repoitemanalysis "github.com/lextures/lextures/server/internal/repos/itemanalysis"
 	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/repos/quizattempts"
 	svcquizanalytics "github.com/lextures/lextures/server/internal/service/quizanalytics"
 )
 
 type quizAnalyticsJSON struct {
-	QuizID         string                      `json:"quizId"`
-	NAttempts      int                         `json:"nAttempts"`
-	MeanScore      *float64                    `json:"meanScore"`
-	ScoreBuckets   []svcquizanalytics.ScoreBucket  `json:"scoreBuckets"`
+	QuizID         string                            `json:"quizId"`
+	NAttempts      int                               `json:"nAttempts"`
+	MeanScore      *float64                          `json:"meanScore"`
+	ScoreBuckets   []svcquizanalytics.ScoreBucket    `json:"scoreBuckets"`
 	QuestionStats  []svcquizanalytics.QuestionStat `json:"questionStats"`
+	FocusAttempts  []svcquizanalytics.AttemptFocusStat `json:"focusAttempts"`
 }
 
 func (d Deps) handleGetQuizAnalytics() http.HandlerFunc {
@@ -42,6 +44,21 @@ func (d Deps) handleGetQuizAnalytics() http.HandlerFunc {
 		}
 
 		report := svcquizanalytics.BuildReport(itemID, rows)
+		focusRows, err := quizattempts.ListAttemptFocusSummariesForItem(ctx, d.Pool, itemID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load focus-loss stats.")
+			return
+		}
+		focusAttempts := make([]svcquizanalytics.AttemptFocusStat, 0, len(focusRows))
+		for _, f := range focusRows {
+			focusAttempts = append(focusAttempts, svcquizanalytics.AttemptFocusStat{
+				AttemptID:             f.AttemptID.String(),
+				AttemptNumber:         f.AttemptNumber,
+				EventCount:            f.EventCount,
+				AcademicIntegrityFlag: f.AcademicIntegrityFlag,
+			})
+		}
+		report.FocusAttempts = focusAttempts
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(quizAnalyticsJSON{
 			QuizID:        report.QuizID.String(),
@@ -49,6 +66,7 @@ func (d Deps) handleGetQuizAnalytics() http.HandlerFunc {
 			MeanScore:     report.MeanScore,
 			ScoreBuckets:  report.ScoreBuckets,
 			QuestionStats: report.QuestionStats,
+			FocusAttempts: report.FocusAttempts,
 		})
 	}
 }

--- a/server/internal/httpserver/quiz_delivery_http.go
+++ b/server/internal/httpserver/quiz_delivery_http.go
@@ -16,12 +16,16 @@ import (
 	"github.com/lextures/lextures/server/internal/repos/coursestructure"
 	"github.com/lextures/lextures/server/internal/repos/questionbank"
 	"github.com/lextures/lextures/server/internal/repos/quizattempts"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
 	acsvc "github.com/lextures/lextures/server/internal/service/accommodations"
 )
 
 func (d Deps) registerQuizDeliveryRoutes(r chi.Router) {
 	r.Post("/api/v1/courses/{course_code}/quizzes/{item_id}/start", d.handleQuizStart())
 	r.Get("/api/v1/courses/{course_code}/quizzes/{item_id}/attempts/{attempt_id}/current-question", d.handleQuizCurrentQuestion())
+	r.Post("/api/v1/courses/{course_code}/quizzes/{item_id}/attempts/{attempt_id}/focus-loss", d.handleQuizFocusLossPost())
+	r.Get("/api/v1/courses/{course_code}/quizzes/{item_id}/attempts/{attempt_id}/focus-loss-events", d.handleQuizFocusLossEventsGet())
+	d.registerQuizSubmitRoutes(r)
 }
 
 func (d Deps) ffAccommodationsAuditEnabled() bool {
@@ -289,5 +293,147 @@ func (d Deps) handleQuizCurrentQuestion() http.HandlerFunc {
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+func (d Deps) parseQuizAttemptForViewer(
+	w http.ResponseWriter,
+	r *http.Request,
+	courseCode string,
+	viewer uuid.UUID,
+) (itemID uuid.UUID, attemptID uuid.UUID, attempt *quizattempts.QuizAttemptRow, ok bool) {
+	var err error
+	itemID, err = uuid.Parse(chi.URLParam(r, "item_id"))
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid item id.")
+		return itemID, attemptID, nil, false
+	}
+	attemptID, err = uuid.Parse(chi.URLParam(r, "attempt_id"))
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid attempt id.")
+		return itemID, attemptID, nil, false
+	}
+	ctx := r.Context()
+	attempt, err = quizattempts.GetAttempt(ctx, d.Pool, attemptID)
+	if err != nil || attempt == nil {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Attempt not found.")
+		return itemID, attemptID, nil, false
+	}
+	if attempt.StudentUserID != viewer || attempt.StructureItemID != itemID {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Attempt not found.")
+		return itemID, attemptID, nil, false
+	}
+	cid, err := course.GetIDByCourseCode(ctx, d.Pool, courseCode)
+	if err != nil || cid == nil || attempt.CourseID != *cid {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Attempt not found.")
+		return itemID, attemptID, nil, false
+	}
+	return itemID, attemptID, attempt, true
+}
+
+// handleQuizFocusLossPost is POST .../attempts/{attempt_id}/focus-loss — learner reports tab blur / visibility change.
+func (d Deps) handleQuizFocusLossPost() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		courseCode, viewer, ok := d.requireCourseAccess(w, r)
+		if !ok {
+			return
+		}
+		_, attemptID, attempt, ok := d.parseQuizAttemptForViewer(w, r, courseCode, viewer)
+		if !ok {
+			return
+		}
+		if attempt.Status != "in_progress" {
+			apierr.WriteJSON(w, http.StatusConflict, apierr.CodeConflict, "Attempt is not in progress.")
+			return
+		}
+		var body coursemodulequiz.QuizFocusLossRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		eventType := strings.TrimSpace(body.EventType)
+		if eventType == "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "eventType is required.")
+			return
+		}
+		if len(eventType) > 64 {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "eventType is too long.")
+			return
+		}
+		if err := quizattempts.InsertFocusLossEvent(r.Context(), d.Pool, attemptID, eventType, body.DurationMS); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to record focus event.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// handleQuizFocusLossEventsGet is GET .../attempts/{attempt_id}/focus-loss-events — instructor review.
+func (d Deps) handleQuizFocusLossEventsGet() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		courseCode, viewer, ok := d.requireCourseAccess(w, r)
+		if !ok {
+			return
+		}
+		itemID, err := uuid.Parse(chi.URLParam(r, "item_id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid item id.")
+			return
+		}
+		attemptID, err := uuid.Parse(chi.URLParam(r, "attempt_id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid attempt id.")
+			return
+		}
+		perm := "course:" + courseCode + ":item:create"
+		can, err := rbac.UserHasPermission(r.Context(), d.Pool, viewer, perm)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")
+			return
+		}
+		if !can {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission to view focus-loss events.")
+			return
+		}
+		ctx := r.Context()
+		attempt, err := quizattempts.GetAttempt(ctx, d.Pool, attemptID)
+		if err != nil || attempt == nil || attempt.StructureItemID != itemID {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Attempt not found.")
+			return
+		}
+		cid, err := course.GetIDByCourseCode(ctx, d.Pool, courseCode)
+		if err != nil || cid == nil || attempt.CourseID != *cid {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Attempt not found.")
+			return
+		}
+		events, total, err := quizattempts.ListFocusLossEvents(ctx, d.Pool, attemptID, 500)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load focus-loss events.")
+			return
+		}
+		outEvents := make([]coursemodulequiz.QuizFocusLossEventAPI, 0, len(events))
+		for _, ev := range events {
+			outEvents = append(outEvents, coursemodulequiz.QuizFocusLossEventAPI{
+				ID:         ev.ID,
+				EventType:  ev.EventType,
+				DurationMS: ev.DurationMS,
+				CreatedAt:  ev.CreatedAt,
+			})
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(coursemodulequiz.QuizFocusLossEventsResponse{
+			Events: outEvents,
+			Total:  total,
+		})
 	}
 }

--- a/server/internal/httpserver/quiz_submit_http.go
+++ b/server/internal/httpserver/quiz_submit_http.go
@@ -1,0 +1,416 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/models/coursemodulequiz"
+	"github.com/lextures/lextures/server/internal/repos/course"
+	"github.com/lextures/lextures/server/internal/repos/coursemodulequizzes"
+	"github.com/lextures/lextures/server/internal/repos/questionbank"
+	"github.com/lextures/lextures/server/internal/repos/quizattempts"
+	"github.com/lextures/lextures/server/internal/service/learningevents"
+	"github.com/lextures/lextures/server/internal/service/quizattemptgrading"
+)
+
+func (d Deps) registerQuizSubmitRoutes(r chi.Router) {
+	r.Post("/api/v1/courses/{course_code}/quizzes/{item_id}/submit", d.handleQuizSubmit())
+	r.Get("/api/v1/courses/{course_code}/quizzes/{item_id}/results", d.handleQuizResults())
+	r.Post("/api/v1/courses/{course_code}/quizzes/{item_id}/attempts/{attempt_id}/advance", d.handleQuizAdvance())
+}
+
+func (d Deps) handleQuizSubmit() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		courseCode, viewer, ok := d.requireCourseAccess(w, r)
+		if !ok {
+			return
+		}
+		itemID, err := uuid.Parse(chi.URLParam(r, "item_id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid item id.")
+			return
+		}
+		var body coursemodulequiz.QuizSubmitRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		if body.AttemptID == uuid.Nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "attemptId is required.")
+			return
+		}
+
+		ctx := r.Context()
+		attempt, err := quizattempts.GetAttempt(ctx, d.Pool, body.AttemptID)
+		if err != nil || attempt == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Attempt not found.")
+			return
+		}
+		if attempt.StudentUserID != viewer || attempt.StructureItemID != itemID {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Attempt not found.")
+			return
+		}
+		cid, err := course.GetIDByCourseCode(ctx, d.Pool, courseCode)
+		if err != nil || cid == nil || attempt.CourseID != *cid {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Attempt not found.")
+			return
+		}
+		if attempt.Status != "in_progress" {
+			apierr.WriteJSON(w, http.StatusConflict, apierr.CodeConflict, "Attempt is not in progress.")
+			return
+		}
+
+		row, err := coursemodulequizzes.GetForCourseItem(ctx, d.Pool, *cid, itemID)
+		if err != nil || row == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Not found.")
+			return
+		}
+		meta, err := course.GetCourseQuizMeta(ctx, d.Pool, *cid)
+		if err != nil || meta == nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course.")
+			return
+		}
+
+		lockdown := effectiveLockdownMode(meta.LockdownModeEnabled, row.LockdownMode)
+		isAdaptive := row.IsAdaptive || len(body.AdaptiveHistory) > 0
+
+		var graded []quizattemptgrading.GradedResponse
+		var adaptiveJSON json.RawMessage
+		if isAdaptive {
+			graded = quizattemptgrading.GradeAdaptiveHistory(body.AdaptiveHistory)
+			adaptiveJSON, _ = json.Marshal(body.AdaptiveHistory)
+		} else if len(body.Responses) > 0 {
+			attemptPtr := &body.AttemptID
+			questions, _, err := questionbank.ResolveDeliveryQuestionsForGet(
+				ctx, d.Pool, *cid, itemID, meta.QuestionBankEnabled, row.Questions, attemptPtr, false,
+			)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+				return
+			}
+			graded = quizattemptgrading.GradeStaticResponses(questions, body.Responses)
+		} else if lockdown != "standard" {
+			existing, err := quizattempts.ListResponses(ctx, d.Pool, body.AttemptID)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load responses.")
+				return
+			}
+			for _, ex := range existing {
+				graded = append(graded, quizattemptgrading.GradedResponse{
+					QuestionIndex:  ex.QuestionIndex,
+					QuestionID:     ex.QuestionID,
+					QuestionType:   ex.QuestionType,
+					PromptSnapshot: ex.PromptSnapshot,
+					ResponseJSON:   ex.ResponseJSON,
+					IsCorrect:      ex.IsCorrect,
+					PointsAwarded:  ex.PointsAwarded,
+					MaxPoints:      ex.MaxPoints,
+					Locked:         ex.Locked,
+				})
+			}
+		} else {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "responses are required.")
+			return
+		}
+
+		earned, possible := quizattemptgrading.SumGradedPoints(graded)
+		score := quizattemptgrading.ScorePercent(earned, possible)
+		now := time.Now().UTC()
+
+		integrityFlag := false
+		if lockdown == "kiosk" && row.FocusLossThreshold != nil {
+			count, err := quizattempts.CountFocusLossEvents(ctx, d.Pool, body.AttemptID)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to check focus events.")
+				return
+			}
+			if count > int64(*row.FocusLossThreshold) {
+				integrityFlag = true
+			}
+		}
+
+		responseRows := make([]quizattempts.ResponseRow, len(graded))
+		for i, g := range graded {
+			responseRows[i] = quizattempts.ResponseRow{
+				QuestionIndex:  g.QuestionIndex,
+				QuestionID:     g.QuestionID,
+				QuestionType:   g.QuestionType,
+				PromptSnapshot: g.PromptSnapshot,
+				ResponseJSON:   g.ResponseJSON,
+				IsCorrect:      g.IsCorrect,
+				PointsAwarded:  g.PointsAwarded,
+				MaxPoints:      g.MaxPoints,
+				Locked:         g.Locked,
+			}
+		}
+
+		tx, err := d.Pool.Begin(ctx)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to submit attempt.")
+			return
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		if err := quizattempts.ReplaceResponses(ctx, tx, body.AttemptID, responseRows); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save responses.")
+			return
+		}
+
+		okFinalize, err := quizattempts.FinalizeAttemptSubmitted(ctx, tx, quizattempts.FinalizeSubmitParams{
+			AttemptID:             body.AttemptID,
+			SubmittedAt:           now,
+			PointsEarned:          earned,
+			PointsPossible:        possible,
+			ScorePercent:          score,
+			AcademicIntegrityFlag: integrityFlag,
+			IsAdaptive:            isAdaptive,
+			AdaptiveHistoryJSON:   adaptiveJSON,
+		})
+		if err != nil || !okFinalize {
+			apierr.WriteJSON(w, http.StatusConflict, apierr.CodeConflict, "Attempt could not be submitted.")
+			return
+		}
+		if err := tx.Commit(ctx); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to submit attempt.")
+			return
+		}
+
+		learningevents.EmitQuizGradedAsync(d.Pool, d.effectiveConfig(), body.AttemptID)
+
+		out := coursemodulequiz.QuizSubmitResponse{
+			AttemptID:      body.AttemptID,
+			PointsEarned:   earned,
+			PointsPossible: possible,
+			ScorePercent:   score,
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+func (d Deps) handleQuizResults() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		courseCode, viewer, ok := d.requireCourseAccess(w, r)
+		if !ok {
+			return
+		}
+		itemID, err := uuid.Parse(chi.URLParam(r, "item_id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid item id.")
+			return
+		}
+		ctx := r.Context()
+		cid, err := course.GetIDByCourseCode(ctx, d.Pool, courseCode)
+		if err != nil || cid == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+			return
+		}
+
+		attemptIDStr := strings.TrimSpace(r.URL.Query().Get("attemptId"))
+		if attemptIDStr == "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "attemptId is required.")
+			return
+		}
+		attemptID, err := uuid.Parse(attemptIDStr)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid attempt id.")
+			return
+		}
+
+		attempt, err := quizattempts.GetAttemptResult(ctx, d.Pool, attemptID)
+		if err != nil || attempt == nil || attempt.StructureItemID != itemID || attempt.CourseID != *cid {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Attempt not found.")
+			return
+		}
+		if attempt.StudentUserID != viewer {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Attempt not found.")
+			return
+		}
+
+		row, err := coursemodulequizzes.GetForCourseItem(ctx, d.Pool, *cid, itemID)
+		if err != nil || row == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Not found.")
+			return
+		}
+
+		showScore := row.ShowScoreTiming == "immediate" || attempt.Status == "submitted"
+		showQuestions := row.ReviewWhen == "always" || (row.ReviewWhen == "after_submit" && attempt.Status == "submitted")
+
+		out := coursemodulequiz.QuizResultsResponse{
+			AttemptID:             attempt.ID,
+			AttemptNumber:         attempt.AttemptNumber,
+			StartedAt:             attempt.StartedAt,
+			AcademicIntegrityFlag: attempt.AcademicIntegrityFlag,
+			ExtendedTimeActive:    attempt.ExtendedTimeApplied,
+			SubmittedAt:           attempt.SubmittedAt,
+			Status:                attempt.Status,
+			IsAdaptive:            attempt.IsAdaptive,
+		}
+
+		if showScore && attempt.PointsEarned != nil && attempt.PointsPossible != nil && attempt.ScorePercent != nil {
+			out.Score = &coursemodulequiz.QuizResultsScoreSummary{
+				PointsEarned:   *attempt.PointsEarned,
+				PointsPossible: *attempt.PointsPossible,
+				ScorePercent:   *attempt.ScorePercent,
+			}
+		}
+
+		if showQuestions {
+			responses, err := quizattempts.ListResponses(ctx, d.Pool, attemptID)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load responses.")
+				return
+			}
+			questions := make([]coursemodulequiz.QuizResultsQuestionResult, 0, len(responses))
+			for _, resp := range responses {
+				qid := resp.QuestionID
+				questions = append(questions, coursemodulequiz.QuizResultsQuestionResult{
+					QuestionIndex:  resp.QuestionIndex,
+					QuestionID:     &qid,
+					QuestionType:   resp.QuestionType,
+					PromptSnapshot: optionalNonEmptyString(resp.PromptSnapshot),
+					ResponseJSON:   resp.ResponseJSON,
+					IsCorrect:      resp.IsCorrect,
+					PointsAwarded:  optionalFiniteFloat(resp.PointsAwarded),
+					MaxPoints:      resp.MaxPoints,
+				})
+			}
+			out.Questions = questions
+		}
+
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+func optionalNonEmptyString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func optionalFiniteFloat(v float64) *float64 {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return nil
+	}
+	return &v
+}
+
+func (d Deps) handleQuizAdvance() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		courseCode, viewer, ok := d.requireCourseAccess(w, r)
+		if !ok {
+			return
+		}
+		itemID, attemptID, attempt, ok := d.parseQuizAttemptForViewer(w, r, courseCode, viewer)
+		if !ok {
+			return
+		}
+		if attempt.Status != "in_progress" {
+			apierr.WriteJSON(w, http.StatusConflict, apierr.CodeConflict, "Attempt is not in progress.")
+			return
+		}
+
+		var body coursemodulequiz.QuizQuestionResponseItem
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		if strings.TrimSpace(body.QuestionID) == "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "questionId is required.")
+			return
+		}
+
+		ctx := r.Context()
+		cid, err := course.GetIDByCourseCode(ctx, d.Pool, courseCode)
+		if err != nil || cid == nil || attempt.CourseID != *cid {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Attempt not found.")
+			return
+		}
+		meta, err := course.GetCourseQuizMeta(ctx, d.Pool, *cid)
+		if err != nil || meta == nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course.")
+			return
+		}
+		row, err := coursemodulequizzes.GetForCourseItem(ctx, d.Pool, *cid, itemID)
+		if err != nil || row == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Not found.")
+			return
+		}
+		lockdown := effectiveLockdownMode(meta.LockdownModeEnabled, row.LockdownMode)
+		if lockdown == "standard" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "This quiz does not use lockdown delivery.")
+			return
+		}
+
+		attemptPtr := &attemptID
+		questions, _, err := questionbank.ResolveDeliveryQuestionsForGet(
+			ctx, d.Pool, *cid, itemID, meta.QuestionBankEnabled, row.Questions, attemptPtr, false,
+		)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+
+		qIdx := int(attempt.CurrentQuestionIndex)
+		if qIdx < 0 || qIdx >= len(questions) {
+			apierr.WriteJSON(w, http.StatusConflict, apierr.CodeConflict, "No current question to advance.")
+			return
+		}
+		q := questions[qIdx]
+		if q.ID != body.QuestionID {
+			apierr.WriteJSON(w, http.StatusConflict, apierr.CodeConflict, "Question mismatch.")
+			return
+		}
+
+		graded := quizattemptgrading.GradeResponseItem(q, body)
+		graded.QuestionIndex = int32(qIdx)
+
+		nextIdx := int32(qIdx + 1)
+		completed := int(nextIdx) >= len(questions)
+
+		tx, err := d.Pool.Begin(ctx)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save answer.")
+			return
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		if err := quizattempts.UpsertLockedResponse(ctx, tx, attemptID, int32(qIdx), quizattempts.ResponseRow{
+			QuestionIndex:  graded.QuestionIndex,
+			QuestionID:     graded.QuestionID,
+			QuestionType:   graded.QuestionType,
+			PromptSnapshot: graded.PromptSnapshot,
+			ResponseJSON:   graded.ResponseJSON,
+			IsCorrect:      graded.IsCorrect,
+			PointsAwarded:  graded.PointsAwarded,
+			MaxPoints:      graded.MaxPoints,
+		}); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save answer.")
+			return
+		}
+		if err := quizattempts.SetAttemptQuestionIndex(ctx, tx, attemptID, nextIdx); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to advance attempt.")
+			return
+		}
+		if err := tx.Commit(ctx); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save answer.")
+			return
+		}
+
+		out := coursemodulequiz.QuizAdvanceResponse{
+			Locked:               true,
+			CurrentQuestionIndex: nextIdx,
+			Completed:            completed,
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}

--- a/server/internal/repos/courseevaluations/repo.go
+++ b/server/internal/repos/courseevaluations/repo.go
@@ -281,7 +281,7 @@ func SubmitResponse(ctx context.Context, pool *pgxpool.Pool, in SubmitInput, now
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback(ctx) //nolint:errcheck
+	defer func() { _ = tx.Rollback(ctx) }()
 
 	// Lock and validate the window.
 	var opensAt, closesAt time.Time

--- a/server/internal/repos/quizattempts/repo.go
+++ b/server/internal/repos/quizattempts/repo.go
@@ -115,10 +115,89 @@ WHERE course_id = $1 AND structure_item_id = $2 AND student_user_id = $3 AND sta
 	return n, err
 }
 
+type FocusLossEventRow struct {
+	ID         uuid.UUID
+	EventType  string
+	DurationMS *int32
+	CreatedAt  time.Time
+}
+
+type AttemptFocusSummary struct {
+	AttemptID             uuid.UUID
+	AttemptNumber         int32
+	EventCount            int64
+	AcademicIntegrityFlag bool
+}
+
 func InsertFocusLossEvent(ctx context.Context, pool *pgxpool.Pool, attemptID uuid.UUID, eventType string, durationMS *int32) error {
 	_, err := pool.Exec(ctx, `
-INSERT INTO course.quiz_focus_loss_events (attempt_id, event_type, duration_ms)
+INSERT INTO course.attempt_focus_loss_events (attempt_id, event_type, duration_ms)
 VALUES ($1, $2, $3)
 `, attemptID, eventType, durationMS)
 	return err
+}
+
+func CountFocusLossEvents(ctx context.Context, pool *pgxpool.Pool, attemptID uuid.UUID) (int64, error) {
+	var n int64
+	err := pool.QueryRow(ctx, `
+SELECT COUNT(*)::bigint FROM course.attempt_focus_loss_events WHERE attempt_id = $1
+`, attemptID).Scan(&n)
+	return n, err
+}
+
+func ListFocusLossEvents(ctx context.Context, pool *pgxpool.Pool, attemptID uuid.UUID, limit int) ([]FocusLossEventRow, int64, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 500
+	}
+	var total int64
+	if err := pool.QueryRow(ctx, `
+SELECT COUNT(*)::bigint FROM course.attempt_focus_loss_events WHERE attempt_id = $1
+`, attemptID).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+	rows, err := pool.Query(ctx, `
+SELECT id, event_type, duration_ms, created_at
+FROM course.attempt_focus_loss_events
+WHERE attempt_id = $1
+ORDER BY created_at ASC
+LIMIT $2
+`, attemptID, limit)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+	var out []FocusLossEventRow
+	for rows.Next() {
+		var r FocusLossEventRow
+		if err := rows.Scan(&r.ID, &r.EventType, &r.DurationMS, &r.CreatedAt); err != nil {
+			return nil, 0, err
+		}
+		out = append(out, r)
+	}
+	return out, total, rows.Err()
+}
+
+func ListAttemptFocusSummariesForItem(ctx context.Context, pool *pgxpool.Pool, structureItemID uuid.UUID) ([]AttemptFocusSummary, error) {
+	rows, err := pool.Query(ctx, `
+SELECT qa.id, qa.attempt_number, qa.academic_integrity_flag, COUNT(afle.id)::bigint
+FROM course.quiz_attempts qa
+LEFT JOIN course.attempt_focus_loss_events afle ON afle.attempt_id = qa.id
+WHERE qa.structure_item_id = $1 AND qa.status = 'submitted'
+GROUP BY qa.id, qa.attempt_number, qa.academic_integrity_flag
+HAVING COUNT(afle.id) > 0 OR qa.academic_integrity_flag
+ORDER BY qa.submitted_at DESC NULLS LAST, qa.started_at DESC
+`, structureItemID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AttemptFocusSummary
+	for rows.Next() {
+		var s AttemptFocusSummary
+		if err := rows.Scan(&s.AttemptID, &s.AttemptNumber, &s.AcademicIntegrityFlag, &s.EventCount); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
 }

--- a/server/internal/repos/quizattempts/submit.go
+++ b/server/internal/repos/quizattempts/submit.go
@@ -1,0 +1,185 @@
+package quizattempts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ResponseRow is one row to insert into course.quiz_responses.
+type ResponseRow struct {
+	QuestionIndex  int32
+	QuestionID     string
+	QuestionType   string
+	PromptSnapshot string
+	ResponseJSON   json.RawMessage
+	IsCorrect      *bool
+	PointsAwarded  float64
+	MaxPoints      float64
+	Locked         bool
+}
+
+// AttemptResultRow extends attempt metadata with score fields for results/submit.
+type AttemptResultRow struct {
+	QuizAttemptRow
+	IsAdaptive            bool
+	PointsEarned          *float64
+	PointsPossible        *float64
+	ScorePercent          *float32
+	AcademicIntegrityFlag bool
+	AdaptiveHistoryJSON   json.RawMessage
+}
+
+func ReplaceResponses(ctx context.Context, tx pgx.Tx, attemptID uuid.UUID, rows []ResponseRow) error {
+	if _, err := tx.Exec(ctx, `DELETE FROM course.quiz_responses WHERE attempt_id = $1`, attemptID); err != nil {
+		return err
+	}
+	for _, r := range rows {
+		if _, err := tx.Exec(ctx, `
+INSERT INTO course.quiz_responses (
+  attempt_id, question_index, question_id, question_type, prompt_snapshot,
+  response_json, is_correct, points_awarded, max_points, locked
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+`, attemptID, r.QuestionIndex, nullString(r.QuestionID), r.QuestionType, nullString(r.PromptSnapshot),
+			r.ResponseJSON, r.IsCorrect, r.PointsAwarded, r.MaxPoints, r.Locked); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func nullString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+type FinalizeSubmitParams struct {
+	AttemptID             uuid.UUID
+	SubmittedAt           time.Time
+	PointsEarned          float64
+	PointsPossible        float64
+	ScorePercent          float32
+	AcademicIntegrityFlag bool
+	IsAdaptive            bool
+	AdaptiveHistoryJSON   json.RawMessage
+	CurrentQuestionIndex  *int32
+}
+
+// FinalizeAttemptSubmitted marks an in-progress attempt as submitted with score.
+func FinalizeAttemptSubmitted(ctx context.Context, tx pgx.Tx, p FinalizeSubmitParams) (bool, error) {
+	var idx any
+	if p.CurrentQuestionIndex != nil {
+		idx = *p.CurrentQuestionIndex
+	}
+	tag, err := tx.Exec(ctx, `
+UPDATE course.quiz_attempts
+SET status = 'submitted',
+    submitted_at = $2,
+    points_earned = $3,
+    points_possible = $4,
+    score_percent = $5,
+    academic_integrity_flag = $6,
+    is_adaptive = $7,
+    adaptive_history_json = $8,
+    current_question_index = COALESCE($9, current_question_index)
+WHERE id = $1 AND status = 'in_progress'
+`, p.AttemptID, p.SubmittedAt, p.PointsEarned, p.PointsPossible, p.ScorePercent,
+		p.AcademicIntegrityFlag, p.IsAdaptive, nullJSON(p.AdaptiveHistoryJSON), idx)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+func nullJSON(b json.RawMessage) any {
+	if len(b) == 0 {
+		return nil
+	}
+	return b
+}
+
+// UpsertLockedResponse saves one lockdown-mode answer and advances the attempt index.
+func UpsertLockedResponse(ctx context.Context, tx pgx.Tx, attemptID uuid.UUID, questionIndex int32, row ResponseRow) error {
+	row.Locked = true
+	_, err := tx.Exec(ctx, `
+INSERT INTO course.quiz_responses (
+  attempt_id, question_index, question_id, question_type, prompt_snapshot,
+  response_json, is_correct, points_awarded, max_points, locked
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+ON CONFLICT (attempt_id, question_index) DO UPDATE SET
+  question_id = EXCLUDED.question_id,
+  question_type = EXCLUDED.question_type,
+  prompt_snapshot = EXCLUDED.prompt_snapshot,
+  response_json = EXCLUDED.response_json,
+  is_correct = EXCLUDED.is_correct,
+  points_awarded = EXCLUDED.points_awarded,
+  max_points = EXCLUDED.max_points,
+  locked = EXCLUDED.locked
+`, attemptID, questionIndex, nullString(row.QuestionID), row.QuestionType, nullString(row.PromptSnapshot),
+		row.ResponseJSON, row.IsCorrect, row.PointsAwarded, row.MaxPoints, row.Locked)
+	return err
+}
+
+func SetAttemptQuestionIndex(ctx context.Context, tx pgx.Tx, attemptID uuid.UUID, idx int32) error {
+	_, err := tx.Exec(ctx, `
+UPDATE course.quiz_attempts SET current_question_index = $2 WHERE id = $1 AND status = 'in_progress'
+`, attemptID, idx)
+	return err
+}
+
+func GetAttemptResult(ctx context.Context, pool *pgxpool.Pool, attemptID uuid.UUID) (*AttemptResultRow, error) {
+	var r AttemptResultRow
+	err := pool.QueryRow(ctx, `
+SELECT id, course_id, structure_item_id, student_user_id, status, attempt_number, started_at, submitted_at,
+       current_question_index, deadline_at, effective_time_limit_seconds, extended_time_applied,
+       is_adaptive, points_earned, points_possible, score_percent, academic_integrity_flag, adaptive_history_json
+FROM course.quiz_attempts
+WHERE id = $1
+`, attemptID).Scan(
+		&r.ID, &r.CourseID, &r.StructureItemID, &r.StudentUserID, &r.Status, &r.AttemptNumber,
+		&r.StartedAt, &r.SubmittedAt, &r.CurrentQuestionIndex,
+		&r.DeadlineAt, &r.EffectiveTimeLimitSeconds, &r.ExtendedTimeApplied,
+		&r.IsAdaptive, &r.PointsEarned, &r.PointsPossible, &r.ScorePercent,
+		&r.AcademicIntegrityFlag, &r.AdaptiveHistoryJSON,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &r, nil
+}
+
+func ListResponses(ctx context.Context, pool *pgxpool.Pool, attemptID uuid.UUID) ([]ResponseRow, error) {
+	rows, err := pool.Query(ctx, `
+SELECT question_index, COALESCE(question_id, ''), question_type, COALESCE(prompt_snapshot, ''),
+       response_json, is_correct, COALESCE(points_awarded, 0), max_points, locked
+FROM course.quiz_responses
+WHERE attempt_id = $1
+ORDER BY question_index ASC
+`, attemptID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []ResponseRow
+	for rows.Next() {
+		var r ResponseRow
+		if err := rows.Scan(
+			&r.QuestionIndex, &r.QuestionID, &r.QuestionType, &r.PromptSnapshot,
+			&r.ResponseJSON, &r.IsCorrect, &r.PointsAwarded, &r.MaxPoints, &r.Locked,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/server/internal/service/officepreview/convert.go
+++ b/server/internal/service/officepreview/convert.go
@@ -44,7 +44,9 @@ func ConvertToHTML(data []byte, filename string, mimeType string) (string, error
 	switch format {
 	case FormatPPTX:
 		return convertPptxToHTML(data, filename, mimeType)
-	case FormatDOCX, FormatXLSX:
+	case FormatDOCX:
+		return convertDocxToHTML(data, filename, mimeType)
+	case FormatXLSX:
 		return convertMarkdownOfficeToHTML(data, filename, mimeType, format)
 	default:
 		return "", fmt.Errorf("officepreview: unsupported format")

--- a/server/internal/service/officepreview/docx.go
+++ b/server/internal/service/officepreview/docx.go
@@ -1,0 +1,9 @@
+package officepreview
+
+// convertDocxToHTML renders Word documents from OOXML (fallback: markitdown extraction).
+func convertDocxToHTML(data []byte, filename, mimeType string) (string, error) {
+	if html, err := convertDocxToVisualHTML(data, filename, mimeType); err == nil {
+		return html, nil
+	}
+	return convertMarkdownOfficeToHTML(data, filename, mimeType, FormatDOCX)
+}

--- a/server/internal/service/officepreview/docx_sprint_test.go
+++ b/server/internal/service/officepreview/docx_sprint_test.go
@@ -1,0 +1,47 @@
+package officepreview
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDocxSprintCardRendersStampBoxes(t *testing.T) {
+	path := "../../../../data/course-files/managed-files/C-VIDVCN/1ab54df5-b727-46ea-820a-68450d38dcb2.docx"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Skip("sample docx not available:", err)
+	}
+	html, err := ConvertToHTML(data, "sprint.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"CSE 199 Sprint Card",
+		"Participation Stamps",
+		"Day 1",
+		"Planning Meeting",
+		"Day 2",
+		"Stand-Up Meeting",
+		"Day 3",
+		"Day 4",
+		"Review Meeting",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("missing %q", want)
+		}
+	}
+	if strings.Count(html, `class="docx-table"`) < 5 {
+		t.Fatalf("expected nested stamp tables, got %d tables", strings.Count(html, `class="docx-table"`))
+	}
+	// Stamp boxes must render inside their cell, not before the page header.
+	headerIdx := strings.Index(html, "CSE 199 Sprint Card")
+	day1Idx := strings.Index(html, "Day 1")
+	if day1Idx >= 0 && day1Idx < headerIdx {
+		t.Fatalf("Day 1 stamp box rendered before page header (absolute positioning leak)")
+	}
+	stampIdx := strings.Index(html, "Participation Stamps")
+	if stampIdx >= 0 && day1Idx >= 0 && day1Idx < stampIdx {
+		t.Fatalf("Day 1 stamp box rendered before Participation Stamps header")
+	}
+}

--- a/server/internal/service/officepreview/docx_styles.go
+++ b/server/internal/service/officepreview/docx_styles.go
@@ -1,0 +1,646 @@
+package officepreview
+
+import (
+	"archive/zip"
+	"fmt"
+	"strings"
+)
+
+type docxResolvedPPr struct {
+	tag        string // p, h1..h6
+	style      string
+	listMarker string
+}
+
+type docxResolvedRPr struct {
+	style string
+}
+
+type docxStyleDef struct {
+	styleType   string
+	styleID     string
+	name        string
+	basedOn     string
+	link        string
+	pPr         *docxXMLNode
+	rPr         *docxXMLNode
+	tblPr       *docxXMLNode
+	tblStylePrs map[string]*docxXMLNode // tblStylePr@type → node
+	outlineLvl  int                     // -1 if unset
+}
+
+type docxStyleSheet struct {
+	docPPr *docxXMLNode
+	docRPr *docxXMLNode
+	styles map[string]*docxStyleDef
+}
+
+type docxNumLevel struct {
+	numFmt  string
+	lvlText string
+	start   int64
+	jc      string
+	pPr     *docxXMLNode
+	rPr     *docxXMLNode
+}
+
+type docxNumbering struct {
+	abstractNums map[string][]docxNumLevel // abstractNumId → levels
+	nums         map[string]string         // numId → abstractNumId
+}
+
+func loadDocxStyleSheet(zr *zip.Reader) *docxStyleSheet {
+	sheet := &docxStyleSheet{styles: make(map[string]*docxStyleDef)}
+	data, err := readZipFile(zr, "word/styles.xml")
+	if err != nil {
+		return sheet
+	}
+	root, err := parseDocxXML(data)
+	if err != nil {
+		return sheet
+	}
+	if dd := root.child("docDefaults"); dd != nil {
+		if rpd := dd.child("rPrDefault"); rpd != nil {
+			sheet.docRPr = rpd.child("rPr")
+		}
+		if ppd := dd.child("pPrDefault"); ppd != nil {
+			sheet.docPPr = ppd.child("pPr")
+		}
+	}
+	for i := range root.Children {
+		st := &root.Children[i]
+		if st.XMLName.Local != "style" {
+			continue
+		}
+		id := st.attr("styleId")
+		if id == "" {
+			continue
+		}
+		def := &docxStyleDef{
+			styleType:   st.attr("type"),
+			styleID:     id,
+			pPr:         st.child("pPr"),
+			rPr:         st.child("rPr"),
+			tblPr:       st.child("tblPr"),
+			tblStylePrs: make(map[string]*docxXMLNode),
+			outlineLvl:  -1,
+		}
+		for j := range st.Children {
+			pr := &st.Children[j]
+			if pr.XMLName.Local == "tblStylePr" {
+				if typ := pr.attr("type"); typ != "" {
+					def.tblStylePrs[typ] = pr
+				}
+			}
+		}
+		if bo := st.child("basedOn"); bo != nil {
+			def.basedOn = bo.attr("val")
+		}
+		if lk := st.child("link"); lk != nil {
+			def.link = lk.attr("val")
+		}
+		if name := st.child("name"); name != nil {
+			def.name = name.attr("val")
+		}
+		if ol := def.pPr; ol != nil {
+			if lvl := ol.child("outlineLvl"); lvl != nil {
+				def.outlineLvl = int(parseDocxInt(lvl.attr("val")))
+			}
+		}
+		sheet.styles[id] = def
+	}
+	return sheet
+}
+
+func loadDocxNumbering(zr *zip.Reader) *docxNumbering {
+	num := &docxNumbering{
+		abstractNums: make(map[string][]docxNumLevel),
+		nums:         make(map[string]string),
+	}
+	data, err := readZipFile(zr, "word/numbering.xml")
+	if err != nil {
+		return num
+	}
+	root, err := parseDocxXML(data)
+	if err != nil {
+		return num
+	}
+	for i := range root.Children {
+		ch := &root.Children[i]
+		switch ch.XMLName.Local {
+		case "abstractNum":
+			id := ch.attr("abstractNumId")
+			if id == "" {
+				continue
+			}
+			var levels []docxNumLevel
+			for j := range ch.Children {
+				lvl := &ch.Children[j]
+				if lvl.XMLName.Local != "lvl" {
+					continue
+				}
+				ilvl := int(parseDocxInt(lvl.attr("ilvl")))
+				for len(levels) <= ilvl {
+					levels = append(levels, docxNumLevel{start: 1})
+				}
+				levels[ilvl] = docxNumLevel{
+					numFmt:  lvl.childAttr("numFmt", "val"),
+					lvlText: lvl.childAttr("lvlText", "val"),
+					start:   parseDocxInt(lvl.childAttr("start", "val")),
+					jc:      lvl.childAttr("lvlJc", "val"),
+					pPr:     lvl.child("pPr"),
+					rPr:     lvl.child("rPr"),
+				}
+				if levels[ilvl].start <= 0 {
+					levels[ilvl].start = 1
+				}
+			}
+			num.abstractNums[id] = levels
+		case "num":
+			id := ch.attr("numId")
+			absNode := ch.child("abstractNumId")
+			if id == "" || absNode == nil {
+				continue
+			}
+			if abs := absNode.attr("val"); abs != "" {
+				num.nums[id] = abs
+			}
+		}
+	}
+	return num
+}
+
+func (s *docxStyleSheet) resolveParagraph(p *docxXMLNode, theme *docxTheme, numbering *docxNumbering, listState map[string][]int64) docxResolvedPPr {
+	var styleIDs []string
+	if pPr := p.child("pPr"); pPr != nil {
+		if ps := pPr.child("pStyle"); ps != nil {
+			if id := ps.attr("val"); id != "" {
+				styleIDs = append(styleIDs, id)
+			}
+		}
+	}
+	chain := s.styleChain(styleIDs)
+	var props []string
+	tag := "p"
+
+	for _, def := range chain {
+		if css := docxPPrCSS(def.pPr, theme); css != "" {
+			props = append(props, css)
+		}
+		if css := docxRPrCSS(def.rPr, theme); css != "" {
+			props = append(props, css)
+		}
+		if h := docxHeadingTag(def); h != "" {
+			tag = h
+		}
+	}
+	if pPr := p.child("pPr"); pPr != nil {
+		if css := docxPPrCSS(pPr, theme); css != "" {
+			props = append(props, css)
+		}
+		if ps := pPr.child("pStyle"); ps != nil {
+			if def := s.styles[ps.attr("val")]; def != nil {
+				if h := docxHeadingTag(def); h != "" {
+					tag = h
+				}
+			}
+		}
+	}
+	if s.docPPr != nil {
+		if css := docxPPrCSS(s.docPPr, theme); css != "" {
+			props = append(props, css)
+		}
+	}
+
+	var marker string
+	if pPr := p.child("pPr"); pPr != nil {
+		if np := pPr.child("numPr"); np != nil && numbering != nil {
+			marker = numbering.listMarker(np, listState)
+			if npPr := numbering.levelPPr(np); npPr != nil {
+				if css := docxPPrCSS(npPr, theme); css != "" {
+					props = append(props, css)
+				}
+			}
+		}
+	}
+
+	return docxResolvedPPr{
+		tag:        tag,
+		style:      strings.Join(dedupCSSProps(props), ";"),
+		listMarker: marker,
+	}
+}
+
+func (s *docxStyleSheet) resolveRun(r *docxXMLNode, paraStyleIDs []string, paraDefaultRPr *docxXMLNode, theme *docxTheme) docxResolvedRPr {
+	var props []string
+	// Apply in ascending priority so later (higher-priority) values win during
+	// dedup: document defaults, then the style chain from base to derived, then
+	// direct paragraph and run formatting.
+	if s.docRPr != nil {
+		if css := docxRPrCSS(s.docRPr, theme); css != "" {
+			props = append(props, css)
+		}
+	}
+	chain := s.styleChain(paraStyleIDs)
+	for i := len(chain) - 1; i >= 0; i-- {
+		def := chain[i]
+		if css := docxRPrCSS(def.rPr, theme); css != "" {
+			props = append(props, css)
+		}
+		if def.link != "" {
+			if linked := s.styles[def.link]; linked != nil && linked.rPr != nil {
+				if css := docxRPrCSS(linked.rPr, theme); css != "" {
+					props = append(props, css)
+				}
+			}
+		}
+	}
+	if paraDefaultRPr != nil {
+		if css := docxRPrCSS(paraDefaultRPr, theme); css != "" {
+			props = append(props, css)
+		}
+	}
+	rPr := r.child("rPr")
+	if rPr != nil {
+		if rs := rPr.child("rStyle"); rs != nil {
+			if id := rs.attr("val"); id != "" {
+				if def := s.styles[id]; def != nil && def.rPr != nil {
+					if css := docxRPrCSS(def.rPr, theme); css != "" {
+						props = append(props, css)
+					}
+				}
+			}
+		}
+		if css := docxRPrCSS(rPr, theme); css != "" {
+			props = append(props, css)
+		}
+	}
+	return docxResolvedRPr{style: strings.Join(dedupCSSProps(props), ";")}
+}
+
+func (s *docxStyleSheet) styleChain(styleIDs []string) []*docxStyleDef {
+	seen := make(map[string]bool)
+	var chain []*docxStyleDef
+	for _, id := range styleIDs {
+		for cur := id; cur != "" && !seen[cur]; {
+			seen[cur] = true
+			def, ok := s.styles[cur]
+			if !ok {
+				break
+			}
+			chain = append(chain, def)
+			cur = def.basedOn
+		}
+	}
+	return chain
+}
+
+func docxHeadingTag(def *docxStyleDef) string {
+	if def == nil {
+		return ""
+	}
+	switch {
+	case strings.EqualFold(def.styleID, "Title"):
+		return "h1"
+	case strings.EqualFold(def.styleID, "Subtitle"):
+		return "h2"
+	case strings.HasPrefix(strings.ToLower(def.styleID), "heading"):
+		n := def.styleID[len("Heading"):]
+		if n >= "1" && n <= "9" {
+			return "h" + n
+		}
+	}
+	if def.outlineLvl >= 0 && def.outlineLvl <= 5 {
+		return fmt.Sprintf("h%d", def.outlineLvl+1)
+	}
+	name := strings.ToLower(def.name)
+	if strings.HasPrefix(name, "heading ") {
+		switch name {
+		case "heading 1":
+			return "h1"
+		case "heading 2":
+			return "h2"
+		case "heading 3":
+			return "h3"
+		case "heading 4":
+			return "h4"
+		case "heading 5":
+			return "h5"
+		case "heading 6":
+			return "h6"
+		}
+	}
+	return ""
+}
+
+func docxPPrCSS(pPr *docxXMLNode, theme *docxTheme) string {
+	if pPr == nil {
+		return ""
+	}
+	var props []string
+	switch pPr.childAttr("jc", "val") {
+	case "center":
+		props = append(props, "text-align:center")
+	case "right":
+		props = append(props, "text-align:right")
+	case "both", "distribute":
+		props = append(props, "text-align:justify")
+	case "left":
+		props = append(props, "text-align:left")
+	}
+	if sp := pPr.child("spacing"); sp != nil {
+		if before := parseDocxInt(sp.attr("before")); before > 0 {
+			props = append(props, fmt.Sprintf("margin-top:%.2fpx", twipsToPx(before)))
+		}
+		if after := parseDocxInt(sp.attr("after")); after > 0 {
+			props = append(props, fmt.Sprintf("margin-bottom:%.2fpx", twipsToPx(after)))
+		}
+		if line := parseDocxInt(sp.attr("line")); line > 0 {
+			rule := sp.attr("lineRule")
+			if rule == "auto" || rule == "" {
+				props = append(props, fmt.Sprintf("line-height:%.2f", float64(line)/240.0))
+			} else {
+				props = append(props, fmt.Sprintf("line-height:%.2fpx", twipsToPx(line)))
+			}
+		}
+	}
+	if ind := pPr.child("ind"); ind != nil {
+		if left := parseDocxInt(ind.attr("left")); left != 0 {
+			props = append(props, fmt.Sprintf("margin-left:%.2fpx", twipsToPx(left)))
+		}
+		if right := parseDocxInt(ind.attr("right")); right != 0 {
+			props = append(props, fmt.Sprintf("margin-right:%.2fpx", twipsToPx(right)))
+		}
+		if first := parseDocxInt(ind.attr("firstLine")); first != 0 {
+			props = append(props, fmt.Sprintf("text-indent:%.2fpx", twipsToPx(first)))
+		} else if hanging := parseDocxInt(ind.attr("hanging")); hanging != 0 {
+			props = append(props, fmt.Sprintf("text-indent:%.2fpx", -twipsToPx(hanging)))
+			props = append(props, fmt.Sprintf("padding-left:%.2fpx", twipsToPx(hanging)))
+		}
+	}
+	if shd := pPr.child("shd"); shd != nil {
+		if css := docxShdCSS(shd, theme); css != "" {
+			props = append(props, strings.TrimSuffix(css, ";"))
+		}
+	}
+	if pBdr := pPr.child("pBdr"); pBdr != nil {
+		if css := docxPBdrCSS(pBdr); css != "" {
+			props = append(props, strings.TrimSuffix(css, ";"))
+		}
+	}
+	return strings.Join(props, ";")
+}
+
+func (s *docxStyleSheet) tblStyleConditionalCSS(styleID, cnfType string, theme *docxTheme) string {
+	if s == nil || styleID == "" || cnfType == "" {
+		return ""
+	}
+	def := s.styles[styleID]
+	if def == nil {
+		return ""
+	}
+	pr, ok := def.tblStylePrs[cnfType]
+	if !ok || pr == nil {
+		return ""
+	}
+	var props []string
+	if tcPr := pr.child("tcPr"); tcPr != nil {
+		if shd := tcPr.child("shd"); shd != nil {
+			if css := docxShdCSS(shd, theme); css != "" {
+				props = append(props, strings.TrimSuffix(css, ";"))
+			}
+		}
+		if css := docxBordersCSS(tcPr.child("tcBorders"), theme); css != "" {
+			props = append(props, strings.TrimSuffix(css, ";"))
+		}
+	}
+	return strings.Join(props, ";")
+}
+
+func (s *docxStyleSheet) defaultFontCSS(theme *docxTheme) string {
+	if s == nil || s.docRPr == nil {
+		return ""
+	}
+	return docxRPrCSS(s.docRPr, theme)
+}
+
+func docxRPrCSS(rPr *docxXMLNode, theme *docxTheme) string {
+	if rPr == nil {
+		return ""
+	}
+	var props []string
+	if docxRPrFlag(rPr, "b") {
+		props = append(props, "font-weight:700")
+	}
+	if docxRPrFlag(rPr, "i") {
+		props = append(props, "font-style:italic")
+	}
+	u := rPr.childAttr("u", "val")
+	if u == "" {
+		u = rPr.attr("u")
+	}
+	if u != "" && u != "none" {
+		props = append(props, "text-decoration:underline")
+	}
+	if strike := rPr.attr("strike"); strike != "" && strike != "noStrike" {
+		props = append(props, "text-decoration:line-through")
+	}
+	sz := parseDocxInt(rPr.childAttr("sz", "val"))
+	if sz <= 0 {
+		sz = parseDocxInt(rPr.attr("sz"))
+	}
+	if sz > 0 {
+		props = append(props, fmt.Sprintf("font-size:%.2fpx", halfPtToPx(sz)))
+	}
+	if clr := resolveDocxColor(rPr, theme); clr != "" {
+		props = append(props, "color:"+clr)
+	}
+	if rf := docxFontFamily(rPr.child("rFonts")); rf != "" {
+		props = append(props, "font-family:'"+rf+"'")
+	}
+	va := rPr.childAttr("vertAlign", "val")
+	if va == "" {
+		va = rPr.attr("vertAlign")
+	}
+	switch va {
+	case "superscript":
+		props = append(props, "vertical-align:super", "font-size:0.75em")
+	case "subscript":
+		props = append(props, "vertical-align:sub", "font-size:0.75em")
+	}
+	if hl := rPr.child("highlight"); hl != nil {
+		if val := strings.ToUpper(hl.attr("val")); val != "" && val != "NONE" {
+			props = append(props, "background-color:#"+docxHighlightHex(val))
+		}
+	} else if shd := rPr.child("shd"); shd != nil {
+		// Run-level shading is how Word fills text with a background color
+		// (e.g. highlighted form placeholders) when not using w:highlight.
+		if css := docxShdCSS(shd, theme); css != "" {
+			props = append(props, strings.TrimSuffix(css, ";"))
+		}
+	}
+	return strings.Join(props, ";")
+}
+
+func docxHighlightHex(name string) string {
+	switch name {
+	case "YELLOW":
+		return "FFFF00"
+	case "GREEN":
+		return "00FF00"
+	case "CYAN":
+		return "00FFFF"
+	case "MAGENTA":
+		return "FF00FF"
+	case "BLUE":
+		return "0000FF"
+	case "RED":
+		return "FF0000"
+	case "DARKBLUE":
+		return "000080"
+	case "DARKCYAN":
+		return "008080"
+	case "DARKGREEN":
+		return "008000"
+	case "DARKMAGENTA":
+		return "800080"
+	case "DARKRED":
+		return "800000"
+	case "DARKYELLOW":
+		return "808000"
+	case "LIGHTGRAY":
+		return "D3D3D3"
+	case "DARKGRAY":
+		return "A9A9A9"
+	case "BLACK":
+		return "000000"
+	case "WHITE":
+		return "FFFFFF"
+	default:
+		return "FFFF00"
+	}
+}
+
+func docxRPrFlag(rPr *docxXMLNode, local string) bool {
+	if ch := rPr.child(local); ch != nil {
+		v := ch.attr("val")
+		return v == "" || v == "1" || strings.EqualFold(v, "true") || strings.EqualFold(v, "on")
+	}
+	v := rPr.attr(local)
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
+func dedupCSSProps(props []string) []string {
+	seen := make(map[string]string)
+	order := []string{}
+	for _, p := range props {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		key := p
+		if idx := strings.Index(p, ":"); idx > 0 {
+			key = p[:idx]
+		}
+		if _, ok := seen[key]; !ok {
+			order = append(order, key)
+		}
+		seen[key] = p
+	}
+	out := make([]string, 0, len(order))
+	for _, k := range order {
+		out = append(out, seen[k])
+	}
+	return out
+}
+
+func (n *docxNumbering) levelPPr(numPr *docxXMLNode) *docxXMLNode {
+	lvl := n.level(numPr)
+	if lvl == nil {
+		return nil
+	}
+	return lvl.pPr
+}
+
+func (n *docxNumbering) level(numPr *docxXMLNode) *docxNumLevel {
+	if n == nil || numPr == nil {
+		return nil
+	}
+	numID := numPr.childAttr("numId", "val")
+	ilvl := int(parseDocxInt(numPr.childAttr("ilvl", "val")))
+	absID, ok := n.nums[numID]
+	if !ok {
+		return nil
+	}
+	levels, ok := n.abstractNums[absID]
+	if !ok || ilvl < 0 || ilvl >= len(levels) {
+		return nil
+	}
+	lvl := levels[ilvl]
+	return &lvl
+}
+
+func (n *docxNumbering) listMarker(numPr *docxXMLNode, state map[string][]int64) string {
+	lvl := n.level(numPr)
+	if lvl == nil {
+		return ""
+	}
+	numID := numPr.childAttr("numId", "val")
+	ilvl := int(parseDocxInt(numPr.childAttr("ilvl", "val")))
+	key := numID
+	if state[key] == nil {
+		state[key] = []int64{}
+	}
+	for len(state[key]) <= ilvl {
+		state[key] = append(state[key], 0)
+	}
+	for i := ilvl + 1; i < len(state[key]); i++ {
+		state[key][i] = 0
+	}
+	if state[key][ilvl] == 0 {
+		state[key][ilvl] = lvl.start
+	} else if lvl.numFmt != "bullet" {
+		state[key][ilvl]++
+	}
+	val := state[key][ilvl]
+	text := lvl.lvlText
+	if text == "" {
+		text = "%1."
+	}
+	text = strings.ReplaceAll(text, "%"+fmt.Sprint(ilvl+1), fmt.Sprint(val))
+	text = strings.ReplaceAll(text, "%1", fmt.Sprint(val))
+	if lvl.numFmt == "bullet" {
+		return docxBulletGlyph(text)
+	}
+	return text
+}
+
+// docxBulletGlyph maps a bullet's lvlText to a renderable Unicode glyph. Bullet
+// characters are usually code points from a symbol font (Symbol/Wingdings) that
+// show as tofu (□) in normal fonts, so translate the common ones and fall back
+// to a round bullet for any other private-use-area glyph.
+func docxBulletGlyph(text string) string {
+	switch text {
+	case "":
+		return "•"
+	case "o":
+		return "○"
+	}
+	runes := []rune(text)
+	if len(runes) == 1 {
+		switch runes[0] {
+		case 0xF0B7, 0x00B7, 0x2022: // Symbol bullet / middle dot
+			return "\u2022"
+		case 0xF0A7, 0xF06E, 0x00A7: // Wingdings filled square
+			return "\u25AA"
+		case 0xF06F, 0xF0A8: // open circle / square
+			return "\u25E6"
+		case 0xF0D8, 0xF0E8: // arrowheads
+			return "\u2023"
+		}
+		if runes[0] >= 0xF000 && runes[0] <= 0xF0FF {
+			return "\u2022"
+		}
+	}
+	return text
+}

--- a/server/internal/service/officepreview/docx_visual.go
+++ b/server/internal/service/officepreview/docx_visual.go
@@ -1,0 +1,1386 @@
+package officepreview
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"path"
+	"strings"
+)
+
+type docxPageLayout struct {
+	widthPx      float64
+	heightPx     float64
+	marginTop    float64
+	marginRight  float64
+	marginBottom float64
+	marginLeft   float64
+}
+
+type docxRenderCtx struct {
+	zr                *zip.Reader
+	docPath           string
+	rels              map[string]packageRel
+	theme             *docxTheme
+	styles            *docxStyleSheet
+	numbering         *docxNumbering
+	listState         map[string][]int64
+	textBoxOriginX    float64
+	textBoxOriginY    float64
+	textBoxHostActive bool
+	page              docxPageLayout
+}
+
+type docxTextBoxSpec struct {
+	drawing *docxXMLNode
+	left    float64
+	top     float64
+	width   float64
+	height  float64
+}
+
+func docxTextBoxSpecs(node *docxXMLNode) []docxTextBoxSpec {
+	if node == nil {
+		return nil
+	}
+	var specs []docxTextBoxSpec
+	for _, drawing := range node.findAllDeep("drawing") {
+		if drawing.findDeep("txbxContent") == nil {
+			continue
+		}
+		anchor := drawing.findDeep("anchor")
+		if anchor == nil {
+			anchor = drawing.findDeep("inline")
+		}
+		left := docxAnchorOffsetPx(anchor, "positionH")
+		top := docxAnchorOffsetPx(anchor, "positionV")
+		width, height := docxAnchorExtentPx(anchor)
+		specs = append(specs, docxTextBoxSpec{
+			drawing: drawing,
+			left:    left,
+			top:     top,
+			width:   width,
+			height:  height,
+		})
+	}
+	return specs
+}
+
+func docxTextBoxBounds(specs []docxTextBoxSpec) (minLeft, minTop, maxBottom float64) {
+	if len(specs) == 0 {
+		return 0, 0, 0
+	}
+	minLeft = specs[0].left
+	minTop = specs[0].top
+	for _, spec := range specs {
+		if spec.left < minLeft {
+			minLeft = spec.left
+		}
+		if spec.top < minTop {
+			minTop = spec.top
+		}
+		if bottom := spec.top + spec.height; bottom > maxBottom {
+			maxBottom = bottom
+		}
+	}
+	return minLeft, minTop, maxBottom
+}
+
+func (ctx *docxRenderCtx) pushTextBoxHost(node *docxXMLNode) (pop func(), hostMinHeight float64, ok bool) {
+	specs := docxTextBoxSpecs(node)
+	if len(specs) == 0 || ctx.textBoxHostActive {
+		return func() {}, 0, false
+	}
+	minLeft, minTop, maxBottom := docxTextBoxBounds(specs)
+	prevX, prevY, prevActive := ctx.textBoxOriginX, ctx.textBoxOriginY, ctx.textBoxHostActive
+	ctx.textBoxOriginX = minLeft
+	ctx.textBoxOriginY = minTop
+	ctx.textBoxHostActive = true
+	return func() {
+		ctx.textBoxOriginX = prevX
+		ctx.textBoxOriginY = prevY
+		ctx.textBoxHostActive = prevActive
+	}, maxBottom - minTop + 4, true
+}
+
+func convertDocxToVisualHTML(data []byte, filename, mimeType string) (string, error) {
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", fmt.Errorf("open docx zip: %w", err)
+	}
+	docData, err := readZipFile(zr, "word/document.xml")
+	if err != nil {
+		return "", fmt.Errorf("read document.xml: %w", err)
+	}
+	root, err := parseDocxXML(docData)
+	if err != nil {
+		return "", fmt.Errorf("parse document.xml: %w", err)
+	}
+	body := root.findDeep("body")
+	if body == nil {
+		return "", fmt.Errorf("no document body")
+	}
+	rels, _ := parsePackageRels(zr, "word/_rels/document.xml.rels")
+	ctx := &docxRenderCtx{
+		zr:        zr,
+		docPath:   "word/document.xml",
+		rels:      rels,
+		theme:     loadDocxTheme(zr),
+		styles:    loadDocxStyleSheet(zr),
+		numbering: loadDocxNumbering(zr),
+		listState: make(map[string][]int64),
+	}
+	page := docxParsePageLayout(body)
+	ctx.page = page
+	footerRoot := loadDocxFooter(ctx, body.child("sectPr"))
+	pageGroups := docxSplitBodyPages(body)
+	if len(pageGroups) == 0 {
+		return "", fmt.Errorf("no visual content rendered")
+	}
+	totalPages := len(pageGroups)
+	var pageFragments []string
+	for pageIdx, nodes := range pageGroups {
+		var b strings.Builder
+		for i := range nodes {
+			b.WriteString(renderDocxBlock(&nodes[i], ctx))
+		}
+		fragment := strings.TrimSpace(b.String())
+		if fragment == "" {
+			continue
+		}
+		fragment += renderDocxPageFooter(footerRoot, ctx, pageIdx+1, totalPages)
+		pageFragments = append(pageFragments, fragment)
+	}
+	if len(pageFragments) == 0 {
+		return "", fmt.Errorf("no visual content rendered")
+	}
+	return wrapDocxHTMLDocument(pageFragments, page, ctx.styles.defaultFontCSS(ctx.theme)), nil
+}
+
+func docxSplitBodyPages(body *docxXMLNode) [][]docxXMLNode {
+	var pages [][]docxXMLNode
+	var current []docxXMLNode
+	for i := range body.Children {
+		ch := body.Children[i]
+		if ch.XMLName.Local == "sectPr" {
+			continue
+		}
+		if ch.XMLName.Local == "p" && docxParagraphStartsNewPage(&ch) {
+			if len(current) > 0 {
+				pages = append(pages, current)
+				current = nil
+			}
+			if docxIsPageBreakOnlyParagraph(&ch) {
+				continue
+			}
+		}
+		current = append(current, ch)
+	}
+	if len(current) > 0 {
+		pages = append(pages, current)
+	}
+	return pages
+}
+
+func docxParagraphStartsNewPage(p *docxXMLNode) bool {
+	if docxIsPageBreakOnlyParagraph(p) {
+		return true
+	}
+	for i := range p.Children {
+		if p.Children[i].XMLName.Local != "r" {
+			continue
+		}
+		r := &p.Children[i]
+		for j := range r.Children {
+			switch r.Children[j].XMLName.Local {
+			case "lastRenderedPageBreak":
+				return true
+			case "br":
+				if r.Children[j].attr("type") == "page" {
+					return true
+				}
+			case "t":
+				if strings.TrimSpace(docxCollectText(&r.Children[j])) != "" {
+					return false
+				}
+			}
+		}
+	}
+	return false
+}
+
+func docxIsPageBreakOnlyParagraph(p *docxXMLNode) bool {
+	hasPageBreak := false
+	hasOther := false
+	for i := range p.Children {
+		ch := &p.Children[i]
+		switch ch.XMLName.Local {
+		case "pPr", "bookmarkStart", "bookmarkEnd", "proofErr":
+			continue
+		case "r":
+			for j := range ch.Children {
+				rc := &ch.Children[j]
+				switch rc.XMLName.Local {
+				case "br":
+					if rc.attr("type") == "page" {
+						hasPageBreak = true
+					} else {
+						hasOther = true
+					}
+				case "t":
+					if strings.TrimSpace(docxCollectText(rc)) != "" {
+						hasOther = true
+					}
+				case "rPr":
+					continue
+				default:
+					hasOther = true
+				}
+			}
+		default:
+			hasOther = true
+		}
+	}
+	return hasPageBreak && !hasOther
+}
+
+func docxParagraphHasText(p *docxXMLNode) bool {
+	for i := range p.Children {
+		ch := &p.Children[i]
+		switch ch.XMLName.Local {
+		case "r":
+			for j := range ch.Children {
+				if ch.Children[j].XMLName.Local == "t" && strings.TrimSpace(docxCollectText(&ch.Children[j])) != "" {
+					return true
+				}
+			}
+		case "hyperlink":
+			for j := range ch.Children {
+				if ch.Children[j].XMLName.Local == "r" && docxRunHasText(&ch.Children[j]) {
+					return true
+				}
+			}
+		case "sdt":
+			if content := ch.child("sdtContent"); content != nil {
+				for j := range content.Children {
+					if content.Children[j].XMLName.Local == "p" && docxParagraphHasText(&content.Children[j]) {
+						return true
+					}
+				}
+			}
+		case "AlternateContent", "drawing":
+			if docxNodeHasTextBox(ch) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func docxNodeHasTextBox(n *docxXMLNode) bool {
+	if n == nil {
+		return false
+	}
+	if n.XMLName.Local == "drawing" && n.findDeep("txbxContent") != nil {
+		return true
+	}
+	for _, drawing := range n.findAllDeep("drawing") {
+		if drawing.findDeep("txbxContent") != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func docxRunHasText(r *docxXMLNode) bool {
+	for i := range r.Children {
+		if r.Children[i].XMLName.Local == "t" && strings.TrimSpace(docxCollectText(&r.Children[i])) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func renderDocxBlock(ch *docxXMLNode, ctx *docxRenderCtx) string {
+	switch ch.XMLName.Local {
+	case "p":
+		return renderDocxParagraph(ch, ctx)
+	case "tbl":
+		return renderDocxTable(ch, ctx)
+	case "sdt":
+		return renderDocxSDT(ch, ctx, nil)
+	default:
+		return ""
+	}
+}
+
+func loadDocxFooter(ctx *docxRenderCtx, sectPr *docxXMLNode) *docxXMLNode {
+	if sectPr == nil {
+		return nil
+	}
+	var footerID string
+	for i := range sectPr.Children {
+		fr := &sectPr.Children[i]
+		if fr.XMLName.Local != "footerReference" {
+			continue
+		}
+		id := fr.relAttr("id")
+		if id == "" {
+			continue
+		}
+		ftype := fr.attr("type")
+		if ftype == "default" || ftype == "" {
+			footerID = id
+			break
+		}
+		if footerID == "" {
+			footerID = id
+		}
+	}
+	if footerID == "" {
+		return nil
+	}
+	rel, ok := ctx.rels[footerID]
+	if !ok {
+		return nil
+	}
+	footerPath := resolveOOXMLPath(ctx.docPath, rel.Target)
+	data, err := readZipFile(ctx.zr, footerPath)
+	if err != nil {
+		return nil
+	}
+	root, err := parseDocxXML(data)
+	if err != nil {
+		return nil
+	}
+	return root
+}
+
+func renderDocxPageFooter(footerRoot *docxXMLNode, ctx *docxRenderCtx, pageNum, totalPages int) string {
+	if footerRoot == nil {
+		return ""
+	}
+	body := footerRoot.findDeep("ftr")
+	if body == nil {
+		body = footerRoot
+	}
+	var b strings.Builder
+	for i := range body.Children {
+		ch := &body.Children[i]
+		switch ch.XMLName.Local {
+		case "p":
+			b.WriteString(renderDocxFooterParagraph(ch, ctx, pageNum, totalPages))
+		case "sdt":
+			if content := ch.child("sdtContent"); content != nil {
+				for j := range content.Children {
+					if content.Children[j].XMLName.Local == "p" {
+						b.WriteString(renderDocxFooterParagraph(&content.Children[j], ctx, pageNum, totalPages))
+					}
+				}
+			}
+		}
+	}
+	inner := strings.TrimSpace(b.String())
+	if inner == "" {
+		return ""
+	}
+	return fmt.Sprintf(`<div class="docx-footer">%s</div>`, inner)
+}
+
+func renderDocxFooterParagraph(p *docxXMLNode, ctx *docxRenderCtx, pageNum, totalPages int) string {
+	pPr := p.child("pPr")
+	var paraStyleIDs []string
+	var paraDefaultRPr *docxXMLNode
+	if pPr != nil {
+		if ps := pPr.child("pStyle"); ps != nil {
+			if id := ps.attr("val"); id != "" {
+				paraStyleIDs = append(paraStyleIDs, id)
+			}
+		}
+		paraDefaultRPr = pPr.child("rPr")
+	}
+	paraCSS := ""
+	if pPr != nil {
+		paraCSS = docxPPrCSS(pPr, ctx.theme)
+	}
+	inner := renderDocxRunsWithFields(p, ctx, paraStyleIDs, paraDefaultRPr, pageNum, totalPages)
+	if inner == "" {
+		return ""
+	}
+	return fmt.Sprintf(`<p class="docx-footer-p"%s>%s</p>`, docxAttrStyle(paraCSS), inner)
+}
+
+func renderDocxRunsWithFields(p *docxXMLNode, ctx *docxRenderCtx, paraStyleIDs []string, paraDefaultRPr *docxXMLNode, pageNum, totalPages int) string {
+	var b strings.Builder
+	var activeField string
+	skipCachedFieldText := false
+	for i := range p.Children {
+		ch := &p.Children[i]
+		switch ch.XMLName.Local {
+		case "r":
+			for j := range ch.Children {
+				rc := &ch.Children[j]
+				switch rc.XMLName.Local {
+				case "fldChar":
+					switch rc.attr("fldCharType") {
+					case "begin":
+						activeField = ""
+						skipCachedFieldText = false
+					case "separate":
+						if activeField != "" {
+							skipCachedFieldText = true
+							b.WriteString(docxFieldValueSpan(ch, ctx, paraStyleIDs, paraDefaultRPr, activeField, pageNum, totalPages))
+						}
+					case "end":
+						activeField = ""
+						skipCachedFieldText = false
+					}
+				case "instrText":
+					instr := strings.ToUpper(strings.TrimSpace(docxCollectText(rc)))
+					switch {
+					case strings.Contains(instr, "NUMPAGES"):
+						activeField = "numpages"
+					case strings.Contains(instr, "PAGE"):
+						activeField = "page"
+					}
+				case "t":
+					if skipCachedFieldText {
+						continue
+					}
+					text := docxCollectText(rc)
+					resolved := ctx.styles.resolveRun(ch, paraStyleIDs, paraDefaultRPr, ctx.theme)
+					if resolved.style != "" {
+						fmt.Fprintf(&b, `<span style="%s">%s</span>`, resolved.style, escapeHTMLText(text))
+					} else {
+						b.WriteString(escapeHTMLText(text))
+					}
+				default:
+					continue
+				}
+			}
+		case "hyperlink":
+			b.WriteString(renderDocxHyperlink(ch, ctx, paraStyleIDs, paraDefaultRPr))
+		}
+	}
+	return b.String()
+}
+
+func docxFieldValueSpan(r *docxXMLNode, ctx *docxRenderCtx, paraStyleIDs []string, paraDefaultRPr *docxXMLNode, field string, pageNum, totalPages int) string {
+	text := ""
+	switch field {
+	case "page":
+		text = fmt.Sprintf("%d", pageNum)
+	case "numpages":
+		text = fmt.Sprintf("%d", totalPages)
+	default:
+		return ""
+	}
+	resolved := ctx.styles.resolveRun(r, paraStyleIDs, paraDefaultRPr, ctx.theme)
+	if resolved.style != "" {
+		return fmt.Sprintf(`<span style="%s">%s</span>`, resolved.style, escapeHTMLText(text))
+	}
+	return escapeHTMLText(text)
+}
+
+func docxParsePageLayout(body *docxXMLNode) docxPageLayout {
+	layout := docxPageLayout{
+		widthPx:      twipsToPx(12240),
+		heightPx:     twipsToPx(15840),
+		marginTop:    twipsToPx(1440),
+		marginRight:  twipsToPx(1440),
+		marginBottom: twipsToPx(1440),
+		marginLeft:   twipsToPx(1440),
+	}
+	sectPr := body.child("sectPr")
+	if sectPr == nil {
+		return layout
+	}
+	if pgSz := sectPr.child("pgSz"); pgSz != nil {
+		if w := parseDocxInt(pgSz.attr("w")); w > 0 {
+			layout.widthPx = twipsToPx(w)
+		}
+		if h := parseDocxInt(pgSz.attr("h")); h > 0 {
+			layout.heightPx = twipsToPx(h)
+		}
+	}
+	if pgMar := sectPr.child("pgMar"); pgMar != nil {
+		if v := parseDocxInt(pgMar.attr("top")); v > 0 {
+			layout.marginTop = twipsToPx(v)
+		}
+		if v := parseDocxInt(pgMar.attr("right")); v > 0 {
+			layout.marginRight = twipsToPx(v)
+		}
+		if v := parseDocxInt(pgMar.attr("bottom")); v > 0 {
+			layout.marginBottom = twipsToPx(v)
+		}
+		if v := parseDocxInt(pgMar.attr("left")); v > 0 {
+			layout.marginLeft = twipsToPx(v)
+		}
+	}
+	return layout
+}
+
+func renderDocxSDT(sdt *docxXMLNode, ctx *docxRenderCtx, paraStyleIDs []string) string {
+	content := sdt.child("sdtContent")
+	if content == nil {
+		return ""
+	}
+	var sdtDefaultRPr *docxXMLNode
+	if sdtPr := sdt.child("sdtPr"); sdtPr != nil {
+		sdtDefaultRPr = sdtPr.child("rPr")
+	}
+	var b strings.Builder
+	for i := range content.Children {
+		ch := &content.Children[i]
+		switch ch.XMLName.Local {
+		case "p":
+			b.WriteString(renderDocxParagraph(ch, ctx))
+		case "tbl":
+			b.WriteString(renderDocxTable(ch, ctx))
+		case "sdt":
+			b.WriteString(renderDocxSDT(ch, ctx, paraStyleIDs))
+		case "r":
+			b.WriteString(renderDocxRun(ch, ctx, paraStyleIDs, sdtDefaultRPr))
+		case "hyperlink":
+			b.WriteString(renderDocxHyperlink(ch, ctx, paraStyleIDs, sdtDefaultRPr))
+		}
+	}
+	rendered := b.String()
+	if strings.TrimSpace(rendered) != "" {
+		return rendered
+	}
+	if sdtPr := sdt.child("sdtPr"); sdtPr != nil {
+		if sdtPr.child("showingPlcHdr") != nil {
+			return ""
+		}
+	}
+	return rendered
+}
+
+func renderDocxParagraph(p *docxXMLNode, ctx *docxRenderCtx) string {
+	pPr := p.child("pPr")
+	var paraStyleIDs []string
+	var paraDefaultRPr *docxXMLNode
+	if pPr != nil {
+		if ps := pPr.child("pStyle"); ps != nil {
+			if id := ps.attr("val"); id != "" {
+				paraStyleIDs = append(paraStyleIDs, id)
+			}
+		}
+		paraDefaultRPr = pPr.child("rPr")
+	}
+	resolved := ctx.styles.resolveParagraph(p, ctx.theme, ctx.numbering, ctx.listState)
+	style := resolved.style
+	if extra := docxEmptyParagraphExtraCSS(p, pPr); extra != "" {
+		if style != "" {
+			style += ";" + extra
+		} else {
+			style = extra
+		}
+	}
+
+	var runs strings.Builder
+	pop, hostMinH, hasHost := ctx.pushTextBoxHost(p)
+	if hasHost {
+		defer pop()
+	}
+	for i := range p.Children {
+		ch := &p.Children[i]
+		switch ch.XMLName.Local {
+		case "r":
+			runs.WriteString(renderDocxRun(ch, ctx, paraStyleIDs, paraDefaultRPr))
+		case "hyperlink":
+			runs.WriteString(renderDocxHyperlink(ch, ctx, paraStyleIDs, paraDefaultRPr))
+		case "sdt":
+			runs.WriteString(renderDocxSDT(ch, ctx, paraStyleIDs))
+		}
+	}
+	inner := runs.String()
+	if hasHost {
+		inner = fmt.Sprintf(
+			`<div class="docx-textbox-host"%s>%s</div>`,
+			docxAttrStyle(fmt.Sprintf("position:relative;min-height:%.2fpx", hostMinH)),
+			inner,
+		)
+	}
+	if strings.TrimSpace(inner) == "" && resolved.listMarker == "" && len(docxTextBoxSpecs(p)) == 0 {
+		return fmt.Sprintf(`<%s class="docx-p"%s></%s>`, resolved.tag, docxAttrStyle(style), resolved.tag)
+	}
+	if resolved.listMarker != "" {
+		markerStyle := "display:inline-block;min-width:1.5em"
+		inner = fmt.Sprintf(`<span class="docx-list-marker" style="%s">%s</span>%s`, markerStyle, escapeHTMLText(resolved.listMarker), inner)
+	}
+	return fmt.Sprintf(`<%s class="docx-p"%s>%s</%s>`, resolved.tag, docxAttrStyle(style), inner, resolved.tag)
+}
+
+func docxEmptyParagraphExtraCSS(p *docxXMLNode, pPr *docxXMLNode) string {
+	// An empty paragraph occupies one line in Word, which is how documents
+	// create vertical spacing between blocks. Without a min-height the empty
+	// <p> collapses to nothing and those gaps disappear. Skip paragraphs that
+	// carry a drawing/picture so anchored shapes don't gain stray height.
+	if docxParagraphHasText(p) || len(p.findAllDeep("drawing")) > 0 || len(p.findAllDeep("pict")) > 0 {
+		return ""
+	}
+	if pPr == nil {
+		return "min-height:1.15em"
+	}
+	if sp := pPr.child("spacing"); sp != nil {
+		if line := parseDocxInt(sp.attr("line")); line > 0 {
+			rule := sp.attr("lineRule")
+			if rule == "auto" || rule == "" {
+				return fmt.Sprintf("min-height:%.2fem", float64(line)/240.0)
+			}
+			return fmt.Sprintf("min-height:%.2fpx", twipsToPx(line))
+		}
+	}
+	return "min-height:1.15em"
+}
+
+func renderDocxHyperlink(hl *docxXMLNode, ctx *docxRenderCtx, paraStyleIDs []string, paraDefaultRPr *docxXMLNode) string {
+	href := ""
+	if id := hl.relAttr("id"); id != "" {
+		if rel, ok := ctx.rels[id]; ok {
+			href = rel.Target
+		}
+	}
+	var inner strings.Builder
+	for i := range hl.Children {
+		if hl.Children[i].XMLName.Local == "r" {
+			inner.WriteString(renderDocxRun(&hl.Children[i], ctx, paraStyleIDs, paraDefaultRPr))
+		}
+	}
+	content := inner.String()
+	if content == "" {
+		return ""
+	}
+	if href == "" {
+		return content
+	}
+	linkStyle := ""
+	if def := ctx.styles.styles["Hyperlink"]; def != nil {
+		linkStyle = docxRPrCSS(def.rPr, ctx.theme)
+	}
+	return fmt.Sprintf(`<a href="%s"%s>%s</a>`, escapeAttr(href), docxAttrStyle(linkStyle), content)
+}
+
+func renderDocxRun(r *docxXMLNode, ctx *docxRenderCtx, paraStyleIDs []string, paraDefaultRPr *docxXMLNode) string {
+	resolved := ctx.styles.resolveRun(r, paraStyleIDs, paraDefaultRPr, ctx.theme)
+	var b strings.Builder
+	for i := range r.Children {
+		ch := &r.Children[i]
+		switch ch.XMLName.Local {
+		case "t":
+			b.WriteString(escapeHTMLText(docxCollectText(ch)))
+		case "tab":
+			b.WriteString("&emsp;")
+		case "br":
+			if ch.attr("type") != "page" {
+				b.WriteString("<br/>")
+			}
+		case "lastRenderedPageBreak":
+			// Page split is handled when grouping body children.
+		case "drawing":
+			if ch.findDeep("txbxContent") != nil {
+				b.WriteString(renderDocxDrawingTextBox(ch, ctx, paraStyleIDs, paraDefaultRPr))
+			} else {
+				b.WriteString(renderDocxDrawing(ch, ctx))
+			}
+		case "AlternateContent":
+			b.WriteString(renderDocxAlternateContent(ch, ctx, paraStyleIDs, paraDefaultRPr))
+		case "pict":
+			if ch.findDeep("txbxContent") != nil {
+				b.WriteString(renderDocxPictTextBox(ch, ctx, paraStyleIDs, paraDefaultRPr))
+			} else {
+				b.WriteString(renderDocxPict(ch, ctx))
+			}
+		case "fldSimple":
+			b.WriteString(escapeHTMLText(docxCollectText(ch)))
+		}
+	}
+	text := b.String()
+	if text == "" {
+		return ""
+	}
+	if (strings.Contains(text, `class="docx-image"`) || strings.Contains(text, `class="docx-textbox"`)) && !strings.Contains(text, "<span") {
+		return text
+	}
+	if resolved.style == "" {
+		return text
+	}
+	return fmt.Sprintf(`<span style="%s">%s</span>`, resolved.style, text)
+}
+
+func renderDocxAlternateContent(ac *docxXMLNode, ctx *docxRenderCtx, paraStyleIDs []string, paraDefaultRPr *docxXMLNode) string {
+	branch := ac.child("Choice")
+	if branch == nil {
+		branch = ac.child("Fallback")
+	}
+	if branch == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, drawing := range branch.findAllDeep("drawing") {
+		if drawing.findDeep("txbxContent") != nil {
+			b.WriteString(renderDocxDrawingTextBox(drawing, ctx, paraStyleIDs, paraDefaultRPr))
+		} else {
+			b.WriteString(renderDocxDrawing(drawing, ctx))
+		}
+	}
+	for _, pict := range branch.findAllDeep("pict") {
+		if pict.findDeep("txbxContent") != nil {
+			b.WriteString(renderDocxPictTextBox(pict, ctx, paraStyleIDs, paraDefaultRPr))
+		} else {
+			b.WriteString(renderDocxPict(pict, ctx))
+		}
+	}
+	return b.String()
+}
+
+// renderDocxTextBoxParagraphs renders the block content of a text box (a text
+// box can hold tables and nested content, not just paragraphs), dropping
+// trailing empty paragraphs. Authors commonly leave blank lines after the
+// caption; in a fixed-height, vertically-centered box those blank lines push
+// the real content past the clip boundary and hide the first line.
+func renderDocxTextBoxParagraphs(txbxContent *docxXMLNode, ctx *docxRenderCtx) string {
+	var blocks []*docxXMLNode
+	for i := range txbxContent.Children {
+		switch txbxContent.Children[i].XMLName.Local {
+		case "p", "tbl", "sdt":
+			blocks = append(blocks, &txbxContent.Children[i])
+		}
+	}
+	for len(blocks) > 0 {
+		last := blocks[len(blocks)-1]
+		if last.XMLName.Local != "p" || docxParagraphHasText(last) || len(docxTextBoxSpecs(last)) > 0 {
+			break
+		}
+		blocks = blocks[:len(blocks)-1]
+	}
+	var inner strings.Builder
+	for _, blk := range blocks {
+		switch blk.XMLName.Local {
+		case "p":
+			inner.WriteString(renderDocxParagraph(blk, ctx))
+		case "tbl":
+			inner.WriteString(renderDocxTable(blk, ctx))
+		case "sdt":
+			inner.WriteString(renderDocxSDT(blk, ctx, nil))
+		}
+	}
+	return inner.String()
+}
+
+func renderDocxDrawingTextBox(drawing *docxXMLNode, ctx *docxRenderCtx, paraStyleIDs []string, paraDefaultRPr *docxXMLNode) string {
+	txbxContent := drawing.findDeep("txbxContent")
+	if txbxContent == nil {
+		return renderDocxDrawing(drawing, ctx)
+	}
+	anchor := drawing.findDeep("anchor")
+	if anchor == nil {
+		anchor = drawing.findDeep("inline")
+	}
+	left := docxAnchorOffsetPx(anchor, "positionH") - ctx.textBoxOriginX
+	top := docxAnchorOffsetPx(anchor, "positionV") - ctx.textBoxOriginY
+	width, height := docxAnchorExtentPx(anchor)
+	boxStyle := docxTextBoxStyle(drawing, ctx.theme)
+	content := strings.TrimSpace(renderDocxTextBoxParagraphs(txbxContent, ctx))
+	if content == "" {
+		return ""
+	}
+	posStyle := "position:absolute;"
+	if ctx.textBoxHostActive || left != 0 || top != 0 {
+		posStyle += fmt.Sprintf("left:%.2fpx;top:%.2fpx;", left, top)
+	}
+	if width > 0 {
+		posStyle += fmt.Sprintf("width:%.2fpx;", width)
+	}
+	if height > 0 {
+		// Word text boxes don't clip overflowing text (unless set to a fixed
+		// autofit); use min-height so longer content grows the box instead of
+		// being cut off.
+		posStyle += fmt.Sprintf("min-height:%.2fpx;", height)
+	}
+	return fmt.Sprintf(
+		`<div class="docx-textbox" style="%s%s">%s</div>`,
+		posStyle,
+		boxStyle,
+		content,
+	)
+}
+
+func docxTextBoxStyle(drawing *docxXMLNode, theme *docxTheme) string {
+	wsp := drawing.findDeep("wsp")
+	if wsp == nil {
+		return "box-sizing:border-box;"
+	}
+	var parts []string
+	parts = append(parts, "box-sizing:border-box")
+	spPr := wsp.child("spPr")
+	if spPr == nil {
+		return strings.Join(parts, ";") + ";"
+	}
+	if fill := spPr.child("solidFill"); fill != nil {
+		if clr := resolveDocxSolidFillColor(fill, theme); clr != "" {
+			parts = append(parts, "background-color:"+clr)
+		}
+	}
+	// Only draw a border when the shape actually defines a line fill. A
+	// <a:ln> carrying <a:noFill/> means "no outline"; drawing one anyway
+	// boxes every text box (e.g. an entire résumé laid out in text boxes).
+	if ln := spPr.child("ln"); ln != nil && ln.child("noFill") == nil {
+		widthPx := docxDrawingLnWidthPx(ln)
+		borderClr := "#000000"
+		if fill := ln.child("solidFill"); fill != nil {
+			if clr := resolveDocxSolidFillColor(fill, theme); clr != "" {
+				borderClr = clr
+			}
+		}
+		parts = append(parts, fmt.Sprintf("border:%.2fpx solid %s", widthPx, borderClr))
+	}
+	if bodyPr := wsp.child("bodyPr"); bodyPr != nil {
+		switch bodyPr.attr("anchor") {
+		case "ctr":
+			parts = append(parts, "display:flex", "flex-direction:column", "justify-content:center")
+		case "b":
+			parts = append(parts, "display:flex", "flex-direction:column", "justify-content:flex-end")
+		default:
+			parts = append(parts, "display:flex", "flex-direction:column", "justify-content:flex-start")
+		}
+	}
+	return strings.Join(parts, ";") + ";"
+}
+
+func renderDocxPictTextBox(pict *docxXMLNode, ctx *docxRenderCtx, paraStyleIDs []string, paraDefaultRPr *docxXMLNode) string {
+	txbxContent := pict.findDeep("txbxContent")
+	if txbxContent == nil {
+		return renderDocxPict(pict, ctx)
+	}
+	content := strings.TrimSpace(renderDocxTextBoxParagraphs(txbxContent, ctx))
+	if content == "" {
+		return ""
+	}
+	return fmt.Sprintf(`<div class="docx-textbox" style="display:inline-block;vertical-align:top;%s">%s</div>`, docxVMLShapeStyle(pict), content)
+}
+
+func docxVMLShapeStyle(pict *docxXMLNode) string {
+	for _, shape := range pict.findAllDeep("shape") {
+		style := shape.attr("style")
+		if style == "" {
+			continue
+		}
+		var parts []string
+		for _, decl := range strings.Split(style, ";") {
+			decl = strings.TrimSpace(decl)
+			if decl == "" {
+				continue
+			}
+			kv := strings.SplitN(decl, ":", 2)
+			if len(kv) != 2 {
+				continue
+			}
+			key := strings.TrimSpace(kv[0])
+			val := strings.TrimSpace(kv[1])
+			switch key {
+			case "margin-left", "margin-top", "width", "height":
+				parts = append(parts, key+":"+val)
+			}
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, ";") + ";"
+		}
+	}
+	return ""
+}
+
+func renderDocxDrawing(drawing *docxXMLNode, ctx *docxRenderCtx) string {
+	embed := findDocxBlipEmbed(drawing)
+	if embed == "" {
+		return renderDocxAnchoredShape(drawing, ctx)
+	}
+	uri := resolveDocxEmbed(ctx, embed)
+	if uri == "" {
+		return ""
+	}
+	widthPx, heightPx := docxDrawingSizePx(drawing)
+	style := "max-width:100%;height:auto;display:block;margin:0 auto;"
+	if widthPx > 0 {
+		style += fmt.Sprintf("width:%.2fpx;", widthPx)
+	}
+	if heightPx > 0 {
+		style += fmt.Sprintf("height:%.2fpx;", heightPx)
+	}
+	return fmt.Sprintf(`<img class="docx-image" src="%s" alt="" style="%s"/>`, uri, style)
+}
+
+// renderDocxAnchoredShape renders an anchored DrawingML shape that carries a
+// solid fill but no image or text (e.g. a decorative side bar) as an absolutely
+// positioned colored box on the page. Shapes without an anchor or a fill render
+// as nothing, matching the prior behavior.
+func renderDocxAnchoredShape(drawing *docxXMLNode, ctx *docxRenderCtx) string {
+	anchor := drawing.findDeep("anchor")
+	if anchor == nil {
+		return ""
+	}
+	wsp := drawing.findDeep("wsp")
+	if wsp == nil {
+		return ""
+	}
+	spPr := wsp.child("spPr")
+	if spPr == nil {
+		return ""
+	}
+	fill := resolveDocxSolidFillColor(spPr.child("solidFill"), ctx.theme)
+	if fill == "" {
+		return ""
+	}
+	width, height := docxAnchorExtentPx(anchor)
+	if width <= 0 || height <= 0 {
+		return ""
+	}
+	var left, top float64
+	if ctx.textBoxHostActive {
+		// The shape shares a text-box host's coordinate system with sibling
+		// anchored boxes, so position it relative to that host origin (the same
+		// way text boxes are placed) instead of the page.
+		left = docxAnchorOffsetPxSigned(anchor, "positionH") - ctx.textBoxOriginX
+		top = docxAnchorOffsetPxSigned(anchor, "positionV") - ctx.textBoxOriginY
+	} else {
+		left = docxAnchorBasePx(anchor, "positionH", ctx.page) + docxAnchorOffsetPxSigned(anchor, "positionH")
+		top = docxAnchorBasePx(anchor, "positionV", ctx.page) + docxAnchorOffsetPxSigned(anchor, "positionV")
+	}
+	z := "z-index:0;"
+	if anchor.attr("behindDoc") == "1" {
+		z = "z-index:-1;"
+	}
+	return fmt.Sprintf(
+		`<div class="docx-shape" style="position:absolute;left:%.2fpx;top:%.2fpx;width:%.2fpx;height:%.2fpx;background-color:%s;%s"></div>`,
+		left, top, width, height, fill, z,
+	)
+}
+
+// docxAnchorBasePx returns the page-relative origin (in px) that an anchor's
+// offset is measured from, based on its relativeFrom reference frame.
+func docxAnchorBasePx(anchor *docxXMLNode, posLocal string, page docxPageLayout) float64 {
+	pos := anchor.child(posLocal)
+	if pos == nil {
+		return 0
+	}
+	switch pos.attr("relativeFrom") {
+	case "page", "leftMargin", "topMargin":
+		return 0
+	case "margin":
+		if posLocal == "positionV" {
+			return page.marginTop
+		}
+		return page.marginLeft
+	default: // column/character/text (H) or paragraph/line/text (V)
+		if posLocal == "positionV" {
+			return page.marginTop
+		}
+		return page.marginLeft
+	}
+}
+
+// docxAnchorOffsetPxSigned reads a posOffset allowing negative values, used for
+// shapes that extend into the page margins.
+func docxAnchorOffsetPxSigned(anchor *docxXMLNode, posLocal string) float64 {
+	if anchor == nil {
+		return 0
+	}
+	pos := anchor.child(posLocal)
+	if pos == nil {
+		return 0
+	}
+	if off := pos.child("posOffset"); off != nil {
+		return emuToPx(parseDocxInt(strings.TrimSpace(docxCollectText(off))))
+	}
+	return 0
+}
+
+func renderDocxPict(pict *docxXMLNode, ctx *docxRenderCtx) string {
+	for _, im := range pict.findAllDeep("imagedata") {
+		if id := im.relAttr("id"); id != "" {
+			uri := resolveDocxEmbed(ctx, id)
+			if uri != "" {
+				return fmt.Sprintf(`<img class="docx-image" src="%s" alt="" style="max-width:100%%;height:auto;"/>`, uri)
+			}
+		}
+	}
+	return ""
+}
+
+func findDocxBlipEmbed(node *docxXMLNode) string {
+	if node.XMLName.Local == "blip" {
+		if id := node.relAttr("embed"); id != "" {
+			return id
+		}
+	}
+	for i := range node.Children {
+		if id := findDocxBlipEmbed(&node.Children[i]); id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+func docxDrawingSizePx(drawing *docxXMLNode) (float64, float64) {
+	for _, local := range []string{"extent", "ext"} {
+		if ext := drawing.findDeep(local); ext != nil {
+			cx := parseDocxInt(ext.attr("cx"))
+			cy := parseDocxInt(ext.attr("cy"))
+			if cx > 0 && cy > 0 {
+				return emuToPx(cx), emuToPx(cy)
+			}
+		}
+	}
+	return 0, 0
+}
+
+func resolveDocxEmbed(ctx *docxRenderCtx, embedID string) string {
+	rel, ok := ctx.rels[embedID]
+	if !ok {
+		return ""
+	}
+	mediaPath := resolveOOXMLPath(ctx.docPath, rel.Target)
+	raw, err := readZipFile(ctx.zr, mediaPath)
+	if err != nil {
+		return ""
+	}
+	ext := strings.ToLower(path.Ext(mediaPath))
+	if ext == ".emf" || ext == ".wmf" {
+		return ""
+	}
+	return dataURIForPath(mediaPath, raw)
+}
+
+type docxTableRenderState struct {
+	styleID     string
+	rowCnfType  string
+	mergeActive []int
+}
+
+func docxDirectTableRows(tbl *docxXMLNode) []*docxXMLNode {
+	var rows []*docxXMLNode
+	for i := range tbl.Children {
+		if tbl.Children[i].XMLName.Local == "tr" {
+			rows = append(rows, &tbl.Children[i])
+		}
+	}
+	return rows
+}
+
+func docxTableStyleID(tbl *docxXMLNode) string {
+	if tblPr := tbl.child("tblPr"); tblPr != nil {
+		if ts := tblPr.child("tblStyle"); ts != nil {
+			return ts.attr("val")
+		}
+	}
+	return ""
+}
+
+func docxTcGridSpan(tc *docxXMLNode) int {
+	if tcPr := tc.child("tcPr"); tcPr != nil {
+		if gs := tcPr.child("gridSpan"); gs != nil {
+			if n := parseDocxInt(gs.attr("val")); n > 0 {
+				return int(n)
+			}
+		}
+	}
+	return 1
+}
+
+func docxTcVMergeVal(tc *docxXMLNode) string {
+	if tcPr := tc.child("tcPr"); tcPr != nil {
+		if vm := tcPr.child("vMerge"); vm != nil {
+			if v := vm.attr("val"); v != "" {
+				return v
+			}
+			return "continue"
+		}
+	}
+	return ""
+}
+
+func docxCountVMergeSpan(rows []*docxXMLNode, rowIdx, cellIdx int) int {
+	if rowIdx >= len(rows) {
+		return 1
+	}
+	cells := docxDirectRowCells(rows[rowIdx])
+	if cellIdx >= len(cells) {
+		return 1
+	}
+	if docxTcVMergeVal(cells[cellIdx]) != "restart" {
+		return 1
+	}
+	span := 1
+	for ri := rowIdx + 1; ri < len(rows); ri++ {
+		nextCells := docxDirectRowCells(rows[ri])
+		if cellIdx >= len(nextCells) {
+			break
+		}
+		if docxTcVMergeVal(nextCells[cellIdx]) == "continue" {
+			span++
+			continue
+		}
+		break
+	}
+	return span
+}
+
+func docxDirectRowCells(tr *docxXMLNode) []*docxXMLNode {
+	var cells []*docxXMLNode
+	for i := range tr.Children {
+		if tr.Children[i].XMLName.Local == "tc" {
+			cells = append(cells, &tr.Children[i])
+		}
+	}
+	return cells
+}
+
+func docxTrCnfStyleType(tr *docxXMLNode) string {
+	if trPr := tr.child("trPr"); trPr != nil {
+		return docxCnfStylePrType(trPr.child("cnfStyle"))
+	}
+	return ""
+}
+
+func docxTcCnfStyleType(tc *docxXMLNode) string {
+	if tcPr := tc.child("tcPr"); tcPr != nil {
+		return docxCnfStylePrType(tcPr.child("cnfStyle"))
+	}
+	return ""
+}
+
+func renderDocxTable(tbl *docxXMLNode, ctx *docxRenderCtx) string {
+	var tableStyle string
+	tblStyleID := docxTableStyleID(tbl)
+	if tblPr := tbl.child("tblPr"); tblPr != nil {
+		if def := ctx.styles.styles[tblStyleID]; def != nil && def.tblPr != nil {
+			tableStyle = docxBordersCSS(def.tblPr.child("tblBorders"), ctx.theme)
+		}
+		tableStyle += docxBordersCSS(tblPr.child("tblBorders"), ctx.theme)
+		if tw := tblPr.child("tblW"); tw != nil && tw.attr("type") == "dxa" {
+			if w := parseDocxInt(tw.attr("w")); w > 0 {
+				tableStyle += fmt.Sprintf("width:%.2fpx;", twipsToPx(w))
+			}
+		}
+	}
+	rows := docxDirectTableRows(tbl)
+	var b strings.Builder
+	fmt.Fprintf(&b, `<table class="docx-table" style="border-collapse:collapse;%s">`, tableStyle)
+	mergeActive := []int{}
+	for rowIdx, tr := range rows {
+		var rowHTML string
+		rowHTML, mergeActive = renderDocxTableRow(tr, ctx, docxTableRenderState{
+			styleID:     tblStyleID,
+			rowCnfType:  docxTrCnfStyleType(tr),
+			mergeActive: mergeActive,
+		}, rows, rowIdx)
+		b.WriteString(rowHTML)
+	}
+	b.WriteString("</table>")
+	return b.String()
+}
+
+func docxTrHeightCSS(tr *docxXMLNode) string {
+	if trPr := tr.child("trPr"); trPr != nil {
+		if th := trPr.child("trHeight"); th != nil {
+			if h := parseDocxInt(th.attr("val")); h > 0 {
+				return fmt.Sprintf("height:%.2fpx", twipsToPx(h))
+			}
+		}
+	}
+	return ""
+}
+
+func renderDocxTableRow(tr *docxXMLNode, ctx *docxRenderCtx, tstate docxTableRenderState, rows []*docxXMLNode, rowIdx int) (string, []int) {
+	var b strings.Builder
+	rowStyle := docxTrHeightCSS(tr)
+	if rowStyle != "" {
+		fmt.Fprintf(&b, `<tr style="%s">`, rowStyle)
+	} else {
+		b.WriteString("<tr>")
+	}
+	colIdx := 0
+	cellIdx := 0
+	mergeActive := append([]int(nil), tstate.mergeActive...)
+	for i := range tr.Children {
+		if tr.Children[i].XMLName.Local != "tc" {
+			continue
+		}
+		tc := &tr.Children[i]
+		for colIdx < len(mergeActive) && mergeActive[colIdx] > 0 {
+			mergeActive[colIdx]--
+			colIdx++
+		}
+		vm := docxTcVMergeVal(tc)
+		if vm == "continue" {
+			colIdx += docxTcGridSpan(tc)
+			cellIdx++
+			continue
+		}
+		rowSpan := 1
+		if vm == "restart" {
+			rowSpan = docxCountVMergeSpan(rows, rowIdx, cellIdx)
+			for len(mergeActive) <= colIdx {
+				mergeActive = append(mergeActive, 0)
+			}
+			mergeActive[colIdx] = rowSpan - 1
+		}
+		cnfType := docxTcCnfStyleType(tc)
+		if cnfType == "" {
+			cnfType = tstate.rowCnfType
+		}
+		b.WriteString(renderDocxTableCell(tc, ctx, tstate.styleID, cnfType, rowSpan))
+		colIdx += docxTcGridSpan(tc)
+		cellIdx++
+	}
+	b.WriteString("</tr>")
+	return b.String(), mergeActive
+}
+
+func renderDocxTableCell(tc *docxXMLNode, ctx *docxRenderCtx, tblStyleID, cnfType string, rowSpan int) string {
+	var cellStyle strings.Builder
+	if tblStyleID != "" && cnfType != "" {
+		cellStyle.WriteString(ctx.styles.tblStyleConditionalCSS(tblStyleID, cnfType, ctx.theme))
+	}
+	if tcPr := tc.child("tcPr"); tcPr != nil {
+		if tw := tcPr.child("tcW"); tw != nil && tw.attr("type") == "dxa" {
+			if w := parseDocxInt(tw.attr("w")); w > 0 {
+				fmt.Fprintf(&cellStyle, "width:%.2fpx;", twipsToPx(w))
+			}
+		}
+		if shd := tcPr.child("shd"); shd != nil {
+			cellStyle.WriteString(docxShdCSS(shd, ctx.theme))
+		}
+		if va := tcPr.child("vAlign"); va != nil {
+			switch va.attr("val") {
+			case "center":
+				cellStyle.WriteString("vertical-align:middle;")
+			case "bottom":
+				cellStyle.WriteString("vertical-align:bottom;")
+			}
+		}
+		cellStyle.WriteString(docxBordersCSS(tcPr.child("tcBorders"), ctx.theme))
+		if mar := docxTcMarCSS(tcPr.child("tcMar")); mar != "" {
+			cellStyle.WriteString(mar)
+			cellStyle.WriteString(";")
+		}
+	}
+	var inner strings.Builder
+	// Floating text boxes are hosted by the paragraph that anchors them
+	// (see renderDocxParagraph), which keeps them in normal flow below any
+	// preceding content in the cell. A cell-wide host would collapse every
+	// box to the cell-top origin and overlap that content.
+	for i := range tc.Children {
+		ch := &tc.Children[i]
+		switch ch.XMLName.Local {
+		case "p":
+			inner.WriteString(renderDocxParagraph(ch, ctx))
+		case "tbl":
+			inner.WriteString(renderDocxTable(ch, ctx))
+		case "sdt":
+			inner.WriteString(renderDocxSDT(ch, ctx, nil))
+		}
+	}
+	innerHTML := inner.String()
+	spanAttr := ""
+	if rowSpan > 1 {
+		spanAttr = fmt.Sprintf(` rowspan="%d"`, rowSpan)
+	}
+	return fmt.Sprintf(`<td class="docx-td"%s%s>%s</td>`, spanAttr, docxAttrStyle(cellStyle.String()), innerHTML)
+}
+
+func docxAttrStyle(css string) string {
+	css = strings.TrimSpace(css)
+	if css == "" {
+		return ""
+	}
+	if !strings.HasSuffix(css, ";") {
+		css += ";"
+	}
+	return ` style="` + css + `"`
+}
+
+func wrapDocxHTMLDocument(pages []string, page docxPageLayout, defaultFontCSS string) string {
+	contentWidth := page.widthPx - page.marginLeft - page.marginRight
+	if contentWidth <= 0 {
+		contentWidth = page.widthPx
+	}
+	pageWidth := contentWidth + page.marginLeft + page.marginRight
+	var pageHTML strings.Builder
+	for i, fragment := range pages {
+		if i > 0 {
+			pageHTML.WriteString("\n")
+		}
+		pageStyle := fmt.Sprintf(
+			"min-height:%.2fpx;%s",
+			page.heightPx,
+			defaultFontCSS,
+		)
+		fmt.Fprintf(&pageHTML, `<div class="docx-page"%s>%s</div>`, docxAttrStyle(pageStyle), fragment)
+	}
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root { color-scheme: light; }
+  body {
+    margin: 0;
+    padding: 1.25rem 1rem 2.5rem;
+    background: #e2e8f0;
+    color: #0f172a;
+  }
+  .docx-pages, body { display: flex; flex-direction: column; gap: 1.5rem; align-items: center; }
+  .docx-page {
+    margin: 0;
+    width: %.2fpx;
+    max-width: 100%%;
+    background: #fff;
+    box-shadow: 0 4px 24px rgba(15,23,42,0.12);
+    border-radius: 0.25rem;
+    padding: %.2fpx %.2fpx %.2fpx %.2fpx;
+    box-sizing: border-box;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    overflow: hidden;
+    position: relative;
+  }
+  .docx-shape { pointer-events: none; }
+  .docx-p { margin: 0; }
+  .docx-p + .docx-p { margin-top: 0; }
+  .docx-table { width: 100%%; max-width: 100%%; margin: 0.5rem 0; table-layout: fixed; }
+  /* OOXML cell widths (tcW) are the full cell width including padding and
+     borders, so use border-box; content-box would inflate every column and
+     push nested tables past their container. */
+  .docx-td { vertical-align: top; box-sizing: border-box; }
+  .docx-image { margin: 0.15rem auto; display: block; max-width: 100%%; height: auto; }
+  .docx-textbox { margin: 0; }
+  .docx-textbox-host { position: relative; }
+  .docx-textbox-host > .docx-p { margin: 0; }
+  .docx-textbox .docx-p { margin: 0; }
+  h1.docx-p, h2.docx-p, h3.docx-p, h4.docx-p, h5.docx-p, h6.docx-p { font-weight: inherit; font-size: inherit; }
+  .docx-footer {
+    position: absolute;
+    left: %.2fpx;
+    right: %.2fpx;
+    bottom: %.2fpx;
+    text-align: right;
+    color: #808080;
+    font-size: 9pt;
+  }
+  .docx-footer-p { margin: 0; }
+  .docx-p h1, .docx-p h2, .docx-p h3, .docx-p h4, .docx-p h5, .docx-p h6 { margin: 0; font: inherit; color: inherit; }
+  a { color: inherit; }
+</style>
+</head>
+<body>
+%s
+</body>
+</html>`, pageWidth,
+		page.marginTop, page.marginRight, page.marginBottom, page.marginLeft,
+		page.marginLeft, page.marginRight, page.marginBottom,
+		pageHTML.String())
+}

--- a/server/internal/service/officepreview/docx_visual_test.go
+++ b/server/internal/service/officepreview/docx_visual_test.go
@@ -1,0 +1,188 @@
+package officepreview
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDocxSDTRendersInlineRunContent(t *testing.T) {
+	t.Parallel()
+	p, err := parseDocxXML([]byte(`<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:sdt>
+    <w:sdtPr><w:showingPlcHdr/></w:sdtPr>
+    <w:sdtContent><w:r><w:t>Score #</w:t></w:r></w:sdtContent>
+  </w:sdt>
+</w:p>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sdt := p.child("sdt")
+	html := renderDocxSDT(sdt, &docxRenderCtx{styles: &docxStyleSheet{styles: map[string]*docxStyleDef{}}, theme: &docxTheme{}}, nil)
+	if !strings.Contains(html, "Score #") {
+		t.Fatalf("html = %q", html)
+	}
+}
+
+func TestDocxPPrCSSParagraphBorder(t *testing.T) {
+	t.Parallel()
+	pPr, err := parseDocxXML([]byte(`<w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:pBdr><w:bottom w:val="single" w:sz="6" w:space="1" w:color="2E75B6"/></w:pBdr>
+</w:pPr>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	css := docxPPrCSS(pPr, &docxTheme{})
+	if !strings.Contains(css, "border-bottom") {
+		t.Fatalf("css = %q", css)
+	}
+	if !strings.Contains(css, "#2E75B6") {
+		t.Fatalf("css = %q", css)
+	}
+}
+
+func TestDocxPPrCSSAlignment(t *testing.T) {
+	t.Parallel()
+	pPr, err := parseDocxXML([]byte(`<w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:jc w:val="center"/>
+  <w:spacing w:after="100"/>
+</w:pPr>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	css := docxPPrCSS(pPr, &docxTheme{})
+	if !strings.Contains(css, "text-align:center") {
+		t.Fatalf("css = %q", css)
+	}
+	if !strings.Contains(css, "margin-bottom") {
+		t.Fatalf("css = %q", css)
+	}
+}
+
+func TestDocxRPrCSSBoldAndColor(t *testing.T) {
+	t.Parallel()
+	rPr, err := parseDocxXML([]byte(`<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:b/>
+  <w:color w:val="666666"/>
+  <w:sz w:val="28"/>
+</w:rPr>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	css := docxRPrCSS(rPr, &docxTheme{})
+	if !strings.Contains(css, "font-weight:700") {
+		t.Fatalf("css = %q", css)
+	}
+	if !strings.Contains(css, "color:#666666") {
+		t.Fatalf("css = %q", css)
+	}
+	if !strings.Contains(css, "font-size:") {
+		t.Fatalf("css = %q", css)
+	}
+}
+
+func TestDocxHeadingStyleResolution(t *testing.T) {
+	t.Parallel()
+	sheet := &docxStyleSheet{
+		styles: map[string]*docxStyleDef{
+			"Heading1": {styleID: "Heading1", name: "heading 1", outlineLvl: 0, rPr: mustDocxNode(`<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:color w:val="2E74B5"/></w:rPr>`)},
+		},
+	}
+	p, err := parseDocxXML([]byte(`<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:pPr><w:pStyle w:val="Heading1"/></w:pPr>
+  <w:r><w:t>Title</w:t></w:r>
+</w:p>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved := sheet.resolveParagraph(p, &docxTheme{}, &docxNumbering{}, map[string][]int64{})
+	if resolved.tag != "h1" {
+		t.Fatalf("tag = %q, want h1", resolved.tag)
+	}
+}
+
+func TestDocxWorksheetRendersVisualHTML(t *testing.T) {
+	path := "../../../../data/course-files/managed-files/C-VIDVCN/7c3257e0-ccd9-45b2-8517-bd33b75fc02a.docx"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Skip("sample docx not available:", err)
+	}
+	html, err := ConvertToHTML(data, "worksheet.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"Project Familiarity Worksheet",
+		"Project Discovery",
+		"docx-page",
+		"font-weight:700",
+		"color:#666666",
+		"border-bottom",
+		"#2E75B6",
+		"#CCCCCC",
+		"docx-footer",
+		"Part 1",
+		"Part 3",
+		"D5E8F0",
+		"Arial",
+		"min-height",
+		" of 2 ",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("missing %q in rendered html", want)
+		}
+	}
+	if strings.Count(html, `class="docx-page"`) != 2 {
+		t.Fatalf("expected 2 pages, got %d", strings.Count(html, `class="docx-page"`))
+	}
+	if strings.Count(html, `<div class="docx-footer">`) != 2 {
+		t.Fatalf("expected footer on each page, got %d", strings.Count(html, `<div class="docx-footer">`))
+	}
+	if strings.Contains(html, "This document has no previewable text") {
+		t.Fatal("fell back to empty markdown path")
+	}
+}
+
+func TestDocxComplexTableRenders(t *testing.T) {
+	path := "../../../../data/course-files/managed-files/C-VIDVCN/17af3c91-1d6a-4f83-af96-5876e8bcf8d5.docx"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Skip("sample docx not available:", err)
+	}
+	html, err := ConvertToHTML(data, "rubric.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"docx-table",
+		"Student Academic",
+		"Self-Assessment",
+		"Score #",
+		"Content details",
+		"Behavior",
+		"Subject:",
+		"#E4EDEB",
+		"#355D7E",
+		"#7BA79D",
+		`<img class="docx-image"`,
+		"color:#FFFFFF",
+		"Teacher",
+		"Use the Self-Assessment",
+		"vertical-align:super",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("missing %q in rendered html", want)
+		}
+	}
+	if strings.Contains(html, "This document has no previewable text") {
+		t.Fatal("fell back to empty markdown path")
+	}
+}
+
+func mustDocxNode(xmlStr string) *docxXMLNode {
+	n, err := parseDocxXML([]byte(xmlStr))
+	if err != nil {
+		panic(err)
+	}
+	return n
+}

--- a/server/internal/service/officepreview/docx_xml_tree.go
+++ b/server/internal/service/officepreview/docx_xml_tree.go
@@ -1,0 +1,483 @@
+package officepreview
+
+import (
+	"archive/zip"
+	"encoding/xml"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// docxXMLNode is a lightweight WordprocessingML tree.
+type docxXMLNode struct {
+	XMLName  xml.Name
+	Attrs    []xml.Attr    `xml:",any,attr"`
+	Children []docxXMLNode `xml:",any"`
+	Content  string        `xml:",chardata"`
+}
+
+func (n *docxXMLNode) attr(local string) string {
+	for _, a := range n.Attrs {
+		if a.Name.Local == local && a.Value != "" {
+			return a.Value
+		}
+	}
+	return ""
+}
+
+func (n *docxXMLNode) relAttr(local string) string {
+	for _, a := range n.Attrs {
+		if a.Name.Local == local && a.Value != "" && strings.Contains(a.Name.Space, "relationships") {
+			return a.Value
+		}
+	}
+	return ""
+}
+
+func (n *docxXMLNode) child(local string) *docxXMLNode {
+	for i := range n.Children {
+		if n.Children[i].XMLName.Local == local {
+			return &n.Children[i]
+		}
+	}
+	return nil
+}
+
+func (n *docxXMLNode) childAttr(childLocal, attrLocal string) string {
+	if ch := n.child(childLocal); ch != nil {
+		return ch.attr(attrLocal)
+	}
+	return ""
+}
+
+func (n *docxXMLNode) findDeep(local string) *docxXMLNode {
+	for i := range n.Children {
+		if n.Children[i].XMLName.Local == local {
+			return &n.Children[i]
+		}
+		if found := n.Children[i].findDeep(local); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func (n *docxXMLNode) findAllDeep(local string) []*docxXMLNode {
+	var out []*docxXMLNode
+	for i := range n.Children {
+		if n.Children[i].XMLName.Local == local {
+			out = append(out, &n.Children[i])
+		}
+		out = append(out, n.Children[i].findAllDeep(local)...)
+	}
+	return out
+}
+
+func parseDocxXML(data []byte) (*docxXMLNode, error) {
+	var root docxXMLNode
+	if err := xml.Unmarshal(data, &root); err != nil {
+		return nil, err
+	}
+	return &root, nil
+}
+
+func parseDocxInt(s string) int64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// twipsToPx converts twentieths of a point (dxa/twips) to CSS pixels at 96 dpi.
+func twipsToPx(twips int64) float64 {
+	return float64(twips) * 96.0 / 1440.0
+}
+
+// halfPtToPx converts Word font size (half-points) to CSS pixels.
+func halfPtToPx(halfPt int64) float64 {
+	return float64(halfPt) * 96.0 / 144.0
+}
+
+func docxCollectText(n *docxXMLNode) string {
+	if strings.TrimSpace(n.Content) != "" {
+		return n.Content
+	}
+	var parts []string
+	for i := range n.Children {
+		if t := docxCollectText(&n.Children[i]); t != "" {
+			parts = append(parts, t)
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// ----- Theme -----
+
+type docxTheme struct {
+	colors map[string]string // scheme name → RRGGBB hex (no #)
+}
+
+func loadDocxTheme(zr *zip.Reader) *docxTheme {
+	theme := &docxTheme{colors: make(map[string]string)}
+	for _, name := range []string{"word/theme/theme1.xml", "word/theme/theme11.xml"} {
+		data, err := readZipFile(zr, name)
+		if err != nil {
+			continue
+		}
+		root, err := parseDocxXML(data)
+		if err != nil {
+			continue
+		}
+		clrScheme := root.findDeep("clrScheme")
+		if clrScheme == nil {
+			continue
+		}
+		for i := range clrScheme.Children {
+			schemeName := clrScheme.Children[i].XMLName.Local
+			hex := docxExtractColorHex(&clrScheme.Children[i])
+			if hex != "" {
+				theme.colors[schemeName] = hex
+			}
+		}
+		break
+	}
+	return theme
+}
+
+func docxExtractColorHex(node *docxXMLNode) string {
+	if srgb := node.child("srgbClr"); srgb != nil {
+		if val := srgb.attr("val"); val != "" {
+			return strings.ToUpper(val)
+		}
+	}
+	if sys := node.child("sysClr"); sys != nil {
+		if val := sys.attr("lastClr"); val != "" {
+			return strings.ToUpper(val)
+		}
+	}
+	return ""
+}
+
+func (t *docxTheme) resolveScheme(name string) string {
+	if t == nil || t.colors == nil {
+		return ""
+	}
+	// Documents reference colors by their logical slot (tx2, bg1, ...) or the
+	// long form (text2, background1), but the theme stores them under the
+	// clrScheme element names (dk2, lt1, ...). Normalize before lookup.
+	switch name {
+	case "tx1", "text1":
+		name = "dk1"
+	case "tx2", "text2":
+		name = "dk2"
+	case "bg1", "background1":
+		name = "lt1"
+	case "bg2", "background2":
+		name = "lt2"
+	}
+	return t.colors[name]
+}
+
+// resolveDocxColor returns a CSS color from w:color or w:themeColor nodes.
+func resolveDocxColor(node *docxXMLNode, theme *docxTheme) string {
+	if node == nil {
+		return ""
+	}
+	if color := node.child("color"); color != nil {
+		if val := strings.ToUpper(color.attr("val")); val != "" && val != "AUTO" {
+			return "#" + val
+		}
+	}
+	if tc := node.child("themeColor"); tc != nil {
+		hex := theme.resolveScheme(tc.attr("val"))
+		if hex == "" {
+			return ""
+		}
+		r, g, b := docxHexToRGB(hex)
+		if tint := tc.child("themeTint"); tint != nil {
+			f := float64(parseDocxInt(tint.attr("val"))) / 255000.0
+			r = uint8(float64(r) + float64(255-r)*f)
+			g = uint8(float64(g) + float64(255-g)*f)
+			b = uint8(float64(b) + float64(255-b)*f)
+		}
+		if shade := tc.child("themeShade"); shade != nil {
+			f := float64(parseDocxInt(shade.attr("val"))) / 255000.0
+			r = uint8(float64(r) * f)
+			g = uint8(float64(g) * f)
+			b = uint8(float64(b) * f)
+		}
+		return fmt.Sprintf("#%02X%02X%02X", r, g, b)
+	}
+	return ""
+}
+
+func docxHexToRGB(hex string) (uint8, uint8, uint8) {
+	if len(hex) != 6 {
+		return 0, 0, 0
+	}
+	r, _ := strconv.ParseInt(hex[0:2], 16, 64)
+	g, _ := strconv.ParseInt(hex[2:4], 16, 64)
+	b, _ := strconv.ParseInt(hex[4:6], 16, 64)
+	return uint8(r), uint8(g), uint8(b)
+}
+
+func docxShdCSS(shd *docxXMLNode, theme *docxTheme) string {
+	if shd == nil || shd.attr("fill") == "" {
+		return ""
+	}
+	fill := strings.ToUpper(shd.attr("fill"))
+	if fill == "AUTO" || fill == "FFFFFF" && shd.attr("val") == "clear" {
+		return ""
+	}
+	return "background-color:#" + fill + ";"
+}
+
+func docxTcMarCSS(tcMar *docxXMLNode) string {
+	if tcMar == nil {
+		return ""
+	}
+	var parts []string
+	for _, side := range []string{"top", "left", "bottom", "right"} {
+		if m := tcMar.child(side); m != nil && m.attr("type") == "dxa" {
+			if w := parseDocxInt(m.attr("w")); w > 0 {
+				parts = append(parts, fmt.Sprintf("padding-%s:%.2fpx", side, twipsToPx(w)))
+			}
+		}
+	}
+	return strings.Join(parts, ";")
+}
+
+func docxCnfStylePrType(cnf *docxXMLNode) string {
+	if cnf == nil {
+		return ""
+	}
+	val := cnf.attr("val")
+	if len(val) != 12 {
+		return ""
+	}
+	types := []string{
+		"firstRow", "lastRow", "firstCol", "lastCol",
+		"oddVBand", "evenVBand", "band1Horz", "band2Horz",
+		"firstRowFirstCol", "firstRowLastCol", "lastRowFirstCol", "lastRowLastCol",
+	}
+	for i, typ := range types {
+		if val[i] == '1' {
+			return typ
+		}
+	}
+	return ""
+}
+
+func docxPBdrCSS(pBdr *docxXMLNode) string {
+	if pBdr == nil {
+		return ""
+	}
+	var parts []string
+	for _, side := range []string{"top", "left", "bottom", "right"} {
+		if b := pBdr.child(side); b != nil {
+			if css := docxParaBorderSideCSS(b, side); css != "" {
+				parts = append(parts, css)
+			}
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+func docxParaBorderSideCSS(border *docxXMLNode, side string) string {
+	val := border.attr("val")
+	if val == "" || val == "nil" || val == "none" {
+		return ""
+	}
+	sz := parseDocxInt(border.attr("sz"))
+	if sz <= 0 {
+		sz = 4
+	}
+	widthPx := float64(sz) / 8.0 * 96.0 / 72.0
+	if widthPx < 0.5 {
+		widthPx = 0.5
+	}
+	clr := "#000000"
+	if c := border.attr("color"); c != "" && strings.ToUpper(c) != "AUTO" {
+		clr = "#" + strings.ToUpper(c)
+	}
+	style := "solid"
+	switch val {
+	case "dashed":
+		style = "dashed"
+	case "dotted":
+		style = "dotted"
+	case "double":
+		style = "double"
+	}
+	css := fmt.Sprintf("border-%s:%.2fpx %s %s", side, widthPx, style, clr)
+	if space := parseDocxInt(border.attr("space")); space > 0 {
+		css += fmt.Sprintf(";padding-%s:%.2fpx", side, float64(space)*96.0/72.0)
+	}
+	return css
+}
+
+func docxBorderCSS(border *docxXMLNode, theme *docxTheme) string {
+	if border == nil {
+		return ""
+	}
+	val := border.attr("val")
+	if val == "" || val == "nil" || val == "none" {
+		return ""
+	}
+	width := parseDocxInt(border.attr("sz"))
+	if width <= 0 {
+		width = 4
+	}
+	// Round table/cell border widths to whole pixels. Under
+	// border-collapse, fractional widths (e.g. a 0.5px table outline meeting
+	// a 2.2px cell border) fail to merge cleanly in browsers and leave a
+	// doubled hairline alongside the thicker border.
+	widthPx := int(float64(width)/8.0 + 0.5)
+	if widthPx < 1 {
+		widthPx = 1
+	}
+	clr := "#000000"
+	if c := border.child("color"); c != nil {
+		if v := strings.ToUpper(c.attr("val")); v != "" && v != "AUTO" {
+			clr = "#" + v
+		}
+	}
+	style := "solid"
+	switch val {
+	case "dashed", "dashSmallGap":
+		style = "dashed"
+	case "dotted":
+		style = "dotted"
+	case "double":
+		style = "double"
+	}
+	return fmt.Sprintf("border:%dpx %s %s;", widthPx, style, clr)
+}
+
+func docxBordersCSS(borders *docxXMLNode, theme *docxTheme) string {
+	if borders == nil {
+		return ""
+	}
+	var parts []string
+	for _, side := range []string{"top", "left", "bottom", "right"} {
+		if b := borders.child(side); b != nil {
+			if v := b.attr("val"); v == "none" || v == "nil" {
+				// An explicit "none" must override a border inherited from the
+				// table/cell style, so emit it rather than nothing.
+				parts = append(parts, "border-"+side+":none;")
+			} else if css := docxBorderCSS(b, theme); css != "" {
+				parts = append(parts, strings.Replace(css, "border:", "border-"+side+":", 1))
+			}
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+func resolveDocxSolidFillColor(fill *docxXMLNode, theme *docxTheme) string {
+	if fill == nil {
+		return ""
+	}
+	if srgb := fill.findDeep("srgbClr"); srgb != nil {
+		if val := strings.ToUpper(strings.TrimSpace(srgb.attr("val"))); len(val) == 6 {
+			return "#" + val
+		}
+	}
+	if scheme := fill.findDeep("schemeClr"); scheme != nil {
+		if hex := theme.resolveScheme(scheme.attr("val")); hex != "" {
+			return "#" + docxApplyColorTransforms(hex, scheme)
+		}
+	}
+	return ""
+}
+
+// docxApplyColorTransforms applies OOXML luminance/tint/shade transforms (as
+// found on schemeClr nodes) to a base hex color, mirroring the DrawingML logic
+// used on the presentation side. Returns the transformed hex (no leading '#').
+func docxApplyColorTransforms(hex string, node *docxXMLNode) string {
+	if len(hex) != 6 || node == nil {
+		return hex
+	}
+	r := hexByteU8(hex, 0)
+	g := hexByteU8(hex, 2)
+	b := hexByteU8(hex, 4)
+	for i := range node.Children {
+		child := &node.Children[i]
+		val := float64(parseDocxInt(child.attr("val")))
+		switch child.XMLName.Local {
+		case "tint":
+			f := val / 100000
+			r = uint8(float64(r) + float64(255-r)*f)
+			g = uint8(float64(g) + float64(255-g)*f)
+			b = uint8(float64(b) + float64(255-b)*f)
+		case "shade":
+			f := val / 100000
+			r = uint8(float64(r) * f)
+			g = uint8(float64(g) * f)
+			b = uint8(float64(b) * f)
+		case "lumMod":
+			h, l, s := rgbToHLS(r, g, b)
+			l = clampF(l * val / 100000)
+			r, g, b = hlsToRGB(h, l, s)
+		case "lumOff":
+			h, l, s := rgbToHLS(r, g, b)
+			l = clampF(l + val/100000)
+			r, g, b = hlsToRGB(h, l, s)
+		}
+	}
+	return fmt.Sprintf("%02X%02X%02X", r, g, b)
+}
+
+func docxDrawingLnWidthPx(ln *docxXMLNode) float64 {
+	if ln == nil {
+		return 1.5
+	}
+	w := parseDocxInt(ln.attr("w"))
+	if w <= 0 {
+		return 1.5
+	}
+	return float64(w) / 12700.0 * 96.0 / 72.0
+}
+
+func docxAnchorOffsetPx(anchor *docxXMLNode, posLocal string) float64 {
+	if anchor == nil {
+		return 0
+	}
+	pos := anchor.child(posLocal)
+	if pos == nil {
+		return 0
+	}
+	if off := pos.child("posOffset"); off != nil {
+		if v := parseDocxInt(strings.TrimSpace(docxCollectText(off))); v > 0 {
+			return emuToPx(v)
+		}
+	}
+	return 0
+}
+
+func docxAnchorExtentPx(anchor *docxXMLNode) (float64, float64) {
+	if anchor == nil {
+		return 0, 0
+	}
+	ext := anchor.child("extent")
+	if ext == nil {
+		return 0, 0
+	}
+	return emuToPx(parseDocxInt(ext.attr("cx"))), emuToPx(parseDocxInt(ext.attr("cy")))
+}
+
+func docxFontFamily(rFonts *docxXMLNode) string {
+	if rFonts == nil {
+		return ""
+	}
+	for _, attr := range []string{"ascii", "hAnsi", "cs", "eastAsia"} {
+		if tf := strings.TrimSpace(rFonts.attr(attr)); tf != "" {
+			return safeFontFamily(tf)
+		}
+	}
+	return ""
+}

--- a/server/internal/service/officepreview/pptx_phkey_test.go
+++ b/server/internal/service/officepreview/pptx_phkey_test.go
@@ -1,0 +1,24 @@
+package officepreview
+
+import "testing"
+
+func TestPhKeyIsCoveredMatchesByIdx(t *testing.T) {
+	t.Parallel()
+	covered := map[phKey]bool{
+		{typ: "", idx: "1"}: true,
+	}
+	if !phKeyIsCovered(covered, phKey{typ: "body", idx: "1"}) {
+		t.Fatal("body idx=1 should be covered when slide defines idx=1 without type")
+	}
+}
+
+func TestLookupPhInfoMatchesByIdx(t *testing.T) {
+	t.Parallel()
+	phMap := map[phKey]phInfo{
+		{typ: "", idx: "1"}: {cx: 100, cy: 200},
+	}
+	info, ok := lookupPhInfo(phMap, phKey{typ: "body", idx: "1"})
+	if !ok || info.cx != 100 || info.cy != 200 {
+		t.Fatalf("lookupPhInfo() = (%v, %v)", info, ok)
+	}
+}

--- a/server/internal/service/officepreview/pptx_visual.go
+++ b/server/internal/service/officepreview/pptx_visual.go
@@ -169,6 +169,7 @@ func renderPptxVisualSlide(zr *zip.Reader, slidePath string, slideNum int, size 
 
 	// Build placeholder geometry + default style map from layout and master.
 	phMap := buildPhMap(masterRoot, layoutRoot, theme)
+	showMasterShapes := layoutShowsMasterShapes(layoutRoot)
 
 	// Collect background (image or solid color).
 	bgURI := ""
@@ -200,18 +201,15 @@ func renderPptxVisualSlide(zr *zip.Reader, slidePath string, slideNum int, size 
 	var layers []pptxVisualLayer
 	z := 0
 
-	// 1. Background (non-placeholder) shapes from master.
-	if masterRoot != nil {
+	// 1–2. Master decorative shapes and placeholders (unless the layout hides them).
+	if masterRoot != nil && showMasterShapes {
 		bgLayers := extractBackgroundLayers(masterRoot, zr, masterPath, masterRels, theme)
 		for i := range bgLayers {
 			bgLayers[i].zIndex = z
 			z++
 		}
 		layers = append(layers, bgLayers...)
-	}
 
-	// 2. Master placeholder content not overridden by the slide or layout.
-	if masterRoot != nil {
 		covered := clonePhKeySet(slidePhKeys)
 		if layoutRoot != nil {
 			for k := range collectSlidePhKeys(layoutRoot) {
@@ -337,7 +335,7 @@ func collectSlidePhKeys(root *pptxXMLNode) map[phKey]bool {
 	}
 	out := make(map[phKey]bool)
 	walkPptxShapes(root, identityTransform, func(local string, n *pptxXMLNode, _ pptxGroupTransform) {
-		if local != "sp" {
+		if !shapeMayHavePlaceholder(local) {
 			return
 		}
 		if ph := n.findDeep("ph"); ph != nil {
@@ -345,6 +343,15 @@ func collectSlidePhKeys(root *pptxXMLNode) map[phKey]bool {
 		}
 	})
 	return out
+}
+
+func shapeMayHavePlaceholder(local string) bool {
+	switch local {
+	case "sp", "pic", "graphicFrame", "cxnSp":
+		return true
+	default:
+		return false
+	}
 }
 
 func clonePhKeySet(src map[phKey]bool) map[phKey]bool {
@@ -368,13 +375,14 @@ func extractInheritedPlaceholderLayers(root *pptxXMLNode, zr *zip.Reader, partPa
 			return
 		}
 		key := phKey{typ: ph.attr("type"), idx: ph.attr("idx")}
-		if covered[key] {
+		if phKeyIsCovered(covered, key) {
 			return
 		}
 		layer, ok := extractSpLayer(n, gt, zr, partPath, rels, theme, phMap, textStyles)
-		if ok {
-			layers = append(layers, layer)
+		if !ok || layerHasOnlyPlaceholderPromptText(layer) {
+			return
 		}
+		layers = append(layers, layer)
 	})
 	return layers
 }
@@ -547,7 +555,7 @@ func extractSpLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partP
 		phk = &k
 	}
 	if (cx <= 0 || cy <= 0) && phk != nil && phMap != nil {
-		if info, ok := phMap[*phk]; ok {
+		if info, ok := lookupPhInfo(phMap, *phk); ok {
 			left, top, cx, cy = info.left, info.top, info.cx, info.cy
 		}
 	}
@@ -614,7 +622,7 @@ func extractSpLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partP
 		}
 	}
 	if phk != nil && phMap != nil {
-		if info, ok := phMap[*phk]; ok {
+		if info, ok := lookupPhInfo(phMap, *phk); ok {
 			if fontPt == 0 && info.defaultFontPt > 0 {
 				fontPt = info.defaultFontPt
 			}
@@ -667,7 +675,7 @@ func extractSpLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partP
 		}
 	}
 
-	return pptxVisualLayer{
+	layer := pptxVisualLayer{
 		left: left, top: top, cx: cx, cy: cy,
 		rotDeg: xfrm.rotDeg, flipH: xfrm.flipH,
 		kind: "text", paraHTML: paraHTML,
@@ -676,7 +684,14 @@ func extractSpLayer(n *pptxXMLNode, gt pptxGroupTransform, zr *zip.Reader, partP
 		vert: vert, noWrap: noWrap,
 		borderRadiusPx: readShapeBorderRadiusPx(n, cx, cy),
 		spID: shapeSpID(n),
-	}, true
+	}
+	if phk != nil && layerHasOnlyPlaceholderPromptText(layer) {
+		if bg == "" && border == "" {
+			return pptxVisualLayer{}, false
+		}
+		layer.paraHTML = nil
+	}
+	return layer, true
 }
 
 // resolveShapeFill returns the background CSS for a shape, checking both

--- a/server/internal/service/officepreview/pptx_visual_test.go
+++ b/server/internal/service/officepreview/pptx_visual_test.go
@@ -1,0 +1,103 @@
+package officepreview
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestLayoutShowsMasterShapes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		xml  string
+		want bool
+	}{
+		{"default when missing", `<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"/>`, true},
+		{"explicit show", `<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" showMasterSp="1"/>`, true},
+		{"hide master shapes", `<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" showMasterSp="0"/>`, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root, err := parsePptxXML([]byte(tc.xml))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := layoutShowsMasterShapes(root); got != tc.want {
+				t.Fatalf("layoutShowsMasterShapes() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPptxSlide1HidesMasterShapesWhenLayoutOptsOut(t *testing.T) {
+	path := "../../../../data/course-files/managed-files/C-5CV2AV/a94acbed-1958-4f0c-824b-4c4486ed1e3c.pptx"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Skip("sample pptx not available:", err)
+	}
+	html, err := ConvertToHTML(data, "week02.pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation")
+	if err != nil {
+		t.Fatal(err)
+	}
+	slide1 := html
+	if idx := strings.Index(html, "Slide 2"); idx > 0 {
+		slide1 = html[:idx]
+	}
+
+	// Master rounded rectangle is ~576px tall; layout content box is ~280px.
+	masterRoundRectH := regexp.MustCompile(`height:5[67][0-9]\.\d+px`)
+	layoutContentH := regexp.MustCompile(`height:28[0-9]\.\d+px`)
+	if masterRoundRectH.FindString(slide1) != "" {
+		t.Fatalf("slide 1 still renders master rounded rectangle height: %s", masterRoundRectH.FindString(slide1))
+	}
+	if layoutContentH.FindString(slide1) == "" {
+		t.Fatalf("slide 1 missing layout content box (~280px tall), got heights: %v", layerHeights(slide1))
+	}
+	if !strings.Contains(slide1, "Week 02:") || !strings.Contains(slide1, "Schedule") {
+		t.Fatalf("slide 1 missing expected text content")
+	}
+}
+
+func TestPptxSlide4OmitsLayoutPlaceholderPromptText(t *testing.T) {
+	path := "../../../../data/course-files/managed-files/C-5CV2AV/a94acbed-1958-4f0c-824b-4c4486ed1e3c.pptx"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Skip("sample pptx not available:", err)
+	}
+	html, err := ConvertToHTML(data, "week02.pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation")
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := strings.Index(html, "Slide 4")
+	if start < 0 {
+		t.Fatal("slide 4 not found")
+	}
+	slide4 := html[start:]
+	if end := strings.Index(slide4, "Slide 5"); end > 0 {
+		slide4 = slide4[:end]
+	}
+	for _, prompt := range []string{
+		"Click to edit Master text styles",
+		"Second level",
+		"Third level",
+	} {
+		if strings.Contains(slide4, prompt) {
+			t.Fatalf("slide 4 still contains placeholder prompt %q", prompt)
+		}
+	}
+	if !strings.Contains(slide4, "Role Prompting - Categories") {
+		t.Fatalf("slide 4 missing title text")
+	}
+}
+
+func layerHeights(fragment string) []string {
+	re := regexp.MustCompile(`height:(\d+\.?\d*)px`)
+	var out []string
+	for _, m := range re.FindAllStringSubmatch(fragment, -1) {
+		out = append(out, m[1])
+	}
+	return out
+}

--- a/server/internal/service/officepreview/pptx_xml_tree.go
+++ b/server/internal/service/officepreview/pptx_xml_tree.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"encoding/xml"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -227,12 +228,71 @@ type phKey struct {
 	idx string
 }
 
+// phKeyIsCovered reports whether a slide already defines the placeholder slot.
+// PowerPoint often omits type on p:ph and only sets idx, while the slide master
+// uses an explicit type (e.g. type="body" idx="1"); idx is the canonical slot id.
+func phKeyIsCovered(covered map[phKey]bool, key phKey) bool {
+	if covered[key] {
+		return true
+	}
+	if key.idx != "" {
+		for k := range covered {
+			if k.idx == key.idx {
+				return true
+			}
+		}
+	}
+	if key.typ != "" && key.idx == "" {
+		for k := range covered {
+			if k.typ == key.typ && k.idx == "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// lookupPhInfo finds placeholder geometry/styles using the same slot matching rules.
+func lookupPhInfo(phMap map[phKey]phInfo, key phKey) (phInfo, bool) {
+	if info, ok := phMap[key]; ok {
+		return info, true
+	}
+	if key.idx != "" {
+		for k, info := range phMap {
+			if k.idx == key.idx {
+				return info, true
+			}
+		}
+	}
+	if key.typ != "" && key.idx == "" {
+		for k, info := range phMap {
+			if k.typ == key.typ && k.idx == "" {
+				return info, true
+			}
+		}
+	}
+	return phInfo{}, false
+}
+
 // phInfo holds the resolved position and default text style for a placeholder.
 type phInfo struct {
 	left, top, cx, cy int64
 	defaultFontPt     float64
 	defaultColor      string
 	defaultBold       bool
+}
+
+// layoutShowsMasterShapes reports whether a slide layout inherits decorative
+// shapes from its slide master (p:sldLayout/@showMasterSp, default true).
+func layoutShowsMasterShapes(layoutRoot *pptxXMLNode) bool {
+	if layoutRoot == nil {
+		return true
+	}
+	val := layoutRoot.attr("showMasterSp")
+	if val == "" {
+		return true
+	}
+	return val != "0" && !strings.EqualFold(val, "false")
 }
 
 // buildPhMap collects placeholder geometry and default text styles from layout
@@ -248,9 +308,45 @@ func buildPhMap(masterRoot, layoutRoot *pptxXMLNode, theme *pptxTheme) map[phKey
 	return m
 }
 
+// pptxPlaceholderPrompts are default editing hints PowerPoint puts in
+// layout/master placeholders; they should not appear in rendered previews.
+var pptxPlaceholderPrompts = map[string]struct{}{
+	"Click to edit Master title style":    {},
+	"Click to edit Master subtitle style": {},
+	"Click to edit Master text styles":    {},
+	"Click to add title":                  {},
+	"Click to add text":                   {},
+	"Click to add subtitle":               {},
+	"Click to add notes":                  {},
+	"Second level":                        {},
+	"Third level":                         {},
+	"Fourth level":                        {},
+	"Fifth level":                         {},
+}
+
+var htmlTagStripper = regexp.MustCompile(`<[^>]*>`)
+
+func layerHasOnlyPlaceholderPromptText(layer pptxVisualLayer) bool {
+	if len(layer.paraHTML) == 0 {
+		return false
+	}
+	found := false
+	for _, para := range layer.paraHTML {
+		text := strings.TrimSpace(htmlTagStripper.ReplaceAllString(para.html, ""))
+		if text == "" {
+			continue
+		}
+		found = true
+		if _, ok := pptxPlaceholderPrompts[text]; !ok {
+			return false
+		}
+	}
+	return found
+}
+
 func collectPhInfo(root *pptxXMLNode, theme *pptxTheme, out map[phKey]phInfo) {
 	walkPptxShapes(root, identityTransform, func(local string, n *pptxXMLNode, gt pptxGroupTransform) {
-		if local != "sp" {
+		if !shapeMayHavePlaceholder(local) {
 			return
 		}
 		ph := n.findDeep("ph")

--- a/server/internal/service/quizanalytics/service.go
+++ b/server/internal/service/quizanalytics/service.go
@@ -28,13 +28,22 @@ type QuestionStat struct {
 	PctCorrect    float64 `json:"pctCorrect"`
 }
 
+// AttemptFocusStat summarizes focus-loss events for one submitted attempt.
+type AttemptFocusStat struct {
+	AttemptID             string `json:"attemptId"`
+	AttemptNumber         int32  `json:"attemptNumber"`
+	EventCount            int64  `json:"eventCount"`
+	AcademicIntegrityFlag bool   `json:"academicIntegrityFlag"`
+}
+
 // Report is the analytics payload for a quiz.
 type Report struct {
-	QuizID        uuid.UUID      `json:"quizId"`
-	NAttempts     int            `json:"nAttempts"`
-	MeanScore     *float64       `json:"meanScore"`
-	ScoreBuckets  []ScoreBucket  `json:"scoreBuckets"`
-	QuestionStats []QuestionStat `json:"questionStats"`
+	QuizID        uuid.UUID          `json:"quizId"`
+	NAttempts     int                `json:"nAttempts"`
+	MeanScore     *float64           `json:"meanScore"`
+	ScoreBuckets  []ScoreBucket      `json:"scoreBuckets"`
+	QuestionStats []QuestionStat     `json:"questionStats"`
+	FocusAttempts []AttemptFocusStat `json:"focusAttempts"`
 }
 
 // BuildReport aggregates submitted attempt data into score and question distributions.

--- a/server/internal/service/quizattemptgrading/grade.go
+++ b/server/internal/service/quizattemptgrading/grade.go
@@ -1,0 +1,341 @@
+package quizattemptgrading
+
+import (
+	"encoding/json"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/lextures/lextures/server/internal/models/coursemodulequiz"
+)
+
+// GradedResponse is one stored quiz_responses row before insert.
+type GradedResponse struct {
+	QuestionIndex  int32
+	QuestionID     string
+	QuestionType   string
+	PromptSnapshot string
+	ResponseJSON   json.RawMessage
+	IsCorrect      *bool
+	PointsAwarded  float64
+	MaxPoints      float64
+	Locked         bool
+}
+
+func maxPointsForQuestion(q coursemodulequiz.QuizQuestion) float64 {
+	if q.Points <= 0 {
+		return 1
+	}
+	return float64(q.Points)
+}
+
+func responseJSONFromItem(item coursemodulequiz.QuizQuestionResponseItem) json.RawMessage {
+	b, err := json.Marshal(item)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return b
+}
+
+// GradeResponseItem auto-grades one learner response against a quiz question definition.
+func GradeResponseItem(q coursemodulequiz.QuizQuestion, item coursemodulequiz.QuizQuestionResponseItem) GradedResponse {
+	maxPts := maxPointsForQuestion(q)
+	respJSON := responseJSONFromItem(item)
+	gr := GradedResponse{
+		QuestionID:     q.ID,
+		QuestionType:   q.QuestionType,
+		PromptSnapshot: q.Prompt,
+		ResponseJSON:   respJSON,
+		MaxPoints:      maxPts,
+	}
+
+	switch q.QuestionType {
+	case "multiple_choice", "true_false":
+		if q.MultipleAnswer && len(item.SelectedChoiceIndices) > 0 {
+			correct := gradeMultipleAnswerIndices(q, item.SelectedChoiceIndices)
+			gr.IsCorrect = &correct
+			if correct {
+				gr.PointsAwarded = maxPts
+			}
+			break
+		}
+		if item.SelectedChoiceIndex != nil && q.CorrectChoiceIndex != nil {
+			correct := *item.SelectedChoiceIndex == *q.CorrectChoiceIndex
+			gr.IsCorrect = &correct
+			if correct {
+				gr.PointsAwarded = maxPts
+			}
+		}
+	case "numeric":
+		if item.NumericValue != nil {
+			correct := numericAnswerCorrect(q.TypeConfig, *item.NumericValue)
+			gr.IsCorrect = &correct
+			if correct {
+				gr.PointsAwarded = maxPts
+			}
+		}
+	case "ordering":
+		if len(item.OrderingSequence) > 0 {
+			correct := orderingAnswerCorrect(q, item.OrderingSequence)
+			gr.IsCorrect = &correct
+			if correct {
+				gr.PointsAwarded = maxPts
+			}
+		}
+	case "matching":
+		if len(item.MatchingPairs) > 0 {
+			correct := matchingAnswerCorrect(q, item.MatchingPairs)
+			gr.IsCorrect = &correct
+			if correct {
+				gr.PointsAwarded = maxPts
+			}
+		}
+	case "short_answer", "fill_in_blank":
+		if item.TextAnswer != nil {
+			correct := textAnswerCorrect(q.TypeConfig, *item.TextAnswer)
+			if correct {
+				gr.IsCorrect = boolPtr(true)
+				gr.PointsAwarded = maxPts
+			} else {
+				gr.IsCorrect = boolPtr(false)
+			}
+		}
+	}
+
+	return gr
+}
+
+func boolPtr(v bool) *bool { return &v }
+
+func gradeMultipleAnswerIndices(q coursemodulequiz.QuizQuestion, selected []uint) bool {
+	expected := correctChoiceIndicesFromConfig(q)
+	if len(expected) == 0 && q.CorrectChoiceIndex != nil {
+		expected = []uint{*q.CorrectChoiceIndex}
+	}
+	if len(expected) == 0 {
+		return false
+	}
+	if len(selected) != len(expected) {
+		return false
+	}
+	sel := append([]uint(nil), selected...)
+	exp := append([]uint(nil), expected...)
+	slices.Sort(sel)
+	slices.Sort(exp)
+	return slices.Equal(sel, exp)
+}
+
+func correctChoiceIndicesFromConfig(q coursemodulequiz.QuizQuestion) []uint {
+	var cfg struct {
+		CorrectChoiceIndices []uint `json:"correctChoiceIndices"`
+	}
+	if len(q.TypeConfig) == 0 || json.Unmarshal(q.TypeConfig, &cfg) != nil {
+		return nil
+	}
+	return cfg.CorrectChoiceIndices
+}
+
+func numericAnswerCorrect(typeConfig json.RawMessage, value float64) bool {
+	var cfg struct {
+		Correct      *float64 `json:"correct"`
+		ToleranceAbs *float64 `json:"toleranceAbs"`
+		TolerancePct *float64 `json:"tolerancePct"`
+	}
+	if len(typeConfig) == 0 || json.Unmarshal(typeConfig, &cfg) != nil || cfg.Correct == nil {
+		return false
+	}
+	target := *cfg.Correct
+	if cfg.ToleranceAbs != nil {
+		return math.Abs(value-target) <= *cfg.ToleranceAbs+0.000001
+	}
+	if cfg.TolerancePct != nil && *cfg.TolerancePct > 0 {
+		return math.Abs(value-target) <= math.Abs(target)*(*cfg.TolerancePct)/100.0+0.000001
+	}
+	return math.Abs(value-target) <= 0.000001
+}
+
+func textAnswerCorrect(typeConfig json.RawMessage, answer string) bool {
+	var cfg struct {
+		AcceptableAnswers []string `json:"acceptableAnswers"`
+		Correct           *string  `json:"correct"`
+	}
+	if len(typeConfig) == 0 || json.Unmarshal(typeConfig, &cfg) != nil {
+		return false
+	}
+	trimmed := normalizeAnswerText(answer)
+	if trimmed == "" {
+		return false
+	}
+	if cfg.Correct != nil && normalizeAnswerText(*cfg.Correct) == trimmed {
+		return true
+	}
+	for _, a := range cfg.AcceptableAnswers {
+		if normalizeAnswerText(a) == trimmed {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeAnswerText(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+func orderingItemsFromConfig(q coursemodulequiz.QuizQuestion) []string {
+	var cfg struct {
+		Items []string `json:"items"`
+	}
+	if len(q.TypeConfig) > 0 && json.Unmarshal(q.TypeConfig, &cfg) == nil && len(cfg.Items) > 0 {
+		out := make([]string, 0, len(cfg.Items))
+		for _, it := range cfg.Items {
+			if t := strings.TrimSpace(it); t != "" {
+				out = append(out, t)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	out := make([]string, 0, len(q.Choices))
+	for _, c := range q.Choices {
+		if t := strings.TrimSpace(c); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func orderingAnswerCorrect(q coursemodulequiz.QuizQuestion, got []string) bool {
+	expected := orderingItemsFromConfig(q)
+	if len(expected) == 0 || len(got) != len(expected) {
+		return false
+	}
+	for i := range expected {
+		if strings.TrimSpace(got[i]) != expected[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func matchingAnswerCorrect(q coursemodulequiz.QuizQuestion, got []coursemodulequiz.QuizMatchingPairResponse) bool {
+	expected := expectedMatchingPairs(q)
+	if len(expected) == 0 {
+		return false
+	}
+	if len(got) != len(expected) {
+		return false
+	}
+	expMap := make(map[string]string, len(expected))
+	for _, p := range expected {
+		expMap[p.LeftID] = p.RightID
+	}
+	for _, p := range got {
+		if expMap[p.LeftID] != p.RightID {
+			return false
+		}
+	}
+	return true
+}
+
+func expectedMatchingPairs(q coursemodulequiz.QuizQuestion) []coursemodulequiz.QuizMatchingPairResponse {
+	var cfg struct {
+		Pairs []struct {
+			LeftID  string `json:"leftId"`
+			RightID string `json:"rightId"`
+			Left    string `json:"left"`
+			Right   string `json:"right"`
+		} `json:"pairs"`
+	}
+	if len(q.TypeConfig) == 0 || json.Unmarshal(q.TypeConfig, &cfg) != nil {
+		return nil
+	}
+	out := make([]coursemodulequiz.QuizMatchingPairResponse, 0, len(cfg.Pairs))
+	for i, p := range cfg.Pairs {
+		leftID := strings.TrimSpace(p.LeftID)
+		rightID := strings.TrimSpace(p.RightID)
+		if leftID == "" {
+			leftID = "left-" + strconv.Itoa(i)
+		}
+		if rightID == "" {
+			rightID = "right-" + strconv.Itoa(i)
+		}
+		if leftID != "" && rightID != "" {
+			out = append(out, coursemodulequiz.QuizMatchingPairResponse{LeftID: leftID, RightID: rightID})
+		}
+	}
+	return out
+}
+
+// GradeStaticResponses grades a full static quiz submission in question order.
+func GradeStaticResponses(
+	questions []coursemodulequiz.QuizQuestion,
+	responses []coursemodulequiz.QuizQuestionResponseItem,
+) []GradedResponse {
+	byID := make(map[string]coursemodulequiz.QuizQuestionResponseItem, len(responses))
+	for _, r := range responses {
+		if strings.TrimSpace(r.QuestionID) != "" {
+			byID[r.QuestionID] = r
+		}
+	}
+	out := make([]GradedResponse, 0, len(questions))
+	for i, q := range questions {
+		item, ok := byID[q.ID]
+		if !ok {
+			item = coursemodulequiz.QuizQuestionResponseItem{QuestionID: q.ID}
+		}
+		gr := GradeResponseItem(q, item)
+		gr.QuestionIndex = int32(i)
+		out = append(out, gr)
+	}
+	return out
+}
+
+// GradeAdaptiveHistory grades adaptive turns in order.
+func GradeAdaptiveHistory(history []coursemodulequiz.AdaptiveQuizHistoryTurn) []GradedResponse {
+	out := make([]GradedResponse, 0, len(history))
+	for i, turn := range history {
+		maxPts := AdaptiveTurnMaxPoints(&turn)
+		correct := AdaptiveTurnIsCorrect(&turn)
+		var pts float64
+		if correct {
+			pts = maxPts
+		}
+		resp := map[string]any{
+			"selectedChoiceIndex": turn.SelectedChoiceIndex,
+		}
+		respJSON, _ := json.Marshal(resp)
+		qid := ""
+		if turn.QuestionID != nil {
+			qid = *turn.QuestionID
+		}
+		out = append(out, GradedResponse{
+			QuestionIndex:  int32(i),
+			QuestionID:     qid,
+			QuestionType:   turn.QuestionType,
+			PromptSnapshot: turn.Prompt,
+			ResponseJSON:   respJSON,
+			IsCorrect:      &correct,
+			PointsAwarded:  pts,
+			MaxPoints:      maxPts,
+		})
+	}
+	return out
+}
+
+func SumGradedPoints(rows []GradedResponse) (earned, possible float64) {
+	for _, r := range rows {
+		possible += r.MaxPoints
+		earned += r.PointsAwarded
+	}
+	return earned, possible
+}
+
+func ScorePercent(earned, possible float64) float32 {
+	if possible <= 0 {
+		return 0
+	}
+	pct := float32(math.Min(100, math.Max(0, (earned/possible)*100)))
+	return pct
+}

--- a/server/internal/service/quizattemptgrading/grade_test.go
+++ b/server/internal/service/quizattemptgrading/grade_test.go
@@ -1,0 +1,69 @@
+package quizattemptgrading
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/models/coursemodulequiz"
+)
+
+func uintPtr(u uint) *uint { return &u }
+
+func TestGradeResponseItem_multipleChoice(t *testing.T) {
+	q := coursemodulequiz.QuizQuestion{
+		ID:                 "q1",
+		Prompt:             "Pick one",
+		QuestionType:       "multiple_choice",
+		Points:             2,
+		CorrectChoiceIndex: uintPtr(1),
+	}
+	item := coursemodulequiz.QuizQuestionResponseItem{
+		QuestionID:          "q1",
+		SelectedChoiceIndex: uintPtr(1),
+	}
+	gr := GradeResponseItem(q, item)
+	if gr.PointsAwarded != 2 {
+		t.Fatalf("expected 2 points, got %v", gr.PointsAwarded)
+	}
+	if gr.IsCorrect == nil || !*gr.IsCorrect {
+		t.Fatal("expected correct")
+	}
+}
+
+func TestGradeResponseItem_numeric(t *testing.T) {
+	cfg, _ := json.Marshal(map[string]any{"correct": 42.0, "toleranceAbs": 0.5})
+	q := coursemodulequiz.QuizQuestion{
+		ID:           "q2",
+		QuestionType: "numeric",
+		TypeConfig:   cfg,
+		Points:       1,
+	}
+	v := 42.25
+	item := coursemodulequiz.QuizQuestionResponseItem{QuestionID: "q2", NumericValue: &v}
+	gr := GradeResponseItem(q, item)
+	if gr.IsCorrect == nil || !*gr.IsCorrect {
+		t.Fatal("expected numeric answer within tolerance to be correct")
+	}
+}
+
+func TestGradeStaticResponses(t *testing.T) {
+	questions := []coursemodulequiz.QuizQuestion{
+		{ID: "a", QuestionType: "multiple_choice", Points: 1, CorrectChoiceIndex: uintPtr(0)},
+		{ID: "b", QuestionType: "multiple_choice", Points: 1, CorrectChoiceIndex: uintPtr(1)},
+	}
+	responses := []coursemodulequiz.QuizQuestionResponseItem{
+		{QuestionID: "a", SelectedChoiceIndex: uintPtr(0)},
+		{QuestionID: "b", SelectedChoiceIndex: uintPtr(0)},
+	}
+	rows := GradeStaticResponses(questions, responses)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	earned, possible := SumGradedPoints(rows)
+	if possible != 2 {
+		t.Fatalf("expected possible 2, got %v", possible)
+	}
+	if earned != 1 {
+		t.Fatalf("expected earned 1, got %v", earned)
+	}
+}


### PR DESCRIPTION
## Summary

- Add server-side quiz submit, results, and advance endpoints with auto-grading via a new `quizattemptgrading` service and quiz attempt persistence layer.
- Introduce a dedicated full-page quiz attempt route (`/modules/quiz/:itemId/attempt`) and extend the student take panel with page layout, improved shell focus stability, and breadcrumb support.
- Add visual DOCX preview rendering and improve PPTX preview fidelity, with accompanying unit tests.

## Test plan

- [ ] `cd server && go test ./internal/service/quizattemptgrading/... ./internal/service/officepreview/... -count=1 -short`
- [ ] `cd clients/web && npm run test -- quiz-student-take-panel quiz-take-utils`
- [ ] Start a quiz as a student, complete questions, submit, and verify score/results display
- [ ] Open a DOCX and PPTX file in course files and confirm preview renders correctly
- [ ] Confirm quiz breadcrumbs and navigation work on the attempt page