### PR TITLE
feat: platform feature toggles in Global settings with nav gating

### DIFF
--- a/clients/web/src/components/layout/__tests__/side-nav-main-links.test.tsx
+++ b/clients/web/src/components/layout/__tests__/side-nav-main-links.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PERM_REPORTS_VIEW } from '../../../lib/rbac-api'
 import { ShellNavProvider } from '../shell-nav-context'
 import { SideNavMainLinks } from '../side-nav-main-links'
+
+const platformFeaturesMock = vi.fn(() => ({
+  accommodationsEngineEnabled: false,
+  ffEportfolio: false,
+}))
 
 vi.mock('../../../context/use-inbox-unread', () => ({
   useInboxUnreadCount: () => 2,
@@ -16,7 +21,18 @@ vi.mock('../../../context/use-permissions', () => ({
   }),
 }))
 
+vi.mock('../../../context/platform-features-context', () => ({
+  usePlatformFeatures: () => platformFeaturesMock(),
+}))
+
 describe('SideNavMainLinks', () => {
+  beforeEach(() => {
+    platformFeaturesMock.mockReturnValue({
+      accommodationsEngineEnabled: false,
+      ffEportfolio: false,
+    })
+  })
+
   it('renders core navigation and unread badge when inbox has items', () => {
     render(
       <MemoryRouter>
@@ -29,5 +45,23 @@ describe('SideNavMainLinks', () => {
     expect(screen.getByRole('link', { name: /^courses$/i })).toHaveAttribute('href', '/courses')
     expect(screen.getByLabelText('2 unread')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /^reports$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /^my portfolio$/i })).not.toBeInTheDocument()
+  })
+
+  it('shows My Portfolio when ePortfolio is enabled', () => {
+    platformFeaturesMock.mockReturnValue({
+      accommodationsEngineEnabled: false,
+      ffEportfolio: true,
+    })
+
+    render(
+      <MemoryRouter>
+        <ShellNavProvider>
+          <SideNavMainLinks />
+        </ShellNavProvider>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('link', { name: /^my portfolio$/i })).toHaveAttribute('href', '/portfolios')
   })
 })

--- a/clients/web/src/components/layout/side-nav-main-links.tsx
+++ b/clients/web/src/components/layout/side-nav-main-links.tsx
@@ -4,6 +4,7 @@ import {
   BookMarked,
   BookOpen,
   Calendar,
+  FolderOpen,
   Inbox,
   LayoutDashboard,
   Settings,
@@ -22,7 +23,7 @@ import { SideNavLink } from './side-nav-link'
 export function SideNavMainLinks() {
   const unreadInboxCount = useInboxUnreadCount()
   const { allows, loading: permLoading } = usePermissions()
-  const { accommodationsEngineEnabled } = usePlatformFeatures()
+  const { accommodationsEngineEnabled, ffEportfolio } = usePlatformFeatures()
 
   const canViewReports = !permLoading && allows(PERM_REPORTS_VIEW)
   const canManageAccommodations = !permLoading && allows(PERM_ACCOMMODATIONS_MANAGE)
@@ -53,6 +54,11 @@ export function SideNavMainLinks() {
       <SideNavLink to="/notebooks" icon={<BookMarked className="h-5 w-5" />}>
         My Notebooks
       </SideNavLink>
+      {ffEportfolio ? (
+        <SideNavLink to="/portfolios" icon={<FolderOpen className="h-5 w-5" />}>
+          My Portfolio
+        </SideNavLink>
+      ) : null}
       <SideNavLink to="/calendar" icon={<Calendar className="h-5 w-5" />}>
         Calendar
       </SideNavLink>

--- a/clients/web/src/components/layout/side-nav-settings-links.tsx
+++ b/clients/web/src/components/layout/side-nav-settings-links.tsx
@@ -15,8 +15,10 @@ import {
   Plug,
   Settings2,
   Shield,
+  Store,
   User,
 } from 'lucide-react'
+import { usePlatformFeatures } from '../../context/platform-features-context'
 import { usePermissions } from '../../context/use-permissions'
 import { usePlatformScimEnabled } from '../../hooks/use-platform-scim-enabled'
 import { oerLibraryEnabled } from '../../lib/oer-api'
@@ -43,6 +45,7 @@ export function SideNavSettingsLinks() {
   const canOrgRoles =
     !permLoading && (allows(PERM_TENANT_ORG_ROLES_MANAGE) || allows(PERM_TENANT_ORG_ROLES_VIEW))
   const { scimEnabled: platformScimEnabled } = usePlatformScimEnabled(canManageRbac)
+  const { ffBookstoreIntegration } = usePlatformFeatures()
   const location = useLocation()
   const view = settingsViewFromPathname(location.pathname)
   const aiSectionActive = view === 'ai-models' || view === 'ai-prompts'
@@ -164,6 +167,17 @@ export function SideNavSettingsLinks() {
                   icon={<BookOpen className="h-5 w-5" />}
                 >
                   OER library
+                </SideNavLink>
+              )}
+              {ffBookstoreIntegration && (
+                <SideNavLink
+                  to="/admin/bookstore"
+                  className={() =>
+                    location.pathname === '/admin/bookstore' ? sideNavActiveClass : ''
+                  }
+                  icon={<Store className="h-5 w-5" />}
+                >
+                  Bookstore
                 </SideNavLink>
               )}
               <SideNavLink

--- a/clients/web/src/components/layout/side-nav.tsx
+++ b/clients/web/src/components/layout/side-nav.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { matchPath, NavLink, useLocation } from 'react-router-dom'
+import { usePlatformFeatures } from '../../context/platform-features-context'
 import { BrandLogo } from '../brand-logo'
 import { useShellNav } from './use-shell-nav'
 import { SideNavCourseLinks } from './side-nav-course-links'
@@ -13,6 +14,7 @@ import { SideNavTooltip } from './side-nav-tooltip'
 export function SideNav() {
   const { mobileNavOpen, closeMobileNav, sideNavCollapsed } = useShellNav()
   const location = useLocation()
+  const { ffBookstoreIntegration } = usePlatformFeatures()
 
   useEffect(() => {
     closeMobileNav()
@@ -56,7 +58,9 @@ export function SideNav() {
   )
   const isCourseSettingsNav = Boolean(courseSettingsMatch)
   const isCourseNav = Boolean(courseCode)
-  const isSettingsNav = location.pathname.startsWith('/settings')
+  const isSettingsNav =
+    location.pathname.startsWith('/settings') ||
+    (location.pathname === '/admin/bookstore' && ffBookstoreIntegration)
 
   const showMainNav = !isCourseNav && !isSettingsNav
   const showCourseNav = isCourseNav && !isCourseSettingsNav

--- a/clients/web/src/components/layout/top-bar-breadcrumbs.tsx
+++ b/clients/web/src/components/layout/top-bar-breadcrumbs.tsx
@@ -122,6 +122,13 @@ function staticCrumbsFromPathname(pathname: string, courseCode: string | null): 
     ]
   }
 
+  if (pathname === '/admin/bookstore') {
+    return [
+      { key: 'admin', label: 'Admin' },
+      { key: 'bookstore', label: 'Bookstore integration' },
+    ]
+  }
+
   if (pathname.startsWith('/settings')) {
     const view = settingsViewFromPathname(pathname)
     return [

--- a/clients/web/src/components/settings/feature-toggle-row.tsx
+++ b/clients/web/src/components/settings/feature-toggle-row.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react'
+
+type Props = {
+  label: string
+  description: string
+  enabled: boolean
+  disabled?: boolean
+  onToggle: () => void
+  /** Optional badge or hint shown beside the label (e.g. env/database source). */
+  meta?: ReactNode
+}
+
+export function FeatureToggleRow({
+  label,
+  description,
+  enabled,
+  disabled = false,
+  onToggle,
+  meta,
+}: Props) {
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-4 py-4">
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+          {label}
+          {meta ? <span className="font-normal">{meta}</span> : null}
+        </p>
+        <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">{description}</p>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={enabled}
+        onClick={onToggle}
+        disabled={disabled}
+        className={`relative mt-0.5 inline-flex h-7 w-12 shrink-0 rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
+          enabled ? 'bg-indigo-600' : 'bg-slate-200 dark:bg-neutral-700'
+        }`}
+      >
+        <span
+          className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition ${
+            enabled ? 'translate-x-5' : 'translate-x-0.5'
+          }`}
+        />
+      </button>
+    </div>
+  )
+}

--- a/clients/web/src/components/settings/platform-feature-definitions.ts
+++ b/clients/web/src/components/settings/platform-feature-definitions.ts
@@ -1,0 +1,205 @@
+import type { PlatformSettingsPayload } from './platform-settings-types'
+
+export type PlatformBooleanFeatureKey = {
+  [K in keyof PlatformSettingsPayload]: PlatformSettingsPayload[K] extends boolean ? K : never
+}[keyof PlatformSettingsPayload]
+
+export type PlatformFeatureDefinition = {
+  key: PlatformBooleanFeatureKey
+  label: string
+  description: string
+  sourceKey?: keyof PlatformSettingsPayload['sources']
+}
+
+const PLATFORM_FEATURE_DEFINITIONS_UNSORTED: PlatformFeatureDefinition[] = [
+  {
+    key: 'ffAccommodationsEngine',
+    label: 'Accommodations audit log',
+    description: 'Record accommodations engine decisions in the audit log for compliance review.',
+  },
+  {
+    key: 'accommodationsEngineEnabled',
+    label: 'Accommodations engine',
+    description: 'Apply IEP/504 accommodation profiles to quizzes, assignments, and timed activities.',
+  },
+  {
+    key: 'sessionManagementUiEnabled',
+    label: 'Active sessions UI',
+    description: 'Let users view and revoke their own active login sessions from account settings.',
+  },
+  {
+    key: 'annotationEnabled',
+    label: 'Annotations',
+    description: 'Inline highlighting and notes on course content and submissions.',
+    sourceKey: 'annotationEnabled',
+  },
+  {
+    key: 'avScanningEnabled',
+    label: 'Antivirus scanning',
+    description: 'Scan uploaded files with ClamAV before they are stored or served.',
+  },
+  {
+    key: 'atRiskAlertsEnabled',
+    label: 'At-risk early-warning alerts',
+    description: 'Surface engagement and grade signals so instructors can intervene early.',
+  },
+  {
+    key: 'blindGradingEnabled',
+    label: 'Blind grading',
+    description: 'Hide student identity from graders until scores are released.',
+    sourceKey: 'blindGradingEnabled',
+  },
+  {
+    key: 'ffBookstoreIntegration',
+    label: 'Bookstore / textbook integration',
+    description:
+      'VitalSource and RedShelf Inclusive Access deep links, opt-out banner, and launch analytics.',
+  },
+  {
+    key: 'outcomesReportEnabled',
+    label: 'Course outcomes report',
+    description: 'Aggregate mastery and coverage reports across course learning outcomes.',
+  },
+  {
+    key: 'ffEportfolio',
+    label: 'ePortfolio / capstone artifacts',
+    description:
+      'Let students curate cross-course evidence into shareable ePortfolios with public links and rubric evaluation.',
+  },
+  {
+    key: 'equationEditorEnabled',
+    label: 'Equation editor',
+    description: 'WYSIWYG math editor for pages, discussions, and rich-text fields.',
+  },
+  {
+    key: 'feedbackMediaEnabled',
+    label: 'Feedback media',
+    description: 'Let instructors attach audio or video feedback on submissions.',
+    sourceKey: 'feedbackMediaEnabled',
+  },
+  {
+    key: 'gradePostingPoliciesEnabled',
+    label: 'Grade posting policies',
+    description: 'Control when assignment and quiz grades become visible to students.',
+    sourceKey: 'gradePostingPoliciesEnabled',
+  },
+  {
+    key: 'gradebookCsvEnabled',
+    label: 'Gradebook CSV export',
+    description: 'Export the course gradebook as a downloadable CSV file.',
+    sourceKey: 'gradebookCsvEnabled',
+  },
+  {
+    key: 'h5pEnabled',
+    label: 'Interactive H5P content',
+    description: 'Embed interactive H5P packages as module items and track attempt results.',
+  },
+  {
+    key: 'selfReflectionEnabled',
+    label: 'Learner self-reflection & coaching',
+    description: 'Prompt learners to reflect on progress and receive lightweight coaching nudges.',
+  },
+  {
+    key: 'ltiEnabled',
+    label: 'LTI',
+    description: 'Launch external LTI 1.3 tools from course modules and assignments.',
+    sourceKey: 'ltiEnabled',
+  },
+  {
+    key: 'moderatedGradingEnabled',
+    label: 'Moderated grading',
+    description: 'Multiple graders score anonymously before a moderator releases a final grade.',
+    sourceKey: 'moderatedGradingEnabled',
+  },
+  {
+    key: 'oerLibraryEnabled',
+    label: 'OER library search',
+    description: 'Search open educational resources when adding module content.',
+  },
+  {
+    key: 'oerStub',
+    label: 'OER stub catalog',
+    description: 'Use a built-in stub OER catalog for local development and end-to-end tests.',
+  },
+  {
+    key: 'oneRosterEnabled',
+    label: 'OneRoster API',
+    description: 'Expose OneRoster roster and grade sync endpoints for SIS integrations.',
+    sourceKey: 'oneRosterEnabled',
+  },
+  {
+    key: 'originalityDetectionEnabled',
+    label: 'Originality detection',
+    description: 'Run similarity checks on student submissions via configured providers.',
+    sourceKey: 'originalityDetectionEnabled',
+  },
+  {
+    key: 'originalityStubExternal',
+    label: 'Originality stub external',
+    description: 'Simulate external originality provider responses without live API calls.',
+    sourceKey: 'originalityStubExternal',
+  },
+  {
+    key: 'studentProgressEnabled',
+    label: 'Per-student progress dashboards',
+    description: 'Show learners and instructors module completion and activity summaries.',
+  },
+  {
+    key: 'itemAnalysisEnabled',
+    label: 'Quiz item analysis',
+    description: 'Discrimination and difficulty statistics for quiz questions.',
+  },
+  {
+    key: 'readingLevelEnabled',
+    label: 'Reading level adaptation',
+    description: 'Adjust displayed reading complexity for supported content types.',
+  },
+  {
+    key: 'resubmissionWorkflowEnabled',
+    label: 'Resubmission workflow',
+    description: 'Allow structured resubmissions after instructor feedback on assignments.',
+    sourceKey: 'resubmissionWorkflowEnabled',
+  },
+  {
+    key: 'scimEnabled',
+    label: 'SCIM 2.0 provisioning',
+    description: 'Provision and deprovision users from an external identity system.',
+    sourceKey: 'scimEnabled',
+  },
+  {
+    key: 'speechToTextEnabled',
+    label: 'Speech-to-text dictation',
+    description: 'Dictation input in editors and response fields where supported.',
+  },
+  {
+    key: 'storageQuotasEnabled',
+    label: 'Storage quotas',
+    description: 'Enforce per-user and per-course upload limits.',
+  },
+  {
+    key: 'translationMemoryEnabled',
+    label: 'Translation memory',
+    description: 'Reuse prior translations when localizing course content.',
+  },
+  {
+    key: 'mfaEnabled',
+    label: 'Two-factor authentication',
+    description: 'Offer TOTP authenticator apps and passkeys as optional login factors.',
+    sourceKey: 'mfaEnabled',
+  },
+  {
+    key: 'virtualClassroomEnabled',
+    label: 'Virtual classroom',
+    description: 'Platform-wide live session tooling used by course live-session features.',
+  },
+  {
+    key: 'xapiEmissionEnabled',
+    label: 'xAPI / Caliper emission',
+    description: 'Emit learning analytics statements to a configured LRS endpoint.',
+  },
+]
+
+/** Platform boolean flags for Settings → Global platform, sorted alphabetically by label. */
+export const PLATFORM_FEATURE_DEFINITIONS = [...PLATFORM_FEATURE_DEFINITIONS_UNSORTED].sort((a, b) =>
+  a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }),
+)

--- a/clients/web/src/components/settings/platform-settings-panel.tsx
+++ b/clients/web/src/components/settings/platform-settings-panel.tsx
@@ -1,84 +1,14 @@
-import { type FormEvent, useCallback, useEffect, useState } from 'react'
+import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import { authorizedFetch } from '../../lib/api'
+import { usePlatformFeatures } from '../../context/platform-features-context'
 import { readApiErrorMessage } from '../../lib/errors'
 import { PLATFORM_SECRET_PLACEHOLDER } from '../../lib/platform-settings'
 import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
+import { FeatureToggleRow } from './feature-toggle-row'
+import { PLATFORM_FEATURE_DEFINITIONS, type PlatformFeatureDefinition } from './platform-feature-definitions'
+import type { FieldSource, PlatformSettingsPayload } from './platform-settings-types'
 
-type FieldSource = 'environment' | 'database' | 'default'
-
-export type PlatformSettingsPayload = {
-  openRouterApiKey: string
-  samlSsoEnabled: boolean
-  samlPublicBaseUrl: string
-  samlSpEntityId: string
-  samlSpX509Pem: string
-  samlSpPrivateKeyPem: string
-  annotationEnabled: boolean
-  feedbackMediaEnabled: boolean
-  blindGradingEnabled: boolean
-  moderatedGradingEnabled: boolean
-  originalityDetectionEnabled: boolean
-  originalityStubExternal: boolean
-  gradePostingPoliciesEnabled: boolean
-  gradebookCsvEnabled: boolean
-  resubmissionWorkflowEnabled: boolean
-  ltiEnabled: boolean
-  oneRosterEnabled: boolean
-  scimEnabled: boolean
-  studentProgressEnabled: boolean
-  selfReflectionEnabled: boolean
-  outcomesReportEnabled: boolean
-  atRiskAlertsEnabled: boolean
-  h5pEnabled: boolean
-  oerLibraryEnabled: boolean
-  oerStub: boolean
-  itemAnalysisEnabled: boolean
-  xapiEmissionEnabled: boolean
-  equationEditorEnabled: boolean
-  readingLevelEnabled: boolean
-  speechToTextEnabled: boolean
-  accommodationsEngineEnabled: boolean
-  ffAccommodationsEngine: boolean
-  translationMemoryEnabled: boolean
-  storageQuotasEnabled: boolean
-  avScanningEnabled: boolean
-  virtualClassroomEnabled: boolean
-  sessionManagementUiEnabled: boolean
-  mfaEnabled: boolean
-  mfaEnforcement: 'none' | 'all' | 'staff'
-  smtpHost: string
-  smtpPort: number
-  smtpFrom: string
-  smtpUser: string
-  smtpPassword: string
-  sources: {
-    openRouterApiKey: FieldSource
-    samlSsoEnabled: FieldSource
-    samlPublicBaseUrl: FieldSource
-    samlSpEntityId: FieldSource
-    samlSpX509Pem: FieldSource
-    samlSpPrivateKeyPem: FieldSource
-    annotationEnabled: FieldSource
-    feedbackMediaEnabled: FieldSource
-    blindGradingEnabled: FieldSource
-    moderatedGradingEnabled: FieldSource
-    originalityDetectionEnabled: FieldSource
-    originalityStubExternal: FieldSource
-    gradePostingPoliciesEnabled: FieldSource
-    gradebookCsvEnabled: FieldSource
-    resubmissionWorkflowEnabled: FieldSource
-    ltiEnabled: FieldSource
-    oneRosterEnabled: FieldSource
-    scimEnabled: FieldSource
-    mfaEnabled: FieldSource
-    mfaEnforcement: FieldSource
-    smtpHost: FieldSource
-    smtpPort: FieldSource
-    smtpFrom: FieldSource
-    smtpUser: FieldSource
-    smtpPassword: FieldSource
-  }
-}
+export type { PlatformSettingsPayload } from './platform-settings-types'
 
 function normalizePlatformPayload(data: PlatformSettingsPayload) {
   if (typeof data.smtpPort !== 'number' || Number.isNaN(data.smtpPort)) {
@@ -125,6 +55,8 @@ function emptyForm(): PlatformSettingsPayload {
     speechToTextEnabled: false,
     accommodationsEngineEnabled: false,
     ffAccommodationsEngine: false,
+    ffBookstoreIntegration: false,
+    ffEportfolio: false,
     translationMemoryEnabled: false,
     storageQuotasEnabled: false,
     avScanningEnabled: false,
@@ -190,11 +122,24 @@ function sourceBadge(src: FieldSource) {
 }
 
 export function PlatformSettingsPanel() {
+  const { refresh: refreshPlatformFeatures } = usePlatformFeatures()
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
+  const [featureSaving, setFeatureSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [featureMessage, setFeatureMessage] = useState<string | null>(null)
+  const [featureError, setFeatureError] = useState<string | null>(null)
+  const [featureQuery, setFeatureQuery] = useState('')
   const [form, setForm] = useState<PlatformSettingsPayload>(() => emptyForm())
   const [baseline, setBaseline] = useState<PlatformSettingsPayload>(() => emptyForm())
+
+  const visiblePlatformFeatures = useMemo(() => {
+    const q = featureQuery.trim().toLowerCase()
+    if (!q) return PLATFORM_FEATURE_DEFINITIONS
+    return PLATFORM_FEATURE_DEFINITIONS.filter(
+      (f) => f.label.toLowerCase().includes(q) || f.description.toLowerCase().includes(q),
+    )
+  }, [featureQuery])
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -223,6 +168,84 @@ export function PlatformSettingsPanel() {
   function update<K extends keyof PlatformSettingsPayload>(key: K, value: PlatformSettingsPayload[K]) {
     setForm((prev) => ({ ...prev, [key]: value }))
   }
+
+  const putPlatformSettings = useCallback(
+    async (body: Record<string, unknown>) => {
+      const res = await authorizedFetch('/api/v1/settings/platform', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      const raw: unknown = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        throw new Error(readApiErrorMessage(raw))
+      }
+      const data = raw as PlatformSettingsPayload
+      normalizePlatformPayload(data)
+      setForm(data)
+      setBaseline(data)
+      await refreshPlatformFeatures()
+      return data
+    },
+    [refreshPlatformFeatures],
+  )
+
+  const persistPlatformFeature = useCallback(
+    async (key: PlatformFeatureDefinition['key'], value: boolean) => {
+      if (featureSaving) return
+      let previous = false
+      setFeatureSaving(true)
+      setFeatureMessage(null)
+      setFeatureError(null)
+      setForm((prev) => {
+        previous = prev[key]
+        return { ...prev, [key]: value }
+      })
+      try {
+        const data = await putPlatformSettings({ [key]: value, updateMask: [key] })
+        if (data[key] !== value) {
+          throw new Error('The server did not persist this feature change. Reload the page and try again.')
+        }
+        setFeatureMessage('Saved.')
+        toastSaveOk('Platform feature updated')
+      } catch (e) {
+        setForm((prev) => ({ ...prev, [key]: previous }))
+        const msg = e instanceof Error ? e.message : 'Could not save feature.'
+        setFeatureError(msg)
+        toastMutationError(msg)
+      } finally {
+        setFeatureSaving(false)
+      }
+    },
+    [featureSaving, putPlatformSettings],
+  )
+
+  const persistMfaEnforcement = useCallback(
+    async (value: PlatformSettingsPayload['mfaEnforcement']) => {
+      if (featureSaving) return
+      let previous: PlatformSettingsPayload['mfaEnforcement'] = 'none'
+      setFeatureSaving(true)
+      setFeatureMessage(null)
+      setFeatureError(null)
+      setForm((prev) => {
+        previous = prev.mfaEnforcement
+        return { ...prev, mfaEnforcement: value }
+      })
+      try {
+        await putPlatformSettings({ mfaEnforcement: value, updateMask: ['mfaEnforcement'] })
+        setFeatureMessage('Saved.')
+        toastSaveOk('MFA requirement updated')
+      } catch (e) {
+        setForm((prev) => ({ ...prev, mfaEnforcement: previous }))
+        const msg = e instanceof Error ? e.message : 'Could not save MFA requirement.'
+        setFeatureError(msg)
+        toastMutationError(msg)
+      } finally {
+        setFeatureSaving(false)
+      }
+    },
+    [featureSaving, putPlatformSettings],
+  )
 
   async function onSubmit(e: FormEvent) {
     e.preventDefault()
@@ -282,136 +305,6 @@ export function PlatformSettingsPanel() {
         }
       })
 
-      maybe('annotationEnabled', baseline.annotationEnabled, form.annotationEnabled, () => {
-        body.annotationEnabled = form.annotationEnabled
-      })
-      maybe('feedbackMediaEnabled', baseline.feedbackMediaEnabled, form.feedbackMediaEnabled, () => {
-        body.feedbackMediaEnabled = form.feedbackMediaEnabled
-      })
-      maybe('blindGradingEnabled', baseline.blindGradingEnabled, form.blindGradingEnabled, () => {
-        body.blindGradingEnabled = form.blindGradingEnabled
-      })
-      maybe('moderatedGradingEnabled', baseline.moderatedGradingEnabled, form.moderatedGradingEnabled, () => {
-        body.moderatedGradingEnabled = form.moderatedGradingEnabled
-      })
-      maybe(
-        'originalityDetectionEnabled',
-        baseline.originalityDetectionEnabled,
-        form.originalityDetectionEnabled,
-        () => {
-          body.originalityDetectionEnabled = form.originalityDetectionEnabled
-        },
-      )
-      maybe('originalityStubExternal', baseline.originalityStubExternal, form.originalityStubExternal, () => {
-        body.originalityStubExternal = form.originalityStubExternal
-      })
-      maybe(
-        'gradePostingPoliciesEnabled',
-        baseline.gradePostingPoliciesEnabled,
-        form.gradePostingPoliciesEnabled,
-        () => {
-          body.gradePostingPoliciesEnabled = form.gradePostingPoliciesEnabled
-        },
-      )
-      maybe('gradebookCsvEnabled', baseline.gradebookCsvEnabled, form.gradebookCsvEnabled, () => {
-        body.gradebookCsvEnabled = form.gradebookCsvEnabled
-      })
-      maybe(
-        'resubmissionWorkflowEnabled',
-        baseline.resubmissionWorkflowEnabled,
-        form.resubmissionWorkflowEnabled,
-        () => {
-          body.resubmissionWorkflowEnabled = form.resubmissionWorkflowEnabled
-        },
-      )
-      maybe('ltiEnabled', baseline.ltiEnabled, form.ltiEnabled, () => {
-        body.ltiEnabled = form.ltiEnabled
-      })
-      maybe('oneRosterEnabled', baseline.oneRosterEnabled, form.oneRosterEnabled, () => {
-        body.oneRosterEnabled = form.oneRosterEnabled
-      })
-      maybe('scimEnabled', baseline.scimEnabled, form.scimEnabled, () => {
-        body.scimEnabled = form.scimEnabled
-      })
-      maybe('studentProgressEnabled', baseline.studentProgressEnabled, form.studentProgressEnabled, () => {
-        body.studentProgressEnabled = form.studentProgressEnabled
-      })
-      maybe('selfReflectionEnabled', baseline.selfReflectionEnabled, form.selfReflectionEnabled, () => {
-        body.selfReflectionEnabled = form.selfReflectionEnabled
-      })
-      maybe('outcomesReportEnabled', baseline.outcomesReportEnabled, form.outcomesReportEnabled, () => {
-        body.outcomesReportEnabled = form.outcomesReportEnabled
-      })
-      maybe('atRiskAlertsEnabled', baseline.atRiskAlertsEnabled, form.atRiskAlertsEnabled, () => {
-        body.atRiskAlertsEnabled = form.atRiskAlertsEnabled
-      })
-      maybe('h5pEnabled', baseline.h5pEnabled, form.h5pEnabled, () => {
-        body.h5pEnabled = form.h5pEnabled
-      })
-      maybe('oerLibraryEnabled', baseline.oerLibraryEnabled, form.oerLibraryEnabled, () => {
-        body.oerLibraryEnabled = form.oerLibraryEnabled
-      })
-      maybe('oerStub', baseline.oerStub, form.oerStub, () => {
-        body.oerStub = form.oerStub
-      })
-      maybe('itemAnalysisEnabled', baseline.itemAnalysisEnabled, form.itemAnalysisEnabled, () => {
-        body.itemAnalysisEnabled = form.itemAnalysisEnabled
-      })
-      maybe('xapiEmissionEnabled', baseline.xapiEmissionEnabled, form.xapiEmissionEnabled, () => {
-        body.xapiEmissionEnabled = form.xapiEmissionEnabled
-      })
-      maybe('equationEditorEnabled', baseline.equationEditorEnabled, form.equationEditorEnabled, () => {
-        body.equationEditorEnabled = form.equationEditorEnabled
-      })
-      maybe('readingLevelEnabled', baseline.readingLevelEnabled, form.readingLevelEnabled, () => {
-        body.readingLevelEnabled = form.readingLevelEnabled
-      })
-      maybe('speechToTextEnabled', baseline.speechToTextEnabled, form.speechToTextEnabled, () => {
-        body.speechToTextEnabled = form.speechToTextEnabled
-      })
-      maybe(
-        'accommodationsEngineEnabled',
-        baseline.accommodationsEngineEnabled,
-        form.accommodationsEngineEnabled,
-        () => {
-          body.accommodationsEngineEnabled = form.accommodationsEngineEnabled
-        },
-      )
-      maybe('ffAccommodationsEngine', baseline.ffAccommodationsEngine, form.ffAccommodationsEngine, () => {
-        body.ffAccommodationsEngine = form.ffAccommodationsEngine
-      })
-      maybe(
-        'translationMemoryEnabled',
-        baseline.translationMemoryEnabled,
-        form.translationMemoryEnabled,
-        () => {
-          body.translationMemoryEnabled = form.translationMemoryEnabled
-        },
-      )
-      maybe('storageQuotasEnabled', baseline.storageQuotasEnabled, form.storageQuotasEnabled, () => {
-        body.storageQuotasEnabled = form.storageQuotasEnabled
-      })
-      maybe('avScanningEnabled', baseline.avScanningEnabled, form.avScanningEnabled, () => {
-        body.avScanningEnabled = form.avScanningEnabled
-      })
-      maybe('virtualClassroomEnabled', baseline.virtualClassroomEnabled, form.virtualClassroomEnabled, () => {
-        body.virtualClassroomEnabled = form.virtualClassroomEnabled
-      })
-      maybe(
-        'sessionManagementUiEnabled',
-        baseline.sessionManagementUiEnabled,
-        form.sessionManagementUiEnabled,
-        () => {
-          body.sessionManagementUiEnabled = form.sessionManagementUiEnabled
-        },
-      )
-      maybe('mfaEnabled', baseline.mfaEnabled, form.mfaEnabled, () => {
-        body.mfaEnabled = form.mfaEnabled
-      })
-      maybe('mfaEnforcement', baseline.mfaEnforcement, form.mfaEnforcement, () => {
-        body.mfaEnforcement = form.mfaEnforcement
-      })
-
       maybe('smtpHost', baseline.smtpHost, form.smtpHost, () => {
         body.smtpHost = form.smtpHost.trim()
       })
@@ -447,20 +340,7 @@ export function PlatformSettingsPanel() {
 
       body.updateMask = mask
 
-      const res = await authorizedFetch('/api/v1/settings/platform', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      })
-      const raw: unknown = await res.json().catch(() => ({}))
-      if (!res.ok) {
-        toastMutationError(readApiErrorMessage(raw))
-        return
-      }
-      const data = raw as PlatformSettingsPayload
-      normalizePlatformPayload(data)
-      setForm(data)
-      setBaseline(data)
+      await putPlatformSettings(body)
       toastSaveOk('Platform settings saved.')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Save failed.')
@@ -653,223 +533,83 @@ export function PlatformSettingsPanel() {
           </div>
         </section>
 
-        <section>
-          <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Platform feature flags</h3>
-          <div className="mt-4 grid gap-3 sm:grid-cols-2">
-            <FlagRow
-              label="Annotations"
-              src={form.sources.annotationEnabled}
-              checked={form.annotationEnabled}
-              onChange={(v) => update('annotationEnabled', v)}
+        <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-900/5 dark:border-neutral-800 dark:bg-neutral-950">
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Platform features</h3>
+          <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+            Turn platform-wide capabilities on or off. Changes save immediately. Database values override environment
+            defaults.
+          </p>
+
+          <div className="mt-3">
+            <input
+              type="search"
+              placeholder="Search features…"
+              value={featureQuery}
+              onChange={(e) => setFeatureQuery(e.target.value)}
+              className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-300 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500"
             />
-            <FlagRow
-              label="Feedback media"
-              src={form.sources.feedbackMediaEnabled}
-              checked={form.feedbackMediaEnabled}
-              onChange={(v) => update('feedbackMediaEnabled', v)}
-            />
-            <FlagRow
-              label="Blind grading"
-              src={form.sources.blindGradingEnabled}
-              checked={form.blindGradingEnabled}
-              onChange={(v) => update('blindGradingEnabled', v)}
-            />
-            <FlagRow
-              label="Moderated grading"
-              src={form.sources.moderatedGradingEnabled}
-              checked={form.moderatedGradingEnabled}
-              onChange={(v) => update('moderatedGradingEnabled', v)}
-            />
-            <FlagRow
-              label="Originality detection"
-              src={form.sources.originalityDetectionEnabled}
-              checked={form.originalityDetectionEnabled}
-              onChange={(v) => update('originalityDetectionEnabled', v)}
-            />
-            <FlagRow
-              label="Originality stub external"
-              src={form.sources.originalityStubExternal}
-              checked={form.originalityStubExternal}
-              onChange={(v) => update('originalityStubExternal', v)}
-            />
-            <FlagRow
-              label="Grade posting policies"
-              src={form.sources.gradePostingPoliciesEnabled}
-              checked={form.gradePostingPoliciesEnabled}
-              onChange={(v) => update('gradePostingPoliciesEnabled', v)}
-            />
-            <FlagRow
-              label="Gradebook CSV export"
-              src={form.sources.gradebookCsvEnabled}
-              checked={form.gradebookCsvEnabled}
-              onChange={(v) => update('gradebookCsvEnabled', v)}
-            />
-            <FlagRow
-              label="Resubmission workflow"
-              src={form.sources.resubmissionWorkflowEnabled}
-              checked={form.resubmissionWorkflowEnabled}
-              onChange={(v) => update('resubmissionWorkflowEnabled', v)}
-            />
-            <FlagRow
-              label="LTI"
-              src={form.sources.ltiEnabled}
-              checked={form.ltiEnabled}
-              onChange={(v) => update('ltiEnabled', v)}
-            />
-            <FlagRow
-              label="OneRoster API"
-              src={form.sources.oneRosterEnabled}
-              checked={form.oneRosterEnabled}
-              onChange={(v) => update('oneRosterEnabled', v)}
-            />
-            <FlagRow
-              label="SCIM 2.0 provisioning"
-              src={form.sources.scimEnabled}
-              checked={form.scimEnabled}
-              onChange={(v) => update('scimEnabled', v)}
-            />
-            <FlagRow
-              label="Per-student progress dashboards"
-              src="default"
-              checked={form.studentProgressEnabled}
-              onChange={(v) => update('studentProgressEnabled', v)}
-            />
-            <FlagRow
-              label="Learner self-reflection & coaching"
-              src="default"
-              checked={form.selfReflectionEnabled}
-              onChange={(v) => update('selfReflectionEnabled', v)}
-            />
-            <FlagRow
-              label="Course outcomes report"
-              src="default"
-              checked={form.outcomesReportEnabled}
-              onChange={(v) => update('outcomesReportEnabled', v)}
-            />
-            <FlagRow
-              label="At-risk early-warning alerts"
-              src="default"
-              checked={form.atRiskAlertsEnabled}
-              onChange={(v) => update('atRiskAlertsEnabled', v)}
-            />
-            <FlagRow
-              label="Interactive H5P content"
-              src="default"
-              checked={form.h5pEnabled}
-              onChange={(v) => update('h5pEnabled', v)}
-            />
-            <FlagRow
-              label="OER library search"
-              src="default"
-              checked={form.oerLibraryEnabled}
-              onChange={(v) => update('oerLibraryEnabled', v)}
-            />
-            <FlagRow
-              label="OER stub catalog (dev/e2e)"
-              src="default"
-              checked={form.oerStub}
-              onChange={(v) => update('oerStub', v)}
-            />
-            <FlagRow
-              label="Quiz item analysis"
-              src="default"
-              checked={form.itemAnalysisEnabled}
-              onChange={(v) => update('itemAnalysisEnabled', v)}
-            />
-            <FlagRow
-              label="xAPI / Caliper emission"
-              src="default"
-              checked={form.xapiEmissionEnabled}
-              onChange={(v) => update('xapiEmissionEnabled', v)}
-            />
-            <FlagRow
-              label="Equation editor"
-              src="default"
-              checked={form.equationEditorEnabled}
-              onChange={(v) => update('equationEditorEnabled', v)}
-            />
-            <FlagRow
-              label="Reading level adaptation"
-              src="default"
-              checked={form.readingLevelEnabled}
-              onChange={(v) => update('readingLevelEnabled', v)}
-            />
-            <FlagRow
-              label="Speech-to-text dictation"
-              src="default"
-              checked={form.speechToTextEnabled}
-              onChange={(v) => update('speechToTextEnabled', v)}
-            />
-            <FlagRow
-              label="Accommodations engine (IEP/504)"
-              src="default"
-              checked={form.accommodationsEngineEnabled}
-              onChange={(v) => update('accommodationsEngineEnabled', v)}
-            />
-            <FlagRow
-              label="Accommodations audit log (engine)"
-              src="default"
-              checked={form.ffAccommodationsEngine}
-              onChange={(v) => update('ffAccommodationsEngine', v)}
-            />
-            <FlagRow
-              label="Translation memory (course content)"
-              src="default"
-              checked={form.translationMemoryEnabled}
-              onChange={(v) => update('translationMemoryEnabled', v)}
-            />
-            <FlagRow
-              label="Storage quotas"
-              src="default"
-              checked={form.storageQuotasEnabled}
-              onChange={(v) => update('storageQuotasEnabled', v)}
-            />
-            <FlagRow
-              label="Antivirus scanning (ClamAV)"
-              src="default"
-              checked={form.avScanningEnabled}
-              onChange={(v) => update('avScanningEnabled', v)}
-            />
-            <FlagRow
-              label="Virtual classroom / live sessions"
-              src="default"
-              checked={form.virtualClassroomEnabled}
-              onChange={(v) => update('virtualClassroomEnabled', v)}
-            />
-            <FlagRow
-              label="Active sessions UI"
-              src="default"
-              checked={form.sessionManagementUiEnabled}
-              onChange={(v) => update('sessionManagementUiEnabled', v)}
-            />
-            <FlagRow
-              label="Two-factor authentication (TOTP and passkeys)"
-              src={form.sources.mfaEnabled}
-              checked={form.mfaEnabled}
-              onChange={(v) => update('mfaEnabled', v)}
-            />
-            <div className="flex flex-col gap-1 rounded-xl border border-slate-100 bg-slate-50/80 px-3 py-2.5 dark:border-neutral-700 dark:bg-neutral-800/40">
-              <label className="text-sm font-medium text-slate-800 dark:text-neutral-100">
-                MFA requirement {sourceBadge(form.sources.mfaEnforcement)}
-              </label>
-              <select
-                value={form.mfaEnforcement}
-                onChange={(e) =>
-                  update('mfaEnforcement', e.target.value as PlatformSettingsPayload['mfaEnforcement'])
-                }
-                className="mt-1 w-full max-w-xs rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
-              >
-                <option value="none">Optional (users choose)</option>
-                <option value="staff">Required for teachers, TAs, and global admins</option>
-                <option value="all">Required for everyone</option>
-              </select>
-              <p className="text-xs text-slate-500 dark:text-neutral-400">
-                When required, users without a factor complete setup after password sign-in. Set{' '}
-                <code className="rounded bg-slate-100 px-1 font-mono dark:bg-neutral-900">PUBLIC_WEB_ORIGIN</code> for
-                passkeys.
-              </p>
-            </div>
           </div>
+
+          <div className="mt-1 divide-y divide-slate-100 dark:divide-neutral-800">
+            {visiblePlatformFeatures.length === 0 ? (
+              <p className="py-6 text-center text-sm text-slate-400 dark:text-neutral-500">
+                No features match &ldquo;{featureQuery}&rdquo;
+              </p>
+            ) : (
+              visiblePlatformFeatures.map((feature) => {
+                const enabled = form[feature.key]
+                const source = feature.sourceKey ? form.sources[feature.sourceKey] : 'default'
+                return (
+                  <FeatureToggleRow
+                    key={feature.key}
+                    label={feature.label}
+                    description={feature.description}
+                    enabled={enabled}
+                    disabled={featureSaving}
+                    meta={sourceBadge(source)}
+                    onToggle={() => void persistPlatformFeature(feature.key, !enabled)}
+                  />
+                )
+              })
+            )}
+          </div>
+
+          <div className="mt-4 border-t border-slate-100 pt-4 dark:border-neutral-800">
+            <label className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+              MFA requirement {sourceBadge(form.sources.mfaEnforcement)}
+            </label>
+            <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+              Require two-factor authentication for some or all users after password sign-in.
+            </p>
+            <select
+              value={form.mfaEnforcement}
+              disabled={featureSaving}
+              onChange={(e) =>
+                void persistMfaEnforcement(e.target.value as PlatformSettingsPayload['mfaEnforcement'])
+              }
+              className="mt-3 w-full max-w-md rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-300 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:focus:border-indigo-500"
+            >
+              <option value="none">Optional (users choose)</option>
+              <option value="staff">Required for teachers, TAs, and global admins</option>
+              <option value="all">Required for everyone</option>
+            </select>
+            <p className="mt-2 text-xs text-slate-500 dark:text-neutral-400">
+              Set{' '}
+              <code className="rounded bg-slate-100 px-1 font-mono dark:bg-neutral-900">PUBLIC_WEB_ORIGIN</code> on the
+              API for passkey registration.
+            </p>
+          </div>
+
+          {featureMessage ? (
+            <p className="mt-4 text-sm text-emerald-700 dark:text-emerald-400" role="status">
+              {featureMessage}
+            </p>
+          ) : null}
+          {featureError ? (
+            <p className="mt-4 text-sm text-rose-700 dark:text-rose-400" role="alert">
+              {featureError}
+            </p>
+          ) : null}
         </section>
 
         <div className="flex flex-wrap gap-3">
@@ -891,24 +631,5 @@ export function PlatformSettingsPanel() {
         </div>
       </form>
     </div>
-  )
-}
-
-function FlagRow(props: {
-  label: string
-  src: FieldSource
-  checked: boolean
-  onChange: (v: boolean) => void
-}) {
-  const chk =
-    'rounded border border-slate-200 bg-white text-indigo-600 focus:ring-indigo-500 dark:border-neutral-600 dark:bg-neutral-800'
-  return (
-    <label className="flex items-start gap-2 rounded-xl border border-slate-100 bg-slate-50/80 px-3 py-2.5 dark:border-neutral-700 dark:bg-neutral-800/40">
-      <input type="checkbox" checked={props.checked} onChange={(e) => props.onChange(e.target.checked)} className={chk} />
-      <span className="text-sm text-slate-800 dark:text-neutral-100">
-        {props.label}
-        {sourceBadge(props.src)}
-      </span>
-    </label>
   )
 }

--- a/clients/web/src/components/settings/platform-settings-types.ts
+++ b/clients/web/src/components/settings/platform-settings-types.ts
@@ -1,0 +1,77 @@
+export type FieldSource = 'environment' | 'database' | 'default'
+
+export type PlatformSettingsPayload = {
+  openRouterApiKey: string
+  samlSsoEnabled: boolean
+  samlPublicBaseUrl: string
+  samlSpEntityId: string
+  samlSpX509Pem: string
+  samlSpPrivateKeyPem: string
+  annotationEnabled: boolean
+  feedbackMediaEnabled: boolean
+  blindGradingEnabled: boolean
+  moderatedGradingEnabled: boolean
+  originalityDetectionEnabled: boolean
+  originalityStubExternal: boolean
+  gradePostingPoliciesEnabled: boolean
+  gradebookCsvEnabled: boolean
+  resubmissionWorkflowEnabled: boolean
+  ltiEnabled: boolean
+  oneRosterEnabled: boolean
+  scimEnabled: boolean
+  studentProgressEnabled: boolean
+  selfReflectionEnabled: boolean
+  outcomesReportEnabled: boolean
+  atRiskAlertsEnabled: boolean
+  h5pEnabled: boolean
+  oerLibraryEnabled: boolean
+  oerStub: boolean
+  itemAnalysisEnabled: boolean
+  xapiEmissionEnabled: boolean
+  equationEditorEnabled: boolean
+  readingLevelEnabled: boolean
+  speechToTextEnabled: boolean
+  accommodationsEngineEnabled: boolean
+  ffAccommodationsEngine: boolean
+  ffBookstoreIntegration: boolean
+  ffEportfolio: boolean
+  translationMemoryEnabled: boolean
+  storageQuotasEnabled: boolean
+  avScanningEnabled: boolean
+  virtualClassroomEnabled: boolean
+  sessionManagementUiEnabled: boolean
+  mfaEnabled: boolean
+  mfaEnforcement: 'none' | 'all' | 'staff'
+  smtpHost: string
+  smtpPort: number
+  smtpFrom: string
+  smtpUser: string
+  smtpPassword: string
+  sources: {
+    openRouterApiKey: FieldSource
+    samlSsoEnabled: FieldSource
+    samlPublicBaseUrl: FieldSource
+    samlSpEntityId: FieldSource
+    samlSpX509Pem: FieldSource
+    samlSpPrivateKeyPem: FieldSource
+    annotationEnabled: FieldSource
+    feedbackMediaEnabled: FieldSource
+    blindGradingEnabled: FieldSource
+    moderatedGradingEnabled: FieldSource
+    originalityDetectionEnabled: FieldSource
+    originalityStubExternal: FieldSource
+    gradePostingPoliciesEnabled: FieldSource
+    gradebookCsvEnabled: FieldSource
+    resubmissionWorkflowEnabled: FieldSource
+    ltiEnabled: FieldSource
+    oneRosterEnabled: FieldSource
+    scimEnabled: FieldSource
+    mfaEnabled: FieldSource
+    mfaEnforcement: FieldSource
+    smtpHost: FieldSource
+    smtpPort: FieldSource
+    smtpFrom: FieldSource
+    smtpUser: FieldSource
+    smtpPassword: FieldSource
+  }
+}

--- a/clients/web/src/lib/build-search-items.ts
+++ b/clients/web/src/lib/build-search-items.ts
@@ -7,6 +7,7 @@ import {
 } from './courses-api'
 import {
   atRiskFeatureEnabled,
+  bookstoreIntegrationEnabled,
   outcomesReportFeatureEnabled,
   xapiEmissionFeatureEnabled,
 } from './platform-features'
@@ -147,6 +148,17 @@ export function buildGlobalSearchItems(allows: (perm: string) => boolean): Searc
       path: '/settings/roles',
       haystack: 'roles permissions rbac security admin page'.toLowerCase(),
     })
+    if (bookstoreIntegrationEnabled()) {
+      items.push({
+        id: 'page:/admin/bookstore',
+        group: 'page',
+        title: 'Bookstore integration',
+        subtitle: 'System settings',
+        path: '/admin/bookstore',
+        haystack:
+          'bookstore textbook vitalsource redshelf inclusive access lti admin page'.toLowerCase(),
+      })
+    }
   }
 
   if (allows(PERM_REPORTS_VIEW)) {

--- a/clients/web/src/pages/lms/course-features-section.tsx
+++ b/clients/web/src/pages/lms/course-features-section.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from 'react'
+import { FeatureToggleRow } from '../../components/settings/feature-toggle-row'
 import { useCourseNavFeatures } from '../../context/course-nav-features-context'
 import { patchCourseFeatures } from '../../lib/courses-api'
 import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
@@ -8,45 +9,6 @@ type Props = {
   courseCode: string
   course: CoursePublic
   onCourseUpdated: (c: CoursePublic) => void
-}
-
-function FeatureToggleRow({
-  label,
-  description,
-  enabled,
-  disabled,
-  onToggle,
-}: {
-  label: string
-  description: string
-  enabled: boolean
-  disabled: boolean
-  onToggle: () => void
-}) {
-  return (
-    <div className="flex flex-wrap items-start justify-between gap-4 py-4">
-      <div className="min-w-0 flex-1">
-        <p className="text-sm font-semibold text-slate-900 dark:text-neutral-100">{label}</p>
-        <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">{description}</p>
-      </div>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={enabled}
-        onClick={onToggle}
-        disabled={disabled}
-        className={`relative mt-0.5 inline-flex h-7 w-12 shrink-0 rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${
-          enabled ? 'bg-indigo-600' : 'bg-slate-200 dark:bg-neutral-700'
-        }`}
-      >
-        <span
-          className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition ${
-            enabled ? 'translate-x-5' : 'translate-x-0.5'
-          }`}
-        />
-      </button>
-    </div>
-  )
 }
 
 export function CourseFeaturesSection({ courseCode, course, onCourseUpdated }: Props) {

--- a/clients/web/src/pages/lms/my-portfolios-page.tsx
+++ b/clients/web/src/pages/lms/my-portfolios-page.tsx
@@ -61,7 +61,10 @@ export default function MyPortfoliosPage() {
   if (!ffEportfolio) {
     return (
       <LmsPage title="My Portfolios">
-        <p className="text-muted-foreground">The ePortfolio feature is not enabled.</p>
+        <p className="text-muted-foreground">
+          The ePortfolio feature is not enabled. A global administrator can turn it on in Settings → Global
+          platform.
+        </p>
       </LmsPage>
     )
   }

--- a/clients/web/src/pages/lms/portfolio-editor-page.tsx
+++ b/clients/web/src/pages/lms/portfolio-editor-page.tsx
@@ -117,7 +117,10 @@ export default function PortfolioEditorPage() {
   if (!ffEportfolio) {
     return (
       <LmsPage title="Portfolio">
-        <p className="text-muted-foreground">The ePortfolio feature is not enabled.</p>
+        <p className="text-muted-foreground">
+          The ePortfolio feature is not enabled. A global administrator can turn it on in Settings → Global
+          platform.
+        </p>
       </LmsPage>
     )
   }

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -327,6 +327,7 @@ type Config struct {
 	// FFBookstoreIntegration enables bookstore / textbook integration: VitalSource & RedShelf Inclusive Access LTI deep links (plan 14.11).
 	FFBookstoreIntegration bool
 	// FFEportfolio enables the ePortfolio / capstone artifact collection module (plan 14.12).
+	// Managed in Settings → Global platform (not process env).
 	FFEportfolio bool
 
 	// CCRSigningSeedB64 is a base64-encoded 32-byte Ed25519 seed for CLR signing (plan 14.13).
@@ -511,7 +512,6 @@ func Load() Config {
 		FFCoCurricularTranscript:        boolEnv("FF_CO_CURRICULAR_TRANSCRIPT"),
 		FFLibraryIntegration:            boolEnv("FF_LIBRARY_INTEGRATION"),
 		FFBookstoreIntegration:          boolEnv("FF_BOOKSTORE_INTEGRATION"),
-		FFEportfolio:                    boolEnv("FF_EPORTFOLIO"),
 
 		CCRSigningSeedB64:  strings.TrimSpace(os.Getenv("CCR_SIGNING_SEED_B64")),
 		CCRInstitutionName: strings.TrimSpace(os.Getenv("CCR_INSTITUTION_NAME")),

--- a/server/internal/httpserver/eportfolio_http.go
+++ b/server/internal/httpserver/eportfolio_http.go
@@ -22,8 +22,7 @@ import (
 
 // requireEportfolioEnabled returns false and writes 501 when the feature flag is off.
 func (d Deps) requireEportfolioEnabled(w http.ResponseWriter) bool {
-	cfg := d.effectiveConfig()
-	if !cfg.FFEportfolio && !d.Config.FFEportfolio {
+	if !d.effectiveConfig().FFEportfolio {
 		apierr.WriteJSON(w, http.StatusNotImplemented, apierr.CodeNotImplemented, "ePortfolio is not enabled.")
 		return false
 	}

--- a/server/internal/httpserver/settings_platform.go
+++ b/server/internal/httpserver/settings_platform.go
@@ -120,6 +120,8 @@ type platformSettingsJSON struct {
 	FFCourseEvaluations             bool `json:"ffCourseEvaluations"`
 	FFProctoringIntegration         bool `json:"ffProctoringIntegration"`
 	FFCoCurricularTranscript        bool `json:"ffCoCurricularTranscript"`
+	FFEportfolio                    bool `json:"ffEportfolio"`
+	FFBookstoreIntegration          bool `json:"ffBookstoreIntegration"`
 
 	MFAEnabled     bool   `json:"mfaEnabled"`
 	MFAEnforcement string `json:"mfaEnforcement"`
@@ -271,6 +273,8 @@ func (d Deps) handleGetPlatformSettings() http.HandlerFunc {
 				FFCourseEvaluations:             merged.FFCourseEvaluations,
 				FFProctoringIntegration:         merged.FFProctoringIntegration,
 				FFCoCurricularTranscript:        merged.FFCoCurricularTranscript,
+				FFEportfolio:                    merged.FFEportfolio,
+				FFBookstoreIntegration:          merged.FFBookstoreIntegration,
 			MFAEnabled:                      merged.MFAEnabled,
 			MFAEnforcement:                  merged.MFAEnforcement,
 			SMTPHost:                        merged.SMTPHost,
@@ -395,6 +399,8 @@ type putPlatformBody struct {
 	FFCourseEvaluations             *bool `json:"ffCourseEvaluations"`
 	FFProctoringIntegration         *bool `json:"ffProctoringIntegration"`
 	FFCoCurricularTranscript        *bool `json:"ffCoCurricularTranscript"`
+	FFEportfolio                    *bool `json:"ffEportfolio"`
+	FFBookstoreIntegration          *bool `json:"ffBookstoreIntegration"`
 
 	MFAEnabled     *bool   `json:"mfaEnabled"`
 	MFAEnforcement *string `json:"mfaEnforcement"`
@@ -680,6 +686,8 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 		setBool("ffcourseevaluations", body.FFCourseEvaluations, func(v bool) { wr.FFCourseEvaluations = &v })
 		setBool("ffproctoringintegration", body.FFProctoringIntegration, func(v bool) { wr.FFProctoringIntegration = &v })
 		setBool("ffcocurriculartranscript", body.FFCoCurricularTranscript, func(v bool) { wr.FFCoCurricularTranscript = &v })
+		setBool("ffeportfolio", body.FFEportfolio, func(v bool) { wr.FFEportfolio = &v })
+		setBool("ffbookstoreintegration", body.FFBookstoreIntegration, func(v bool) { wr.FFBookstoreIntegration = &v })
 		set("mfaenabled", body.MFAEnabled != nil, func() {
 			v := *body.MFAEnabled
 			wr.MFAEnabled = &v
@@ -787,6 +795,8 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 				FFCourseEvaluations:             merged.FFCourseEvaluations,
 				FFProctoringIntegration:         merged.FFProctoringIntegration,
 				FFCoCurricularTranscript:        merged.FFCoCurricularTranscript,
+				FFEportfolio:                    merged.FFEportfolio,
+				FFBookstoreIntegration:          merged.FFBookstoreIntegration,
 			MFAEnabled:                      merged.MFAEnabled,
 			MFAEnforcement:                  merged.MFAEnforcement,
 			SMTPHost:                        merged.SMTPHost,

--- a/server/internal/repos/platformconfig/features.go
+++ b/server/internal/repos/platformconfig/features.go
@@ -73,6 +73,8 @@ func applyPlatformBools(out *config.Config, db *Row, def Defaults) {
 	out.FFCourseEvaluations = mergeBool(db.FFCourseEvaluations, false)
 	out.FFProctoringIntegration = mergeBool(db.FFProctoringIntegration, false)
 	out.FFCoCurricularTranscript = mergeBool(db.FFCoCurricularTranscript, false)
+	out.FFEportfolio = mergeBool(db.FFEportfolio, false)
+	out.FFBookstoreIntegration = mergeBool(db.FFBookstoreIntegration, out.FFBookstoreIntegration)
 	out.SpeechToTextEnabled = mergeBool(db.SpeechToTextEnabled, false)
 	out.AccommodationsEngineEnabled = mergeBool(db.AccommodationsEngineEnabled, false)
 	out.FFAccommodationsEngine = mergeBool(db.FFAccommodationsEngine, false)

--- a/server/internal/repos/platformconfig/merge_test.go
+++ b/server/internal/repos/platformconfig/merge_test.go
@@ -68,4 +68,19 @@ func TestMerge_H5PDefaultOff(t *testing.T) {
 	}
 }
 
+func TestMerge_BookstoreIntegrationEnvWhenDBUnset(t *testing.T) {
+	got := Merge(config.Config{FFBookstoreIntegration: true}, nil)
+	if !got.FFBookstoreIntegration {
+		t.Fatal("expected bookstore integration from env when DB unset")
+	}
+}
+
+func TestMerge_BookstoreIntegrationDBOverridesEnv(t *testing.T) {
+	off := false
+	got := Merge(config.Config{FFBookstoreIntegration: true}, &Row{FFBookstoreIntegration: &off})
+	if got.FFBookstoreIntegration {
+		t.Fatal("expected DB false to override env true")
+	}
+}
+
 func ptr(s string) *string { return &s }

--- a/server/internal/repos/platformconfig/patch.go
+++ b/server/internal/repos/platformconfig/patch.go
@@ -1,0 +1,156 @@
+package platformconfig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// patch applies only non-nil fields in w to the existing singleton row.
+// Partial platform settings updates must not use INSERT ... ON CONFLICT with NULLs for
+// NOT NULL columns (PostgreSQL validates the INSERT row before conflict resolution).
+func patch(ctx context.Context, pool *pgxpool.Pool, w *Write) error {
+	var sets []string
+	var args []any
+
+	addBool := func(col string, v *bool) {
+		if v == nil {
+			return
+		}
+		args = append(args, *v)
+		sets = append(sets, fmt.Sprintf("%s = $%d", col, len(args)))
+	}
+	addString := func(col string, v *string) {
+		if v == nil {
+			return
+		}
+		args = append(args, *v)
+		sets = append(sets, fmt.Sprintf("%s = $%d", col, len(args)))
+	}
+	addInt32 := func(col string, v *int32) {
+		if v == nil {
+			return
+		}
+		args = append(args, *v)
+		sets = append(sets, fmt.Sprintf("%s = $%d", col, len(args)))
+	}
+	addBytes := func(col string, v *[]byte) {
+		if v == nil {
+			return
+		}
+		args = append(args, *v)
+		sets = append(sets, fmt.Sprintf("%s = $%d", col, len(args)))
+	}
+
+	if w.OpenRouterAPIKey != nil {
+		addString("openrouter_api_key", w.OpenRouterAPIKey)
+	}
+	addBool("saml_sso_enabled", w.SAMLSSOEnabled)
+	addString("saml_public_base_url", w.SAMLPublicBaseURL)
+	addString("saml_sp_entity_id", w.SAMLSPEntityID)
+	addString("saml_sp_x509_pem", w.SAMLSPX509PEM)
+	addString("saml_sp_private_key_pem", w.SAMLSPPrivateKeyPEM)
+	addBool("annotation_enabled", w.AnnotationEnabled)
+	addBool("feedback_media_enabled", w.FeedbackMediaEnabled)
+	addBool("blind_grading_enabled", w.BlindGradingEnabled)
+	addBool("moderated_grading_enabled", w.ModeratedGradingEnabled)
+	addBool("originality_detection_enabled", w.OriginalityDetectionEnabled)
+	addBool("originality_stub_external", w.OriginalityStubExternal)
+	addBool("grade_posting_policies_enabled", w.GradePostingPoliciesEnabled)
+	addBool("gradebook_csv_enabled", w.GradebookCSVEnabled)
+	addBool("resubmission_workflow_enabled", w.ResubmissionWorkflowEnabled)
+	addBool("lti_enabled", w.LTIEnabled)
+	addBool("oneroster_enabled", w.OneRosterEnabled)
+	addBool("scim_enabled", w.ScimEnabled)
+	addBool("oidc_sso_enabled", w.OIDCSSOEnabled)
+	addBool("clever_sso_enabled", w.CleverSSOEnabled)
+	addBool("classlink_sso_enabled", w.ClassLinkSSOEnabled)
+	addBool("magic_link_enabled", w.MagicLinkEnabled)
+	addBool("magic_link_enrolled_only", w.MagicLinkEnrolledOnly)
+	addBool("session_management_ui_enabled", w.SessionManagementUIEnabled)
+	addBool("email_notifications_enabled", w.EmailNotificationsEnabled)
+	addBool("push_notifications_enabled", w.PushNotificationsEnabled)
+	addBool("virtual_classroom_enabled", w.VirtualClassroomEnabled)
+	addBool("drm_enabled", w.DRMEnabled)
+	addBool("video_transcoding_enabled", w.VideoTranscodingEnabled)
+	addBool("auto_captioning_enabled", w.AutoCaptioningEnabled)
+	addBool("video_captions_enabled", w.VideoCaptionsEnabled)
+	addBool("storage_quotas_enabled", w.StorageQuotasEnabled)
+	addBool("at_risk_alerts_enabled", w.AtRiskAlertsEnabled)
+	addBool("av_scanning_enabled", w.AvScanningEnabled)
+	addBool("clamav_stub", w.ClamAVStub)
+	addBool("h5p_enabled", w.H5PEnabled)
+	addBool("oer_library_enabled", w.OERLibraryEnabled)
+	addBool("oer_stub", w.OERStub)
+	addBool("item_analysis_enabled", w.ItemAnalysisEnabled)
+	addBool("student_progress_enabled", w.StudentProgressEnabled)
+	addBool("engagement_tracking_enabled", w.EngagementTrackingEnabled)
+	addBool("self_reflection_enabled", w.SelfReflectionEnabled)
+	addBool("outcomes_report_enabled", w.OutcomesReportEnabled)
+	addBool("equation_editor_enabled", w.EquationEditorEnabled)
+	addBool("reading_level_enabled", w.ReadingLevelEnabled)
+	addBool("alt_text_enforcement_enabled", w.AltTextEnforcementEnabled)
+	addBool("ff_alt_text_enforcement", w.FFAltTextEnforcement)
+	addBool("speech_to_text_enabled", w.SpeechToTextEnabled)
+	addBool("accommodations_engine_enabled", w.AccommodationsEngineEnabled)
+	addBool("ff_accommodations_engine", w.FFAccommodationsEngine)
+	addBool("read_aloud_enabled", w.ReadAloudEnabled)
+	addBool("ff_read_aloud", w.FFReadAloud)
+	addBool("translation_memory_enabled", w.TranslationMemoryEnabled)
+	addBool("report_export_enabled", w.ReportExportEnabled)
+	addBool("xapi_emission_enabled", w.XAPIEmissionEnabled)
+	addBool("instructor_insights_enabled", w.InstructorInsightsEnabled)
+	addBool("coppa_workflow_enabled", w.CoppaWorkflowEnabled)
+	addBool("gdpr_module_enabled", w.GDPRModuleEnabled)
+	addBool("ccpa_module_enabled", w.CCPAModuleEnabled)
+	addBool("state_privacy_enabled", w.StatePrivacyEnabled)
+	addBool("iso_isms_enabled", w.IsoIsmsEnabled)
+	addBool("admin_audit_log_enabled", w.AdminAuditLogEnabled)
+	addBool("data_residency_enabled", w.DataResidencyEnabled)
+	addBool("ai_disclosure_enabled", w.AiDisclosureEnabled)
+	addBool("rtl_enabled", w.RTLEnabled)
+	addBool("security_disclosure_module_enabled", w.SecurityDisclosureModuleEnabled)
+	addBool("backup_module_enabled", w.BackupModuleEnabled)
+	addBool("ff_high_contrast_reduced_motion", w.FFHighContrastReducedMotion)
+	addBool("ff_parent_portal", w.FFParentPortal)
+	addBool("ff_report_cards", w.FFReportCards)
+	addBool("ff_sbg_report_cards", w.FFSBGReportCards)
+	addBool("ff_sis_integration", w.FFSISIntegration)
+	addBool("ff_catalog_integration", w.FFCatalogIntegration)
+	addBool("ff_enrollment_state_machine", w.FFEnrollmentStateMachine)
+	addBool("ff_incomplete_grade_workflow", w.FFIncompleteGradeWorkflow)
+	addBool("ff_library", w.FFLibrary)
+	addBool("ff_broadcasts", w.FFBroadcasts)
+	addBool("ff_conference_scheduling", w.FFConferenceScheduling)
+	addBool("ff_demographics", w.FFDemographics)
+	addBool("ff_content_filter_integration", w.FFContentFilterIntegration)
+	addBool("ff_grade_submission", w.FFGradeSubmission)
+	addBool("ff_academic_calendar", w.FFAcademicCalendar)
+	addBool("ff_plagiarism_checks", w.FFPlagiarismChecks)
+	addBool("ff_course_evaluations", w.FFCourseEvaluations)
+	addBool("ff_proctoring_integration", w.FFProctoringIntegration)
+	addBool("ff_co_curricular_transcript", w.FFCoCurricularTranscript)
+	addBool("ff_eportfolio", w.FFEportfolio)
+	addBool("ff_bookstore_integration", w.FFBookstoreIntegration)
+	addBool("mfa_enabled", w.MFAEnabled)
+	addString("mfa_enforcement", w.MFAEnforcement)
+	addString("smtp_host", w.SMTPHost)
+	addInt32("smtp_port", w.SMTPPort)
+	addString("smtp_from", w.SMTPFrom)
+	addString("smtp_user", w.SMTPUser)
+	addBytes("smtp_password_ciphertext", w.SMTPPasswordCiphertext)
+
+	if len(sets) == 0 {
+		return nil
+	}
+
+	sets = append(sets, "updated_at = NOW()")
+	q := fmt.Sprintf(
+		"UPDATE settings.platform_app_settings SET %s WHERE id = 1",
+		strings.Join(sets, ", "),
+	)
+	_, err := pool.Exec(ctx, q, args...)
+	return err
+}

--- a/server/internal/repos/platformconfig/platformconfig.go
+++ b/server/internal/repos/platformconfig/platformconfig.go
@@ -105,6 +105,8 @@ type Row struct {
 	FFCourseEvaluations               *bool
 	FFProctoringIntegration           *bool
 	FFCoCurricularTranscript          *bool
+	FFEportfolio                      *bool
+	FFBookstoreIntegration            *bool
 
 	MFAEnabled     *bool
 	MFAEnforcement *string
@@ -210,6 +212,8 @@ type Write struct {
 	FFCourseEvaluations               *bool
 	FFProctoringIntegration           *bool
 	FFCoCurricularTranscript          *bool
+	FFEportfolio                      *bool
+	FFBookstoreIntegration            *bool
 
 	MFAEnabled     *bool
 	MFAEnforcement *string
@@ -312,6 +316,8 @@ SELECT
 	ff_course_evaluations,
 	ff_proctoring_integration,
 	ff_co_curricular_transcript,
+	ff_eportfolio,
+	ff_bookstore_integration,
 	mfa_enabled,
 	mfa_enforcement,
 	smtp_host,
@@ -409,6 +415,8 @@ WHERE id = 1
 		&r.FFCourseEvaluations,
 		&r.FFProctoringIntegration,
 		&r.FFCoCurricularTranscript,
+		&r.FFEportfolio,
+		&r.FFBookstoreIntegration,
 		&r.MFAEnabled,
 		&r.MFAEnforcement,
 		&r.SMTPHost,
@@ -449,6 +457,17 @@ WHERE id = 1
 
 // Upsert applies non-nil fields in w to the singleton row (COALESCE keeps existing values).
 func Upsert(ctx context.Context, pool *pgxpool.Pool, w *Write) (*Row, error) {
+	existing, err := Get(ctx, pool)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		if err := patch(ctx, pool, w); err != nil {
+			return nil, err
+		}
+		return Get(ctx, pool)
+	}
+
 	var smtpPort any
 	if w.SMTPPort != nil {
 		smtpPort = *w.SMTPPort
@@ -457,7 +476,7 @@ func Upsert(ctx context.Context, pool *pgxpool.Pool, w *Write) (*Row, error) {
 	if w.SMTPPasswordCiphertext != nil {
 		smtpCipher = *w.SMTPPasswordCiphertext
 	}
-	_, err := pool.Exec(ctx, `
+	_, err = pool.Exec(ctx, `
 INSERT INTO settings.platform_app_settings (
 	id,
 	openrouter_api_key,
@@ -546,6 +565,8 @@ INSERT INTO settings.platform_app_settings (
 	ff_course_evaluations,
 	ff_proctoring_integration,
 	ff_co_curricular_transcript,
+	ff_eportfolio,
+	ff_bookstore_integration,
 	mfa_enabled,
 	mfa_enforcement,
 	smtp_host,
@@ -558,7 +579,7 @@ INSERT INTO settings.platform_app_settings (
 	1,
 	$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18,
 	$19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40,
-	$41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, $66, $67, $68, $69, $70, $71, $72, $73, $74, $75, $76, $77, $78, $79, $80, $81, $82, $83, $84, $85, $86, $87, $88, $89, $90, $91, $92, $93,
+	$41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, $66, $67, $68, $69, $70, $71, $72, $73, $74, $75, $76, $77, $78, $79, $80, $81, $82, $83, $84, $85, $86, $87, $88, $89, $90, $91, $92, $93, $94, $95,
 	NOW()
 )
 ON CONFLICT (id) DO UPDATE SET
@@ -648,6 +669,8 @@ ON CONFLICT (id) DO UPDATE SET
 	ff_course_evaluations = COALESCE(EXCLUDED.ff_course_evaluations, settings.platform_app_settings.ff_course_evaluations),
 	ff_proctoring_integration = COALESCE(EXCLUDED.ff_proctoring_integration, settings.platform_app_settings.ff_proctoring_integration),
 	ff_co_curricular_transcript = COALESCE(EXCLUDED.ff_co_curricular_transcript, settings.platform_app_settings.ff_co_curricular_transcript),
+	ff_eportfolio = COALESCE(EXCLUDED.ff_eportfolio, settings.platform_app_settings.ff_eportfolio),
+	ff_bookstore_integration = COALESCE(EXCLUDED.ff_bookstore_integration, settings.platform_app_settings.ff_bookstore_integration),
 	mfa_enabled = COALESCE(EXCLUDED.mfa_enabled, settings.platform_app_settings.mfa_enabled),
 	mfa_enforcement = COALESCE(EXCLUDED.mfa_enforcement, settings.platform_app_settings.mfa_enforcement),
 	smtp_host = COALESCE(EXCLUDED.smtp_host, settings.platform_app_settings.smtp_host),
@@ -743,6 +766,8 @@ ON CONFLICT (id) DO UPDATE SET
 		w.FFCourseEvaluations,
 		w.FFProctoringIntegration,
 		w.FFCoCurricularTranscript,
+		w.FFEportfolio,
+		w.FFBookstoreIntegration,
 		w.MFAEnabled,
 		w.MFAEnforcement,
 		w.SMTPHost,

--- a/server/internal/repos/platformconfig/upsert_bookstore_integration_db_test.go
+++ b/server/internal/repos/platformconfig/upsert_bookstore_integration_db_test.go
@@ -1,0 +1,44 @@
+package platformconfig_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lextures/lextures/server/internal/config"
+	"github.com/lextures/lextures/server/internal/repos/platformconfig"
+)
+
+func TestUpsert_WithBookstoreIntegrationColumn(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+
+	v := true
+	_, err = platformconfig.Upsert(ctx, pool, &platformconfig.Write{
+		FFBookstoreIntegration: &v,
+	})
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	merged := platformconfig.Merge(config.Config{FFBookstoreIntegration: false}, nil)
+	row, err := platformconfig.Get(ctx, pool)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if row == nil {
+		t.Fatal("expected row")
+	}
+	merged = platformconfig.Merge(merged, row)
+	if !merged.FFBookstoreIntegration {
+		t.Fatalf("expected FFBookstoreIntegration true, got false")
+	}
+}

--- a/server/migrations/260_ff_eportfolio_platform_flag.sql
+++ b/server/migrations/260_ff_eportfolio_platform_flag.sql
@@ -1,0 +1,3 @@
+-- Document ff_eportfolio as a Settings → Global platform flag (plan 14.12).
+COMMENT ON COLUMN settings.platform_app_settings.ff_eportfolio IS
+    'ePortfolio / capstone artifact collection (plan 14.12). Managed in Settings → Global platform.';


### PR DESCRIPTION
## Summary

- Refactors Settings → Global platform into a searchable, definition-driven feature toggle panel with per-flag auto-save via partial `PUT` + `updateMask`.
- Adds `ffEportfolio` and `ffBookstoreIntegration` as managed platform flags (migration 260 documents ePortfolio); gates My Portfolio nav, portfolio pages, and bookstore admin settings links on runtime feature state.
- Introduces server-side `patch.go` for masked platform config updates and DB test coverage for bookstore integration upsert.

## Test plan

- [ ] Open Settings → Global platform as Global Admin; verify feature list is alphabetically sorted and searchable.
- [ ] Toggle ePortfolio on/off; confirm My Portfolio appears/disappears in side nav and `/portfolios` routes respect the flag.
- [ ] Toggle bookstore integration on/off; confirm Bookstore link appears under Admin settings and `/admin/bookstore` breadcrumbs work.
- [ ] Verify other platform settings (SAML, SMTP) still save via the main form without affecting feature toggles.
- [ ] `cd server && go test ./internal/repos/platformconfig/... -count=1 -short`
- [ ] `cd clients/web && npm run typecheck && npm run test`