### PR TITLE
feat: student notebook cloud sync, rich mobile editor, grading backlog, and student reports

### DIFF
--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -37,7 +37,7 @@ jobs:
           xcodebuild build \
             -project Lextures.xcodeproj \
             -scheme Lextures \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'generic/platform=iOS Simulator' \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \
             | xcpretty
@@ -50,7 +50,7 @@ jobs:
       #     xcodebuild test \
       #       -project Lextures.xcodeproj \
       #       -scheme Lextures \
-      #       -destination 'platform=iOS Simulator,name=iPhone 16' \
+      #       -destination 'generic/platform=iOS Simulator' \
       #       -configuration Debug \
       #       CODE_SIGNING_ALLOWED=NO \
       #       | xcpretty

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/lms/NotebookTasksApi.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/lms/NotebookTasksApi.kt
@@ -1,0 +1,33 @@
+package com.lextures.android.core.lms
+
+import com.lextures.android.core.network.ApiClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** Notebook-task body sent to the dashboard sync endpoint (`dueAt: null` clears, web parity). */
+@Serializable
+data class NotebookTaskUpsert(
+    val id: String,
+    val courseCode: String,
+    val notebookPageId: String,
+    val taskText: String,
+    val completed: Boolean,
+    val dueAt: String?,
+)
+
+/** Server-side notebook tasks (dashboard sync, parity with web `notebook-tasks-api`). */
+object NotebookTasksApi {
+    private val client = ApiClient()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun upsert(task: NotebookTaskUpsert, accessToken: String): Unit = withContext(Dispatchers.IO) {
+        client.request(
+            "/api/v1/me/notebook-tasks",
+            method = "POST",
+            body = json.encodeToString(NotebookTaskUpsert.serializer(), task),
+            accessToken = accessToken,
+        )
+    }
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/lms/NotebooksApi.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/lms/NotebooksApi.kt
@@ -1,0 +1,50 @@
+package com.lextures.android.core.lms
+
+import com.lextures.android.core.network.ApiClient
+import com.lextures.android.core.notebook.CourseNotebook
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.net.URLEncoder
+
+/** One server notebook row; `data` is null when the stored document fails to decode. */
+data class ServerNotebookEntry(
+    val courseCode: String,
+    val updatedAt: String,
+    val data: CourseNotebook?,
+)
+
+/** Server-side notebook documents (sync, parity with web `student-notebook-sync`). */
+object NotebooksApi {
+    private val client = ApiClient()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun encodeQuery(value: String): String = URLEncoder.encode(value, "UTF-8")
+
+    suspend fun fetchAll(accessToken: String): List<ServerNotebookEntry> = withContext(Dispatchers.IO) {
+        val (body, _) = client.request("/api/v1/me/notebooks", accessToken = accessToken)
+        val root = json.parseToJsonElement(body).jsonObject
+        (root["notebooks"]?.jsonArray ?: return@withContext emptyList()).mapNotNull { el ->
+            val obj = el as? JsonObject ?: return@mapNotNull null
+            val courseCode = obj["courseCode"]?.jsonPrimitive?.content ?: return@mapNotNull null
+            val updatedAt = obj["updatedAt"]?.jsonPrimitive?.content ?: return@mapNotNull null
+            // Lenient: one malformed document must not break the whole list.
+            val data = obj["data"]?.let { runCatching { json.decodeFromJsonElement(CourseNotebook.serializer(), it) }.getOrNull() }
+            ServerNotebookEntry(courseCode, updatedAt, data)
+        }
+    }
+
+    suspend fun put(courseCode: String, notebook: CourseNotebook, accessToken: String): Unit =
+        withContext(Dispatchers.IO) {
+            client.request(
+                "/api/v1/me/notebooks?courseCode=${encodeQuery(courseCode)}",
+                method = "PUT",
+                body = json.encodeToString(CourseNotebook.serializer(), notebook),
+                accessToken = accessToken,
+            )
+        }
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/notebook/NotebookDrawing.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/notebook/NotebookDrawing.kt
@@ -1,0 +1,273 @@
+package com.lextures.android.core.notebook
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.math.abs
+import kotlin.math.hypot
+import kotlin.math.max
+import kotlin.math.min
+
+/** One whiteboard element from a ```drawing fenced block (parity with web `whiteboard/types`). */
+sealed interface NotebookDrawEl {
+    val color: String
+    val width: Double
+
+    data class StrokeEl(override val color: String, override val width: Double, val pts: List<Offset>) : NotebookDrawEl
+    data class RectEl(override val color: String, override val width: Double, val x: Double, val y: Double, val w: Double, val h: Double) : NotebookDrawEl
+    data class CircleEl(override val color: String, override val width: Double, val cx: Double, val cy: Double, val rx: Double, val ry: Double) : NotebookDrawEl
+    data class TriangleEl(
+        override val color: String,
+        override val width: Double,
+        val x1: Double, val y1: Double, val x2: Double, val y2: Double, val x3: Double, val y3: Double,
+    ) : NotebookDrawEl
+    data class LineEl(override val color: String, override val width: Double, val x1: Double, val y1: Double, val x2: Double, val y2: Double) : NotebookDrawEl
+}
+
+object NotebookDrawing {
+    val colors: List<String> = listOf(
+        "#1e293b", "#ef4444", "#f97316", "#eab308", "#22c55e",
+        "#3b82f6", "#a855f7", "#ec4899", "#ffffff",
+    )
+    val strokeWidths: List<Double> = listOf(2.0, 4.0, 8.0)
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // JSON (parity with web `whiteboard/serialize`)
+
+    fun parseElements(raw: String): List<NotebookDrawEl> {
+        val array = runCatching { json.parseToJsonElement(raw.trim()) as? JsonArray }.getOrNull() ?: return emptyList()
+        return array.mapNotNull { el -> (el as? JsonObject)?.let(::parseElement) }
+    }
+
+    private fun JsonObject.num(key: String): Double? = (get(key) as? kotlinx.serialization.json.JsonPrimitive)?.doubleOrNull
+
+    private fun parseElement(obj: JsonObject): NotebookDrawEl? {
+        val color = (obj["color"] as? kotlinx.serialization.json.JsonPrimitive)?.contentOrNull ?: "#1e293b"
+        val width = obj.num("width") ?: 2.0
+        return when ((obj["type"] as? kotlinx.serialization.json.JsonPrimitive)?.contentOrNull) {
+            "stroke" -> {
+                val pts = (obj["pts"] as? JsonArray ?: return null).mapNotNull { pair ->
+                    val arr = runCatching { pair.jsonArray }.getOrNull() ?: return@mapNotNull null
+                    if (arr.size < 2) return@mapNotNull null
+                    val x = arr[0].jsonPrimitive.doubleOrNull ?: return@mapNotNull null
+                    val y = arr[1].jsonPrimitive.doubleOrNull ?: return@mapNotNull null
+                    Offset(x.toFloat(), y.toFloat())
+                }
+                NotebookDrawEl.StrokeEl(color, width, pts)
+            }
+            "rect" -> NotebookDrawEl.RectEl(
+                color, width,
+                obj.num("x") ?: return null, obj.num("y") ?: return null,
+                obj.num("w") ?: return null, obj.num("h") ?: return null,
+            )
+            "circle" -> NotebookDrawEl.CircleEl(
+                color, width,
+                obj.num("cx") ?: return null, obj.num("cy") ?: return null,
+                obj.num("rx") ?: return null, obj.num("ry") ?: return null,
+            )
+            "triangle" -> NotebookDrawEl.TriangleEl(
+                color, width,
+                obj.num("x1") ?: return null, obj.num("y1") ?: return null,
+                obj.num("x2") ?: return null, obj.num("y2") ?: return null,
+                obj.num("x3") ?: return null, obj.num("y3") ?: return null,
+            )
+            "line" -> NotebookDrawEl.LineEl(
+                color, width,
+                obj.num("x1") ?: return null, obj.num("y1") ?: return null,
+                obj.num("x2") ?: return null, obj.num("y2") ?: return null,
+            )
+            else -> null
+        }
+    }
+
+    fun serializeElements(elements: List<NotebookDrawEl>): String {
+        val array = buildJsonArray {
+            for (el in elements) {
+                add(
+                    buildJsonObject {
+                        put("color", el.color)
+                        put("width", el.width)
+                        when (el) {
+                            is NotebookDrawEl.StrokeEl -> {
+                                put("type", "stroke")
+                                put(
+                                    "pts",
+                                    buildJsonArray {
+                                        for (p in el.pts) {
+                                            add(
+                                                buildJsonArray {
+                                                    add(kotlinx.serialization.json.JsonPrimitive(p.x.toDouble()))
+                                                    add(kotlinx.serialization.json.JsonPrimitive(p.y.toDouble()))
+                                                },
+                                            )
+                                        }
+                                    },
+                                )
+                            }
+                            is NotebookDrawEl.RectEl -> {
+                                put("type", "rect"); put("x", el.x); put("y", el.y); put("w", el.w); put("h", el.h)
+                            }
+                            is NotebookDrawEl.CircleEl -> {
+                                put("type", "circle"); put("cx", el.cx); put("cy", el.cy); put("rx", el.rx); put("ry", el.ry)
+                            }
+                            is NotebookDrawEl.TriangleEl -> {
+                                put("type", "triangle")
+                                put("x1", el.x1); put("y1", el.y1); put("x2", el.x2); put("y2", el.y2); put("x3", el.x3); put("y3", el.y3)
+                            }
+                            is NotebookDrawEl.LineEl -> {
+                                put("type", "line"); put("x1", el.x1); put("y1", el.y1); put("x2", el.x2); put("y2", el.y2)
+                            }
+                        }
+                    },
+                )
+            }
+        }
+        return json.encodeToString(JsonArray.serializer(), array)
+    }
+
+    // Geometry
+
+    /** Content extent of the elements (origin-anchored), with a sensible floor for empty boards. */
+    fun contentSize(elements: List<NotebookDrawEl>, minWidth: Float = 320f, minHeight: Float = 220f): Size {
+        var maxX = minWidth
+        var maxY = minHeight
+        fun grow(x: Double, y: Double) {
+            maxX = max(maxX, x.toFloat())
+            maxY = max(maxY, y.toFloat())
+        }
+        for (el in elements) {
+            when (el) {
+                is NotebookDrawEl.StrokeEl -> el.pts.forEach { grow(it.x.toDouble(), it.y.toDouble()) }
+                is NotebookDrawEl.RectEl -> { grow(el.x + el.w, el.y + el.h); grow(el.x, el.y) }
+                is NotebookDrawEl.CircleEl -> grow(el.cx + el.rx, el.cy + el.ry)
+                is NotebookDrawEl.TriangleEl -> { grow(el.x1, el.y1); grow(el.x2, el.y2); grow(el.x3, el.y3) }
+                is NotebookDrawEl.LineEl -> { grow(el.x1, el.y1); grow(el.x2, el.y2) }
+            }
+        }
+        return Size(maxX, maxY)
+    }
+
+    fun color(hex: String, fallback: Color = Color.Black): Color {
+        val value = hex.trim().removePrefix("#")
+        if (value.length != 6) return fallback
+        val rgb = value.toLongOrNull(16) ?: return fallback
+        return Color(
+            red = ((rgb shr 16) and 0xFF).toInt() / 255f,
+            green = ((rgb shr 8) and 0xFF).toInt() / 255f,
+            blue = (rgb and 0xFF).toInt() / 255f,
+        )
+    }
+
+    /** Draw all elements into a Compose draw scope at the given scale. */
+    fun DrawScope.drawElements(elements: List<NotebookDrawEl>, scale: Float) {
+        for (el in elements) {
+            val c = color(el.color)
+            val strokeWidth = (el.width * scale).toFloat()
+            when (el) {
+                is NotebookDrawEl.StrokeEl -> {
+                    if (el.pts.size < 2) {
+                        el.pts.firstOrNull()?.let { p ->
+                            drawCircle(c, radius = max(strokeWidth, 2f) / 2, center = Offset(p.x * scale, p.y * scale))
+                        }
+                        continue
+                    }
+                    val path = Path()
+                    path.moveTo(el.pts[0].x * scale, el.pts[0].y * scale)
+                    for (p in el.pts.drop(1)) path.lineTo(p.x * scale, p.y * scale)
+                    drawPath(path, c, style = Stroke(width = strokeWidth, cap = StrokeCap.Round, join = StrokeJoin.Round))
+                }
+                is NotebookDrawEl.RectEl -> drawRect(
+                    c,
+                    topLeft = Offset((el.x * scale).toFloat(), (el.y * scale).toFloat()),
+                    size = Size((el.w * scale).toFloat(), (el.h * scale).toFloat()),
+                    style = Stroke(width = strokeWidth),
+                )
+                is NotebookDrawEl.CircleEl -> drawOval(
+                    c,
+                    topLeft = Offset(((el.cx - el.rx) * scale).toFloat(), ((el.cy - el.ry) * scale).toFloat()),
+                    size = Size((el.rx * 2 * scale).toFloat(), (el.ry * 2 * scale).toFloat()),
+                    style = Stroke(width = strokeWidth),
+                )
+                is NotebookDrawEl.TriangleEl -> {
+                    val path = Path()
+                    path.moveTo((el.x1 * scale).toFloat(), (el.y1 * scale).toFloat())
+                    path.lineTo((el.x2 * scale).toFloat(), (el.y2 * scale).toFloat())
+                    path.lineTo((el.x3 * scale).toFloat(), (el.y3 * scale).toFloat())
+                    path.close()
+                    drawPath(path, c, style = Stroke(width = strokeWidth, join = StrokeJoin.Round))
+                }
+                is NotebookDrawEl.LineEl -> drawLine(
+                    c,
+                    start = Offset((el.x1 * scale).toFloat(), (el.y1 * scale).toFloat()),
+                    end = Offset((el.x2 * scale).toFloat(), (el.y2 * scale).toFloat()),
+                    strokeWidth = strokeWidth,
+                    cap = StrokeCap.Round,
+                )
+            }
+        }
+    }
+
+    /** Whether a point (content coordinates) is within `radius` of an element — eraser hit test. */
+    fun hitTest(el: NotebookDrawEl, point: Offset, radius: Double): Boolean {
+        fun distToSegment(p: Offset, ax: Double, ay: Double, bx: Double, by: Double): Double {
+            val dx = bx - ax
+            val dy = by - ay
+            val lengthSq = dx * dx + dy * dy
+            if (lengthSq == 0.0) return hypot(p.x - ax, p.y - ay)
+            val t = (((p.x - ax) * dx + (p.y - ay) * dy) / lengthSq).coerceIn(0.0, 1.0)
+            return hypot(p.x - (ax + t * dx), p.y - (ay + t * dy))
+        }
+        val r = radius + el.width / 2
+        return when (el) {
+            is NotebookDrawEl.StrokeEl -> {
+                if (el.pts.size == 1) return hypot((point.x - el.pts[0].x).toDouble(), (point.y - el.pts[0].y).toDouble()) <= r
+                el.pts.zipWithNext().any { (a, b) ->
+                    distToSegment(point, a.x.toDouble(), a.y.toDouble(), b.x.toDouble(), b.y.toDouble()) <= r
+                }
+            }
+            is NotebookDrawEl.LineEl -> distToSegment(point, el.x1, el.y1, el.x2, el.y2) <= r
+            is NotebookDrawEl.RectEl -> {
+                val corners = listOf(
+                    el.x to el.y, (el.x + el.w) to el.y,
+                    (el.x + el.w) to (el.y + el.h), el.x to (el.y + el.h),
+                )
+                (0 until 4).any { i ->
+                    val (ax, ay) = corners[i]
+                    val (bx, by) = corners[(i + 1) % 4]
+                    distToSegment(point, ax, ay, bx, by) <= r
+                }
+            }
+            is NotebookDrawEl.CircleEl -> {
+                if (el.rx <= 0 || el.ry <= 0) return false
+                val nx = (point.x - el.cx) / el.rx
+                val ny = (point.y - el.cy) / el.ry
+                abs(hypot(nx, ny) - 1) * min(el.rx, el.ry) <= r
+            }
+            is NotebookDrawEl.TriangleEl -> {
+                val pts = listOf(el.x1 to el.y1, el.x2 to el.y2, el.x3 to el.y3)
+                (0 until 3).any { i ->
+                    val (ax, ay) = pts[i]
+                    val (bx, by) = pts[(i + 1) % 3]
+                    distToSegment(point, ax, ay, bx, by) <= r
+                }
+            }
+        }
+    }
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/notebook/NotebookMarkdown.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/notebook/NotebookMarkdown.kt
@@ -1,0 +1,392 @@
+package com.lextures.android.core.notebook
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import java.util.UUID
+
+/** A task parsed from a ```task fenced block (parity with web `notebook-task-markdown`). */
+data class ParsedNotebookTask(
+    val id: String,
+    val text: String,
+    val checked: Boolean,
+    val dueAt: String?,
+)
+
+/** One slash-command / toolbar insert action (parity with web `markdown-body-slash`). */
+data class NotebookSlashCommand(
+    val id: String,
+    val label: String,
+    val detail: String,
+    val keywords: List<String>,
+)
+
+/** Renderable markdown block for the notebook reading view. */
+sealed interface NotebookBlock {
+    data class Heading(val level: Int, val text: String) : NotebookBlock
+    data class Paragraph(val text: String) : NotebookBlock
+    data class BulletItem(val text: String) : NotebookBlock
+    data class OrderedItem(val number: String, val text: String) : NotebookBlock
+    data class Quote(val text: String) : NotebookBlock
+    data class Code(val text: String) : NotebookBlock
+    data object Divider : NotebookBlock
+    data class TaskBlock(val task: ParsedNotebookTask) : NotebookBlock
+    data class Image(val alt: String, val url: String) : NotebookBlock
+
+    /** [index] is the drawing's ordinal among all drawings on the page (for write-back). */
+    data class Drawing(val index: Int, val elementsJson: String) : NotebookBlock
+}
+
+/**
+ * One editable block in the WYSIWYG notebook editor (parity with the web block editor:
+ * blocks stay rendered while editing; markdown is only the storage format).
+ */
+data class NotebookEditBlock(
+    val id: String = UUID.randomUUID().toString(),
+    val kind: Kind,
+    val text: String = "",
+) {
+    sealed interface Kind {
+        data object Paragraph : Kind
+        data class Heading(val level: Int) : Kind
+        data object Bullet : Kind
+        data object Ordered : Kind
+        data object Quote : Kind
+        data object Code : Kind
+        data object Divider : Kind
+        data class Task(val taskId: String, val checked: Boolean, val dueAt: String?) : Kind
+        data class Image(val alt: String, val url: String) : Kind
+        data class Drawing(val elementsJson: String) : Kind
+    }
+
+    /** Whether the block carries user-editable text (false for divider / image / drawing). */
+    val isTextual: Boolean
+        get() = kind !is Kind.Divider && kind !is Kind.Image && kind !is Kind.Drawing
+}
+
+object NotebookMarkdown {
+    private val taskBlockRegex = Regex("```task[ \\t]*\\n([\\s\\S]*?)```")
+    private val orderedItemRegex = Regex("^(\\d+)[.)] (.*)$")
+    private val imageRegex = Regex("^!\\[([^\\]]*)]\\(([^)]+)\\)$")
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun newTaskId(): String = UUID.randomUUID().toString()
+
+    fun taskMetaLine(id: String, checked: Boolean, dueAt: String?): String {
+        val obj = buildJsonObject {
+            put("id", id)
+            put("checked", checked)
+            if (dueAt != null) put("dueAt", dueAt) else put("dueAt", JsonNull)
+        }
+        return json.encodeToString(JsonObject.serializer(), obj)
+    }
+
+    private fun parseTaskMeta(line: String): Triple<String, Boolean, String?>? {
+        val obj = runCatching { json.parseToJsonElement(line) as? JsonObject }.getOrNull() ?: return null
+        val id = (obj["id"] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotEmpty() } ?: return null
+        val checked = (obj["checked"] as? JsonPrimitive)?.contentOrNull == "true"
+        val dueAt = (obj["dueAt"] as? JsonPrimitive)?.takeIf { it.isString }?.contentOrNull
+        return Triple(id, checked, dueAt)
+    }
+
+    private fun parseTaskInner(inner: String): ParsedNotebookTask? {
+        val lines = inner.split("\n")
+        val (id, checked, dueAt) = parseTaskMeta(lines.firstOrNull().orEmpty()) ?: return null
+        val text = lines.drop(1).joinToString("\n").trim()
+        return ParsedNotebookTask(id = id, text = text, checked = checked, dueAt = dueAt)
+    }
+
+    fun parseTasks(contentMd: String): List<ParsedNotebookTask> =
+        taskBlockRegex.findAll(contentMd).mapNotNull { parseTaskInner(it.groupValues[1]) }.toList()
+
+    private fun rewriteTask(
+        contentMd: String,
+        taskId: String,
+        transform: (ParsedNotebookTask) -> Pair<Boolean, String?>,
+    ): String = taskBlockRegex.replace(contentMd) { match ->
+        val inner = match.groupValues[1]
+        val task = parseTaskInner(inner)
+        if (task == null || task.id != taskId) {
+            match.value
+        } else {
+            val (checked, dueAt) = transform(task)
+            val body = inner.split("\n").drop(1).joinToString("\n").trim()
+            "```task\n${taskMetaLine(task.id, checked, dueAt)}\n$body\n```"
+        }
+    }
+
+    fun setTaskChecked(contentMd: String, taskId: String, checked: Boolean): String =
+        rewriteTask(contentMd, taskId) { checked to it.dueAt }
+
+    fun setTaskDueAt(contentMd: String, taskId: String, dueAt: String?): String =
+        rewriteTask(contentMd, taskId) { it.checked to dueAt }
+
+    // Block parsing (reading view)
+
+    fun parseBlocks(contentMd: String): List<NotebookBlock> {
+        val blocks = mutableListOf<NotebookBlock>()
+        val paragraph = mutableListOf<String>()
+        val quote = mutableListOf<String>()
+
+        fun flushParagraph() {
+            if (paragraph.isNotEmpty()) {
+                blocks.add(NotebookBlock.Paragraph(paragraph.joinToString("\n")))
+                paragraph.clear()
+            }
+        }
+        fun flushQuote() {
+            if (quote.isNotEmpty()) {
+                blocks.add(NotebookBlock.Quote(quote.joinToString("\n")))
+                quote.clear()
+            }
+        }
+        fun flushAll() {
+            flushParagraph()
+            flushQuote()
+        }
+
+        val lines = contentMd.replace("\r\n", "\n").split("\n")
+        var i = 0
+        var drawingIndex = 0
+        while (i < lines.size) {
+            val trimmed = lines[i].trim()
+            when {
+                trimmed.startsWith("```drawing") -> {
+                    flushAll()
+                    val inner = mutableListOf<String>()
+                    i++
+                    while (i < lines.size && lines[i].trim() != "```") {
+                        inner.add(lines[i])
+                        i++
+                    }
+                    blocks.add(NotebookBlock.Drawing(index = drawingIndex, elementsJson = inner.joinToString("\n").trim()))
+                    drawingIndex++
+                }
+                trimmed.startsWith("```task") -> {
+                    flushAll()
+                    val inner = mutableListOf<String>()
+                    i++
+                    while (i < lines.size && lines[i].trim() != "```") {
+                        inner.add(lines[i])
+                        i++
+                    }
+                    parseTaskInner(inner.joinToString("\n"))?.let { blocks.add(NotebookBlock.TaskBlock(it)) }
+                }
+                trimmed.startsWith("```") -> {
+                    flushAll()
+                    val inner = mutableListOf<String>()
+                    i++
+                    while (i < lines.size && !lines[i].trim().startsWith("```")) {
+                        inner.add(lines[i])
+                        i++
+                    }
+                    blocks.add(NotebookBlock.Code(inner.joinToString("\n")))
+                }
+                parseHeading(trimmed) != null -> {
+                    flushAll()
+                    blocks.add(parseHeading(trimmed)!!)
+                }
+                trimmed == "---" || trimmed == "***" || trimmed == "___" -> {
+                    flushAll()
+                    blocks.add(NotebookBlock.Divider)
+                }
+                imageRegex.matches(trimmed) -> {
+                    flushAll()
+                    val match = imageRegex.find(trimmed)!!
+                    blocks.add(NotebookBlock.Image(alt = match.groupValues[1], url = match.groupValues[2]))
+                }
+                trimmed.startsWith("- ") || trimmed.startsWith("* ") -> {
+                    flushAll()
+                    blocks.add(NotebookBlock.BulletItem(trimmed.drop(2)))
+                }
+                orderedItemRegex.matches(trimmed) -> {
+                    flushAll()
+                    val match = orderedItemRegex.find(trimmed)!!
+                    blocks.add(NotebookBlock.OrderedItem(number = match.groupValues[1], text = match.groupValues[2]))
+                }
+                trimmed.startsWith(">") -> {
+                    flushParagraph()
+                    quote.add(trimmed.drop(1).trim())
+                }
+                trimmed.isEmpty() -> flushAll()
+                else -> {
+                    flushQuote()
+                    paragraph.add(trimmed)
+                }
+            }
+            i++
+        }
+        flushAll()
+        return blocks
+    }
+
+    private fun parseHeading(line: String): NotebookBlock.Heading? {
+        if (!line.startsWith("#")) return null
+        val hashes = line.takeWhile { it == '#' }
+        if (hashes.length > 6) return null
+        val rest = line.drop(hashes.length)
+        if (!rest.startsWith(" ")) return null
+        return NotebookBlock.Heading(level = hashes.length, text = rest.trim())
+    }
+
+    // Edit blocks (WYSIWYG editor, parity with web block editor)
+
+    fun editBlocks(contentMd: String): List<NotebookEditBlock> {
+        val out = mutableListOf<NotebookEditBlock>()
+        for (block in parseBlocks(contentMd)) {
+            when (block) {
+                is NotebookBlock.Heading ->
+                    out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Heading(block.level), text = block.text))
+                is NotebookBlock.Paragraph ->
+                    block.text.split("\n").forEach {
+                        out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Paragraph, text = it))
+                    }
+                is NotebookBlock.BulletItem ->
+                    out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Bullet, text = block.text))
+                is NotebookBlock.OrderedItem ->
+                    out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Ordered, text = block.text))
+                is NotebookBlock.Quote ->
+                    block.text.split("\n").forEach {
+                        out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Quote, text = it))
+                    }
+                is NotebookBlock.Code ->
+                    out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Code, text = block.text))
+                NotebookBlock.Divider ->
+                    out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Divider))
+                is NotebookBlock.TaskBlock ->
+                    out.add(
+                        NotebookEditBlock(
+                            kind = NotebookEditBlock.Kind.Task(block.task.id, block.task.checked, block.task.dueAt),
+                            text = block.task.text,
+                        ),
+                    )
+                is NotebookBlock.Image ->
+                    out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Image(block.alt, block.url)))
+                is NotebookBlock.Drawing ->
+                    out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Drawing(block.elementsJson)))
+            }
+        }
+        if (out.isEmpty()) out.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Paragraph))
+        return out
+    }
+
+    /** Consecutive items of the same list/quote kind join with one newline, not a blank line. */
+    private fun sameListRun(a: NotebookEditBlock.Kind, b: NotebookEditBlock.Kind?): Boolean = when {
+        a is NotebookEditBlock.Kind.Bullet && b is NotebookEditBlock.Kind.Bullet -> true
+        a is NotebookEditBlock.Kind.Ordered && b is NotebookEditBlock.Kind.Ordered -> true
+        a is NotebookEditBlock.Kind.Quote && b is NotebookEditBlock.Kind.Quote -> true
+        else -> false
+    }
+
+    fun markdownFromBlocks(blocks: List<NotebookEditBlock>): String {
+        val out = StringBuilder()
+        var previous: NotebookEditBlock.Kind? = null
+        var orderedRun = 0
+
+        for (block in blocks) {
+            val chunk = when (val kind = block.kind) {
+                NotebookEditBlock.Kind.Paragraph -> {
+                    if (block.text.isBlank()) continue
+                    block.text
+                }
+                is NotebookEditBlock.Kind.Heading -> "#".repeat(kind.level.coerceIn(1, 6)) + " " + block.text
+                NotebookEditBlock.Kind.Bullet -> "- ${block.text}"
+                NotebookEditBlock.Kind.Ordered -> {
+                    orderedRun = if (previous is NotebookEditBlock.Kind.Ordered) orderedRun + 1 else 1
+                    "$orderedRun. ${block.text}"
+                }
+                NotebookEditBlock.Kind.Quote -> "> ${block.text}"
+                NotebookEditBlock.Kind.Code -> "```\n${block.text}\n```"
+                NotebookEditBlock.Kind.Divider -> "---"
+                is NotebookEditBlock.Kind.Task ->
+                    "```task\n${taskMetaLine(kind.taskId, kind.checked, kind.dueAt)}\n${block.text}\n```"
+                is NotebookEditBlock.Kind.Image -> "![${kind.alt}](${kind.url})"
+                is NotebookEditBlock.Kind.Drawing -> "```drawing\n${kind.elementsJson}\n```"
+            }
+            when {
+                out.isEmpty() -> out.append(chunk)
+                sameListRun(block.kind, previous) -> out.append("\n").append(chunk)
+                else -> out.append("\n\n").append(chunk)
+            }
+            previous = block.kind
+        }
+        return out.toString()
+    }
+
+    /** Replace the elements JSON of the page's Nth drawing fence (0-based, document order). */
+    fun replaceDrawing(contentMd: String, index: Int, elementsJson: String): String {
+        val out = mutableListOf<String>()
+        var current = -1
+        val lines = contentMd.replace("\r\n", "\n").split("\n")
+        var i = 0
+        while (i < lines.size) {
+            val trimmed = lines[i].trim()
+            if (trimmed.startsWith("```drawing")) {
+                current++
+                val inner = mutableListOf<String>()
+                i++
+                while (i < lines.size && lines[i].trim() != "```") {
+                    inner.add(lines[i])
+                    i++
+                }
+                i++
+                val body = if (current == index) elementsJson else inner.joinToString("\n").trim()
+                out.add("```drawing\n$body\n```")
+            } else {
+                out.add(lines[i])
+                i++
+            }
+        }
+        return out.joinToString("\n")
+    }
+
+    // Slash commands
+
+    val slashCommands: List<NotebookSlashCommand> = listOf(
+        NotebookSlashCommand("heading1", "Heading 1", "Large section heading", listOf("h1", "title", "heading")),
+        NotebookSlashCommand("heading2", "Heading 2", "Medium section heading", listOf("h2", "heading")),
+        NotebookSlashCommand("heading3", "Heading 3", "Small section heading", listOf("h3", "heading")),
+        NotebookSlashCommand("task", "Task", "Checkbox task with optional due date", listOf("task", "todo", "checkbox", "checklist")),
+        NotebookSlashCommand("drawing", "Drawing", "Insert a whiteboard to draw on", listOf("drawing", "whiteboard", "sketch", "draw", "canvas")),
+        NotebookSlashCommand("bulletList", "Bullet list", "Unordered list", listOf("ul", "list", "bullets")),
+        NotebookSlashCommand("orderedList", "Numbered list", "Ordered list", listOf("ol", "list", "numbers")),
+        NotebookSlashCommand("blockquote", "Quote", "Indented quotation", listOf("quote", "blockquote")),
+        NotebookSlashCommand("codeBlock", "Code", "Code block", listOf("code", "pre", "snippet")),
+        NotebookSlashCommand("horizontalRule", "Divider", "Horizontal line", listOf("hr", "divider", "line", "rule")),
+    )
+
+    fun filterCommands(query: String): List<NotebookSlashCommand> {
+        val q = query.trim().lowercase()
+        if (q.isEmpty()) return slashCommands
+        return slashCommands.filter { cmd ->
+            val cmdId = cmd.id.lowercase()
+            cmdId == q || cmdId.startsWith(q) || q.startsWith(cmdId) ||
+                cmd.label.lowercase().contains(q) || cmd.detail.lowercase().contains(q) ||
+                cmd.keywords.any { kw ->
+                    kw == q || (kw.length >= 2 && q.length >= 2 && (kw.startsWith(q) || q.startsWith(kw)))
+                }
+        }
+    }
+
+    /** Human-readable preview: strips fences and task meta lines so cards never show raw JSON. */
+    fun previewText(contentMd: String): String =
+        parseBlocks(contentMd).mapNotNull { block ->
+            when (block) {
+                is NotebookBlock.Heading -> block.text
+                is NotebookBlock.Paragraph -> block.text
+                is NotebookBlock.BulletItem -> block.text
+                is NotebookBlock.OrderedItem -> block.text
+                is NotebookBlock.Quote -> block.text
+                is NotebookBlock.Code -> block.text
+                is NotebookBlock.TaskBlock -> block.task.text
+                is NotebookBlock.Image -> block.alt
+                is NotebookBlock.Drawing -> "Drawing"
+                NotebookBlock.Divider -> null
+            }.takeIf { !it.isNullOrBlank() }
+        }.joinToString(" · ").trim()
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/notebook/NotebookStore.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/notebook/NotebookStore.kt
@@ -75,6 +75,18 @@ class NotebookStore(context: Context, accessToken: String?) {
         writeAll(all)
     }
 
+    fun exists(courseCode: String): Boolean = readAll().containsKey(courseCode)
+
+    /** Every stored course code, including the global key. */
+    fun allCourseCodes(): List<String> = readAll().keys.toList()
+
+    /** Write a server copy verbatim — keeps the server `updatedAt` so last-write-wins stays stable. */
+    fun saveFromServer(courseCode: String, notebook: CourseNotebook) {
+        val all = readAll().toMutableMap()
+        all[courseCode] = notebook
+        writeAll(all)
+    }
+
     /** Course-scoped notebooks with content (excludes the global key). */
     fun listCourseNotebooks(): Map<String, CourseNotebook> =
         readAll().filter { (key, notebook) -> key != GLOBAL_KEY && notebook.previewText.isNotEmpty() }

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/notebook/NotebookSync.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/notebook/NotebookSync.kt
@@ -1,0 +1,57 @@
+package com.lextures.android.core.notebook
+
+import com.lextures.android.core.lms.NotebooksApi
+import java.time.Instant
+import java.time.OffsetDateTime
+
+/**
+ * Server sync for student notebooks — last-write-wins by `updatedAt`, parity with web
+ * `student-notebook-sync`. Device storage stays the editor's source of truth; sync runs
+ * fire-and-forget around it.
+ */
+object NotebookSync {
+    /**
+     * Pull all server notebooks and merge into the device store. Server copy wins when newer;
+     * local copies that are newer or missing on the server are pushed back.
+     * Returns true when any local notebook changed.
+     */
+    suspend fun pull(store: NotebookStore, accessToken: String?): Boolean {
+        if (accessToken.isNullOrBlank()) return false
+        val entries = runCatching { NotebooksApi.fetchAll(accessToken) }.getOrNull() ?: return false
+
+        var changed = false
+        val serverCodes = mutableSetOf<String>()
+        for (entry in entries) {
+            val server = entry.data ?: continue
+            serverCodes.add(entry.courseCode)
+            if (!store.exists(entry.courseCode)) {
+                store.saveFromServer(entry.courseCode, server)
+                changed = true
+                continue
+            }
+            val local = store.load(entry.courseCode)
+            val serverTime = parseIso(entry.updatedAt)
+            val localTime = parseIso(local.updatedAt)
+            if (serverTime > localTime) {
+                store.saveFromServer(entry.courseCode, server)
+                changed = true
+            } else if (localTime > serverTime) {
+                push(store, entry.courseCode, accessToken)
+            }
+        }
+        for (code in store.allCourseCodes()) {
+            if (code !in serverCodes) push(store, code, accessToken)
+        }
+        return changed
+    }
+
+    /** Push one notebook to the server, swallowing transport errors (next save retries). */
+    suspend fun push(store: NotebookStore, courseCode: String, accessToken: String?) {
+        if (accessToken.isNullOrBlank()) return
+        val notebook = store.load(courseCode)
+        runCatching { NotebooksApi.put(courseCode, notebook, accessToken) }
+    }
+
+    private fun parseIso(value: String): Instant =
+        runCatching { OffsetDateTime.parse(value).toInstant() }.getOrElse { Instant.EPOCH }
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/notebook/NotebookTree.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/notebook/NotebookTree.kt
@@ -1,0 +1,108 @@
+package com.lextures.android.core.notebook
+
+import java.util.UUID
+
+/** Page-tree helpers over the flat [NotebookPage] list (parity with web `course-notebook-tree`). */
+object NotebookTree {
+    data class FlatRow(val page: NotebookPage, val depth: Int)
+
+    fun isGroup(page: NotebookPage): Boolean = page.kind == "group"
+
+    fun sortedChildren(pages: List<NotebookPage>, parentId: String?): List<NotebookPage> =
+        pages.filter { it.parentId == parentId }.sortedWith(compareBy({ it.sortOrder }, { it.id }))
+
+    /** Depth-first flattening for list rendering (groups followed by their children). */
+    fun flatten(pages: List<NotebookPage>): List<FlatRow> {
+        val rows = mutableListOf<FlatRow>()
+        fun walk(parentId: String?, depth: Int) {
+            for (page in sortedChildren(pages, parentId)) {
+                rows.add(FlatRow(page, depth))
+                walk(page.id, depth + 1)
+            }
+        }
+        walk(null, 0)
+        return rows
+    }
+
+    /** True if [targetId] is [ancestorId] or nested under it. */
+    fun isUnderAncestor(pages: List<NotebookPage>, ancestorId: String, targetId: String): Boolean {
+        val map = pages.associateBy { it.id }
+        var cur: String? = targetId
+        while (cur != null) {
+            if (cur == ancestorId) return true
+            cur = map[cur]?.parentId
+        }
+        return false
+    }
+
+    private fun nextSortOrder(pages: List<NotebookPage>, parentId: String?): Int =
+        (sortedChildren(pages, parentId).maxOfOrNull { it.sortOrder } ?: -1) + 1
+
+    fun addPage(pages: List<NotebookPage>, parentId: String?, title: String = "Untitled"): Pair<List<NotebookPage>, String> {
+        val page = NotebookPage(
+            id = UUID.randomUUID().toString(),
+            title = title,
+            parentId = parentId,
+            sortOrder = nextSortOrder(pages, parentId),
+        )
+        return (pages + page) to page.id
+    }
+
+    fun addGroup(pages: List<NotebookPage>, parentId: String?, title: String = "Untitled group"): Pair<List<NotebookPage>, String> {
+        val group = NotebookPage(
+            id = UUID.randomUUID().toString(),
+            title = title,
+            parentId = parentId,
+            sortOrder = nextSortOrder(pages, parentId),
+            kind = "group",
+        )
+        return (pages + group) to group.id
+    }
+
+    /** Delete a page or group along with all descendants. */
+    fun delete(pages: List<NotebookPage>, pageId: String): List<NotebookPage> {
+        val toRemove = mutableSetOf<String>()
+        fun walk(id: String) {
+            toRemove.add(id)
+            pages.filter { it.parentId == id }.forEach { walk(it.id) }
+        }
+        walk(pageId)
+        return pages.filterNot { it.id in toRemove }
+    }
+
+    fun rename(pages: List<NotebookPage>, pageId: String, title: String): List<NotebookPage> =
+        pages.map { if (it.id == pageId) it.copy(title = title) else it }
+
+    fun updateContent(pages: List<NotebookPage>, pageId: String, contentMd: String): List<NotebookPage> =
+        pages.map { if (it.id == pageId) it.copy(contentMd = contentMd) else it }
+
+    /** Move a page or group under [newParentId] (null = top level), appended last. Null on invalid move. */
+    fun moveToParent(pages: List<NotebookPage>, pageId: String, newParentId: String?): List<NotebookPage>? {
+        if (pageId == newParentId) return null
+        if (newParentId != null && isUnderAncestor(pages, ancestorId = pageId, targetId = newParentId)) return null
+        if (pages.none { it.id == pageId }) return null
+        val order = nextSortOrder(pages, newParentId)
+        return pages.map {
+            if (it.id == pageId) it.copy(parentId = newParentId, sortOrder = order) else it
+        }
+    }
+
+    /** Groups the page can be moved into (excludes self and own descendants). */
+    fun groupMoveTargets(pages: List<NotebookPage>, pageId: String): List<NotebookPage> =
+        pages
+            .filter { isGroup(it) && it.id != pageId }
+            .filterNot { isUnderAncestor(pages, ancestorId = pageId, targetId = it.id) }
+            .sortedBy { pathLabel(pages, it.id) }
+
+    fun pathLabel(pages: List<NotebookPage>, pageId: String): String {
+        val map = pages.associateBy { it.id }
+        val parts = mutableListOf<String>()
+        var cur: String? = pageId
+        while (cur != null) {
+            val row = map[cur] ?: break
+            parts.add(0, row.title.ifBlank { "Untitled" })
+            cur = row.parentId
+        }
+        return parts.joinToString(" / ")
+    }
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/notebooks/NotebookContentView.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/notebooks/NotebookContentView.kt
@@ -1,0 +1,353 @@
+package com.lextures.android.features.notebooks
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.CheckBox
+import androidx.compose.material.icons.filled.CheckBoxOutlineBlank
+import androidx.compose.material.icons.filled.Draw
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.lextures.android.core.design.LexturesColors
+import com.lextures.android.core.design.LexturesType
+import com.lextures.android.core.design.accentColor
+import com.lextures.android.core.design.cardBackground
+import com.lextures.android.core.design.fieldBorder
+import com.lextures.android.core.design.isDarkTheme
+import com.lextures.android.core.design.sceneBackground
+import com.lextures.android.core.design.textPrimary
+import com.lextures.android.core.design.textSecondary
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.lextures.android.core.config.AppConfiguration
+import com.lextures.android.core.lms.LmsDates
+import com.lextures.android.core.notebook.NotebookBlock
+import com.lextures.android.core.notebook.NotebookDrawing
+import com.lextures.android.core.notebook.NotebookMarkdown
+import com.lextures.android.core.notebook.ParsedNotebookTask
+import java.time.Instant
+
+/**
+ * Rendered reading view for a notebook page: headings, lists, quotes, code,
+ * and interactive task checkboxes (parity with the web notebook editor output).
+ */
+@Composable
+fun NotebookContentView(
+    markdown: String,
+    onToggleTask: (ParsedNotebookTask) -> Unit,
+    onEditTaskDue: (ParsedNotebookTask) -> Unit,
+    modifier: Modifier = Modifier,
+    accessToken: String? = null,
+    onEditDrawing: ((index: Int, elementsJson: String) -> Unit)? = null,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        NotebookMarkdown.parseBlocks(markdown).forEach { block ->
+            when (block) {
+                is NotebookBlock.Heading -> Text(
+                    text = inlineMarkdown(block.text),
+                    style = LexturesType.display(if (block.level == 1) 24 else if (block.level == 2) 19 else 16),
+                    color = textPrimary(),
+                    modifier = Modifier.padding(top = if (block.level == 1) 6.dp else 2.dp),
+                )
+
+                is NotebookBlock.Paragraph -> Text(
+                    text = inlineMarkdown(block.text),
+                    fontSize = 14.sp,
+                    lineHeight = 21.sp,
+                    color = textPrimary(),
+                )
+
+                is NotebookBlock.BulletItem -> Row(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    modifier = Modifier.padding(start = 4.dp),
+                ) {
+                    Box(
+                        Modifier
+                            .padding(top = 8.dp)
+                            .size(5.dp)
+                            .clip(CircleShape)
+                            .background(accentColor()),
+                    )
+                    Text(text = inlineMarkdown(block.text), fontSize = 14.sp, color = textPrimary())
+                }
+
+                is NotebookBlock.OrderedItem -> Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.padding(start = 4.dp),
+                ) {
+                    Text(
+                        text = "${block.number}.",
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = accentColor(),
+                    )
+                    Text(text = inlineMarkdown(block.text), fontSize = 14.sp, color = textPrimary())
+                }
+
+                is NotebookBlock.Quote -> Row(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    modifier = Modifier.padding(vertical = 2.dp),
+                ) {
+                    Box(
+                        Modifier
+                            .width(3.dp)
+                            .height(24.dp)
+                            .clip(RoundedCornerShape(2.dp))
+                            .background(LexturesColors.BrandAmber),
+                    )
+                    Text(
+                        text = inlineMarkdown(block.text),
+                        fontSize = 14.sp,
+                        fontStyle = FontStyle.Italic,
+                        color = textSecondary(),
+                    )
+                }
+
+                is NotebookBlock.Code -> Text(
+                    text = block.text,
+                    fontSize = 12.sp,
+                    fontFamily = FontFamily.Monospace,
+                    color = textPrimary(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(if (isDarkTheme()) sceneBackground() else LexturesColors.SceneBackground)
+                        .border(1.dp, fieldBorder(), RoundedCornerShape(10.dp))
+                        .padding(12.dp),
+                )
+
+                NotebookBlock.Divider -> Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp)
+                        .height(1.dp)
+                        .background(fieldBorder()),
+                )
+
+                is NotebookBlock.TaskBlock -> NotebookTaskRow(
+                    task = block.task,
+                    onToggle = { onToggleTask(block.task) },
+                    onEditDue = { onEditTaskDue(block.task) },
+                )
+
+                is NotebookBlock.Image -> AuthorizedNotebookImage(
+                    url = block.url,
+                    alt = block.alt,
+                    accessToken = accessToken,
+                )
+
+                is NotebookBlock.Drawing -> NotebookDrawingBlock(
+                    elementsJson = block.elementsJson,
+                    onClick = { onEditDrawing?.invoke(block.index, block.elementsJson) },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Notebook image loader. Web stores relative course-file paths (`/api/v1/...`) that need the
+ * bearer token (parity with web's authorized blob fetch).
+ */
+@Composable
+private fun AuthorizedNotebookImage(url: String, alt: String, accessToken: String?) {
+    val context = LocalContext.current
+    val resolved = when {
+        url.startsWith("/") -> AppConfiguration.apiUrl(url).toString()
+        url.startsWith("http://") || url.startsWith("https://") -> url
+        else -> null
+    }
+    if (resolved == null) {
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.Image, contentDescription = null, tint = textSecondary(), modifier = Modifier.size(16.dp))
+            Text(text = alt.ifBlank { "Image" }, fontSize = 12.sp, color = textSecondary())
+        }
+        return
+    }
+    AsyncImage(
+        model = ImageRequest.Builder(context)
+            .data(resolved)
+            .apply { if (!accessToken.isNullOrBlank()) setHeader("Authorization", "Bearer $accessToken") }
+            .build(),
+        contentDescription = alt.ifBlank { "Image" },
+        contentScale = ContentScale.FillWidth,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp)),
+    )
+}
+
+/** Rendered whiteboard drawing in the reading view; tap to edit. */
+@Composable
+private fun NotebookDrawingBlock(elementsJson: String, onClick: () -> Unit) {
+    val elements = remember(elementsJson) { NotebookDrawing.parseElements(elementsJson) }
+    val content = remember(elementsJson) { NotebookDrawing.contentSize(elements) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(content.width / content.height)
+            .clip(RoundedCornerShape(12.dp))
+            .background(if (isDarkTheme()) Color(0xFF1F1F1F) else Color.White)
+            .border(1.dp, fieldBorder(), RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick),
+    ) {
+        Canvas(modifier = Modifier.matchParentSize()) {
+            val scale = minOf(size.width / content.width, 1f)
+            with(NotebookDrawing) { drawElements(elements, scale) }
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(8.dp)
+                .clip(RoundedCornerShape(50))
+                .background(sceneBackground().copy(alpha = 0.85f))
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+        ) {
+            Icon(Icons.Default.Draw, contentDescription = null, tint = textSecondary(), modifier = Modifier.size(12.dp))
+            Text(
+                text = if (elements.isEmpty()) "Tap to draw" else "Edit drawing",
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Medium,
+                color = textSecondary(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun NotebookTaskRow(
+    task: ParsedNotebookTask,
+    onToggle: () -> Unit,
+    onEditDue: () -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(cardBackground())
+            .border(1.dp, fieldBorder(), RoundedCornerShape(12.dp))
+            .padding(10.dp),
+    ) {
+        Icon(
+            imageVector = if (task.checked) Icons.Default.CheckBox else Icons.Default.CheckBoxOutlineBlank,
+            contentDescription = if (task.checked) "Mark task incomplete" else "Mark task complete",
+            tint = if (task.checked) accentColor() else textSecondary(),
+            modifier = Modifier
+                .size(22.dp)
+                .clickable(onClick = onToggle),
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            Text(
+                text = inlineMarkdown(task.text.ifBlank { "Untitled task" }),
+                fontSize = 14.sp,
+                color = if (task.checked) textSecondary() else textPrimary(),
+                textDecoration = if (task.checked) TextDecoration.LineThrough else TextDecoration.None,
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.clickable(onClick = onEditDue),
+            ) {
+                val overdue = task.dueAt != null && !task.checked && isPastDue(task.dueAt)
+                val dueColor = when {
+                    overdue -> LexturesColors.Coral
+                    task.dueAt != null -> textSecondary()
+                    else -> textSecondary().copy(alpha = 0.8f)
+                }
+                Icon(Icons.Default.CalendarMonth, contentDescription = "Edit due date", tint = dueColor, modifier = Modifier.size(13.dp))
+                Text(
+                    text = task.dueAt?.let { "Due ${LmsDates.shortDate(it)}" } ?: "Add due date",
+                    fontSize = 12.sp,
+                    color = dueColor,
+                )
+            }
+        }
+        Spacer(Modifier.weight(1f))
+    }
+}
+
+private fun isPastDue(dueAt: String): Boolean =
+    runCatching { Instant.parse(dueAt).isBefore(Instant.now()) }.getOrDefault(false)
+
+/** Minimal inline markdown: **bold**, *italic*, `code`. */
+fun inlineMarkdown(raw: String): AnnotatedString = buildAnnotatedString {
+    var i = 0
+    while (i < raw.length) {
+        when {
+            raw.startsWith("**", i) -> {
+                val end = raw.indexOf("**", i + 2)
+                if (end > i + 1) {
+                    pushStyle(SpanStyle(fontWeight = FontWeight.Bold))
+                    append(raw.substring(i + 2, end))
+                    pop()
+                    i = end + 2
+                } else {
+                    append(raw[i]); i++
+                }
+            }
+            raw.startsWith("*", i) && !raw.startsWith("**", i) -> {
+                val end = raw.indexOf('*', i + 1)
+                if (end > i) {
+                    pushStyle(SpanStyle(fontStyle = FontStyle.Italic))
+                    append(raw.substring(i + 1, end))
+                    pop()
+                    i = end + 1
+                } else {
+                    append(raw[i]); i++
+                }
+            }
+            raw.startsWith("`", i) -> {
+                val end = raw.indexOf('`', i + 1)
+                if (end > i) {
+                    pushStyle(SpanStyle(fontFamily = FontFamily.Monospace, fontSize = 13.sp))
+                    append(raw.substring(i + 1, end))
+                    pop()
+                    i = end + 1
+                } else {
+                    append(raw[i]); i++
+                }
+            }
+            else -> {
+                append(raw[i]); i++
+            }
+        }
+    }
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/notebooks/NotebookDrawingEditor.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/notebooks/NotebookDrawingEditor.kt
@@ -1,0 +1,314 @@
+package com.lextures.android.features.notebooks
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Undo
+import androidx.compose.material.icons.filled.ChangeHistory
+import androidx.compose.material.icons.outlined.Circle
+import androidx.compose.material.icons.filled.CleaningServices
+import androidx.compose.material.icons.filled.CropSquare
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Draw
+import androidx.compose.material.icons.filled.HorizontalRule
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import com.lextures.android.core.design.LexturesType
+import com.lextures.android.core.design.accentColor
+import com.lextures.android.core.design.cardBackground
+import com.lextures.android.core.design.fieldBorder
+import com.lextures.android.core.design.isDarkTheme
+import com.lextures.android.core.design.sceneBackground
+import com.lextures.android.core.design.textPrimary
+import com.lextures.android.core.notebook.NotebookDrawEl
+import com.lextures.android.core.notebook.NotebookDrawing
+import com.lextures.android.core.notebook.NotebookDrawing.drawElements
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+private enum class DrawTool(val icon: ImageVector) {
+    PEN(Icons.Default.Draw),
+    LINE(Icons.Default.HorizontalRule),
+    RECT(Icons.Default.CropSquare),
+    CIRCLE(Icons.Outlined.Circle),
+    TRIANGLE(Icons.Default.ChangeHistory),
+    ERASER(Icons.Default.CleaningServices),
+}
+
+/**
+ * Full-screen whiteboard editor: pen / line / rect / circle / triangle / eraser,
+ * the web palette and stroke widths, undo and clear (parity with web `/drawing`).
+ */
+@Composable
+fun NotebookDrawingEditor(
+    initialElementsJson: String,
+    onDismiss: () -> Unit,
+    onSave: (String) -> Unit,
+) {
+    var elements by remember { mutableStateOf(NotebookDrawing.parseElements(initialElementsJson)) }
+    var undoStack by remember { mutableStateOf(listOf<List<NotebookDrawEl>>()) }
+    var tool by remember { mutableStateOf(DrawTool.PEN) }
+    var color by remember { mutableStateOf(NotebookDrawing.colors[0]) }
+    var lineWidth by remember { mutableStateOf(NotebookDrawing.strokeWidths[1]) }
+    var draftElement by remember { mutableStateOf<NotebookDrawEl?>(null) }
+
+    fun pushUndo() {
+        undoStack = (undoStack + listOf(elements)).takeLast(50)
+    }
+
+    Dialog(onDismissRequest = onDismiss, properties = DialogProperties(usePlatformDefaultWidth = false)) {
+        Column(modifier = Modifier.fillMaxSize().background(sceneBackground())) {
+            // Header
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
+            ) {
+                TextButton(onClick = onDismiss) { Text("Cancel", color = textPrimary()) }
+                Spacer(Modifier.weight(1f))
+                Text("Drawing", style = LexturesType.display(17), color = textPrimary())
+                Spacer(Modifier.weight(1f))
+                TextButton(onClick = { onSave(NotebookDrawing.serializeElements(elements)) }) {
+                    Text("Save", color = accentColor(), fontWeight = FontWeight.SemiBold)
+                }
+            }
+
+            // Canvas
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(12.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(if (isDarkTheme()) Color(0xFF1F1F1F) else Color.White),
+            ) {
+                Canvas(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .pointerInput(tool, color, lineWidth) {
+                            val content = NotebookDrawing.contentSize(
+                                elements,
+                                minWidth = size.width.toFloat(),
+                                minHeight = size.height.toFloat(),
+                            )
+                            val scale = min(min(size.width / content.width, size.height / content.height), 1f)
+                            var dragAnchor: Offset? = null
+
+                            fun contentPoint(position: Offset) = Offset(position.x / scale, position.y / scale)
+
+                            detectDragGestures(
+                                onDragStart = { position ->
+                                    val point = contentPoint(position)
+                                    when (tool) {
+                                        DrawTool.ERASER -> {
+                                            val radius = max(lineWidth * 2, 12.0)
+                                            val next = elements.filterNot { NotebookDrawing.hitTest(it, point, radius) }
+                                            if (next.size != elements.size) {
+                                                pushUndo()
+                                                elements = next
+                                            }
+                                        }
+                                        DrawTool.PEN ->
+                                            draftElement = NotebookDrawEl.StrokeEl(color, lineWidth, listOf(point))
+                                        DrawTool.LINE ->
+                                            draftElement = NotebookDrawEl.LineEl(
+                                                color, lineWidth,
+                                                point.x.toDouble(), point.y.toDouble(), point.x.toDouble(), point.y.toDouble(),
+                                            )
+                                        DrawTool.RECT ->
+                                            draftElement = NotebookDrawEl.RectEl(
+                                                color, lineWidth, point.x.toDouble(), point.y.toDouble(), 0.0, 0.0,
+                                            )
+                                        DrawTool.CIRCLE ->
+                                            draftElement = NotebookDrawEl.CircleEl(
+                                                color, lineWidth, point.x.toDouble(), point.y.toDouble(), 0.0, 0.0,
+                                            )
+                                        DrawTool.TRIANGLE ->
+                                            draftElement = NotebookDrawEl.TriangleEl(
+                                                color, lineWidth,
+                                                point.x.toDouble(), point.y.toDouble(),
+                                                point.x.toDouble(), point.y.toDouble(),
+                                                point.x.toDouble(), point.y.toDouble(),
+                                            )
+                                    }
+                                    // Anchor for shape tools.
+                                    dragAnchor = point
+                                },
+                                onDrag = { change, _ ->
+                                    val point = contentPoint(change.position)
+                                    val start = dragAnchor ?: point
+                                    when (tool) {
+                                        DrawTool.ERASER -> {
+                                            val radius = max(lineWidth * 2, 12.0)
+                                            val next = elements.filterNot { NotebookDrawing.hitTest(it, point, radius) }
+                                            if (next.size != elements.size) {
+                                                pushUndo()
+                                                elements = next
+                                            }
+                                        }
+                                        DrawTool.PEN -> {
+                                            val stroke = draftElement as? NotebookDrawEl.StrokeEl ?: return@detectDragGestures
+                                            draftElement = stroke.copy(pts = stroke.pts + point)
+                                        }
+                                        DrawTool.LINE -> draftElement = NotebookDrawEl.LineEl(
+                                            color, lineWidth,
+                                            start.x.toDouble(), start.y.toDouble(), point.x.toDouble(), point.y.toDouble(),
+                                        )
+                                        DrawTool.RECT -> draftElement = NotebookDrawEl.RectEl(
+                                            color, lineWidth,
+                                            min(start.x, point.x).toDouble(), min(start.y, point.y).toDouble(),
+                                            abs(point.x - start.x).toDouble(), abs(point.y - start.y).toDouble(),
+                                        )
+                                        DrawTool.CIRCLE -> draftElement = NotebookDrawEl.CircleEl(
+                                            color, lineWidth,
+                                            ((start.x + point.x) / 2).toDouble(), ((start.y + point.y) / 2).toDouble(),
+                                            (abs(point.x - start.x) / 2).toDouble(), (abs(point.y - start.y) / 2).toDouble(),
+                                        )
+                                        DrawTool.TRIANGLE -> draftElement = NotebookDrawEl.TriangleEl(
+                                            color, lineWidth,
+                                            ((start.x + point.x) / 2).toDouble(), min(start.y, point.y).toDouble(),
+                                            start.x.toDouble(), max(start.y, point.y).toDouble(),
+                                            point.x.toDouble(), max(start.y, point.y).toDouble(),
+                                        )
+                                    }
+                                },
+                                onDragEnd = {
+                                    draftElement?.let {
+                                        pushUndo()
+                                        elements = elements + it
+                                    }
+                                    draftElement = null
+                                    dragAnchor = null
+                                },
+                                onDragCancel = {
+                                    draftElement = null
+                                    dragAnchor = null
+                                },
+                            )
+                        },
+                ) {
+                    val content = NotebookDrawing.contentSize(elements, minWidth = size.width, minHeight = size.height)
+                    val scale = min(min(size.width / content.width, size.height / content.height), 1f)
+                    drawElements(elements, scale)
+                    draftElement?.let { drawElements(listOf(it), scale) }
+                }
+            }
+
+            // Tools
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth().background(cardBackground()).padding(horizontal = 14.dp, vertical = 10.dp),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    DrawTool.entries.forEach { item ->
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier
+                                .size(36.dp)
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(if (tool == item) accentColor() else Color.Transparent)
+                                .clickable { tool = item },
+                        ) {
+                            Icon(
+                                item.icon,
+                                contentDescription = item.name.lowercase(),
+                                tint = if (tool == item) Color.White else textPrimary(),
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                    }
+                    Spacer(Modifier.weight(1f))
+                    IconButton(
+                        onClick = {
+                            undoStack.lastOrNull()?.let {
+                                elements = it
+                                undoStack = undoStack.dropLast(1)
+                            }
+                        },
+                        enabled = undoStack.isNotEmpty(),
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.Undo, contentDescription = "Undo", tint = textPrimary())
+                    }
+                    IconButton(
+                        onClick = {
+                            if (elements.isNotEmpty()) {
+                                pushUndo()
+                                elements = emptyList()
+                            }
+                        },
+                        enabled = elements.isNotEmpty(),
+                    ) {
+                        Icon(Icons.Default.Delete, contentDescription = "Clear", tint = textPrimary())
+                    }
+                }
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    NotebookDrawing.colors.forEach { hex ->
+                        Box(
+                            modifier = Modifier
+                                .size(24.dp)
+                                .clip(CircleShape)
+                                .background(NotebookDrawing.color(hex))
+                                .border(
+                                    width = if (color == hex) 2.5.dp else 1.dp,
+                                    color = if (color == hex) accentColor() else fieldBorder(),
+                                    shape = CircleShape,
+                                )
+                                .clickable { color = hex },
+                        )
+                    }
+                    Spacer(Modifier.weight(1f))
+                    NotebookDrawing.strokeWidths.forEach { w ->
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier
+                                .size(28.dp)
+                                .clip(CircleShape)
+                                .background(if (lineWidth == w) accentColor().copy(alpha = 0.18f) else Color.Transparent)
+                                .clickable { lineWidth = w },
+                        ) {
+                            Box(
+                                Modifier
+                                    .size((6 + w * 1.5).dp)
+                                    .clip(CircleShape)
+                                    .background(textPrimary()),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/notebooks/NotebookEditorScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/notebooks/NotebookEditorScreen.kt
@@ -8,50 +8,113 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.CheckBox
+import androidx.compose.material.icons.filled.CheckBoxOutlineBlank
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.font.FontStyle
+import com.lextures.android.core.design.isDarkTheme
+import com.lextures.android.core.design.sceneBackground
+import com.lextures.android.core.lms.LmsDates
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.FormatListBulleted
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.AddTask
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.CreateNewFolder
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Draw
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.FormatListNumbered
+import androidx.compose.material.icons.filled.FormatQuote
+import androidx.compose.material.icons.filled.HorizontalRule
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.UnfoldMore
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.lextures.android.core.design.LexturesColors
+import com.lextures.android.core.design.LexturesType
+import com.lextures.android.core.design.accentColor
 import com.lextures.android.core.design.cardBackground
 import com.lextures.android.core.design.fieldBorder
 import com.lextures.android.core.design.textPrimary
 import com.lextures.android.core.design.textSecondary
+import com.lextures.android.core.lms.NotebookTaskUpsert
+import com.lextures.android.core.lms.NotebookTasksApi
+import com.lextures.android.core.notebook.NotebookEditBlock
+import com.lextures.android.core.notebook.NotebookMarkdown
 import com.lextures.android.core.notebook.NotebookPage
+import com.lextures.android.core.notebook.NotebookSlashCommand
 import com.lextures.android.core.notebook.NotebookStore
+import com.lextures.android.core.notebook.NotebookSync
+import com.lextures.android.core.notebook.NotebookTree
+import com.lextures.android.core.notebook.ParsedNotebookTask
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
 
-/** Markdown notebook editor with a page picker; saves to device-local storage as you type. */
+/**
+ * Notebook page editor with a page tree, a rendered reading view (interactive tasks),
+ * and a markdown edit mode with `/` commands + insert toolbar (parity with web).
+ */
 @Composable
 fun NotebookEditorScreen(
     store: NotebookStore,
@@ -59,6 +122,7 @@ fun NotebookEditorScreen(
     title: String,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
+    accessToken: String? = null,
 ) {
     var notebook by remember {
         val loaded = store.load(courseCode)
@@ -66,36 +130,164 @@ fun NotebookEditorScreen(
             if (courseCode == NotebookStore.GLOBAL_KEY) loaded else loaded.copy(courseTitle = title),
         )
     }
-    val activePage = notebook.pages.firstOrNull { it.id == notebook.activePageId } ?: notebook.pages.firstOrNull()
-    var draft by remember { mutableStateOf(activePage?.contentMd.orEmpty()) }
+    val activePage = notebook.pages.firstOrNull { it.id == notebook.activePageId }
+        ?: notebook.pages.firstOrNull { !NotebookTree.isGroup(it) }
+    val activeIsGroup = activePage != null && NotebookTree.isGroup(activePage)
+
+    // WYSIWYG edit mode: the page is a list of rendered blocks (web block-editor parity);
+    // markdown is only the storage format.
+    var blocks by remember { mutableStateOf(NotebookMarkdown.editBlocks(activePage?.contentMd.orEmpty())) }
+    var focusedBlockId by remember { mutableStateOf<String?>(null) }
+    var pendingFocusId by remember { mutableStateOf<String?>(null) }
+    var editingDrawing by remember { mutableStateOf<EditingDrawingTarget?>(null) }
+    var editing by remember { mutableStateOf(activePage != null && !activeIsGroup && activePage.contentMd.isBlank()) }
+    var showPages by remember { mutableStateOf(false) }
     var menuOpen by remember { mutableStateOf(false) }
     var renaming by remember { mutableStateOf(false) }
     var renameText by remember { mutableStateOf("") }
+    var dueTask by remember { mutableStateOf<ParsedNotebookTask?>(null) }
+    var pushRevision by remember { mutableIntStateOf(0) }
+    val scope = rememberCoroutineScope()
 
-    fun commitDraft() {
-        val active = activePage ?: return
-        notebook = notebook.copy(
-            pages = notebook.pages.map { if (it.id == active.id) it.copy(contentMd = draft) else it },
-        )
+    fun persist() {
+        store.save(courseCode, notebook)
+        pushRevision++
     }
 
-    fun save() {
-        commitDraft()
-        store.save(courseCode, notebook)
+    // Rendered edit blocks from canonical markdown (fences never shown to the user).
+    fun loadBlocks(contentMd: String) {
+        blocks = NotebookMarkdown.editBlocks(contentMd)
+    }
+
+    // Canonical markdown rebuilt from the edit blocks.
+    fun draftMarkdown(): String = NotebookMarkdown.markdownFromBlocks(blocks)
+
+    // Merge any newer server copy (e.g. written on web) once on open.
+    LaunchedEffect(courseCode) {
+        if (NotebookSync.pull(store, accessToken)) {
+            val loaded = store.load(courseCode)
+            notebook = if (courseCode == NotebookStore.GLOBAL_KEY) loaded else loaded.copy(courseTitle = title)
+            val page = loaded.pages.firstOrNull { it.id == loaded.activePageId }
+                ?: loaded.pages.firstOrNull { !NotebookTree.isGroup(it) }
+            loadBlocks(page?.contentMd.orEmpty())
+            editing = page != null && !NotebookTree.isGroup(page) && page.contentMd.isBlank()
+        }
+    }
+
+    // Debounced server push so typing doesn't fire a request per keystroke; each persist
+    // restarts the effect, which cancels the pending delay.
+    LaunchedEffect(pushRevision) {
+        if (pushRevision == 0) return@LaunchedEffect
+        delay(1_500)
+        NotebookSync.push(store, courseCode, accessToken)
+    }
+
+    fun saveDraft() {
+        val active = activePage ?: return
+        if (editing && !NotebookTree.isGroup(active)) {
+            notebook = notebook.copy(pages = NotebookTree.updateContent(notebook.pages, active.id, draftMarkdown()))
+        }
+        persist()
+    }
+
+    fun syncTask(task: ParsedNotebookTask) {
+        val token = accessToken ?: return
+        val pageId = activePage?.id ?: return
+        scope.launch {
+            runCatching {
+                NotebookTasksApi.upsert(
+                    NotebookTaskUpsert(
+                        id = task.id,
+                        courseCode = courseCode,
+                        notebookPageId = pageId,
+                        taskText = task.text,
+                        completed = task.checked,
+                        dueAt = task.dueAt,
+                    ),
+                    token,
+                )
+            }
+        }
+    }
+
+    fun updateActiveContent(contentMd: String) {
+        val active = activePage ?: return
+        notebook = notebook.copy(pages = NotebookTree.updateContent(notebook.pages, active.id, contentMd))
+        loadBlocks(contentMd)
+        persist()
+    }
+
+    fun selectPage(pageId: String) {
+        saveDraft()
+        editing = false
+        val page = notebook.pages.firstOrNull { it.id == pageId }
+        notebook = notebook.copy(activePageId = pageId)
+        loadBlocks(page?.contentMd.orEmpty())
+        if (page != null && !NotebookTree.isGroup(page) && page.contentMd.isBlank()) {
+            editing = true
+        }
+        persist()
+    }
+
+    fun createPage(parentId: String?) {
+        saveDraft()
+        val (pages, newId) = NotebookTree.addPage(notebook.pages, parentId)
+        notebook = notebook.copy(pages = pages, activePageId = newId)
+        loadBlocks("")
+        pendingFocusId = blocks.firstOrNull()?.id
+        editing = true
+        persist()
+    }
+
+    fun createGroup() {
+        saveDraft()
+        val (pages, _) = NotebookTree.addGroup(notebook.pages, parentId = null, title = "New group")
+        notebook = notebook.copy(pages = pages)
+        persist()
+    }
+
+    fun deletePage(pageId: String) {
+        var pages = NotebookTree.delete(notebook.pages, pageId)
+        var activeId = notebook.activePageId
+        if (pages.none { !NotebookTree.isGroup(it) }) {
+            val (withPage, newId) = NotebookTree.addPage(pages, parentId = null)
+            pages = withPage
+            activeId = newId
+        }
+        if (pages.none { it.id == activeId }) {
+            activeId = pages.firstOrNull { !NotebookTree.isGroup(it) }?.id ?: pages.firstOrNull()?.id
+        }
+        notebook = notebook.copy(pages = pages, activePageId = activeId)
+        loadBlocks(pages.firstOrNull { it.id == activeId }?.contentMd.orEmpty())
+        editing = false
+        persist()
+    }
+
+    fun finishEditing() {
+        saveDraft()
+        editing = false
+        activePage?.let { page ->
+            NotebookMarkdown.parseTasks(page.contentMd).forEach { syncTask(it) }
+        }
     }
 
     BackHandler {
-        save()
-        onBack()
+        if (editing) {
+            finishEditing()
+        } else {
+            saveDraft()
+            onBack()
+        }
     }
 
-    Column(modifier = modifier) {
+    Column(modifier = modifier.imePadding()) {
+        // Top bar
         Row(
             modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             IconButton(onClick = {
-                save()
+                saveDraft()
                 onBack()
             }) {
                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", tint = textPrimary())
@@ -109,50 +301,40 @@ fun NotebookEditorScreen(
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
             )
-            Box {
-                IconButton(onClick = { menuOpen = true }) {
-                    Icon(Icons.Default.MoreVert, contentDescription = "Page actions", tint = textPrimary())
+            if (editing) {
+                TextButton(onClick = { finishEditing() }) {
+                    Text("Done", fontWeight = FontWeight.SemiBold, color = accentColor())
                 }
-                DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
-                    DropdownMenuItem(
-                        text = { Text("Rename page") },
-                        leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
-                        onClick = {
-                            menuOpen = false
-                            renameText = activePage?.title.orEmpty()
-                            renaming = true
-                        },
-                    )
-                    DropdownMenuItem(
-                        text = { Text("New page") },
-                        leadingIcon = { Icon(Icons.Default.Add, contentDescription = null) },
-                        onClick = {
-                            menuOpen = false
-                            commitDraft()
-                            val maxOrder = notebook.pages.maxOfOrNull { it.sortOrder } ?: 0
-                            val page = NotebookPage.new(sortOrder = maxOrder + 1)
-                            notebook = notebook.copy(
-                                pages = notebook.pages + page,
-                                activePageId = page.id,
-                            )
-                            draft = ""
-                            store.save(courseCode, notebook)
-                        },
-                    )
-                    if (notebook.pages.size > 1) {
+            } else {
+                Box {
+                    IconButton(onClick = { menuOpen = true }) {
+                        Icon(Icons.Default.MoreVert, contentDescription = "Page actions", tint = textPrimary())
+                    }
+                    DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
                         DropdownMenuItem(
-                            text = { Text("Delete page") },
-                            leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                            text = { Text("Rename page") },
+                            leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
                             onClick = {
                                 menuOpen = false
-                                val active = activePage ?: return@DropdownMenuItem
-                                val remaining = notebook.pages.filterNot { it.id == active.id }
-                                notebook = notebook.copy(
-                                    pages = remaining,
-                                    activePageId = remaining.firstOrNull()?.id,
-                                )
-                                draft = remaining.firstOrNull()?.contentMd.orEmpty()
-                                store.save(courseCode, notebook)
+                                renameText = activePage?.title.orEmpty()
+                                renaming = true
+                            },
+                        )
+                        DropdownMenuItem(
+                            text = { Text("New page") },
+                            leadingIcon = { Icon(Icons.Default.Add, contentDescription = null) },
+                            onClick = {
+                                menuOpen = false
+                                createPage(null)
+                            },
+                        )
+                        DropdownMenuItem(
+                            text = { Text("New group") },
+                            leadingIcon = { Icon(Icons.Default.CreateNewFolder, contentDescription = null) },
+                            onClick = {
+                                menuOpen = false
+                                createGroup()
+                                showPages = true
                             },
                         )
                     }
@@ -160,59 +342,191 @@ fun NotebookEditorScreen(
             }
         }
 
+        // Page header: current page (opens the page tree) + Edit
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp, vertical = 6.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            notebook.pages.sortedBy { it.sortOrder }.forEach { page ->
-                val selected = page.id == activePage?.id
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(50))
+                    .background(cardBackground())
+                    .border(1.dp, fieldBorder(), RoundedCornerShape(50))
+                    .clickable {
+                        saveDraft()
+                        showPages = true
+                    }
+                    .padding(horizontal = 14.dp, vertical = 9.dp)
+                    .weight(1f, fill = false),
+            ) {
+                Icon(
+                    imageVector = if (activeIsGroup) Icons.Default.Folder else Icons.Default.Description,
+                    contentDescription = null,
+                    tint = if (activeIsGroup) LexturesColors.BrandAmber else accentColor(),
+                    modifier = Modifier.size(14.dp),
+                )
                 Text(
-                    text = page.title.ifBlank { "Untitled" },
+                    text = activePage?.let { NotebookTree.pathLabel(notebook.pages, it.id) }?.ifBlank { "Untitled" } ?: "Untitled",
                     fontSize = 13.sp,
-                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
-                    color = if (selected) LexturesColors.Primary else textSecondary(),
+                    fontWeight = FontWeight.SemiBold,
+                    color = textPrimary(),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Icon(Icons.Default.UnfoldMore, contentDescription = "Show pages", tint = textSecondary(), modifier = Modifier.size(14.dp))
+            }
+
+            Spacer(Modifier.weight(1f))
+
+            if (!editing && !activeIsGroup) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(5.dp),
+                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
                         .clip(RoundedCornerShape(50))
                         .background(
-                            if (selected) LexturesColors.Primary.copy(alpha = 0.14f) else cardBackground(),
-                        )
-                        .border(
-                            1.dp,
-                            if (selected) LexturesColors.Primary.copy(alpha = 0.4f) else fieldBorder(),
-                            RoundedCornerShape(50),
+                            Brush.horizontalGradient(
+                                listOf(LexturesColors.Primary, Color(0xFF17897B)),
+                            ),
                         )
                         .clickable {
-                            commitDraft()
-                            notebook = notebook.copy(activePageId = page.id)
-                            draft = notebook.pages.first { it.id == page.id }.contentMd
-                            store.save(courseCode, notebook)
+                            loadBlocks(activePage?.contentMd.orEmpty())
+                            editing = true
+                            pendingFocusId = blocks.lastOrNull { it.isTextual }?.id
                         }
-                        .padding(horizontal = 14.dp, vertical = 7.dp),
-                )
+                        .padding(horizontal = 16.dp, vertical = 9.dp),
+                ) {
+                    Icon(Icons.Default.Edit, contentDescription = null, tint = Color.White, modifier = Modifier.size(14.dp))
+                    Text("Edit", fontSize = 13.sp, fontWeight = FontWeight.SemiBold, color = Color.White)
+                }
             }
         }
 
-        BasicTextField(
-            value = draft,
-            onValueChange = {
-                draft = it
-                save()
+        when {
+            activeIsGroup -> GroupPanel(
+                notebookPages = notebook.pages,
+                group = activePage,
+                onSelect = { selectPage(it) },
+                onCreatePage = { createPage(activePage?.id) },
+            )
+
+            editing -> BlockEditorPane(
+                blocks = blocks,
+                pendingFocusId = pendingFocusId,
+                onPendingFocusConsumed = { pendingFocusId = null },
+                onFocusedChange = { focusedBlockId = it },
+                onBlocksChange = { next, focusId ->
+                    blocks = next
+                    if (focusId != null) pendingFocusId = focusId
+                    val active = activePage
+                    if (active != null) {
+                        notebook = notebook.copy(pages = NotebookTree.updateContent(notebook.pages, active.id, draftMarkdown()))
+                        persist()
+                    }
+                },
+                onToggleTask = { blockId ->
+                    val idx = blocks.indexOfFirst { it.id == blockId }
+                    val kind = blocks.getOrNull(idx)?.kind as? NotebookEditBlock.Kind.Task ?: return@BlockEditorPane
+                    blocks = blocks.toMutableList().also {
+                        it[idx] = it[idx].copy(kind = kind.copy(checked = !kind.checked))
+                    }
+                    saveDraft()
+                    syncTask(ParsedNotebookTask(kind.taskId, blocks[idx].text, !kind.checked, kind.dueAt))
+                },
+                onEditTaskDue = { blockId ->
+                    val block = blocks.firstOrNull { it.id == blockId } ?: return@BlockEditorPane
+                    val kind = block.kind as? NotebookEditBlock.Kind.Task ?: return@BlockEditorPane
+                    dueTask = ParsedNotebookTask(kind.taskId, block.text, kind.checked, kind.dueAt)
+                },
+                onEditDrawing = { blockId, elementsJson ->
+                    editingDrawing = EditingDrawingTarget(elementsJson, readIndex = null, blockId = blockId)
+                },
+                accessToken = accessToken,
+            )
+
+            else -> ReadingPane(
+                contentMd = activePage?.contentMd.orEmpty(),
+                onStartEditing = {
+                    loadBlocks(activePage?.contentMd.orEmpty())
+                    editing = true
+                    pendingFocusId = blocks.lastOrNull { it.isTextual }?.id
+                },
+                onToggleTask = { task ->
+                    val active = activePage ?: return@ReadingPane
+                    updateActiveContent(NotebookMarkdown.setTaskChecked(active.contentMd, task.id, !task.checked))
+                    syncTask(task.copy(checked = !task.checked))
+                },
+                onEditTaskDue = { dueTask = it },
+                accessToken = accessToken,
+                onEditDrawing = { index, elementsJson ->
+                    editingDrawing = EditingDrawingTarget(elementsJson, readIndex = index, blockId = null)
+                },
+            )
+        }
+    }
+
+    if (showPages) {
+        NotebookPagesSheet(
+            pages = notebook.pages,
+            activePageId = activePage?.id,
+            onDismiss = { showPages = false },
+            onSelect = { selectPage(it) },
+            onCreatePage = { createPage(it) },
+            onCreateGroup = { createGroup() },
+            onRename = { pageId, name ->
+                notebook = notebook.copy(pages = NotebookTree.rename(notebook.pages, pageId, name))
+                persist()
             },
-            textStyle = TextStyle(
-                fontSize = 14.sp,
-                fontFamily = FontFamily.Monospace,
-                color = textPrimary(),
-            ),
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp)
-                .clip(RoundedCornerShape(12.dp))
-                .background(cardBackground())
-                .border(1.dp, fieldBorder().copy(alpha = 0.9f), RoundedCornerShape(12.dp))
-                .padding(12.dp),
+            onMove = { pageId, newParentId ->
+                NotebookTree.moveToParent(notebook.pages, pageId, newParentId)?.let {
+                    notebook = notebook.copy(pages = it)
+                    persist()
+                }
+            },
+            onDelete = { deletePage(it) },
+        )
+    }
+
+    dueTask?.let { task ->
+        TaskDueDateDialog(
+            task = task,
+            onDismiss = { dueTask = null },
+            onSave = { dueAt ->
+                saveDraft()
+                val active = activePage
+                if (active != null) {
+                    val next = NotebookMarkdown.setTaskDueAt(active.contentMd, task.id, dueAt)
+                    updateActiveContent(next)
+                    NotebookMarkdown.parseTasks(next).firstOrNull { it.id == task.id }?.let { syncTask(it) }
+                }
+                dueTask = null
+            },
+        )
+    }
+
+    editingDrawing?.let { target ->
+        NotebookDrawingEditor(
+            initialElementsJson = target.elementsJson,
+            onDismiss = { editingDrawing = null },
+            onSave = { newJson ->
+                val blockId = target.blockId
+                if (blockId != null) {
+                    val idx = blocks.indexOfFirst { it.id == blockId }
+                    if (idx >= 0) {
+                        blocks = blocks.toMutableList().also {
+                            it[idx] = it[idx].copy(kind = NotebookEditBlock.Kind.Drawing(newJson))
+                        }
+                        saveDraft()
+                    }
+                } else if (target.readIndex != null) {
+                    activePage?.let { active ->
+                        updateActiveContent(NotebookMarkdown.replaceDrawing(active.contentMd, target.readIndex, newJson))
+                    }
+                }
+                editingDrawing = null
+            },
         )
     }
 
@@ -221,32 +535,666 @@ fun NotebookEditorScreen(
             onDismissRequest = { renaming = false },
             title = { Text("Rename page") },
             text = {
-                OutlinedTextField(
-                    value = renameText,
-                    onValueChange = { renameText = it },
-                    singleLine = true,
-                )
+                OutlinedTextField(value = renameText, onValueChange = { renameText = it }, singleLine = true)
             },
             confirmButton = {
                 TextButton(onClick = {
                     val name = renameText.trim()
                     val active = activePage
                     if (name.isNotEmpty() && active != null) {
-                        notebook = notebook.copy(
-                            pages = notebook.pages.map {
-                                if (it.id == active.id) it.copy(title = name) else it
-                            },
-                        )
-                        store.save(courseCode, notebook)
+                        notebook = notebook.copy(pages = NotebookTree.rename(notebook.pages, active.id, name))
+                        persist()
                     }
                     renaming = false
-                }) {
-                    Text("Save")
-                }
+                }) { Text("Save") }
             },
             dismissButton = {
                 TextButton(onClick = { renaming = false }) { Text("Cancel") }
             },
         )
+    }
+}
+
+// MARK: Reading
+
+@Composable
+private fun ReadingPane(
+    contentMd: String,
+    onStartEditing: () -> Unit,
+    onToggleTask: (ParsedNotebookTask) -> Unit,
+    onEditTaskDue: (ParsedNotebookTask) -> Unit,
+    accessToken: String? = null,
+    onEditDrawing: ((Int, String) -> Unit)? = null,
+) {
+    if (contentMd.isBlank()) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 40.dp, vertical = 70.dp),
+        ) {
+            Icon(Icons.Default.Edit, contentDescription = null, tint = accentColor().copy(alpha = 0.7f), modifier = Modifier.size(34.dp))
+            Text("This page is empty", style = LexturesType.display(19), color = textPrimary())
+            Text(
+                text = "Tap Edit to start writing. Type / while editing for headings, tasks, lists, and more.",
+                fontSize = 13.sp,
+                color = textSecondary(),
+                textAlign = TextAlign.Center,
+            )
+            TextButton(onClick = onStartEditing) {
+                Text("Start writing", fontWeight = FontWeight.SemiBold, color = accentColor())
+            }
+        }
+        return
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 24.dp),
+    ) {
+        NotebookContentView(
+            markdown = contentMd,
+            onToggleTask = onToggleTask,
+            onEditTaskDue = onEditTaskDue,
+            accessToken = accessToken,
+            onEditDrawing = onEditDrawing,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(cardBackground())
+                .border(1.dp, fieldBorder().copy(alpha = 0.9f), RoundedCornerShape(16.dp))
+                .padding(16.dp),
+        )
+    }
+}
+
+// MARK: Group panel
+
+@Composable
+private fun GroupPanel(
+    notebookPages: List<NotebookPage>,
+    group: NotebookPage?,
+    onSelect: (String) -> Unit,
+    onCreatePage: () -> Unit,
+) {
+    val children = NotebookTree.sortedChildren(notebookPages, group?.id)
+    Column(
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+    ) {
+        if (children.isEmpty()) {
+            Text(
+                text = "No pages in this group yet.",
+                fontSize = 13.sp,
+                color = textSecondary(),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth().padding(top = 20.dp),
+            )
+        }
+        children.forEach { child ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(cardBackground())
+                    .border(1.dp, fieldBorder(), RoundedCornerShape(12.dp))
+                    .clickable { onSelect(child.id) }
+                    .padding(14.dp),
+            ) {
+                Icon(
+                    imageVector = if (NotebookTree.isGroup(child)) Icons.Default.Folder else Icons.Default.Description,
+                    contentDescription = null,
+                    tint = if (NotebookTree.isGroup(child)) LexturesColors.BrandAmber else accentColor(),
+                    modifier = Modifier.size(18.dp),
+                )
+                Text(
+                    text = child.title.ifBlank { "Untitled" },
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = textPrimary(),
+                    modifier = Modifier.weight(1f),
+                )
+                Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = textSecondary(), modifier = Modifier.size(18.dp))
+            }
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.clickable(onClick = onCreatePage).padding(vertical = 8.dp),
+        ) {
+            Icon(Icons.Default.Add, contentDescription = null, tint = accentColor(), modifier = Modifier.size(18.dp))
+            Text("New page in group", fontSize = 14.sp, fontWeight = FontWeight.SemiBold, color = accentColor())
+        }
+    }
+}
+
+// MARK: Block editor (WYSIWYG, web parity)
+
+/** Drawing being edited — from the reading view (by document index) or the block editor (by block id). */
+private data class EditingDrawingTarget(
+    val elementsJson: String,
+    val readIndex: Int?,
+    val blockId: String?,
+)
+
+@Composable
+private fun ColumnScope.BlockEditorPane(
+    blocks: List<NotebookEditBlock>,
+    pendingFocusId: String?,
+    onPendingFocusConsumed: () -> Unit,
+    onFocusedChange: (String?) -> Unit,
+    onBlocksChange: (List<NotebookEditBlock>, focusId: String?) -> Unit,
+    onToggleTask: (String) -> Unit,
+    onEditTaskDue: (String) -> Unit,
+    onEditDrawing: (blockId: String, elementsJson: String) -> Unit,
+    accessToken: String?,
+) {
+    var focusedId by remember { mutableStateOf<String?>(null) }
+    val focusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+
+    fun requesterFor(id: String): FocusRequester = focusRequesters.getOrPut(id) { FocusRequester() }
+
+    LaunchedEffect(pendingFocusId, blocks.size) {
+        val id = pendingFocusId ?: return@LaunchedEffect
+        if (blocks.any { it.id == id }) {
+            runCatching { requesterFor(id).requestFocus() }
+            onPendingFocusConsumed()
+        }
+    }
+
+    // `/query` typed at the start of the focused block opens the command menu (web parity).
+    val slashQuery = blocks.firstOrNull { it.id == focusedId && it.isTextual }
+        ?.text
+        ?.takeIf { it.startsWith("/") }
+        ?.drop(1)
+        ?.takeIf { !it.contains(' ') && !it.contains('\n') && it.length <= 24 }
+    val commands = slashQuery?.let { NotebookMarkdown.filterCommands(it) }.orEmpty()
+
+    /** Newlines never live inside a text block (except code): a return splits the block. */
+    fun handleTextChange(blockId: String, newText: String) {
+        val idx = blocks.indexOfFirst { it.id == blockId }
+        if (idx < 0) return
+        val block = blocks[idx]
+        if (block.kind is NotebookEditBlock.Kind.Code || !newText.contains('\n')) {
+            onBlocksChange(blocks.toMutableList().also { it[idx] = block.copy(text = newText) }, null)
+            return
+        }
+        val parts = newText.split('\n')
+        val first = parts.first()
+        val rest = parts.drop(1).joinToString(" ")
+
+        // Return on an empty list/quote/task line exits the list back to a paragraph.
+        if (first.isEmpty() && rest.isEmpty() && block.kind != NotebookEditBlock.Kind.Paragraph) {
+            onBlocksChange(
+                blocks.toMutableList().also {
+                    it[idx] = block.copy(kind = NotebookEditBlock.Kind.Paragraph, text = "")
+                },
+                null,
+            )
+            return
+        }
+
+        val continuation = when (block.kind) {
+            NotebookEditBlock.Kind.Bullet -> NotebookEditBlock.Kind.Bullet
+            NotebookEditBlock.Kind.Ordered -> NotebookEditBlock.Kind.Ordered
+            NotebookEditBlock.Kind.Quote -> NotebookEditBlock.Kind.Quote
+            is NotebookEditBlock.Kind.Task ->
+                NotebookEditBlock.Kind.Task(NotebookMarkdown.newTaskId(), checked = false, dueAt = null)
+            else -> NotebookEditBlock.Kind.Paragraph
+        }
+        val newBlock = NotebookEditBlock(kind = continuation, text = rest)
+        onBlocksChange(
+            blocks.toMutableList().also {
+                it[idx] = block.copy(text = first)
+                it.add(idx + 1, newBlock)
+            },
+            newBlock.id,
+        )
+    }
+
+    fun deleteBlock(blockId: String) {
+        val idx = blocks.indexOfFirst { it.id == blockId }
+        if (idx < 0) return
+        val next = blocks.toMutableList().also { it.removeAt(idx) }
+        if (next.isEmpty()) next.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Paragraph))
+        onBlocksChange(next, next[(idx - 1).coerceIn(0, next.size - 1)].id)
+    }
+
+    /** Convert the focused block (text kinds) or insert after it (divider / drawing). */
+    fun applyCommand(command: NotebookSlashCommand) {
+        var next = blocks.toMutableList()
+        var idx = next.indexOfFirst { it.id == focusedId }
+        if (idx < 0) {
+            next.add(NotebookEditBlock(kind = NotebookEditBlock.Kind.Paragraph))
+            idx = next.size - 1
+        }
+        if (next[idx].isTextual && next[idx].text.startsWith("/")) {
+            next[idx] = next[idx].copy(text = "")
+        }
+        var focusId: String? = next[idx].id
+        when (command.id) {
+            "heading1" -> next[idx] = next[idx].copy(kind = NotebookEditBlock.Kind.Heading(1))
+            "heading2" -> next[idx] = next[idx].copy(kind = NotebookEditBlock.Kind.Heading(2))
+            "heading3" -> next[idx] = next[idx].copy(kind = NotebookEditBlock.Kind.Heading(3))
+            "bulletList" -> next[idx] = next[idx].copy(kind = NotebookEditBlock.Kind.Bullet)
+            "orderedList" -> next[idx] = next[idx].copy(kind = NotebookEditBlock.Kind.Ordered)
+            "blockquote" -> next[idx] = next[idx].copy(kind = NotebookEditBlock.Kind.Quote)
+            "codeBlock" -> next[idx] = next[idx].copy(kind = NotebookEditBlock.Kind.Code)
+            "task" -> {
+                if (next[idx].kind !is NotebookEditBlock.Kind.Task) {
+                    next[idx] = next[idx].copy(
+                        kind = NotebookEditBlock.Kind.Task(NotebookMarkdown.newTaskId(), checked = false, dueAt = null),
+                    )
+                }
+            }
+            "horizontalRule", "drawing" -> {
+                val inserted = if (command.id == "drawing") {
+                    NotebookEditBlock(kind = NotebookEditBlock.Kind.Drawing("[]"))
+                } else {
+                    NotebookEditBlock(kind = NotebookEditBlock.Kind.Divider)
+                }
+                val paragraph = NotebookEditBlock(kind = NotebookEditBlock.Kind.Paragraph)
+                next.add(idx + 1, inserted)
+                next.add(idx + 2, paragraph)
+                focusId = paragraph.id
+            }
+        }
+        onBlocksChange(next, focusId)
+    }
+
+    Column(
+        modifier = Modifier
+            .weight(1f)
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(cardBackground())
+            .border(1.dp, fieldBorder().copy(alpha = 0.9f), RoundedCornerShape(16.dp))
+            .verticalScroll(rememberScrollState())
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        blocks.forEachIndexed { index, block ->
+            // Ordered numbering: position within the current run of ordered blocks.
+            var orderedNumber = 1
+            if (block.kind is NotebookEditBlock.Kind.Ordered) {
+                var i = index - 1
+                while (i >= 0 && blocks[i].kind is NotebookEditBlock.Kind.Ordered) {
+                    orderedNumber++
+                    i--
+                }
+            }
+            EditBlockRow(
+                block = block,
+                orderedNumber = orderedNumber,
+                focusRequester = requesterFor(block.id),
+                onFocused = { has ->
+                    if (has) {
+                        focusedId = block.id
+                        onFocusedChange(block.id)
+                    } else if (focusedId == block.id) {
+                        focusedId = null
+                        onFocusedChange(null)
+                    }
+                },
+                onTextChange = { handleTextChange(block.id, it) },
+                onToggleTask = { onToggleTask(block.id) },
+                onEditTaskDue = { onEditTaskDue(block.id) },
+                onEditDrawing = {
+                    (block.kind as? NotebookEditBlock.Kind.Drawing)?.let { onEditDrawing(block.id, it.elementsJson) }
+                },
+                onDelete = { deleteBlock(block.id) },
+                accessToken = accessToken,
+            )
+        }
+    }
+
+    // `/` command menu (anchored above the insert toolbar, parity with the web slash menu).
+    if (commands.isNotEmpty()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .heightIn(max = 220.dp)
+                .clip(RoundedCornerShape(14.dp))
+                .background(cardBackground())
+                .border(1.dp, fieldBorder(), RoundedCornerShape(14.dp))
+                .verticalScroll(rememberScrollState()),
+        ) {
+            commands.forEach { command ->
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { applyCommand(command) }
+                        .padding(horizontal = 14.dp, vertical = 8.dp),
+                ) {
+                    Icon(
+                        imageVector = commandIcon(command.id),
+                        contentDescription = null,
+                        tint = accentColor(),
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Column {
+                        Text(command.label, fontSize = 14.sp, fontWeight = FontWeight.Medium, color = textPrimary())
+                        Text(command.detail, fontSize = 11.sp, color = textSecondary())
+                    }
+                }
+            }
+        }
+    }
+
+    // Insert toolbar — converts the focused block, or inserts divider/drawing after it.
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(cardBackground())
+            .border(1.dp, fieldBorder())
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+    ) {
+        fun insert(commandId: String) {
+            applyCommand(NotebookMarkdown.slashCommands.first { it.id == commandId })
+        }
+        ToolbarTextButton("H1") { insert("heading1") }
+        ToolbarTextButton("H2") { insert("heading2") }
+        ToolbarTextButton("H3") { insert("heading3") }
+        ToolbarDividerLine()
+        ToolbarIconButton(Icons.Default.AddTask, "Task") { insert("task") }
+        ToolbarIconButton(Icons.Default.Draw, "Drawing") { insert("drawing") }
+        ToolbarIconButton(Icons.AutoMirrored.Filled.FormatListBulleted, "Bullet list") { insert("bulletList") }
+        ToolbarIconButton(Icons.Default.FormatListNumbered, "Numbered list") { insert("orderedList") }
+        ToolbarDividerLine()
+        ToolbarIconButton(Icons.Default.FormatQuote, "Quote") { insert("blockquote") }
+        ToolbarIconButton(Icons.Default.Code, "Code") { insert("codeBlock") }
+        ToolbarIconButton(Icons.Default.HorizontalRule, "Divider") { insert("horizontalRule") }
+        ToolbarDividerLine()
+        ToolbarIconButton(Icons.Default.Delete, "Delete block") {
+            focusedId?.let { deleteBlock(it) }
+        }
+    }
+}
+
+/** One block row in edit mode: styled like the reading view, but editable in place. */
+@Composable
+private fun EditBlockRow(
+    block: NotebookEditBlock,
+    orderedNumber: Int,
+    focusRequester: FocusRequester,
+    onFocused: (Boolean) -> Unit,
+    onTextChange: (String) -> Unit,
+    onToggleTask: () -> Unit,
+    onEditTaskDue: () -> Unit,
+    onEditDrawing: () -> Unit,
+    onDelete: () -> Unit,
+    accessToken: String?,
+) {
+    @Composable
+    fun blockTextField(textStyle: TextStyle, modifier: Modifier = Modifier) {
+        BasicTextField(
+            value = block.text,
+            onValueChange = onTextChange,
+            textStyle = textStyle,
+            cursorBrush = SolidColor(accentColor()),
+            modifier = modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester)
+                .onFocusChanged { onFocused(it.isFocused) },
+        )
+    }
+
+    when (val kind = block.kind) {
+        NotebookEditBlock.Kind.Paragraph ->
+            blockTextField(TextStyle(fontSize = 14.sp, lineHeight = 21.sp, color = textPrimary()))
+
+        is NotebookEditBlock.Kind.Heading -> {
+            val size = if (kind.level == 1) 24 else if (kind.level == 2) 19 else 16
+            blockTextField(LexturesType.display(size).copy(color = textPrimary()))
+        }
+
+        NotebookEditBlock.Kind.Bullet -> Row(
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            modifier = Modifier.padding(start = 4.dp),
+        ) {
+            Box(
+                Modifier
+                    .padding(top = 8.dp)
+                    .size(5.dp)
+                    .clip(CircleShape)
+                    .background(accentColor()),
+            )
+            blockTextField(TextStyle(fontSize = 14.sp, color = textPrimary()))
+        }
+
+        NotebookEditBlock.Kind.Ordered -> Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(start = 4.dp),
+        ) {
+            Text(
+                text = "$orderedNumber.",
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = accentColor(),
+            )
+            blockTextField(TextStyle(fontSize = 14.sp, color = textPrimary()))
+        }
+
+        NotebookEditBlock.Kind.Quote -> Row(
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            modifier = Modifier.padding(vertical = 2.dp),
+        ) {
+            Box(
+                Modifier
+                    .width(3.dp)
+                    .height(24.dp)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(LexturesColors.BrandAmber),
+            )
+            blockTextField(TextStyle(fontSize = 14.sp, fontStyle = FontStyle.Italic, color = textSecondary()))
+        }
+
+        NotebookEditBlock.Kind.Code -> blockTextField(
+            TextStyle(fontSize = 12.sp, fontFamily = FontFamily.Monospace, color = textPrimary()),
+            modifier = Modifier
+                .clip(RoundedCornerShape(10.dp))
+                .background(if (isDarkTheme()) sceneBackground() else LexturesColors.SceneBackground)
+                .border(1.dp, fieldBorder(), RoundedCornerShape(10.dp))
+                .padding(12.dp),
+        )
+
+        NotebookEditBlock.Kind.Divider -> NonTextBlockRow(onDelete) {
+            Box(
+                Modifier
+                    .weight(1f)
+                    .padding(vertical = 8.dp)
+                    .height(1.dp)
+                    .background(fieldBorder()),
+            )
+        }
+
+        is NotebookEditBlock.Kind.Task -> Row(
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(cardBackground())
+                .border(1.dp, fieldBorder(), RoundedCornerShape(12.dp))
+                .padding(10.dp),
+        ) {
+            Icon(
+                imageVector = if (kind.checked) Icons.Default.CheckBox else Icons.Default.CheckBoxOutlineBlank,
+                contentDescription = if (kind.checked) "Mark task incomplete" else "Mark task complete",
+                tint = if (kind.checked) accentColor() else textSecondary(),
+                modifier = Modifier
+                    .size(22.dp)
+                    .clickable(onClick = onToggleTask),
+            )
+            Column(verticalArrangement = Arrangement.spacedBy(3.dp), modifier = Modifier.weight(1f)) {
+                blockTextField(TextStyle(fontSize = 14.sp, color = textPrimary()))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.clickable(onClick = onEditTaskDue),
+                ) {
+                    Icon(
+                        Icons.Default.CalendarMonth,
+                        contentDescription = "Edit due date",
+                        tint = textSecondary(),
+                        modifier = Modifier.size(13.dp),
+                    )
+                    Text(
+                        text = kind.dueAt?.let { "Due ${LmsDates.shortDate(it)}" } ?: "Add due date",
+                        fontSize = 12.sp,
+                        color = textSecondary(),
+                    )
+                }
+            }
+        }
+
+        is NotebookEditBlock.Kind.Image -> NonTextBlockRow(onDelete) {
+            Box(Modifier.weight(1f)) {
+                NotebookContentView(
+                    markdown = "![${kind.alt}](${kind.url})",
+                    onToggleTask = {},
+                    onEditTaskDue = {},
+                    accessToken = accessToken,
+                )
+            }
+        }
+
+        is NotebookEditBlock.Kind.Drawing -> NonTextBlockRow(onDelete) {
+            Box(Modifier.weight(1f)) {
+                NotebookContentView(
+                    markdown = "```drawing\n${kind.elementsJson}\n```",
+                    onToggleTask = {},
+                    onEditTaskDue = {},
+                    onEditDrawing = { _, _ -> onEditDrawing() },
+                )
+            }
+        }
+    }
+}
+
+/** Non-text blocks get a small delete affordance since they can't be backspaced away. */
+@Composable
+private fun NonTextBlockRow(onDelete: () -> Unit, content: @Composable RowScope.() -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.Top) {
+        content()
+        Icon(
+            Icons.Default.Close,
+            contentDescription = "Delete block",
+            tint = textSecondary().copy(alpha = 0.7f),
+            modifier = Modifier
+                .size(20.dp)
+                .clip(CircleShape)
+                .clickable(onClick = onDelete),
+        )
+    }
+}
+
+private fun commandIcon(commandId: String): ImageVector = when (commandId) {
+    "task" -> Icons.Default.AddTask
+    "drawing" -> Icons.Default.Draw
+    "bulletList" -> Icons.AutoMirrored.Filled.FormatListBulleted
+    "orderedList" -> Icons.Default.FormatListNumbered
+    "blockquote" -> Icons.Default.FormatQuote
+    "codeBlock" -> Icons.Default.Code
+    "horizontalRule" -> Icons.Default.HorizontalRule
+    else -> Icons.Default.Edit
+}
+
+@Composable
+private fun ToolbarTextButton(label: String, onClick: () -> Unit) {
+    Text(
+        text = label,
+        fontSize = 13.sp,
+        fontWeight = FontWeight.Bold,
+        color = textPrimary(),
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 9.dp),
+    )
+}
+
+@Composable
+private fun ToolbarIconButton(icon: ImageVector, label: String, onClick: () -> Unit) {
+    Icon(
+        imageVector = icon,
+        contentDescription = label,
+        tint = textPrimary(),
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 8.dp)
+            .size(20.dp),
+    )
+}
+
+@Composable
+private fun ToolbarDividerLine() {
+    Box(
+        Modifier
+            .padding(horizontal = 4.dp)
+            .width(1.dp)
+            .heightIn(min = 22.dp)
+            .background(fieldBorder()),
+    )
+}
+
+// MARK: Due date
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TaskDueDateDialog(
+    task: ParsedNotebookTask,
+    onDismiss: () -> Unit,
+    onSave: (String?) -> Unit,
+) {
+    val initialMillis = task.dueAt
+        ?.let { runCatching { Instant.parse(it) }.getOrNull() }
+        ?.atZone(ZoneId.systemDefault())
+        ?.toLocalDate()
+        ?.atStartOfDay(ZoneOffset.UTC)
+        ?.toInstant()
+        ?.toEpochMilli()
+    val state = rememberDatePickerState(initialSelectedDateMillis = initialMillis)
+
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = {
+                val millis = state.selectedDateMillis
+                if (millis == null) {
+                    onSave(null)
+                } else {
+                    // Picker returns UTC midnight; due time is local end of day (web parity).
+                    val localDate = Instant.ofEpochMilli(millis).atZone(ZoneOffset.UTC).toLocalDate()
+                    val dueAt = localDate.atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant().toString()
+                    onSave(dueAt)
+                }
+            }) { Text("Save", fontWeight = FontWeight.SemiBold) }
+        },
+        dismissButton = {
+            Row {
+                if (task.dueAt != null) {
+                    TextButton(onClick = { onSave(null) }) {
+                        Text("Remove", color = LexturesColors.Error)
+                    }
+                }
+                TextButton(onClick = onDismiss) { Text("Cancel") }
+            }
+        },
+    ) {
+        DatePicker(state = state, showModeToggle = false)
     }
 }

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/notebooks/NotebookPagesSheet.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/notebooks/NotebookPagesSheet.kt
@@ -1,0 +1,313 @@
+package com.lextures.android.features.notebooks
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CreateNewFolder
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.lextures.android.core.design.LexturesColors
+import com.lextures.android.core.design.accentColor
+import com.lextures.android.core.design.cardBackground
+import com.lextures.android.core.design.textPrimary
+import com.lextures.android.core.design.textSecondary
+import com.lextures.android.core.notebook.NotebookPage
+import com.lextures.android.core.notebook.NotebookTree
+
+/**
+ * Page tree for a notebook: groups with nested pages, plus create / rename / move / delete
+ * (parity with the web notebook sidebar).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotebookPagesSheet(
+    pages: List<NotebookPage>,
+    activePageId: String?,
+    onDismiss: () -> Unit,
+    onSelect: (String) -> Unit,
+    onCreatePage: (parentId: String?) -> Unit,
+    onCreateGroup: () -> Unit,
+    onRename: (pageId: String, title: String) -> Unit,
+    onMove: (pageId: String, newParentId: String?) -> Unit,
+    onDelete: (pageId: String) -> Unit,
+) {
+    var renameTarget by remember { mutableStateOf<NotebookPage?>(null) }
+    var renameText by remember { mutableStateOf("") }
+    var deleteTarget by remember { mutableStateOf<NotebookPage?>(null) }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, containerColor = cardBackground()) {
+        Text(
+            text = "Pages",
+            fontSize = 17.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = textPrimary(),
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp),
+        )
+        Text(
+            text = "Pages live on this device. Use groups to organize related pages.",
+            fontSize = 12.sp,
+            color = textSecondary(),
+            modifier = Modifier.padding(horizontal = 20.dp),
+        )
+
+        LazyColumn(
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 10.dp),
+        ) {
+            items(NotebookTree.flatten(pages), key = { it.page.id }) { row ->
+                PageRow(
+                    pages = pages,
+                    row = row,
+                    isActive = row.page.id == activePageId,
+                    onSelect = {
+                        onSelect(row.page.id)
+                        onDismiss()
+                    },
+                    onRename = {
+                        renameTarget = row.page
+                        renameText = row.page.title
+                    },
+                    onCreateInside = {
+                        onCreatePage(row.page.id)
+                        onDismiss()
+                    },
+                    onMove = { newParent -> onMove(row.page.id, newParent) },
+                    onDelete = { deleteTarget = row.page },
+                )
+            }
+
+            item {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            onCreatePage(null)
+                            onDismiss()
+                        }
+                        .padding(horizontal = 20.dp, vertical = 12.dp),
+                ) {
+                    Icon(Icons.Default.Add, contentDescription = null, tint = accentColor(), modifier = Modifier.size(20.dp))
+                    Text("New page", fontSize = 14.sp, fontWeight = FontWeight.SemiBold, color = accentColor())
+                }
+            }
+            item {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onCreateGroup() }
+                        .padding(horizontal = 20.dp, vertical = 12.dp),
+                ) {
+                    Icon(Icons.Default.CreateNewFolder, contentDescription = null, tint = accentColor(), modifier = Modifier.size(20.dp))
+                    Text("New group", fontSize = 14.sp, fontWeight = FontWeight.SemiBold, color = accentColor())
+                }
+            }
+        }
+    }
+
+    renameTarget?.let { target ->
+        AlertDialog(
+            onDismissRequest = { renameTarget = null },
+            title = { Text("Rename") },
+            text = {
+                OutlinedTextField(value = renameText, onValueChange = { renameText = it }, singleLine = true)
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    val name = renameText.trim()
+                    if (name.isNotEmpty()) onRename(target.id, name)
+                    renameTarget = null
+                }) { Text("Save") }
+            },
+            dismissButton = {
+                TextButton(onClick = { renameTarget = null }) { Text("Cancel") }
+            },
+        )
+    }
+
+    deleteTarget?.let { target ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text("Delete \"${target.title.ifBlank { "Untitled" }}\"?") },
+            text = {
+                Text(
+                    if (NotebookTree.isGroup(target)) {
+                        "The group and everything inside it will be deleted."
+                    } else {
+                        "This page and its notes will be deleted."
+                    },
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    onDelete(target.id)
+                    deleteTarget = null
+                }) { Text("Delete", color = LexturesColors.Error) }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleteTarget = null }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+@Composable
+private fun PageRow(
+    pages: List<NotebookPage>,
+    row: NotebookTree.FlatRow,
+    isActive: Boolean,
+    onSelect: () -> Unit,
+    onRename: () -> Unit,
+    onCreateInside: () -> Unit,
+    onMove: (String?) -> Unit,
+    onDelete: () -> Unit,
+) {
+    val page = row.page
+    val isGroup = NotebookTree.isGroup(page)
+    var menuOpen by remember { mutableStateOf(false) }
+    var moveOpen by remember { mutableStateOf(false) }
+    val canDelete = NotebookTree.delete(pages, page.id).any { !NotebookTree.isGroup(it) }
+    val moveTargets = NotebookTree.groupMoveTargets(pages, page.id).filter { it.id != page.parentId }
+
+    Box {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 2.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(if (isActive) accentColor().copy(alpha = 0.10f) else cardBackground())
+                .clickable(onClick = onSelect)
+                .padding(start = 8.dp + (row.depth * 20).dp, top = 10.dp, bottom = 10.dp, end = 8.dp),
+        ) {
+            Icon(
+                imageVector = if (isGroup) Icons.Default.Folder else Icons.Default.Description,
+                contentDescription = null,
+                tint = if (isGroup) LexturesColors.BrandAmber else accentColor(),
+                modifier = Modifier.size(18.dp),
+            )
+            Text(
+                text = page.title.ifBlank { "Untitled" },
+                fontSize = 14.sp,
+                fontWeight = if (isActive) FontWeight.SemiBold else FontWeight.Normal,
+                color = textPrimary(),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            if (isActive) {
+                Icon(Icons.Default.Check, contentDescription = "Active page", tint = accentColor(), modifier = Modifier.size(16.dp))
+            }
+            Icon(
+                imageVector = Icons.Default.Edit,
+                contentDescription = "Page actions",
+                tint = textSecondary(),
+                modifier = Modifier
+                    .size(18.dp)
+                    .clickable { menuOpen = true },
+            )
+        }
+
+        DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+            DropdownMenuItem(
+                text = { Text("Rename") },
+                leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
+                onClick = {
+                    menuOpen = false
+                    onRename()
+                },
+            )
+            if (isGroup) {
+                DropdownMenuItem(
+                    text = { Text("New page inside") },
+                    leadingIcon = { Icon(Icons.Default.Add, contentDescription = null) },
+                    onClick = {
+                        menuOpen = false
+                        onCreateInside()
+                    },
+                )
+            }
+            if (moveTargets.isNotEmpty() || page.parentId != null) {
+                DropdownMenuItem(
+                    text = { Text("Move to…") },
+                    leadingIcon = { Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = null) },
+                    onClick = {
+                        menuOpen = false
+                        moveOpen = true
+                    },
+                )
+            }
+            if (canDelete) {
+                DropdownMenuItem(
+                    text = { Text("Delete", color = LexturesColors.Error) },
+                    leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null, tint = LexturesColors.Error) },
+                    onClick = {
+                        menuOpen = false
+                        onDelete()
+                    },
+                )
+            }
+        }
+
+        DropdownMenu(expanded = moveOpen, onDismissRequest = { moveOpen = false }) {
+            if (page.parentId != null) {
+                DropdownMenuItem(
+                    text = { Text("Top level") },
+                    onClick = {
+                        moveOpen = false
+                        onMove(null)
+                    },
+                )
+            }
+            moveTargets.forEach { group ->
+                DropdownMenuItem(
+                    text = { Text(NotebookTree.pathLabel(pages, group.id)) },
+                    leadingIcon = { Icon(Icons.Default.Folder, contentDescription = null, tint = LexturesColors.BrandAmber) },
+                    onClick = {
+                        moveOpen = false
+                        onMove(group.id)
+                    },
+                )
+            }
+        }
+    }
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/notebooks/NotebooksTab.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/notebooks/NotebooksTab.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,11 +44,14 @@ import com.lextures.android.core.lms.CourseSummary
 import com.lextures.android.core.lms.LmsApi
 import com.lextures.android.core.lms.LmsDates
 import com.lextures.android.core.notebook.CourseNotebook
+import com.lextures.android.core.notebook.NotebookMarkdown
 import com.lextures.android.core.notebook.NotebookStore
+import com.lextures.android.core.notebook.NotebookSync
 import com.lextures.android.features.home.LmsCard
 import com.lextures.android.features.home.LmsCoverTile
 import com.lextures.android.features.home.LmsEmptyState
 import com.lextures.android.features.home.LmsSectionHeader
+import kotlinx.coroutines.launch
 
 private data class NotebookRow(
     val courseCode: String,
@@ -62,6 +66,7 @@ fun NotebooksTab(session: AuthSession, modifier: Modifier = Modifier) {
     val accessToken by session.accessToken.collectAsState()
     val store = remember(accessToken) { NotebookStore(context, accessToken) }
 
+    val scope = rememberCoroutineScope()
     var courses by remember { mutableStateOf<List<CourseSummary>>(emptyList()) }
     var openNotebook by remember { mutableStateOf<NotebookRow?>(null) }
     // Bumped after the editor closes so previews re-read from the store.
@@ -69,6 +74,8 @@ fun NotebooksTab(session: AuthSession, modifier: Modifier = Modifier) {
 
     LaunchedEffect(accessToken) {
         val token = accessToken ?: return@LaunchedEffect
+        // Pull server notebooks first so web-created ones appear in the list.
+        if (NotebookSync.pull(store, token)) revision++
         courses = runCatching { LmsApi.fetchCourses(token) }.getOrDefault(emptyList())
     }
 
@@ -80,8 +87,11 @@ fun NotebooksTab(session: AuthSession, modifier: Modifier = Modifier) {
             onBack = {
                 openNotebook = null
                 revision++
+                // The editor's debounced push dies with its composition — flush from here.
+                scope.launch { NotebookSync.push(store, row.courseCode, accessToken) }
             },
             modifier = modifier,
+            accessToken = accessToken,
         )
         return
     }
@@ -169,7 +179,7 @@ private fun NotebookCard(
                     color = textPrimary(),
                 )
                 Text(text = subtitle, fontSize = 12.sp, color = textSecondary())
-                val preview = notebook?.previewText.orEmpty()
+                val preview = NotebookMarkdown.previewText(notebook?.previewText.orEmpty())
                 if (preview.isNotEmpty()) {
                     Text(
                         text = preview,

--- a/clients/ios/Lextures.xcodeproj/project.pbxproj
+++ b/clients/ios/Lextures.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		21794DCE0F7F4E2291E13329 /* AuthFieldRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574334E883A949A1B00BEA7E /* AuthFieldRepresentable.swift */; };
 		39084479F6C04C9ABBCA91AA /* NotebookStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F94B6FA6AB244FC840F2082 /* NotebookStore.swift */; };
 		6B2E11D1BB124F37C20E42B1 /* NotebookMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F00C1AA014E26B10D31A1 /* NotebookMarkdown.swift */; };
+		6B2E11D6BB124F37C20E42B6 /* NotebookSlashCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F00C6AA014E26B10D31A6 /* NotebookSlashCommands.swift */; };
+		6B2E11D7BB124F37C20E42B7 /* NotebookEditorSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F00C7AA014E26B10D31A7 /* NotebookEditorSupportViews.swift */; };
 		6B2E11D2BB124F37C20E42B2 /* NotebookTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F00C2AA014E26B10D31A2 /* NotebookTree.swift */; };
 		6B2E11EABB124F37C20E42EA /* NotebookDrawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F00EAAA014E26B10D31EA /* NotebookDrawing.swift */; };
 		6B2E11E9BB124F37C20E42E9 /* NotebookSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F00E9AA014E26B10D31E9 /* NotebookSync.swift */; };
@@ -63,6 +65,8 @@
 		4F94B6FA6AB244FC840F2082 /* NotebookStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookStore.swift; sourceTree = "<group>"; };
 		55556549CC7648629ED206D3 /* LMSModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSModels.swift; sourceTree = "<group>"; };
 		5A1F00C1AA014E26B10D31A1 /* NotebookMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookMarkdown.swift; sourceTree = "<group>"; };
+		5A1F00C6AA014E26B10D31A6 /* NotebookSlashCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSlashCommands.swift; sourceTree = "<group>"; };
+		5A1F00C7AA014E26B10D31A7 /* NotebookEditorSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorSupportViews.swift; sourceTree = "<group>"; };
 		5A1F00C2AA014E26B10D31A2 /* NotebookTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookTree.swift; sourceTree = "<group>"; };
 		5A1F00EAAA014E26B10D31EA /* NotebookDrawing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawing.swift; sourceTree = "<group>"; };
 		5A1F00E9AA014E26B10D31E9 /* NotebookSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSync.swift; sourceTree = "<group>"; };
@@ -223,6 +227,7 @@
 				5A1F00EBAA014E26B10D31EB /* NotebookDrawingViews.swift */,
 				5A1F00C4AA014E26B10D31A4 /* NotebookContentView.swift */,
 				64F60254486B40848E7855DD /* NotebookEditorView.swift */,
+				5A1F00C7AA014E26B10D31A7 /* NotebookEditorSupportViews.swift */,
 				5A1F00C5AA014E26B10D31A5 /* NotebookPagesSheet.swift */,
 				45F7D43BE028418E80C1FCD3 /* NotebooksListView.swift */,
 			);
@@ -233,6 +238,7 @@
 			isa = PBXGroup;
 			children = (
 				5A1F00C1AA014E26B10D31A1 /* NotebookMarkdown.swift */,
+				5A1F00C6AA014E26B10D31A6 /* NotebookSlashCommands.swift */,
 				4F94B6FA6AB244FC840F2082 /* NotebookStore.swift */,
 				5A1F00C2AA014E26B10D31A2 /* NotebookTree.swift */,
 				5A1F00EAAA014E26B10D31EA /* NotebookDrawing.swift */,
@@ -395,6 +401,7 @@
 				526718352EC24C6C92BB7AF2 /* NetworkBootstrap.swift in Sources */,
 				39084479F6C04C9ABBCA91AA /* NotebookStore.swift in Sources */,
 				6B2E11D1BB124F37C20E42B1 /* NotebookMarkdown.swift in Sources */,
+				6B2E11D6BB124F37C20E42B6 /* NotebookSlashCommands.swift in Sources */,
 				6B2E11D2BB124F37C20E42B2 /* NotebookTree.swift in Sources */,
 				6B2E11EABB124F37C20E42EA /* NotebookDrawing.swift in Sources */,
 				6B2E11E9BB124F37C20E42E9 /* NotebookSync.swift in Sources */,
@@ -413,6 +420,7 @@
 				A108965FD77349D8A3448CDA /* InboxView.swift in Sources */,
 				F7CA8C3DF6C94432975ACEAC /* MessageDetailView.swift in Sources */,
 				D649B2C460344F0182EE662A /* NotebookEditorView.swift in Sources */,
+				6B2E11D7BB124F37C20E42B7 /* NotebookEditorSupportViews.swift in Sources */,
 				4CBBAE4108D04616A02D1967 /* NotebooksListView.swift in Sources */,
 				FA9B4A2B7C3C4CABB220C97B /* SplashView.swift in Sources */,
 			);

--- a/clients/ios/Lextures.xcodeproj/project.pbxproj
+++ b/clients/ios/Lextures.xcodeproj/project.pbxproj
@@ -3,321 +3,348 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		F471E822E14842DC842C2CF8 /* LexturesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE2DF5581934971B97883DB /* LexturesApp.swift */; };
-		4A2F7A5668CD49888B2AFCBB /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6514F6E7C2D4AE19E71E2F6 /* RootView.swift */; };
-		221366A1EC19428EA2FE4CD3 /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7610B08545164B0693D35150 /* AuthAPI.swift */; };
-		D899CDDD85EB4F5C820540DB /* AuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5704723739F4CECAA69031A /* AuthSession.swift */; };
-		905323AF9DF849F0AFCEFD7E /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C59B5F4E7448A9A66C73C7 /* KeychainStore.swift */; };
-		10B28DC1ACD34BF78661BDF0 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBEC00F0FB2E41278AA86F37 /* AppConfiguration.swift */; };
-		CA2ADB71493C486D86F08106 /* AuthFieldRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6F008527784405956EF9A8 /* AuthFieldRepresentable.swift */; };
-		3C522B2B68564728B39272F7 /* BrandLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63F8265C533466288417525 /* BrandLogoView.swift */; };
-		00F39AC689714B25AB6B33C2 /* LexturesTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EEA1F7F16D946648524E46B /* LexturesTheme.swift */; };
-		FBAF9D9CB72E431BA0188DCA /* LMSAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81C6037604D4F119339AF04 /* LMSAPI.swift */; };
-		76E8791B81AD471CB3BEF582 /* LMSModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914F470CE97E47B187997460 /* LMSModels.swift */; };
-		BDE3E1F7D5134B2993E65FAE /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6306A4B556EB4D51BD439377 /* APIClient.swift */; };
-		EF5D0114E9914C14B5D85EC0 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CAE1F667FE404D9EF16AB6 /* APIError.swift */; };
-		5EE0E016B4444E648DEBB9EB /* NotebookStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91A8B37A9924B92BDDB9463 /* NotebookStore.swift */; };
-		ACF243F164224C90A8697F7E /* AuthFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28398E5821743009F1B29BC /* AuthFlowView.swift */; };
-		AF324E219D5749B78AFD712E /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9287855DF061458F9769F0CF /* LoginView.swift */; };
-		8DEB7C62AC17474EBD3DA567 /* SignupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F28101052F24DFCA9A014FB /* SignupView.swift */; };
-		F9827C2992FF468BAE2E2CE6 /* CourseDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C55BD432CC41F392BA66DE /* CourseDetailView.swift */; };
-		296896314F784D149AF920AA /* CoursesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E37D6A2BCF94D8DBC7F36C1 /* CoursesListView.swift */; };
-		63B9D3FEF05348B499699F4E /* ItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90E1F93FDFB47F59125E7EE /* ItemDetailView.swift */; };
-		B7E84FA89C8B4DF690EB62DF /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46EA4231C77646BAAC75C1AB /* DashboardView.swift */; };
-		8B524D40FCC248D9A0B40CF4 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBDEC0591C67447F8AC0C9C5 /* MainTabView.swift */; };
-		B37B5C5D48414298B470CC47 /* ComposeMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B57752B4C344DAAD96746D /* ComposeMessageView.swift */; };
-		D8F57DF3CEAB46CF9A734E35 /* InboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3546DC7C896B409BA5E14EA1 /* InboxView.swift */; };
-		FE4C8C3A3A3E423F93032076 /* MessageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7C6253673643D68E211710 /* MessageDetailView.swift */; };
-		67EF1C89FE8A4A51ACBD28F7 /* NotebookEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8A36BAF44146BFB4021FFD /* NotebookEditorView.swift */; };
-		B31F5E6DDC164D23A0CF70F5 /* NotebooksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AA3467023A43DAA3FD1179 /* NotebooksListView.swift */; };
-		3B9D1828434C4D2D8E6F63EF /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8999EE4AE0F4C83ABE83AD5 /* SplashView.swift */; };
-		FC8ACA3BF9404A7B90BE4DC6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E249A86BAF0142B29900C95F /* Assets.xcassets */; };
+		06BF80A426EF448BA01D5D07 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C166E253A248319B432443 /* AppDelegate.swift */; };
+		127C2C5F5F844D9597155F25 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50E08BD384A4697B9C1F3DC /* DashboardView.swift */; };
+		21794DCE0F7F4E2291E13329 /* AuthFieldRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574334E883A949A1B00BEA7E /* AuthFieldRepresentable.swift */; };
+		39084479F6C04C9ABBCA91AA /* NotebookStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F94B6FA6AB244FC840F2082 /* NotebookStore.swift */; };
+		6B2E11D1BB124F37C20E42B1 /* NotebookMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F00C1AA014E26B10D31A1 /* NotebookMarkdown.swift */; };
+		6B2E11D2BB124F37C20E42B2 /* NotebookTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F00C2AA014E26B10D31A2 /* NotebookTree.swift */; };
+		6B2E11EABB124F37C20E42EA /* NotebookDrawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F00EAAA014E26B10D31EA /* NotebookDrawing.swift */; };
+		6B2E11E9BB124F37C20E42E9 /* NotebookSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F00E9AA014E26B10D31E9 /* NotebookSync.swift */; };
+		6B2E11EBBB124F37C20E42EB /* NotebookDrawingViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F00EBAA014E26B10D31EB /* NotebookDrawingViews.swift */; };
+		6B2E11D4BB124F37C20E42B4 /* NotebookContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F00C4AA014E26B10D31A4 /* NotebookContentView.swift */; };
+		6B2E11D5BB124F37C20E42B5 /* NotebookPagesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F00C5AA014E26B10D31A5 /* NotebookPagesSheet.swift */; };
+		3D97BCA1E1C04ABB8E3F1CFB /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09366EEEBD474A3486EF26B5 /* AuthAPI.swift */; };
+		4CBBAE4108D04616A02D1967 /* NotebooksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F7D43BE028418E80C1FCD3 /* NotebooksListView.swift */; };
+		526718352EC24C6C92BB7AF2 /* NetworkBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1DD2040B4149E6AA37DFAD /* NetworkBootstrap.swift */; };
+		6D29BD2496E144AE94667496 /* AuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E5C11281A734885A5225821 /* AuthSession.swift */; };
+		6F77BD6E17D541CCA600A2A3 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA84786CE3E40D7A9188708 /* APIError.swift */; };
+		714948F6C3974B438AF9606B /* SignupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3885BB140F514CC89AA230DA /* SignupView.swift */; };
+		78342E8E60C94C9DA3ACD30C /* ComposeMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A099DF30BE403E8B497367 /* ComposeMessageView.swift */; };
+		8535B234CC374B51A1357BC7 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639E37A4AD2422B88992EE7 /* AppConfiguration.swift */; };
+		8626A52CA242419395680D7C /* CoursesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1CE1476C934A9AA6413D11 /* CoursesListView.swift */; };
+		8DF636AE2DAB4652884755AA /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C3AE465810E4C95A8DA05EB /* MainTabView.swift */; };
+		95C7A86B713B440987ED538B /* CourseDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D772B6B345E4F9186466F5C /* CourseDetailView.swift */; };
+		9B7C60D5E4EC484695674274 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4226539F2F92407082A144BC /* APIClient.swift */; };
+		A108965FD77349D8A3448CDA /* InboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA82FE2F5D5843FDB745F8C4 /* InboxView.swift */; };
+		A6B59F177C784BD48141CAE3 /* ItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754857A61A1E403EADE65C71 /* ItemDetailView.swift */; };
+		BA2CF77B1C104CD1B084D9C3 /* LexturesTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828D1E66BA2348C88AA26E8B /* LexturesTheme.swift */; };
+		BBEB12AD7717454CBA9D0486 /* LMSAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C2CB6CF9014B9898889AF6 /* LMSAPI.swift */; };
+		BD2D03D462914A0DA21C4E1F /* AuthFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066587B2811146C78E80D685 /* AuthFlowView.swift */; };
+		C56B4BBECE8E4855AC93BF0C /* LMSModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55556549CC7648629ED206D3 /* LMSModels.swift */; };
+		C7ED0963E92D40EA97A6CC63 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99360CB1AD24036BC812D07 /* LoginView.swift */; };
+		CF3CB48C18154910B172EC4C /* BrandLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F610E9623944027A6D175ED /* BrandLogoView.swift */; };
+		D649B2C460344F0182EE662A /* NotebookEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F60254486B40848E7855DD /* NotebookEditorView.swift */; };
+		DE268217B82A4F71ACBF7087 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F2D236BFA8544BBAC7BFE0D /* Assets.xcassets */; };
+		F31ADB1A369347A3B5EA4206 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9C72DBF2624D0082C7B3E1 /* KeychainStore.swift */; };
+		F7CA8C3DF6C94432975ACEAC /* MessageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F79394D97A5849A290A3797D /* MessageDetailView.swift */; };
+		F8063C33E42546F4A2560646 /* LexturesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99A80628C78E4205901E36D0 /* LexturesApp.swift */; };
+		FA9B4A2B7C3C4CABB220C97B /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CDDB289A918498F9CD746F7 /* SplashView.swift */; };
+		FB57FE93AF5140839554847E /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEE2A4C41994279888559BF /* RootView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		7EA05A85DE53454496B1A6AC /* Lextures.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lextures.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		DBE2DF5581934971B97883DB /* LexturesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesApp.swift; sourceTree = "<group>"; };
-		E6514F6E7C2D4AE19E71E2F6 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
-		7610B08545164B0693D35150 /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
-		E5704723739F4CECAA69031A /* AuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
-		94C59B5F4E7448A9A66C73C7 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
-		FBEC00F0FB2E41278AA86F37 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
-		FD6F008527784405956EF9A8 /* AuthFieldRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFieldRepresentable.swift; sourceTree = "<group>"; };
-		E63F8265C533466288417525 /* BrandLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandLogoView.swift; sourceTree = "<group>"; };
-		8EEA1F7F16D946648524E46B /* LexturesTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesTheme.swift; sourceTree = "<group>"; };
-		F81C6037604D4F119339AF04 /* LMSAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPI.swift; sourceTree = "<group>"; };
-		914F470CE97E47B187997460 /* LMSModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSModels.swift; sourceTree = "<group>"; };
-		6306A4B556EB4D51BD439377 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
-		A8CAE1F667FE404D9EF16AB6 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
-		E91A8B37A9924B92BDDB9463 /* NotebookStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookStore.swift; sourceTree = "<group>"; };
-		A28398E5821743009F1B29BC /* AuthFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFlowView.swift; sourceTree = "<group>"; };
-		9287855DF061458F9769F0CF /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
-		2F28101052F24DFCA9A014FB /* SignupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupView.swift; sourceTree = "<group>"; };
-		F1C55BD432CC41F392BA66DE /* CourseDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailView.swift; sourceTree = "<group>"; };
-		1E37D6A2BCF94D8DBC7F36C1 /* CoursesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesListView.swift; sourceTree = "<group>"; };
-		A90E1F93FDFB47F59125E7EE /* ItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailView.swift; sourceTree = "<group>"; };
-		46EA4231C77646BAAC75C1AB /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
-		BBDEC0591C67447F8AC0C9C5 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
-		F1B57752B4C344DAAD96746D /* ComposeMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeMessageView.swift; sourceTree = "<group>"; };
-		3546DC7C896B409BA5E14EA1 /* InboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxView.swift; sourceTree = "<group>"; };
-		9B7C6253673643D68E211710 /* MessageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDetailView.swift; sourceTree = "<group>"; };
-		AE8A36BAF44146BFB4021FFD /* NotebookEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorView.swift; sourceTree = "<group>"; };
-		E1AA3467023A43DAA3FD1179 /* NotebooksListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebooksListView.swift; sourceTree = "<group>"; };
-		C8999EE4AE0F4C83ABE83AD5 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
-		E249A86BAF0142B29900C95F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		09966B95224C4555A4C3ECF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B3E15A8D0DC847F882C75F6F /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
+		066587B2811146C78E80D685 /* AuthFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFlowView.swift; sourceTree = "<group>"; };
+		09366EEEBD474A3486EF26B5 /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
+		0EA84786CE3E40D7A9188708 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
+		1639E37A4AD2422B88992EE7 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
+		1D772B6B345E4F9186466F5C /* CourseDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailView.swift; sourceTree = "<group>"; };
+		1F1DD2040B4149E6AA37DFAD /* NetworkBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkBootstrap.swift; sourceTree = "<group>"; };
+		2C9C72DBF2624D0082C7B3E1 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
+		3885BB140F514CC89AA230DA /* SignupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupView.swift; sourceTree = "<group>"; };
+		38C166E253A248319B432443 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		4226539F2F92407082A144BC /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		45F7D43BE028418E80C1FCD3 /* NotebooksListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebooksListView.swift; sourceTree = "<group>"; };
+		47C2CB6CF9014B9898889AF6 /* LMSAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPI.swift; sourceTree = "<group>"; };
+		4F94B6FA6AB244FC840F2082 /* NotebookStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookStore.swift; sourceTree = "<group>"; };
+		55556549CC7648629ED206D3 /* LMSModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSModels.swift; sourceTree = "<group>"; };
+		5A1F00C1AA014E26B10D31A1 /* NotebookMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookMarkdown.swift; sourceTree = "<group>"; };
+		5A1F00C2AA014E26B10D31A2 /* NotebookTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookTree.swift; sourceTree = "<group>"; };
+		5A1F00EAAA014E26B10D31EA /* NotebookDrawing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawing.swift; sourceTree = "<group>"; };
+		5A1F00E9AA014E26B10D31E9 /* NotebookSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSync.swift; sourceTree = "<group>"; };
+		5A1F00EBAA014E26B10D31EB /* NotebookDrawingViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawingViews.swift; sourceTree = "<group>"; };
+		5A1F00C4AA014E26B10D31A4 /* NotebookContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookContentView.swift; sourceTree = "<group>"; };
+		5A1F00C5AA014E26B10D31A5 /* NotebookPagesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookPagesSheet.swift; sourceTree = "<group>"; };
+		55A099DF30BE403E8B497367 /* ComposeMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeMessageView.swift; sourceTree = "<group>"; };
+		574334E883A949A1B00BEA7E /* AuthFieldRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFieldRepresentable.swift; sourceTree = "<group>"; };
+		5D5A5EE18D354039BB4617AA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		64F60254486B40848E7855DD /* NotebookEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorView.swift; sourceTree = "<group>"; };
+		6C3AE465810E4C95A8DA05EB /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
+		6F1CE1476C934A9AA6413D11 /* CoursesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesListView.swift; sourceTree = "<group>"; };
+		6F2D236BFA8544BBAC7BFE0D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		754857A61A1E403EADE65C71 /* ItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailView.swift; sourceTree = "<group>"; };
+		828D1E66BA2348C88AA26E8B /* LexturesTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesTheme.swift; sourceTree = "<group>"; };
+		8BEE2A4C41994279888559BF /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		8E5C11281A734885A5225821 /* AuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
+		99A80628C78E4205901E36D0 /* LexturesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesApp.swift; sourceTree = "<group>"; };
+		9C25089EC8754D55A657071D /* Lextures.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lextures.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9CDDB289A918498F9CD746F7 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
+		9F610E9623944027A6D175ED /* BrandLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandLogoView.swift; sourceTree = "<group>"; };
+		A50E08BD384A4697B9C1F3DC /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
+		A99360CB1AD24036BC812D07 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		BA82FE2F5D5843FDB745F8C4 /* InboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxView.swift; sourceTree = "<group>"; };
+		D8840EED931D44B1BF5313CB /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
+		F79394D97A5849A290A3797D /* MessageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDetailView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		8AB93ADD97FB422BB02386A7 /* Frameworks */ = {
+		8A64F18F3A704914846D04CC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
-			runOnlyForDeploymentPostprocessing = 0;
 			files = (
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		24EB55C2B40A42B2AAF37C2E /* Lextures */ = {
+		14638BA90EE943D7945C0E69 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
-				0480AC0736294E5A8E7F6E6A /* Resources */,
-				A07DE8D8254947E98C33E73C /* App */,
-				D917A28548394F5A93218D8C /* Core */,
-				33BC4D5773D34834A86C8630 /* Features */,
-			);
-			path = Lextures;
-			sourceTree = "<group>";
-		};
-		A07DE8D8254947E98C33E73C /* App */ = {
-			isa = PBXGroup;
-			children = (
-				DBE2DF5581934971B97883DB /* LexturesApp.swift */,
-				E6514F6E7C2D4AE19E71E2F6 /* RootView.swift */,
-			);
-			path = App;
-			sourceTree = "<group>";
-		};
-		D917A28548394F5A93218D8C /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				7A87C55C181D40A6917C99DE /* Auth */,
-				F6C7E9C1BB2E4A36964020FB /* Config */,
-				CB05802316C549C1B2833C20 /* Design */,
-				09D233193DBB41169DB634C3 /* LMS */,
-				38B9DA9F3B5646A1AF0EBC05 /* Networking */,
-				503262AF0EEC4F83A8C12265 /* Notebook */,
-			);
-			path = Core;
-			sourceTree = "<group>";
-		};
-		33BC4D5773D34834A86C8630 /* Features */ = {
-			isa = PBXGroup;
-			children = (
-				4A5153BE49B847FE9B80839C /* Auth */,
-				6FE0D6EDB33F49F091FE1270 /* Courses */,
-				A0838BB0AB4649898259705E /* Dashboard */,
-				720A5D4A033341A882D139DD /* Home */,
-				9E36A67352E942A7868B8F9D /* Inbox */,
-				237F3DC6F57B4C7BA16B4638 /* Notebooks */,
-				DFFC67DB361143D8BD0A3EB9 /* Splash */,
-			);
-			path = Features;
-			sourceTree = "<group>";
-		};
-		0480AC0736294E5A8E7F6E6A /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				E249A86BAF0142B29900C95F /* Assets.xcassets */,
-				09966B95224C4555A4C3ECF3 /* Info.plist */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		7A87C55C181D40A6917C99DE /* Auth */ = {
-			isa = PBXGroup;
-			children = (
-				7610B08545164B0693D35150 /* AuthAPI.swift */,
-				E5704723739F4CECAA69031A /* AuthSession.swift */,
-				94C59B5F4E7448A9A66C73C7 /* KeychainStore.swift */,
-			);
-			path = Auth;
-			sourceTree = "<group>";
-		};
-		F6C7E9C1BB2E4A36964020FB /* Config */ = {
-			isa = PBXGroup;
-			children = (
-				FBEC00F0FB2E41278AA86F37 /* AppConfiguration.swift */,
-			);
-			path = Config;
-			sourceTree = "<group>";
-		};
-		CB05802316C549C1B2833C20 /* Design */ = {
-			isa = PBXGroup;
-			children = (
-				FD6F008527784405956EF9A8 /* AuthFieldRepresentable.swift */,
-				E63F8265C533466288417525 /* BrandLogoView.swift */,
-				8EEA1F7F16D946648524E46B /* LexturesTheme.swift */,
-			);
-			path = Design;
-			sourceTree = "<group>";
-		};
-		09D233193DBB41169DB634C3 /* LMS */ = {
-			isa = PBXGroup;
-			children = (
-				F81C6037604D4F119339AF04 /* LMSAPI.swift */,
-				914F470CE97E47B187997460 /* LMSModels.swift */,
-			);
-			path = LMS;
-			sourceTree = "<group>";
-		};
-		38B9DA9F3B5646A1AF0EBC05 /* Networking */ = {
-			isa = PBXGroup;
-			children = (
-				6306A4B556EB4D51BD439377 /* APIClient.swift */,
-				A8CAE1F667FE404D9EF16AB6 /* APIError.swift */,
+				4226539F2F92407082A144BC /* APIClient.swift */,
+				0EA84786CE3E40D7A9188708 /* APIError.swift */,
+				1F1DD2040B4149E6AA37DFAD /* NetworkBootstrap.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
 		};
-		503262AF0EEC4F83A8C12265 /* Notebook */ = {
+		22461602B8F8491B8A1CE2E7 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				E91A8B37A9924B92BDDB9463 /* NotebookStore.swift */,
+				6F2D236BFA8544BBAC7BFE0D /* Assets.xcassets */,
+				5D5A5EE18D354039BB4617AA /* Info.plist */,
 			);
-			path = Notebook;
+			path = Resources;
 			sourceTree = "<group>";
 		};
-		4A5153BE49B847FE9B80839C /* Auth */ = {
+		33C6D48B0BC745AC92CD743C /* Courses */ = {
 			isa = PBXGroup;
 			children = (
-				A28398E5821743009F1B29BC /* AuthFlowView.swift */,
-				9287855DF061458F9769F0CF /* LoginView.swift */,
-				2F28101052F24DFCA9A014FB /* SignupView.swift */,
-			);
-			path = Auth;
-			sourceTree = "<group>";
-		};
-		6FE0D6EDB33F49F091FE1270 /* Courses */ = {
-			isa = PBXGroup;
-			children = (
-				F1C55BD432CC41F392BA66DE /* CourseDetailView.swift */,
-				1E37D6A2BCF94D8DBC7F36C1 /* CoursesListView.swift */,
-				A90E1F93FDFB47F59125E7EE /* ItemDetailView.swift */,
+				1D772B6B345E4F9186466F5C /* CourseDetailView.swift */,
+				6F1CE1476C934A9AA6413D11 /* CoursesListView.swift */,
+				754857A61A1E403EADE65C71 /* ItemDetailView.swift */,
 			);
 			path = Courses;
 			sourceTree = "<group>";
 		};
-		A0838BB0AB4649898259705E /* Dashboard */ = {
+		3579036A02E148CC95C3C40C /* Features */ = {
 			isa = PBXGroup;
 			children = (
-				46EA4231C77646BAAC75C1AB /* DashboardView.swift */,
+				9EF536582BDA43B28FAA8C7B /* Auth */,
+				33C6D48B0BC745AC92CD743C /* Courses */,
+				52E20C2E76414B6D9D5F08C5 /* Dashboard */,
+				909C86F41CD8464D90AD80CB /* Home */,
+				3ECE80A5084F4387916A998F /* Inbox */,
+				BEF7CB0206B449A6BC327F72 /* Notebooks */,
+				E7D02DBA66C644A5B1D31EB0 /* Splash */,
 			);
-			path = Dashboard;
+			path = Features;
 			sourceTree = "<group>";
 		};
-		720A5D4A033341A882D139DD /* Home */ = {
+		3ECE80A5084F4387916A998F /* Inbox */ = {
 			isa = PBXGroup;
 			children = (
-				BBDEC0591C67447F8AC0C9C5 /* MainTabView.swift */,
-			);
-			path = Home;
-			sourceTree = "<group>";
-		};
-		9E36A67352E942A7868B8F9D /* Inbox */ = {
-			isa = PBXGroup;
-			children = (
-				F1B57752B4C344DAAD96746D /* ComposeMessageView.swift */,
-				3546DC7C896B409BA5E14EA1 /* InboxView.swift */,
-				9B7C6253673643D68E211710 /* MessageDetailView.swift */,
+				55A099DF30BE403E8B497367 /* ComposeMessageView.swift */,
+				BA82FE2F5D5843FDB745F8C4 /* InboxView.swift */,
+				F79394D97A5849A290A3797D /* MessageDetailView.swift */,
 			);
 			path = Inbox;
 			sourceTree = "<group>";
 		};
-		237F3DC6F57B4C7BA16B4638 /* Notebooks */ = {
+		52E20C2E76414B6D9D5F08C5 /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
-				AE8A36BAF44146BFB4021FFD /* NotebookEditorView.swift */,
-				E1AA3467023A43DAA3FD1179 /* NotebooksListView.swift */,
+				A50E08BD384A4697B9C1F3DC /* DashboardView.swift */,
 			);
-			path = Notebooks;
+			path = Dashboard;
 			sourceTree = "<group>";
 		};
-		DFFC67DB361143D8BD0A3EB9 /* Splash */ = {
+		5E058C31308649DF8586A531 /* Config */ = {
 			isa = PBXGroup;
 			children = (
-				C8999EE4AE0F4C83ABE83AD5 /* SplashView.swift */,
-			);
-			path = Splash;
-			sourceTree = "<group>";
-		};
-		19F31DE43B914BB79C4A4C61 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				7EA05A85DE53454496B1A6AC /* Lextures.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		F53E57A5BE41477CA4A26332 /* Config */ = {
-			isa = PBXGroup;
-			children = (
-				B3E15A8D0DC847F882C75F6F /* Development.xcconfig */,
+				D8840EED931D44B1BF5313CB /* Development.xcconfig */,
 			);
 			path = Config;
 			sourceTree = "<group>";
 		};
-		D3C28190A9E14E7B8AD9306C = {
+		647AB81F3D014AD28EE763BF /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				24EB55C2B40A42B2AAF37C2E /* Lextures */,
-				F53E57A5BE41477CA4A26332 /* Config */,
-				19F31DE43B914BB79C4A4C61 /* Products */,
+				9C25089EC8754D55A657071D /* Lextures.app */,
 			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		6A755962AEFF455594F7F915 /* Lextures */ = {
+			isa = PBXGroup;
+			children = (
+				22461602B8F8491B8A1CE2E7 /* Resources */,
+				F4136B0F59CF4B8E8B96C7BF /* App */,
+				CAB9C124D0674BF0A7C37EA0 /* Core */,
+				3579036A02E148CC95C3C40C /* Features */,
+			);
+			path = Lextures;
+			sourceTree = "<group>";
+		};
+		909C86F41CD8464D90AD80CB /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				6C3AE465810E4C95A8DA05EB /* MainTabView.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		986AC5D863474DBE9D0160FD = {
+			isa = PBXGroup;
+			children = (
+				6A755962AEFF455594F7F915 /* Lextures */,
+				5E058C31308649DF8586A531 /* Config */,
+				647AB81F3D014AD28EE763BF /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		9EF536582BDA43B28FAA8C7B /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				066587B2811146C78E80D685 /* AuthFlowView.swift */,
+				A99360CB1AD24036BC812D07 /* LoginView.swift */,
+				3885BB140F514CC89AA230DA /* SignupView.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		BEF7CB0206B449A6BC327F72 /* Notebooks */ = {
+			isa = PBXGroup;
+			children = (
+				5A1F00EBAA014E26B10D31EB /* NotebookDrawingViews.swift */,
+				5A1F00C4AA014E26B10D31A4 /* NotebookContentView.swift */,
+				64F60254486B40848E7855DD /* NotebookEditorView.swift */,
+				5A1F00C5AA014E26B10D31A5 /* NotebookPagesSheet.swift */,
+				45F7D43BE028418E80C1FCD3 /* NotebooksListView.swift */,
+			);
+			path = Notebooks;
+			sourceTree = "<group>";
+		};
+		C121A14D68474CC1BBF9DF4D /* Notebook */ = {
+			isa = PBXGroup;
+			children = (
+				5A1F00C1AA014E26B10D31A1 /* NotebookMarkdown.swift */,
+				4F94B6FA6AB244FC840F2082 /* NotebookStore.swift */,
+				5A1F00C2AA014E26B10D31A2 /* NotebookTree.swift */,
+				5A1F00EAAA014E26B10D31EA /* NotebookDrawing.swift */,
+				5A1F00E9AA014E26B10D31E9 /* NotebookSync.swift */,
+			);
+			path = Notebook;
+			sourceTree = "<group>";
+		};
+		C96C45AA454A4F6EBCDA73E6 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				09366EEEBD474A3486EF26B5 /* AuthAPI.swift */,
+				8E5C11281A734885A5225821 /* AuthSession.swift */,
+				2C9C72DBF2624D0082C7B3E1 /* KeychainStore.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		CAB9C124D0674BF0A7C37EA0 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				C96C45AA454A4F6EBCDA73E6 /* Auth */,
+				FD331751A29941778E7948ED /* Config */,
+				F7EB50F4758C47DFA7763BF7 /* Design */,
+				E24985077A294BC89135BCAF /* LMS */,
+				14638BA90EE943D7945C0E69 /* Networking */,
+				C121A14D68474CC1BBF9DF4D /* Notebook */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		E24985077A294BC89135BCAF /* LMS */ = {
+			isa = PBXGroup;
+			children = (
+				47C2CB6CF9014B9898889AF6 /* LMSAPI.swift */,
+				55556549CC7648629ED206D3 /* LMSModels.swift */,
+			);
+			path = LMS;
+			sourceTree = "<group>";
+		};
+		E7D02DBA66C644A5B1D31EB0 /* Splash */ = {
+			isa = PBXGroup;
+			children = (
+				9CDDB289A918498F9CD746F7 /* SplashView.swift */,
+			);
+			path = Splash;
+			sourceTree = "<group>";
+		};
+		F4136B0F59CF4B8E8B96C7BF /* App */ = {
+			isa = PBXGroup;
+			children = (
+				38C166E253A248319B432443 /* AppDelegate.swift */,
+				99A80628C78E4205901E36D0 /* LexturesApp.swift */,
+				8BEE2A4C41994279888559BF /* RootView.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		F7EB50F4758C47DFA7763BF7 /* Design */ = {
+			isa = PBXGroup;
+			children = (
+				574334E883A949A1B00BEA7E /* AuthFieldRepresentable.swift */,
+				9F610E9623944027A6D175ED /* BrandLogoView.swift */,
+				828D1E66BA2348C88AA26E8B /* LexturesTheme.swift */,
+			);
+			path = Design;
+			sourceTree = "<group>";
+		};
+		FD331751A29941778E7948ED /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				1639E37A4AD2422B88992EE7 /* AppConfiguration.swift */,
+			);
+			path = Config;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		CDF82E8E29D74604846A38CA /* Lextures */ = {
+		A599432A8B3F4BC3BC4DBDBC /* Lextures */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F8F7A7EE0D844DAD9BE51BF5 /* Build configuration list for PBXNativeTarget "Lextures" */;
+			buildConfigurationList = 1BE630C05B5B4BCDAEF5D4F4 /* Build configuration list for PBXNativeTarget "Lextures" */;
 			buildPhases = (
-				8C0F1260386849749787EA6F /* Sources */,
-				8AB93ADD97FB422BB02386A7 /* Frameworks */,
-				E86FBEC2CD404F95932C7776 /* Resources */,
+				7A18FBFCAAAA406D86E73FB9 /* Sources */,
+				8A64F18F3A704914846D04CC /* Frameworks */,
+				672317E13AB9401EAC133168 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = "Lextures";
+			name = Lextures;
 			productName = Lextures;
-			productReference = 7EA05A85DE53454496B1A6AC /* Lextures.app */;
+			productReference = 9C25089EC8754D55A657071D /* Lextures.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		022D11785DCB42BC8E064760 /* Project object */ = {
+		B016DB91B32142698E6AEA55 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
-					CDF82E8E29D74604846A38CA = {
+					A599432A8B3F4BC3BC4DBDBC = {
 						CreatedOnToolsVersion = 16.0;
 					};
 				};
 			};
-			buildConfigurationList = D0933CD5F9F44115B427E8DE /* Build configuration list for PBXProject "Lextures" */;
+			buildConfigurationList = 0AAC871663044DCAB5CA8D0B /* Build configuration list for PBXProject "Lextures" */;
 			compatibilityVersion = "Xcode 15.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -325,67 +352,148 @@
 				en,
 				Base,
 			);
-			mainGroup = D3C28190A9E14E7B8AD9306C;
-			productRefGroup = 19F31DE43B914BB79C4A4C61 /* Products */;
+			mainGroup = 986AC5D863474DBE9D0160FD;
+			productRefGroup = 647AB81F3D014AD28EE763BF /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				CDF82E8E29D74604846A38CA /* Lextures */,
+				A599432A8B3F4BC3BC4DBDBC /* Lextures */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		E86FBEC2CD404F95932C7776 /* Resources */ = {
+		672317E13AB9401EAC133168 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
-			runOnlyForDeploymentPostprocessing = 0;
 			files = (
-				FC8ACA3BF9404A7B90BE4DC6 /* Assets.xcassets in Resources */,
+				DE268217B82A4F71ACBF7087 /* Assets.xcassets in Resources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		8C0F1260386849749787EA6F /* Sources */ = {
+		7A18FBFCAAAA406D86E73FB9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
-			runOnlyForDeploymentPostprocessing = 0;
 			files = (
-				F471E822E14842DC842C2CF8 /* LexturesApp.swift in Sources */,
-				4A2F7A5668CD49888B2AFCBB /* RootView.swift in Sources */,
-				221366A1EC19428EA2FE4CD3 /* AuthAPI.swift in Sources */,
-				D899CDDD85EB4F5C820540DB /* AuthSession.swift in Sources */,
-				905323AF9DF849F0AFCEFD7E /* KeychainStore.swift in Sources */,
-				10B28DC1ACD34BF78661BDF0 /* AppConfiguration.swift in Sources */,
-				CA2ADB71493C486D86F08106 /* AuthFieldRepresentable.swift in Sources */,
-				3C522B2B68564728B39272F7 /* BrandLogoView.swift in Sources */,
-				00F39AC689714B25AB6B33C2 /* LexturesTheme.swift in Sources */,
-				FBAF9D9CB72E431BA0188DCA /* LMSAPI.swift in Sources */,
-				76E8791B81AD471CB3BEF582 /* LMSModels.swift in Sources */,
-				BDE3E1F7D5134B2993E65FAE /* APIClient.swift in Sources */,
-				EF5D0114E9914C14B5D85EC0 /* APIError.swift in Sources */,
-				5EE0E016B4444E648DEBB9EB /* NotebookStore.swift in Sources */,
-				ACF243F164224C90A8697F7E /* AuthFlowView.swift in Sources */,
-				AF324E219D5749B78AFD712E /* LoginView.swift in Sources */,
-				8DEB7C62AC17474EBD3DA567 /* SignupView.swift in Sources */,
-				F9827C2992FF468BAE2E2CE6 /* CourseDetailView.swift in Sources */,
-				296896314F784D149AF920AA /* CoursesListView.swift in Sources */,
-				63B9D3FEF05348B499699F4E /* ItemDetailView.swift in Sources */,
-				B7E84FA89C8B4DF690EB62DF /* DashboardView.swift in Sources */,
-				8B524D40FCC248D9A0B40CF4 /* MainTabView.swift in Sources */,
-				B37B5C5D48414298B470CC47 /* ComposeMessageView.swift in Sources */,
-				D8F57DF3CEAB46CF9A734E35 /* InboxView.swift in Sources */,
-				FE4C8C3A3A3E423F93032076 /* MessageDetailView.swift in Sources */,
-				67EF1C89FE8A4A51ACBD28F7 /* NotebookEditorView.swift in Sources */,
-				B31F5E6DDC164D23A0CF70F5 /* NotebooksListView.swift in Sources */,
-				3B9D1828434C4D2D8E6F63EF /* SplashView.swift in Sources */,
+				06BF80A426EF448BA01D5D07 /* AppDelegate.swift in Sources */,
+				F8063C33E42546F4A2560646 /* LexturesApp.swift in Sources */,
+				FB57FE93AF5140839554847E /* RootView.swift in Sources */,
+				3D97BCA1E1C04ABB8E3F1CFB /* AuthAPI.swift in Sources */,
+				6D29BD2496E144AE94667496 /* AuthSession.swift in Sources */,
+				F31ADB1A369347A3B5EA4206 /* KeychainStore.swift in Sources */,
+				8535B234CC374B51A1357BC7 /* AppConfiguration.swift in Sources */,
+				21794DCE0F7F4E2291E13329 /* AuthFieldRepresentable.swift in Sources */,
+				CF3CB48C18154910B172EC4C /* BrandLogoView.swift in Sources */,
+				BA2CF77B1C104CD1B084D9C3 /* LexturesTheme.swift in Sources */,
+				BBEB12AD7717454CBA9D0486 /* LMSAPI.swift in Sources */,
+				C56B4BBECE8E4855AC93BF0C /* LMSModels.swift in Sources */,
+				9B7C60D5E4EC484695674274 /* APIClient.swift in Sources */,
+				6F77BD6E17D541CCA600A2A3 /* APIError.swift in Sources */,
+				526718352EC24C6C92BB7AF2 /* NetworkBootstrap.swift in Sources */,
+				39084479F6C04C9ABBCA91AA /* NotebookStore.swift in Sources */,
+				6B2E11D1BB124F37C20E42B1 /* NotebookMarkdown.swift in Sources */,
+				6B2E11D2BB124F37C20E42B2 /* NotebookTree.swift in Sources */,
+				6B2E11EABB124F37C20E42EA /* NotebookDrawing.swift in Sources */,
+				6B2E11E9BB124F37C20E42E9 /* NotebookSync.swift in Sources */,
+				6B2E11EBBB124F37C20E42EB /* NotebookDrawingViews.swift in Sources */,
+				6B2E11D4BB124F37C20E42B4 /* NotebookContentView.swift in Sources */,
+				6B2E11D5BB124F37C20E42B5 /* NotebookPagesSheet.swift in Sources */,
+				BD2D03D462914A0DA21C4E1F /* AuthFlowView.swift in Sources */,
+				C7ED0963E92D40EA97A6CC63 /* LoginView.swift in Sources */,
+				714948F6C3974B438AF9606B /* SignupView.swift in Sources */,
+				95C7A86B713B440987ED538B /* CourseDetailView.swift in Sources */,
+				8626A52CA242419395680D7C /* CoursesListView.swift in Sources */,
+				A6B59F177C784BD48141CAE3 /* ItemDetailView.swift in Sources */,
+				127C2C5F5F844D9597155F25 /* DashboardView.swift in Sources */,
+				8DF636AE2DAB4652884755AA /* MainTabView.swift in Sources */,
+				78342E8E60C94C9DA3ACD30C /* ComposeMessageView.swift in Sources */,
+				A108965FD77349D8A3448CDA /* InboxView.swift in Sources */,
+				F7CA8C3DF6C94432975ACEAC /* MessageDetailView.swift in Sources */,
+				D649B2C460344F0182EE662A /* NotebookEditorView.swift in Sources */,
+				4CBBAE4108D04616A02D1967 /* NotebooksListView.swift in Sources */,
+				FA9B4A2B7C3C4CABB220C97B /* SplashView.swift in Sources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		223C4FEDA3B549919A9D6C3F /* Debug */ = {
+		1E7F3183DB264CCB8022046B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = s;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				ONLY_ACTIVE_ARCH = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		298C2ADA6D1F4B7EBA42E2AF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D8840EED931D44B1BF5313CB /* Development.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8RF75885C9;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Lextures/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lextures.ios;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		8373F35BC4974A7A99419F1F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D8840EED931D44B1BF5313CB /* Development.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8RF75885C9;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Lextures/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lextures.ios;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+		9D55FC5F45894D5DBC1AEECA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -400,104 +508,32 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = -Onone;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
-		};
-		89ADC696D4B64D15A599DEEB /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ENABLE_MODULES = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf-with-dsym;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = s;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				ONLY_ACTIVE_ARCH = NO;
-				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = -O;
-			};
-			name = Release;
-		};
-		E54767640FE244A4942C80F9 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B3E15A8D0DC847F882C75F6F /* Development.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = Lextures/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.lextures.ios;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
-			};
-			name = Debug;
-		};
-		188C570E38C24B52B03852CE /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B3E15A8D0DC847F882C75F6F /* Development.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = Lextures/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.lextures.ios;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
-			};
-			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		D0933CD5F9F44115B427E8DE /* Build configuration list for PBXProject "Lextures" */ = {
+		0AAC871663044DCAB5CA8D0B /* Build configuration list for PBXProject "Lextures" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				223C4FEDA3B549919A9D6C3F /* Debug */,
-				89ADC696D4B64D15A599DEEB /* Release */,
+				9D55FC5F45894D5DBC1AEECA /* Debug */,
+				1E7F3183DB264CCB8022046B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		F8F7A7EE0D844DAD9BE51BF5 /* Build configuration list for PBXNativeTarget "Lextures" */ = {
+		1BE630C05B5B4BCDAEF5D4F4 /* Build configuration list for PBXNativeTarget "Lextures" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E54767640FE244A4942C80F9 /* Debug */,
-				188C570E38C24B52B03852CE /* Release */,
+				298C2ADA6D1F4B7EBA42E2AF /* Debug */,
+				8373F35BC4974A7A99419F1F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 022D11785DCB42BC8E064760 /* Project object */;
+	rootObject = B016DB91B32142698E6AEA55 /* Project object */;
 }

--- a/clients/ios/Lextures.xcodeproj/xcshareddata/xcschemes/Lextures-Device.xcscheme
+++ b/clients/ios/Lextures.xcodeproj/xcshareddata/xcschemes/Lextures-Device.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A599432A8B3F4BC3BC4DBDBC"
+               BuildableName = "Lextures.app"
+               BlueprintName = "Lextures"
+               ReferencedContainer = "container:Lextures.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A599432A8B3F4BC3BC4DBDBC"
+            BuildableName = "Lextures.app"
+            BlueprintName = "Lextures"
+            ReferencedContainer = "container:Lextures.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/clients/ios/Lextures.xcodeproj/xcshareddata/xcschemes/Lextures.xcscheme
+++ b/clients/ios/Lextures.xcodeproj/xcshareddata/xcschemes/Lextures.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CDF82E8E29D74604846A38CA"
+               BlueprintIdentifier = "A599432A8B3F4BC3BC4DBDBC"
                BuildableName = "Lextures.app"
                BlueprintName = "Lextures"
                ReferencedContainer = "container:Lextures.xcodeproj">
@@ -43,7 +43,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CDF82E8E29D74604846A38CA"
+            BlueprintIdentifier = "A599432A8B3F4BC3BC4DBDBC"
             BuildableName = "Lextures.app"
             BlueprintName = "Lextures"
             ReferencedContainer = "container:Lextures.xcodeproj">

--- a/clients/ios/Lextures/App/AppDelegate.swift
+++ b/clients/ios/Lextures/App/AppDelegate.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        NetworkBootstrap.warmup()
+        return true
+    }
+}

--- a/clients/ios/Lextures/App/LexturesApp.swift
+++ b/clients/ios/Lextures/App/LexturesApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 @main
 struct LexturesApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var authSession = AuthSession()
 
     var body: some Scene {

--- a/clients/ios/Lextures/App/RootView.swift
+++ b/clients/ios/Lextures/App/RootView.swift
@@ -10,11 +10,10 @@ struct RootView: View {
             case .splash:
                 SplashView()
                     .task {
-                        // Refresh in parallel with the splash animation so a stale
-                        // 15-minute access token is replaced before the app shows.
-                        async let minimumSplash: Void? = try? await Task.sleep(for: .milliseconds(900))
+                        // Show splash first, then refresh. Avoids overlapping Swift concurrency +
+                        // URLSession work at process start (problematic on iOS 26/27 betas).
+                        try? await Task.sleep(for: .milliseconds(900))
                         await session.refreshIfNeeded()
-                        _ = await minimumSplash
                         withAnimation(.easeInOut(duration: 0.35)) {
                             session.finishSplash()
                         }

--- a/clients/ios/Lextures/Core/LMS/LMSAPI.swift
+++ b/clients/ios/Lextures/Core/LMS/LMSAPI.swift
@@ -145,6 +145,85 @@ enum LMSAPI {
         )
     }
 
+    // MARK: - Notebook tasks (dashboard sync, parity with web `notebook-tasks-api`)
+
+    struct NotebookTaskUpsert: Encodable {
+        var id: String
+        var courseCode: String
+        var notebookPageId: String
+        var taskText: String
+        var completed: Bool
+        var dueAt: String?
+
+        enum CodingKeys: String, CodingKey {
+            case id, courseCode, notebookPageId, taskText, completed, dueAt
+        }
+
+        // Explicit `dueAt: null` (web parity) — synthesized encoding would omit the key,
+        // which leaves a stale due date on the server.
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(courseCode, forKey: .courseCode)
+            try container.encode(notebookPageId, forKey: .notebookPageId)
+            try container.encode(taskText, forKey: .taskText)
+            try container.encode(completed, forKey: .completed)
+            try container.encode(dueAt, forKey: .dueAt)
+        }
+    }
+
+    static func upsertNotebookTask(_ task: NotebookTaskUpsert, accessToken: String) async throws {
+        _ = try await client.request(
+            path: "/api/v1/me/notebook-tasks",
+            method: "POST",
+            body: task,
+            authorized: true,
+            accessToken: accessToken
+        )
+    }
+
+    // MARK: - Notebooks (server sync, parity with web `student-notebook-sync`)
+
+    struct NotebookEntry: Decodable {
+        var courseCode: String
+        var updatedAt: String
+        var data: CourseNotebook?
+
+        enum CodingKeys: String, CodingKey { case courseCode, updatedAt, data }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            courseCode = try c.decode(String.self, forKey: .courseCode)
+            updatedAt = try c.decode(String.self, forKey: .updatedAt)
+            // Lenient: one malformed document must not break the whole list.
+            data = try? c.decode(CourseNotebook.self, forKey: .data)
+        }
+    }
+
+    private struct NotebooksResponse: Decodable {
+        var notebooks: [NotebookEntry]
+    }
+
+    static func fetchNotebooks(accessToken: String) async throws -> [NotebookEntry] {
+        let (data, _) = try await client.request(
+            path: "/api/v1/me/notebooks",
+            authorized: true,
+            accessToken: accessToken
+        )
+        return try decode(NotebooksResponse.self, from: data).notebooks
+    }
+
+    static func putNotebook(courseCode: String, notebook: CourseNotebook, accessToken: String) async throws {
+        let code = courseCode.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? courseCode
+        _ = try await client.request(
+            path: "/api/v1/me/notebooks?courseCode=\(code)",
+            method: "PUT",
+            body: notebook,
+            authorized: true,
+            accessToken: accessToken
+        )
+    }
+
     private static func encodePath(_ component: String) -> String {
         component.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? component
     }

--- a/clients/ios/Lextures/Core/LMS/LMSAPI.swift
+++ b/clients/ios/Lextures/Core/LMS/LMSAPI.swift
@@ -192,11 +192,11 @@ enum LMSAPI {
         enum CodingKeys: String, CodingKey { case courseCode, updatedAt, data }
 
         init(from decoder: Decoder) throws {
-            let c = try decoder.container(keyedBy: CodingKeys.self)
-            courseCode = try c.decode(String.self, forKey: .courseCode)
-            updatedAt = try c.decode(String.self, forKey: .updatedAt)
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            courseCode = try container.decode(String.self, forKey: .courseCode)
+            updatedAt = try container.decode(String.self, forKey: .updatedAt)
             // Lenient: one malformed document must not break the whole list.
-            data = try? c.decode(CourseNotebook.self, forKey: .data)
+            data = try? container.decode(CourseNotebook.self, forKey: .data)
         }
     }
 

--- a/clients/ios/Lextures/Core/Networking/APIClient.swift
+++ b/clients/ios/Lextures/Core/Networking/APIClient.swift
@@ -3,8 +3,8 @@ import Foundation
 struct APIClient {
     let session: URLSession
 
-    init(session: URLSession = .shared) {
-        self.session = session
+    init(session: URLSession? = nil) {
+        self.session = session ?? NetworkBootstrap.makeSession()
     }
 
     func request(

--- a/clients/ios/Lextures/Core/Networking/NetworkBootstrap.swift
+++ b/clients/ios/Lextures/Core/Networking/NetworkBootstrap.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Network
+
+/// Warms up Network.framework before URLSession on iOS 26+.
+///
+/// Apple DTS: a library load-order bug can crash when URLSession initializes before Network.framework
+/// (see https://developer.apple.com/forums/thread/787365). Call `warmup()` as early as possible.
+enum NetworkBootstrap {
+    private static let once: Void = {
+        _ = nw_tls_create_options()
+        _ = nw_endpoint_create_host("127.0.0.1", "80")
+        // `.ephemeral` is safe to touch before `.default` on affected OS versions.
+        _ = URLSessionConfiguration.ephemeral.timeoutIntervalForRequest
+    }()
+
+    static func warmup() {
+        _ = once
+    }
+
+    static func makeSession() -> URLSession {
+        warmup()
+        return URLSession(configuration: .ephemeral)
+    }
+}

--- a/clients/ios/Lextures/Core/Notebook/NotebookDrawing.swift
+++ b/clients/ios/Lextures/Core/Notebook/NotebookDrawing.swift
@@ -1,0 +1,221 @@
+import Foundation
+import SwiftUI
+
+/// One whiteboard element from a ```drawing fenced block (parity with web `whiteboard/types`).
+enum NotebookDrawEl: Equatable {
+    case stroke(color: String, width: Double, pts: [CGPoint])
+    case rect(color: String, width: Double, x: Double, y: Double, w: Double, h: Double)
+    case circle(color: String, width: Double, cx: Double, cy: Double, rx: Double, ry: Double)
+    case triangle(color: String, width: Double, x1: Double, y1: Double, x2: Double, y2: Double, x3: Double, y3: Double)
+    case line(color: String, width: Double, x1: Double, y1: Double, x2: Double, y2: Double)
+}
+
+enum NotebookDrawing {
+    static let colors: [String] = [
+        "#1e293b", "#ef4444", "#f97316", "#eab308", "#22c55e",
+        "#3b82f6", "#a855f7", "#ec4899", "#ffffff",
+    ]
+    static let strokeWidths: [Double] = [2, 4, 8]
+
+    // MARK: - JSON (parity with web `whiteboard/serialize`)
+
+    static func parseElements(_ raw: String) -> [NotebookDrawEl] {
+        guard
+            let data = raw.data(using: .utf8),
+            let array = (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]]
+        else { return [] }
+        return array.compactMap(parseElement)
+    }
+
+    private static func num(_ value: Any?) -> Double? {
+        (value as? NSNumber)?.doubleValue
+    }
+
+    private static func parseElement(_ obj: [String: Any]) -> NotebookDrawEl? {
+        let color = obj["color"] as? String ?? "#1e293b"
+        let width = num(obj["width"]) ?? 2
+        switch obj["type"] as? String {
+        case "stroke":
+            let pts = (obj["pts"] as? [[Any]] ?? []).compactMap { pair -> CGPoint? in
+                guard pair.count >= 2, let x = num(pair[0]), let y = num(pair[1]) else { return nil }
+                return CGPoint(x: x, y: y)
+            }
+            return .stroke(color: color, width: width, pts: pts)
+        case "rect":
+            guard let x = num(obj["x"]), let y = num(obj["y"]), let w = num(obj["w"]), let h = num(obj["h"]) else { return nil }
+            return .rect(color: color, width: width, x: x, y: y, w: w, h: h)
+        case "circle":
+            guard let cx = num(obj["cx"]), let cy = num(obj["cy"]), let rx = num(obj["rx"]), let ry = num(obj["ry"]) else { return nil }
+            return .circle(color: color, width: width, cx: cx, cy: cy, rx: rx, ry: ry)
+        case "triangle":
+            guard
+                let x1 = num(obj["x1"]), let y1 = num(obj["y1"]),
+                let x2 = num(obj["x2"]), let y2 = num(obj["y2"]),
+                let x3 = num(obj["x3"]), let y3 = num(obj["y3"])
+            else { return nil }
+            return .triangle(color: color, width: width, x1: x1, y1: y1, x2: x2, y2: y2, x3: x3, y3: y3)
+        case "line":
+            guard let x1 = num(obj["x1"]), let y1 = num(obj["y1"]), let x2 = num(obj["x2"]), let y2 = num(obj["y2"]) else { return nil }
+            return .line(color: color, width: width, x1: x1, y1: y1, x2: x2, y2: y2)
+        default:
+            return nil
+        }
+    }
+
+    static func serializeElements(_ elements: [NotebookDrawEl]) -> String {
+        let array: [[String: Any]] = elements.map { el in
+            switch el {
+            case .stroke(let color, let width, let pts):
+                return ["type": "stroke", "color": color, "width": width, "pts": pts.map { [$0.x, $0.y] }]
+            case .rect(let color, let width, let x, let y, let w, let h):
+                return ["type": "rect", "color": color, "width": width, "x": x, "y": y, "w": w, "h": h]
+            case .circle(let color, let width, let cx, let cy, let rx, let ry):
+                return ["type": "circle", "color": color, "width": width, "cx": cx, "cy": cy, "rx": rx, "ry": ry]
+            case .triangle(let color, let width, let x1, let y1, let x2, let y2, let x3, let y3):
+                return ["type": "triangle", "color": color, "width": width, "x1": x1, "y1": y1, "x2": x2, "y2": y2, "x3": x3, "y3": y3]
+            case .line(let color, let width, let x1, let y1, let x2, let y2):
+                return ["type": "line", "color": color, "width": width, "x1": x1, "y1": y1, "x2": x2, "y2": y2]
+            }
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: array) else { return "[]" }
+        return String(data: data, encoding: .utf8) ?? "[]"
+    }
+
+    // MARK: - Geometry
+
+    /// Content extent of the elements (origin-anchored), with a sensible floor for empty boards.
+    static func contentSize(_ elements: [NotebookDrawEl], minSize: CGSize = CGSize(width: 320, height: 220)) -> CGSize {
+        var maxX = minSize.width
+        var maxY = minSize.height
+        func grow(_ x: Double, _ y: Double) {
+            maxX = max(maxX, x)
+            maxY = max(maxY, y)
+        }
+        for el in elements {
+            switch el {
+            case .stroke(_, _, let pts):
+                for p in pts { grow(p.x, p.y) }
+            case .rect(_, _, let x, let y, let w, let h):
+                grow(x + w, y + h)
+                grow(x, y)
+            case .circle(_, _, let cx, let cy, let rx, let ry):
+                grow(cx + rx, cy + ry)
+            case .triangle(_, _, let x1, let y1, let x2, let y2, let x3, let y3):
+                grow(x1, y1); grow(x2, y2); grow(x3, y3)
+            case .line(_, _, let x1, let y1, let x2, let y2):
+                grow(x1, y1); grow(x2, y2)
+            }
+        }
+        return CGSize(width: maxX, height: maxY)
+    }
+
+    static func color(from hex: String, fallback: Color = .primary) -> Color {
+        var value = hex.trimmingCharacters(in: .whitespaces)
+        guard value.hasPrefix("#") else { return fallback }
+        value.removeFirst()
+        guard value.count == 6, let rgb = UInt32(value, radix: 16) else { return fallback }
+        return Color(
+            red: Double((rgb >> 16) & 0xFF) / 255,
+            green: Double((rgb >> 8) & 0xFF) / 255,
+            blue: Double(rgb & 0xFF) / 255
+        )
+    }
+
+    /// Draw all elements into a SwiftUI canvas context at the given scale.
+    static func draw(_ elements: [NotebookDrawEl], in context: GraphicsContext, scale: CGFloat) {
+        for el in elements {
+            switch el {
+            case .stroke(let color, let width, let pts):
+                guard pts.count > 1 else {
+                    if let p = pts.first {
+                        let r = max(width, 2) * scale / 2
+                        let dot = Path(ellipseIn: CGRect(x: p.x * scale - r, y: p.y * scale - r, width: r * 2, height: r * 2))
+                        context.fill(dot, with: .color(NotebookDrawing.color(from: color)))
+                    }
+                    continue
+                }
+                var path = Path()
+                path.move(to: CGPoint(x: pts[0].x * scale, y: pts[0].y * scale))
+                for p in pts.dropFirst() {
+                    path.addLine(to: CGPoint(x: p.x * scale, y: p.y * scale))
+                }
+                context.stroke(
+                    path,
+                    with: .color(NotebookDrawing.color(from: color)),
+                    style: StrokeStyle(lineWidth: width * scale, lineCap: .round, lineJoin: .round)
+                )
+            case .rect(let color, let width, let x, let y, let w, let h):
+                let rect = CGRect(x: x * scale, y: y * scale, width: w * scale, height: h * scale)
+                context.stroke(Path(rect), with: .color(NotebookDrawing.color(from: color)), lineWidth: width * scale)
+            case .circle(let color, let width, let cx, let cy, let rx, let ry):
+                let rect = CGRect(x: (cx - rx) * scale, y: (cy - ry) * scale, width: rx * 2 * scale, height: ry * 2 * scale)
+                context.stroke(Path(ellipseIn: rect), with: .color(NotebookDrawing.color(from: color)), lineWidth: width * scale)
+            case .triangle(let color, let width, let x1, let y1, let x2, let y2, let x3, let y3):
+                var path = Path()
+                path.move(to: CGPoint(x: x1 * scale, y: y1 * scale))
+                path.addLine(to: CGPoint(x: x2 * scale, y: y2 * scale))
+                path.addLine(to: CGPoint(x: x3 * scale, y: y3 * scale))
+                path.closeSubpath()
+                context.stroke(
+                    path,
+                    with: .color(NotebookDrawing.color(from: color)),
+                    style: StrokeStyle(lineWidth: width * scale, lineJoin: .round)
+                )
+            case .line(let color, let width, let x1, let y1, let x2, let y2):
+                var path = Path()
+                path.move(to: CGPoint(x: x1 * scale, y: y1 * scale))
+                path.addLine(to: CGPoint(x: x2 * scale, y: y2 * scale))
+                context.stroke(
+                    path,
+                    with: .color(NotebookDrawing.color(from: color)),
+                    style: StrokeStyle(lineWidth: width * scale, lineCap: .round)
+                )
+            }
+        }
+    }
+
+    /// Whether a point (content coordinates) is within `radius` of an element — eraser hit test.
+    static func hitTest(_ el: NotebookDrawEl, point: CGPoint, radius: Double) -> Bool {
+        func distToSegment(_ p: CGPoint, _ a: CGPoint, _ b: CGPoint) -> Double {
+            let dx = b.x - a.x, dy = b.y - a.y
+            let lengthSq = dx * dx + dy * dy
+            if lengthSq == 0 { return Double(hypot(p.x - a.x, p.y - a.y)) }
+            let t = max(0, min(1, ((p.x - a.x) * dx + (p.y - a.y) * dy) / lengthSq))
+            return Double(hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy)))
+        }
+        switch el {
+        case .stroke(_, let width, let pts):
+            let r = radius + width / 2
+            if pts.count == 1 { return Double(hypot(point.x - pts[0].x, point.y - pts[0].y)) <= r }
+            for i in 0 ..< max(0, pts.count - 1) where distToSegment(point, pts[i], pts[i + 1]) <= r {
+                return true
+            }
+            return false
+        case .line(_, let width, let x1, let y1, let x2, let y2):
+            return distToSegment(point, CGPoint(x: x1, y: y1), CGPoint(x: x2, y: y2)) <= radius + width / 2
+        case .rect(_, let width, let x, let y, let w, let h):
+            let corners = [
+                CGPoint(x: x, y: y), CGPoint(x: x + w, y: y),
+                CGPoint(x: x + w, y: y + h), CGPoint(x: x, y: y + h),
+            ]
+            let r = radius + width / 2
+            for i in 0 ..< 4 where distToSegment(point, corners[i], corners[(i + 1) % 4]) <= r {
+                return true
+            }
+            return false
+        case .circle(_, let width, let cx, let cy, let rx, let ry):
+            guard rx > 0, ry > 0 else { return false }
+            let nx = (point.x - cx) / rx
+            let ny = (point.y - cy) / ry
+            let norm = Double(hypot(nx, ny))
+            return abs(norm - 1) * min(rx, ry) <= radius + width / 2
+        case .triangle(_, let width, let x1, let y1, let x2, let y2, let x3, let y3):
+            let pts = [CGPoint(x: x1, y: y1), CGPoint(x: x2, y: y2), CGPoint(x: x3, y: y3)]
+            let r = radius + width / 2
+            for i in 0 ..< 3 where distToSegment(point, pts[i], pts[(i + 1) % 3]) <= r {
+                return true
+            }
+            return false
+        }
+    }
+}

--- a/clients/ios/Lextures/Core/Notebook/NotebookDrawing.swift
+++ b/clients/ios/Lextures/Core/Notebook/NotebookDrawing.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// One whiteboard element from a ```drawing fenced block (parity with web `whiteboard/types`).
 enum NotebookDrawEl: Equatable {
     case stroke(color: String, width: Double, pts: [CGPoint])
-    case rect(color: String, width: Double, x: Double, y: Double, w: Double, h: Double)
+    case rect(color: String, width: Double, rectX: Double, rectY: Double, rectWidth: Double, rectHeight: Double)
     case circle(color: String, width: Double, cx: Double, cy: Double, rx: Double, ry: Double)
     case triangle(color: String, width: Double, x1: Double, y1: Double, x2: Double, y2: Double, x3: Double, y3: Double)
     case line(color: String, width: Double, x1: Double, y1: Double, x2: Double, y2: Double)
@@ -37,16 +37,22 @@ enum NotebookDrawing {
         switch obj["type"] as? String {
         case "stroke":
             let pts = (obj["pts"] as? [[Any]] ?? []).compactMap { pair -> CGPoint? in
-                guard pair.count >= 2, let x = num(pair[0]), let y = num(pair[1]) else { return nil }
-                return CGPoint(x: x, y: y)
+                guard pair.count >= 2, let pointX = num(pair[0]), let pointY = num(pair[1]) else { return nil }
+                return CGPoint(x: pointX, y: pointY)
             }
             return .stroke(color: color, width: width, pts: pts)
         case "rect":
-            guard let x = num(obj["x"]), let y = num(obj["y"]), let w = num(obj["w"]), let h = num(obj["h"]) else { return nil }
-            return .rect(color: color, width: width, x: x, y: y, w: w, h: h)
+            guard
+                let rectX = num(obj["x"]), let rectY = num(obj["y"]),
+                let rectW = num(obj["w"]), let rectH = num(obj["h"])
+            else { return nil }
+            return .rect(color: color, width: width, rectX: rectX, rectY: rectY, rectWidth: rectW, rectHeight: rectH)
         case "circle":
-            guard let cx = num(obj["cx"]), let cy = num(obj["cy"]), let rx = num(obj["rx"]), let ry = num(obj["ry"]) else { return nil }
-            return .circle(color: color, width: width, cx: cx, cy: cy, rx: rx, ry: ry)
+            guard
+                let centerX = num(obj["cx"]), let centerY = num(obj["cy"]),
+                let radiusX = num(obj["rx"]), let radiusY = num(obj["ry"])
+            else { return nil }
+            return .circle(color: color, width: width, cx: centerX, cy: centerY, rx: radiusX, ry: radiusY)
         case "triangle":
             guard
                 let x1 = num(obj["x1"]), let y1 = num(obj["y1"]),
@@ -55,7 +61,10 @@ enum NotebookDrawing {
             else { return nil }
             return .triangle(color: color, width: width, x1: x1, y1: y1, x2: x2, y2: y2, x3: x3, y3: y3)
         case "line":
-            guard let x1 = num(obj["x1"]), let y1 = num(obj["y1"]), let x2 = num(obj["x2"]), let y2 = num(obj["y2"]) else { return nil }
+            guard
+                let x1 = num(obj["x1"]), let y1 = num(obj["y1"]),
+                let x2 = num(obj["x2"]), let y2 = num(obj["y2"])
+            else { return nil }
             return .line(color: color, width: width, x1: x1, y1: y1, x2: x2, y2: y2)
         default:
             return nil
@@ -63,14 +72,14 @@ enum NotebookDrawing {
     }
 
     static func serializeElements(_ elements: [NotebookDrawEl]) -> String {
-        let array: [[String: Any]] = elements.map { el in
-            switch el {
+        let array: [[String: Any]] = elements.map { element in
+            switch element {
             case .stroke(let color, let width, let pts):
                 return ["type": "stroke", "color": color, "width": width, "pts": pts.map { [$0.x, $0.y] }]
-            case .rect(let color, let width, let x, let y, let w, let h):
-                return ["type": "rect", "color": color, "width": width, "x": x, "y": y, "w": w, "h": h]
-            case .circle(let color, let width, let cx, let cy, let rx, let ry):
-                return ["type": "circle", "color": color, "width": width, "cx": cx, "cy": cy, "rx": rx, "ry": ry]
+            case .rect(let color, let width, let rectX, let rectY, let rectWidth, let rectHeight):
+                return ["type": "rect", "color": color, "width": width, "x": rectX, "y": rectY, "w": rectWidth, "h": rectHeight]
+            case .circle(let color, let width, let centerX, let centerY, let radiusX, let radiusY):
+                return ["type": "circle", "color": color, "width": width, "cx": centerX, "cy": centerY, "rx": radiusX, "ry": radiusY]
             case .triangle(let color, let width, let x1, let y1, let x2, let y2, let x3, let y3):
                 return ["type": "triangle", "color": color, "width": width, "x1": x1, "y1": y1, "x2": x2, "y2": y2, "x3": x3, "y3": y3]
             case .line(let color, let width, let x1, let y1, let x2, let y2):
@@ -87,19 +96,19 @@ enum NotebookDrawing {
     static func contentSize(_ elements: [NotebookDrawEl], minSize: CGSize = CGSize(width: 320, height: 220)) -> CGSize {
         var maxX = minSize.width
         var maxY = minSize.height
-        func grow(_ x: Double, _ y: Double) {
-            maxX = max(maxX, x)
-            maxY = max(maxY, y)
+        func grow(_ coordX: Double, _ coordY: Double) {
+            maxX = max(maxX, coordX)
+            maxY = max(maxY, coordY)
         }
-        for el in elements {
-            switch el {
+        for element in elements {
+            switch element {
             case .stroke(_, _, let pts):
-                for p in pts { grow(p.x, p.y) }
-            case .rect(_, _, let x, let y, let w, let h):
-                grow(x + w, y + h)
-                grow(x, y)
-            case .circle(_, _, let cx, let cy, let rx, let ry):
-                grow(cx + rx, cy + ry)
+                for point in pts { grow(point.x, point.y) }
+            case .rect(_, _, let rectX, let rectY, let rectWidth, let rectHeight):
+                grow(rectX + rectWidth, rectY + rectHeight)
+                grow(rectX, rectY)
+            case .circle(_, _, let centerX, let centerY, let radiusX, let radiusY):
+                grow(centerX + radiusX, centerY + radiusY)
             case .triangle(_, _, let x1, let y1, let x2, let y2, let x3, let y3):
                 grow(x1, y1); grow(x2, y2); grow(x3, y3)
             case .line(_, _, let x1, let y1, let x2, let y2):
@@ -123,32 +132,42 @@ enum NotebookDrawing {
 
     /// Draw all elements into a SwiftUI canvas context at the given scale.
     static func draw(_ elements: [NotebookDrawEl], in context: GraphicsContext, scale: CGFloat) {
-        for el in elements {
-            switch el {
+        for element in elements {
+            switch element {
             case .stroke(let color, let width, let pts):
                 guard pts.count > 1 else {
-                    if let p = pts.first {
-                        let r = max(width, 2) * scale / 2
-                        let dot = Path(ellipseIn: CGRect(x: p.x * scale - r, y: p.y * scale - r, width: r * 2, height: r * 2))
+                    if let point = pts.first {
+                        let dotRadius = max(width, 2) * scale / 2
+                        let dot = Path(ellipseIn: CGRect(
+                            x: point.x * scale - dotRadius,
+                            y: point.y * scale - dotRadius,
+                            width: dotRadius * 2,
+                            height: dotRadius * 2
+                        ))
                         context.fill(dot, with: .color(NotebookDrawing.color(from: color)))
                     }
                     continue
                 }
                 var path = Path()
                 path.move(to: CGPoint(x: pts[0].x * scale, y: pts[0].y * scale))
-                for p in pts.dropFirst() {
-                    path.addLine(to: CGPoint(x: p.x * scale, y: p.y * scale))
+                for point in pts.dropFirst() {
+                    path.addLine(to: CGPoint(x: point.x * scale, y: point.y * scale))
                 }
                 context.stroke(
                     path,
                     with: .color(NotebookDrawing.color(from: color)),
                     style: StrokeStyle(lineWidth: width * scale, lineCap: .round, lineJoin: .round)
                 )
-            case .rect(let color, let width, let x, let y, let w, let h):
-                let rect = CGRect(x: x * scale, y: y * scale, width: w * scale, height: h * scale)
+            case .rect(let color, let width, let rectX, let rectY, let rectWidth, let rectHeight):
+                let rect = CGRect(x: rectX * scale, y: rectY * scale, width: rectWidth * scale, height: rectHeight * scale)
                 context.stroke(Path(rect), with: .color(NotebookDrawing.color(from: color)), lineWidth: width * scale)
-            case .circle(let color, let width, let cx, let cy, let rx, let ry):
-                let rect = CGRect(x: (cx - rx) * scale, y: (cy - ry) * scale, width: rx * 2 * scale, height: ry * 2 * scale)
+            case .circle(let color, let width, let centerX, let centerY, let radiusX, let radiusY):
+                let rect = CGRect(
+                    x: (centerX - radiusX) * scale,
+                    y: (centerY - radiusY) * scale,
+                    width: radiusX * 2 * scale,
+                    height: radiusY * 2 * scale
+                )
                 context.stroke(Path(ellipseIn: rect), with: .color(NotebookDrawing.color(from: color)), lineWidth: width * scale)
             case .triangle(let color, let width, let x1, let y1, let x2, let y2, let x3, let y3):
                 var path = Path()
@@ -175,44 +194,47 @@ enum NotebookDrawing {
     }
 
     /// Whether a point (content coordinates) is within `radius` of an element — eraser hit test.
-    static func hitTest(_ el: NotebookDrawEl, point: CGPoint, radius: Double) -> Bool {
-        func distToSegment(_ p: CGPoint, _ a: CGPoint, _ b: CGPoint) -> Double {
-            let dx = b.x - a.x, dy = b.y - a.y
-            let lengthSq = dx * dx + dy * dy
-            if lengthSq == 0 { return Double(hypot(p.x - a.x, p.y - a.y)) }
-            let t = max(0, min(1, ((p.x - a.x) * dx + (p.y - a.y) * dy) / lengthSq))
-            return Double(hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy)))
+    static func hitTest(_ element: NotebookDrawEl, point: CGPoint, radius: Double) -> Bool {
+        func distToSegment(_ probe: CGPoint, _ start: CGPoint, _ end: CGPoint) -> Double {
+            let deltaX = end.x - start.x, deltaY = end.y - start.y
+            let lengthSq = deltaX * deltaX + deltaY * deltaY
+            if lengthSq == 0 { return Double(hypot(probe.x - start.x, probe.y - start.y)) }
+            let projection = max(0, min(1, ((probe.x - start.x) * deltaX + (probe.y - start.y) * deltaY) / lengthSq))
+            return Double(hypot(
+                probe.x - (start.x + projection * deltaX),
+                probe.y - (start.y + projection * deltaY)
+            ))
         }
-        switch el {
+        switch element {
         case .stroke(_, let width, let pts):
-            let r = radius + width / 2
-            if pts.count == 1 { return Double(hypot(point.x - pts[0].x, point.y - pts[0].y)) <= r }
-            for i in 0 ..< max(0, pts.count - 1) where distToSegment(point, pts[i], pts[i + 1]) <= r {
+            let hitRadius = radius + width / 2
+            if pts.count == 1 { return Double(hypot(point.x - pts[0].x, point.y - pts[0].y)) <= hitRadius }
+            for segIndex in 0 ..< max(0, pts.count - 1) where distToSegment(point, pts[segIndex], pts[segIndex + 1]) <= hitRadius {
                 return true
             }
             return false
         case .line(_, let width, let x1, let y1, let x2, let y2):
             return distToSegment(point, CGPoint(x: x1, y: y1), CGPoint(x: x2, y: y2)) <= radius + width / 2
-        case .rect(_, let width, let x, let y, let w, let h):
+        case .rect(_, let width, let rectX, let rectY, let rectWidth, let rectHeight):
             let corners = [
-                CGPoint(x: x, y: y), CGPoint(x: x + w, y: y),
-                CGPoint(x: x + w, y: y + h), CGPoint(x: x, y: y + h),
+                CGPoint(x: rectX, y: rectY), CGPoint(x: rectX + rectWidth, y: rectY),
+                CGPoint(x: rectX + rectWidth, y: rectY + rectHeight), CGPoint(x: rectX, y: rectY + rectHeight),
             ]
-            let r = radius + width / 2
-            for i in 0 ..< 4 where distToSegment(point, corners[i], corners[(i + 1) % 4]) <= r {
+            let hitRadius = radius + width / 2
+            for cornerIndex in 0 ..< 4 where distToSegment(point, corners[cornerIndex], corners[(cornerIndex + 1) % 4]) <= hitRadius {
                 return true
             }
             return false
-        case .circle(_, let width, let cx, let cy, let rx, let ry):
-            guard rx > 0, ry > 0 else { return false }
-            let nx = (point.x - cx) / rx
-            let ny = (point.y - cy) / ry
-            let norm = Double(hypot(nx, ny))
-            return abs(norm - 1) * min(rx, ry) <= radius + width / 2
+        case .circle(_, let width, let centerX, let centerY, let radiusX, let radiusY):
+            guard radiusX > 0, radiusY > 0 else { return false }
+            let normX = (point.x - centerX) / radiusX
+            let normY = (point.y - centerY) / radiusY
+            let norm = Double(hypot(normX, normY))
+            return abs(norm - 1) * min(radiusX, radiusY) <= radius + width / 2
         case .triangle(_, let width, let x1, let y1, let x2, let y2, let x3, let y3):
             let pts = [CGPoint(x: x1, y: y1), CGPoint(x: x2, y: y2), CGPoint(x: x3, y: y3)]
-            let r = radius + width / 2
-            for i in 0 ..< 3 where distToSegment(point, pts[i], pts[(i + 1) % 3]) <= r {
+            let hitRadius = radius + width / 2
+            for cornerIndex in 0 ..< 3 where distToSegment(point, pts[cornerIndex], pts[(cornerIndex + 1) % 3]) <= hitRadius {
                 return true
             }
             return false

--- a/clients/ios/Lextures/Core/Notebook/NotebookMarkdown.swift
+++ b/clients/ios/Lextures/Core/Notebook/NotebookMarkdown.swift
@@ -1,0 +1,498 @@
+import Foundation
+
+/// A task parsed from a ```task fenced block (parity with web `notebook-task-markdown`).
+struct ParsedNotebookTask: Identifiable, Equatable {
+    let id: String
+    var text: String
+    var checked: Bool
+    var dueAt: String?
+}
+
+/// One slash-command / toolbar insert action (parity with web `markdown-body-slash`).
+struct NotebookSlashCommand: Identifiable, Equatable {
+    let id: String
+    let label: String
+    let detail: String
+    let icon: String
+    let keywords: [String]
+}
+
+/// Renderable markdown block for the notebook reading view.
+enum NotebookBlockKind: Equatable {
+    case heading(level: Int, text: String)
+    case paragraph(String)
+    case bulletItem(String)
+    case orderedItem(number: String, text: String)
+    case quote(String)
+    case code(String)
+    case divider
+    case task(ParsedNotebookTask)
+    case image(alt: String, url: String)
+    /// `index` is the drawing's ordinal among all drawings on the page (for write-back).
+    case drawing(index: Int, elementsJson: String)
+}
+
+struct NotebookBlock: Identifiable, Equatable {
+    let id: Int
+    let kind: NotebookBlockKind
+}
+
+/// One editable block in the WYSIWYG notebook editor (parity with the web block editor:
+/// blocks stay rendered while editing; markdown is only the storage format).
+struct NotebookEditBlock: Identifiable, Equatable {
+    enum Kind: Equatable {
+        case paragraph
+        case heading(Int)
+        case bullet
+        case ordered
+        case quote
+        case code
+        case divider
+        case task(taskId: String, checked: Bool, dueAt: String?)
+        case image(alt: String, url: String)
+        case drawing(elementsJson: String)
+
+        var isOrdered: Bool {
+            if case .ordered = self { return true }
+            return false
+        }
+
+        /// Consecutive items of the same list/quote kind join with one newline, not a blank line.
+        func sameListRun(as other: Kind?) -> Bool {
+            switch (self, other) {
+            case (.bullet, .bullet), (.ordered, .ordered), (.quote, .quote): return true
+            default: return false
+            }
+        }
+    }
+
+    let id: UUID
+    var kind: Kind
+    var text: String
+
+    init(kind: Kind, text: String = "") {
+        id = UUID()
+        self.kind = kind
+        self.text = text
+    }
+
+    /// Whether the block carries user-editable text (false for divider / image / drawing).
+    var isTextual: Bool {
+        switch kind {
+        case .divider, .image, .drawing: return false
+        default: return true
+        }
+    }
+}
+
+enum NotebookMarkdown {
+    // MARK: - Task blocks (```task + JSON meta line)
+
+    private static let taskBlockRegex = try! NSRegularExpression(pattern: "```task[ \\t]*\\n([\\s\\S]*?)```")
+
+    static func newTaskId() -> String {
+        UUID().uuidString.lowercased()
+    }
+
+    static func taskMetaLine(id: String, checked: Bool, dueAt: String?) -> String {
+        let due = dueAt.map { "\"\(jsonEscape($0))\"" } ?? "null"
+        return "{\"id\":\"\(jsonEscape(id))\",\"checked\":\(checked),\"dueAt\":\(due)}"
+    }
+
+    private static func jsonEscape(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+    }
+
+    private static func parseTaskMeta(line: String) -> (id: String, checked: Bool, dueAt: String?)? {
+        guard
+            let data = line.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let id = json["id"] as? String, !id.isEmpty
+        else { return nil }
+        return (id, json["checked"] as? Bool == true, json["dueAt"] as? String)
+    }
+
+    private static func parseTaskInner(_ inner: String) -> ParsedNotebookTask? {
+        var lines = inner.components(separatedBy: "\n")
+        guard let meta = parseTaskMeta(line: lines.first ?? "") else { return nil }
+        lines.removeFirst()
+        let text = lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        return ParsedNotebookTask(id: meta.id, text: text, checked: meta.checked, dueAt: meta.dueAt)
+    }
+
+    static func parseTasks(in contentMd: String) -> [ParsedNotebookTask] {
+        let ns = contentMd as NSString
+        return taskBlockRegex.matches(in: contentMd, range: NSRange(location: 0, length: ns.length))
+            .compactMap { match in
+                parseTaskInner(ns.substring(with: match.range(at: 1)))
+            }
+    }
+
+    /// Rewrite the matching task block, transforming its meta (`checked` / `dueAt`); body text unchanged.
+    private static func rewriteTask(
+        in contentMd: String,
+        taskId: String,
+        transform: (ParsedNotebookTask) -> (checked: Bool, dueAt: String?)
+    ) -> String {
+        let ns = contentMd as NSString
+        var result = ""
+        var cursor = 0
+        for match in taskBlockRegex.matches(in: contentMd, range: NSRange(location: 0, length: ns.length)) {
+            result += ns.substring(with: NSRange(location: cursor, length: match.range.location - cursor))
+            let inner = ns.substring(with: match.range(at: 1))
+            if let task = parseTaskInner(inner), task.id == taskId {
+                let next = transform(task)
+                var bodyLines = inner.components(separatedBy: "\n")
+                bodyLines.removeFirst()
+                let body = bodyLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+                let meta = taskMetaLine(id: task.id, checked: next.checked, dueAt: next.dueAt)
+                result += "```task\n\(meta)\n\(body)\n```"
+            } else {
+                result += ns.substring(with: match.range)
+            }
+            cursor = match.range.location + match.range.length
+        }
+        result += ns.substring(from: cursor)
+        return result
+    }
+
+    static func setTaskChecked(in contentMd: String, taskId: String, checked: Bool) -> String {
+        rewriteTask(in: contentMd, taskId: taskId) { (checked, $0.dueAt) }
+    }
+
+    static func setTaskDueAt(in contentMd: String, taskId: String, dueAt: String?) -> String {
+        rewriteTask(in: contentMd, taskId: taskId) { ($0.checked, dueAt) }
+    }
+
+    // MARK: - Block parsing (reading view)
+
+    static func parseBlocks(_ contentMd: String) -> [NotebookBlock] {
+        var kinds: [NotebookBlockKind] = []
+        var paragraph: [String] = []
+        var quote: [String] = []
+
+        func flushParagraph() {
+            if !paragraph.isEmpty {
+                kinds.append(.paragraph(paragraph.joined(separator: "\n")))
+                paragraph = []
+            }
+        }
+        func flushQuote() {
+            if !quote.isEmpty {
+                kinds.append(.quote(quote.joined(separator: "\n")))
+                quote = []
+            }
+        }
+        func flushAll() {
+            flushParagraph()
+            flushQuote()
+        }
+
+        let lines = contentMd.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
+        var i = 0
+        var drawingIndex = 0
+        while i < lines.count {
+            let line = lines[i]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.hasPrefix("```drawing") {
+                flushAll()
+                var inner: [String] = []
+                i += 1
+                while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces) != "```" {
+                    inner.append(lines[i])
+                    i += 1
+                }
+                kinds.append(.drawing(index: drawingIndex, elementsJson: inner.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)))
+                drawingIndex += 1
+                i += 1
+                continue
+            }
+            if trimmed == "```task" || trimmed.hasPrefix("```task") {
+                flushAll()
+                var inner: [String] = []
+                i += 1
+                while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces) != "```" {
+                    inner.append(lines[i])
+                    i += 1
+                }
+                if let task = parseTaskInner(inner.joined(separator: "\n")) {
+                    kinds.append(.task(task))
+                }
+                i += 1
+                continue
+            }
+            if trimmed.hasPrefix("```") {
+                flushAll()
+                var inner: [String] = []
+                i += 1
+                while i < lines.count, !lines[i].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+                    inner.append(lines[i])
+                    i += 1
+                }
+                kinds.append(.code(inner.joined(separator: "\n")))
+                i += 1
+                continue
+            }
+            if let heading = parseHeading(trimmed) {
+                flushAll()
+                kinds.append(heading)
+            } else if trimmed == "---" || trimmed == "***" || trimmed == "___" {
+                flushAll()
+                kinds.append(.divider)
+            } else if let image = parseImage(trimmed) {
+                flushAll()
+                kinds.append(image)
+            } else if trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ") {
+                flushAll()
+                kinds.append(.bulletItem(String(trimmed.dropFirst(2))))
+            } else if let ordered = parseOrderedItem(trimmed) {
+                flushAll()
+                kinds.append(ordered)
+            } else if trimmed.hasPrefix(">") {
+                flushParagraph()
+                quote.append(trimmed.dropFirst().trimmingCharacters(in: .whitespaces))
+            } else if trimmed.isEmpty {
+                flushAll()
+            } else {
+                flushQuote()
+                paragraph.append(trimmed)
+            }
+            i += 1
+        }
+        flushAll()
+        return kinds.enumerated().map { NotebookBlock(id: $0.offset, kind: $0.element) }
+    }
+
+    private static func parseHeading(_ line: String) -> NotebookBlockKind? {
+        guard line.hasPrefix("#") else { return nil }
+        let hashes = line.prefix(while: { $0 == "#" })
+        guard hashes.count <= 6 else { return nil }
+        let rest = line.dropFirst(hashes.count)
+        guard rest.hasPrefix(" ") else { return nil }
+        return .heading(level: hashes.count, text: rest.trimmingCharacters(in: .whitespaces))
+    }
+
+    private static let orderedItemRegex = try! NSRegularExpression(pattern: "^(\\d+)[.)] (.*)$")
+
+    private static func parseOrderedItem(_ line: String) -> NotebookBlockKind? {
+        let ns = line as NSString
+        guard let match = orderedItemRegex.firstMatch(in: line, range: NSRange(location: 0, length: ns.length)) else {
+            return nil
+        }
+        return .orderedItem(number: ns.substring(with: match.range(at: 1)), text: ns.substring(with: match.range(at: 2)))
+    }
+
+    private static let imageRegex = try! NSRegularExpression(pattern: "^!\\[([^\\]]*)\\]\\(([^)]+)\\)$")
+
+    private static func parseImage(_ line: String) -> NotebookBlockKind? {
+        let ns = line as NSString
+        guard let match = imageRegex.firstMatch(in: line, range: NSRange(location: 0, length: ns.length)) else {
+            return nil
+        }
+        return .image(alt: ns.substring(with: match.range(at: 1)), url: ns.substring(with: match.range(at: 2)))
+    }
+
+    // MARK: - Edit blocks (WYSIWYG editor, parity with web block editor)
+
+    static func editBlocks(from contentMd: String) -> [NotebookEditBlock] {
+        var out: [NotebookEditBlock] = []
+        for block in parseBlocks(contentMd) {
+            switch block.kind {
+            case .heading(let level, let text):
+                out.append(NotebookEditBlock(kind: .heading(level), text: text))
+            case .paragraph(let text):
+                for line in text.components(separatedBy: "\n") {
+                    out.append(NotebookEditBlock(kind: .paragraph, text: line))
+                }
+            case .bulletItem(let text):
+                out.append(NotebookEditBlock(kind: .bullet, text: text))
+            case .orderedItem(_, let text):
+                out.append(NotebookEditBlock(kind: .ordered, text: text))
+            case .quote(let text):
+                for line in text.components(separatedBy: "\n") {
+                    out.append(NotebookEditBlock(kind: .quote, text: line))
+                }
+            case .code(let text):
+                out.append(NotebookEditBlock(kind: .code, text: text))
+            case .divider:
+                out.append(NotebookEditBlock(kind: .divider))
+            case .task(let task):
+                out.append(NotebookEditBlock(
+                    kind: .task(taskId: task.id, checked: task.checked, dueAt: task.dueAt),
+                    text: task.text
+                ))
+            case .image(let alt, let url):
+                out.append(NotebookEditBlock(kind: .image(alt: alt, url: url)))
+            case .drawing(_, let elementsJson):
+                out.append(NotebookEditBlock(kind: .drawing(elementsJson: elementsJson)))
+            }
+        }
+        if out.isEmpty {
+            out.append(NotebookEditBlock(kind: .paragraph))
+        }
+        return out
+    }
+
+    static func markdown(from blocks: [NotebookEditBlock]) -> String {
+        var out = ""
+        var previous: NotebookEditBlock.Kind?
+        var orderedRun = 0
+
+        for block in blocks {
+            let chunk: String
+            switch block.kind {
+            case .paragraph:
+                if block.text.trimmingCharacters(in: .whitespaces).isEmpty { continue }
+                chunk = block.text
+            case .heading(let level):
+                chunk = String(repeating: "#", count: max(1, min(level, 6))) + " " + block.text
+            case .bullet:
+                chunk = "- \(block.text)"
+            case .ordered:
+                orderedRun = previous?.isOrdered == true ? orderedRun + 1 : 1
+                chunk = "\(orderedRun). \(block.text)"
+            case .quote:
+                chunk = "> \(block.text)"
+            case .code:
+                chunk = "```\n\(block.text)\n```"
+            case .divider:
+                chunk = "---"
+            case .task(let taskId, let checked, let dueAt):
+                chunk = "```task\n\(taskMetaLine(id: taskId, checked: checked, dueAt: dueAt))\n\(block.text)\n```"
+            case .image(let alt, let url):
+                chunk = "![\(alt)](\(url))"
+            case .drawing(let elementsJson):
+                chunk = "```drawing\n\(elementsJson)\n```"
+            }
+            if out.isEmpty {
+                out = chunk
+            } else if block.kind.sameListRun(as: previous) {
+                out += "\n" + chunk
+            } else {
+                out += "\n\n" + chunk
+            }
+            previous = block.kind
+        }
+        return out
+    }
+
+    /// Replace the elements JSON of the page's Nth drawing fence (0-based, document order).
+    static func replaceDrawing(in contentMd: String, index: Int, elementsJson: String) -> String {
+        var out: [String] = []
+        var current = -1
+        let lines = contentMd.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
+        var i = 0
+        while i < lines.count {
+            let trimmed = lines[i].trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("```drawing") {
+                current += 1
+                var inner: [String] = []
+                i += 1
+                while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces) != "```" {
+                    inner.append(lines[i])
+                    i += 1
+                }
+                i += 1
+                let body = current == index
+                    ? elementsJson
+                    : inner.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+                out.append("```drawing\n\(body)\n```")
+                continue
+            }
+            out.append(lines[i])
+            i += 1
+        }
+        return out.joined(separator: "\n")
+    }
+
+    // MARK: - Slash commands
+
+    static let slashCommands: [NotebookSlashCommand] = [
+        NotebookSlashCommand(
+            id: "heading1", label: "Heading 1", detail: "Large section heading",
+            icon: "textformat.size.larger", keywords: ["h1", "title", "heading"]
+        ),
+        NotebookSlashCommand(
+            id: "heading2", label: "Heading 2", detail: "Medium section heading",
+            icon: "textformat.size", keywords: ["h2", "heading"]
+        ),
+        NotebookSlashCommand(
+            id: "heading3", label: "Heading 3", detail: "Small section heading",
+            icon: "textformat.size.smaller", keywords: ["h3", "heading"]
+        ),
+        NotebookSlashCommand(
+            id: "task", label: "Task", detail: "Checkbox task with optional due date",
+            icon: "checkmark.square", keywords: ["task", "todo", "checkbox", "checklist"]
+        ),
+        NotebookSlashCommand(
+            id: "drawing", label: "Drawing", detail: "Insert a whiteboard to draw on",
+            icon: "scribble.variable", keywords: ["drawing", "whiteboard", "sketch", "draw", "canvas"]
+        ),
+        NotebookSlashCommand(
+            id: "bulletList", label: "Bullet list", detail: "Unordered list",
+            icon: "list.bullet", keywords: ["ul", "list", "bullets"]
+        ),
+        NotebookSlashCommand(
+            id: "orderedList", label: "Numbered list", detail: "Ordered list",
+            icon: "list.number", keywords: ["ol", "list", "numbers"]
+        ),
+        NotebookSlashCommand(
+            id: "blockquote", label: "Quote", detail: "Indented quotation",
+            icon: "text.quote", keywords: ["quote", "blockquote"]
+        ),
+        NotebookSlashCommand(
+            id: "codeBlock", label: "Code", detail: "Code block",
+            icon: "curlybraces", keywords: ["code", "pre", "snippet"]
+        ),
+        NotebookSlashCommand(
+            id: "horizontalRule", label: "Divider", detail: "Horizontal line",
+            icon: "minus", keywords: ["hr", "divider", "line", "rule"]
+        ),
+    ]
+
+    static func filterCommands(query: String) -> [NotebookSlashCommand] {
+        let q = query.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !q.isEmpty else { return slashCommands }
+        return slashCommands.filter { cmd in
+            if cmd.id.lowercased() == q || cmd.id.lowercased().hasPrefix(q) || q.hasPrefix(cmd.id.lowercased()) {
+                return true
+            }
+            if cmd.label.lowercased().contains(q) || cmd.detail.lowercased().contains(q) { return true }
+            return cmd.keywords.contains { kw in
+                if kw == q { return true }
+                guard kw.count >= 2, q.count >= 2 else { return false }
+                return kw.hasPrefix(q) || q.hasPrefix(kw)
+            }
+        }
+    }
+
+    // MARK: - Preview text (notebook cards)
+
+    /// Human-readable preview: strips fences and task meta lines so cards never show raw JSON.
+    static func previewText(_ contentMd: String) -> String {
+        var out: [String] = []
+        for block in parseBlocks(contentMd) {
+            switch block.kind {
+            case .heading(_, let text), .paragraph(let text), .bulletItem(let text), .quote(let text):
+                out.append(text)
+            case .orderedItem(_, let text):
+                out.append(text)
+            case .task(let task):
+                out.append(task.text)
+            case .code(let text):
+                out.append(text)
+            case .image(let alt, _):
+                out.append(alt)
+            case .drawing:
+                out.append("Drawing")
+            case .divider:
+                continue
+            }
+        }
+        return out.joined(separator: " · ").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/clients/ios/Lextures/Core/Notebook/NotebookMarkdown.swift
+++ b/clients/ios/Lextures/Core/Notebook/NotebookMarkdown.swift
@@ -88,7 +88,14 @@ struct NotebookEditBlock: Identifiable, Equatable {
 enum NotebookMarkdown {
     // MARK: - Task blocks (```task + JSON meta line)
 
-    private static let taskBlockRegex = try! NSRegularExpression(pattern: "```task[ \\t]*\\n([\\s\\S]*?)```")
+    private static let taskBlockRegex = makeRegex("```task[ \\t]*\\n([\\s\\S]*?)```")
+
+    private static func makeRegex(_ pattern: String) -> NSRegularExpression {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            preconditionFailure("Invalid regex: \(pattern)")
+        }
+        return regex
+    }
 
     static func newTaskId() -> String {
         UUID().uuidString.lowercased()
@@ -192,49 +199,49 @@ enum NotebookMarkdown {
         }
 
         let lines = contentMd.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
-        var i = 0
+        var lineIndex = 0
         var drawingIndex = 0
-        while i < lines.count {
-            let line = lines[i]
+        while lineIndex < lines.count {
+            let line = lines[lineIndex]
             let trimmed = line.trimmingCharacters(in: .whitespaces)
 
             if trimmed.hasPrefix("```drawing") {
                 flushAll()
                 var inner: [String] = []
-                i += 1
-                while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces) != "```" {
-                    inner.append(lines[i])
-                    i += 1
+                lineIndex += 1
+                while lineIndex < lines.count, lines[lineIndex].trimmingCharacters(in: .whitespaces) != "```" {
+                    inner.append(lines[lineIndex])
+                    lineIndex += 1
                 }
                 kinds.append(.drawing(index: drawingIndex, elementsJson: inner.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)))
                 drawingIndex += 1
-                i += 1
+                lineIndex += 1
                 continue
             }
             if trimmed == "```task" || trimmed.hasPrefix("```task") {
                 flushAll()
                 var inner: [String] = []
-                i += 1
-                while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces) != "```" {
-                    inner.append(lines[i])
-                    i += 1
+                lineIndex += 1
+                while lineIndex < lines.count, lines[lineIndex].trimmingCharacters(in: .whitespaces) != "```" {
+                    inner.append(lines[lineIndex])
+                    lineIndex += 1
                 }
                 if let task = parseTaskInner(inner.joined(separator: "\n")) {
                     kinds.append(.task(task))
                 }
-                i += 1
+                lineIndex += 1
                 continue
             }
             if trimmed.hasPrefix("```") {
                 flushAll()
                 var inner: [String] = []
-                i += 1
-                while i < lines.count, !lines[i].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
-                    inner.append(lines[i])
-                    i += 1
+                lineIndex += 1
+                while lineIndex < lines.count, !lines[lineIndex].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+                    inner.append(lines[lineIndex])
+                    lineIndex += 1
                 }
                 kinds.append(.code(inner.joined(separator: "\n")))
-                i += 1
+                lineIndex += 1
                 continue
             }
             if let heading = parseHeading(trimmed) {
@@ -261,7 +268,7 @@ enum NotebookMarkdown {
                 flushQuote()
                 paragraph.append(trimmed)
             }
-            i += 1
+            lineIndex += 1
         }
         flushAll()
         return kinds.enumerated().map { NotebookBlock(id: $0.offset, kind: $0.element) }
@@ -276,7 +283,7 @@ enum NotebookMarkdown {
         return .heading(level: hashes.count, text: rest.trimmingCharacters(in: .whitespaces))
     }
 
-    private static let orderedItemRegex = try! NSRegularExpression(pattern: "^(\\d+)[.)] (.*)$")
+    private static let orderedItemRegex = makeRegex("^(\\d+)[.)] (.*)$")
 
     private static func parseOrderedItem(_ line: String) -> NotebookBlockKind? {
         let ns = line as NSString
@@ -286,7 +293,7 @@ enum NotebookMarkdown {
         return .orderedItem(number: ns.substring(with: match.range(at: 1)), text: ns.substring(with: match.range(at: 2)))
     }
 
-    private static let imageRegex = try! NSRegularExpression(pattern: "^!\\[([^\\]]*)\\]\\(([^)]+)\\)$")
+    private static let imageRegex = makeRegex("^!\\[([^\\]]*)\\]\\(([^)]+)\\)$")
 
     private static func parseImage(_ line: String) -> NotebookBlockKind? {
         let ns = line as NSString
@@ -385,89 +392,28 @@ enum NotebookMarkdown {
         var out: [String] = []
         var current = -1
         let lines = contentMd.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
-        var i = 0
-        while i < lines.count {
-            let trimmed = lines[i].trimmingCharacters(in: .whitespaces)
+        var lineIndex = 0
+        while lineIndex < lines.count {
+            let trimmed = lines[lineIndex].trimmingCharacters(in: .whitespaces)
             if trimmed.hasPrefix("```drawing") {
                 current += 1
                 var inner: [String] = []
-                i += 1
-                while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces) != "```" {
-                    inner.append(lines[i])
-                    i += 1
+                lineIndex += 1
+                while lineIndex < lines.count, lines[lineIndex].trimmingCharacters(in: .whitespaces) != "```" {
+                    inner.append(lines[lineIndex])
+                    lineIndex += 1
                 }
-                i += 1
+                lineIndex += 1
                 let body = current == index
                     ? elementsJson
                     : inner.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
                 out.append("```drawing\n\(body)\n```")
                 continue
             }
-            out.append(lines[i])
-            i += 1
+            out.append(lines[lineIndex])
+            lineIndex += 1
         }
         return out.joined(separator: "\n")
-    }
-
-    // MARK: - Slash commands
-
-    static let slashCommands: [NotebookSlashCommand] = [
-        NotebookSlashCommand(
-            id: "heading1", label: "Heading 1", detail: "Large section heading",
-            icon: "textformat.size.larger", keywords: ["h1", "title", "heading"]
-        ),
-        NotebookSlashCommand(
-            id: "heading2", label: "Heading 2", detail: "Medium section heading",
-            icon: "textformat.size", keywords: ["h2", "heading"]
-        ),
-        NotebookSlashCommand(
-            id: "heading3", label: "Heading 3", detail: "Small section heading",
-            icon: "textformat.size.smaller", keywords: ["h3", "heading"]
-        ),
-        NotebookSlashCommand(
-            id: "task", label: "Task", detail: "Checkbox task with optional due date",
-            icon: "checkmark.square", keywords: ["task", "todo", "checkbox", "checklist"]
-        ),
-        NotebookSlashCommand(
-            id: "drawing", label: "Drawing", detail: "Insert a whiteboard to draw on",
-            icon: "scribble.variable", keywords: ["drawing", "whiteboard", "sketch", "draw", "canvas"]
-        ),
-        NotebookSlashCommand(
-            id: "bulletList", label: "Bullet list", detail: "Unordered list",
-            icon: "list.bullet", keywords: ["ul", "list", "bullets"]
-        ),
-        NotebookSlashCommand(
-            id: "orderedList", label: "Numbered list", detail: "Ordered list",
-            icon: "list.number", keywords: ["ol", "list", "numbers"]
-        ),
-        NotebookSlashCommand(
-            id: "blockquote", label: "Quote", detail: "Indented quotation",
-            icon: "text.quote", keywords: ["quote", "blockquote"]
-        ),
-        NotebookSlashCommand(
-            id: "codeBlock", label: "Code", detail: "Code block",
-            icon: "curlybraces", keywords: ["code", "pre", "snippet"]
-        ),
-        NotebookSlashCommand(
-            id: "horizontalRule", label: "Divider", detail: "Horizontal line",
-            icon: "minus", keywords: ["hr", "divider", "line", "rule"]
-        ),
-    ]
-
-    static func filterCommands(query: String) -> [NotebookSlashCommand] {
-        let q = query.trimmingCharacters(in: .whitespaces).lowercased()
-        guard !q.isEmpty else { return slashCommands }
-        return slashCommands.filter { cmd in
-            if cmd.id.lowercased() == q || cmd.id.lowercased().hasPrefix(q) || q.hasPrefix(cmd.id.lowercased()) {
-                return true
-            }
-            if cmd.label.lowercased().contains(q) || cmd.detail.lowercased().contains(q) { return true }
-            return cmd.keywords.contains { kw in
-                if kw == q { return true }
-                guard kw.count >= 2, q.count >= 2 else { return false }
-                return kw.hasPrefix(q) || q.hasPrefix(kw)
-            }
-        }
     }
 
     // MARK: - Preview text (notebook cards)

--- a/clients/ios/Lextures/Core/Notebook/NotebookSlashCommands.swift
+++ b/clients/ios/Lextures/Core/Notebook/NotebookSlashCommands.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Slash-command palette for the notebook block editor (parity with web `markdown-body-slash`).
+enum NotebookSlashCommands {
+    static let all: [NotebookSlashCommand] = [
+        NotebookSlashCommand(
+            id: "heading1", label: "Heading 1", detail: "Large section heading",
+            icon: "textformat.size.larger", keywords: ["h1", "title", "heading"]
+        ),
+        NotebookSlashCommand(
+            id: "heading2", label: "Heading 2", detail: "Medium section heading",
+            icon: "textformat.size", keywords: ["h2", "heading"]
+        ),
+        NotebookSlashCommand(
+            id: "heading3", label: "Heading 3", detail: "Small section heading",
+            icon: "textformat.size.smaller", keywords: ["h3", "heading"]
+        ),
+        NotebookSlashCommand(
+            id: "task", label: "Task", detail: "Checkbox task with optional due date",
+            icon: "checkmark.square", keywords: ["task", "todo", "checkbox", "checklist"]
+        ),
+        NotebookSlashCommand(
+            id: "drawing", label: "Drawing", detail: "Insert a whiteboard to draw on",
+            icon: "scribble.variable", keywords: ["drawing", "whiteboard", "sketch", "draw", "canvas"]
+        ),
+        NotebookSlashCommand(
+            id: "bulletList", label: "Bullet list", detail: "Unordered list",
+            icon: "list.bullet", keywords: ["ul", "list", "bullets"]
+        ),
+        NotebookSlashCommand(
+            id: "orderedList", label: "Numbered list", detail: "Ordered list",
+            icon: "list.number", keywords: ["ol", "list", "numbers"]
+        ),
+        NotebookSlashCommand(
+            id: "blockquote", label: "Quote", detail: "Indented quotation",
+            icon: "text.quote", keywords: ["quote", "blockquote"]
+        ),
+        NotebookSlashCommand(
+            id: "codeBlock", label: "Code", detail: "Code block",
+            icon: "curlybraces", keywords: ["code", "pre", "snippet"]
+        ),
+        NotebookSlashCommand(
+            id: "horizontalRule", label: "Divider", detail: "Horizontal line",
+            icon: "minus", keywords: ["hr", "divider", "line", "rule"]
+        ),
+    ]
+
+    static func filter(query: String) -> [NotebookSlashCommand] {
+        let normalizedQuery = query.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !normalizedQuery.isEmpty else { return all }
+        return all.filter { cmd in
+            if cmd.id.lowercased() == normalizedQuery
+                || cmd.id.lowercased().hasPrefix(normalizedQuery)
+                || normalizedQuery.hasPrefix(cmd.id.lowercased()) {
+                return true
+            }
+            if cmd.label.lowercased().contains(normalizedQuery)
+                || cmd.detail.lowercased().contains(normalizedQuery) {
+                return true
+            }
+            return cmd.keywords.contains { kw in
+                if kw == normalizedQuery { return true }
+                guard kw.count >= 2, normalizedQuery.count >= 2 else { return false }
+                return kw.hasPrefix(normalizedQuery) || normalizedQuery.hasPrefix(kw)
+            }
+        }
+    }
+}

--- a/clients/ios/Lextures/Core/Notebook/NotebookStore.swift
+++ b/clients/ios/Lextures/Core/Notebook/NotebookStore.swift
@@ -84,6 +84,22 @@ final class NotebookStore {
         writeAll(all)
     }
 
+    func exists(courseCode: String) -> Bool {
+        readAll()[courseCode] != nil
+    }
+
+    /// Every stored course code, including the global key.
+    func allCourseCodes() -> [String] {
+        Array(readAll().keys)
+    }
+
+    /// Write a server copy verbatim — keeps the server `updatedAt` so last-write-wins stays stable.
+    func saveFromServer(courseCode: String, notebook: CourseNotebook) {
+        var all = readAll()
+        all[courseCode] = notebook
+        writeAll(all)
+    }
+
     /// Course-scoped notebooks with content (excludes the global key).
     func listCourseNotebooks() -> [String: CourseNotebook] {
         readAll().filter { key, notebook in

--- a/clients/ios/Lextures/Core/Notebook/NotebookSync.swift
+++ b/clients/ios/Lextures/Core/Notebook/NotebookSync.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Server sync for student notebooks — last-write-wins by `updatedAt`, parity with web
+/// `student-notebook-sync`. Device storage stays the editor's source of truth; sync runs
+/// fire-and-forget around it.
+@MainActor
+enum NotebookSync {
+    /// Pull all server notebooks and merge into the device store. Server copy wins when
+    /// newer; local copies that are newer or missing on the server are pushed back.
+    /// Returns true when any local notebook changed.
+    @discardableResult
+    static func pull(store: NotebookStore, accessToken: String?) async -> Bool {
+        guard let token = accessToken else { return false }
+        guard let entries = try? await LMSAPI.fetchNotebooks(accessToken: token) else { return false }
+
+        var changed = false
+        var serverCodes = Set<String>()
+        for entry in entries {
+            guard let server = entry.data else { continue }
+            serverCodes.insert(entry.courseCode)
+            guard store.exists(courseCode: entry.courseCode) else {
+                store.saveFromServer(courseCode: entry.courseCode, notebook: server)
+                changed = true
+                continue
+            }
+            let local = store.load(courseCode: entry.courseCode)
+            let serverTime = parseISO(entry.updatedAt) ?? .distantPast
+            let localTime = parseISO(local.updatedAt) ?? .distantPast
+            if serverTime > localTime {
+                store.saveFromServer(courseCode: entry.courseCode, notebook: server)
+                changed = true
+            } else if localTime > serverTime {
+                push(store: store, courseCode: entry.courseCode, accessToken: token)
+            }
+        }
+        for code in store.allCourseCodes() where !serverCodes.contains(code) {
+            push(store: store, courseCode: code, accessToken: token)
+        }
+        return changed
+    }
+
+    /// Fire-and-forget push of one notebook to the server.
+    static func push(store: NotebookStore, courseCode: String, accessToken: String?) {
+        guard let token = accessToken else { return }
+        let notebook = store.load(courseCode: courseCode)
+        Task {
+            try? await LMSAPI.putNotebook(courseCode: courseCode, notebook: notebook, accessToken: token)
+        }
+    }
+
+    /// Tolerant ISO-8601 parse — web writes fractional seconds, mobile does not.
+    static func parseISO(_ value: String) -> Date? {
+        let plain = ISO8601DateFormatter()
+        if let date = plain.date(from: value) { return date }
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractional.date(from: value)
+    }
+}

--- a/clients/ios/Lextures/Core/Notebook/NotebookTree.swift
+++ b/clients/ios/Lextures/Core/Notebook/NotebookTree.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// Page-tree helpers over the flat `NotebookPage` list (parity with web `course-notebook-tree`).
+enum NotebookTree {
+    struct FlatRow: Identifiable, Equatable {
+        let page: NotebookPage
+        let depth: Int
+        var id: String { page.id }
+    }
+
+    static func isGroup(_ page: NotebookPage) -> Bool {
+        page.kind == "group"
+    }
+
+    static func sortedChildren(_ pages: [NotebookPage], parentId: String?) -> [NotebookPage] {
+        pages
+            .filter { $0.parentId == parentId }
+            .sorted { ($0.sortOrder, $0.id) < ($1.sortOrder, $1.id) }
+    }
+
+    /// Depth-first flattening for list rendering (groups followed by their children).
+    static func flatten(_ pages: [NotebookPage]) -> [FlatRow] {
+        var rows: [FlatRow] = []
+        func walk(parentId: String?, depth: Int) {
+            for page in sortedChildren(pages, parentId: parentId) {
+                rows.append(FlatRow(page: page, depth: depth))
+                walk(parentId: page.id, depth: depth + 1)
+            }
+        }
+        walk(parentId: nil, depth: 0)
+        return rows
+    }
+
+    /// True if `targetId` is `ancestorId` or nested under it.
+    static func isUnderAncestor(_ pages: [NotebookPage], ancestorId: String, targetId: String) -> Bool {
+        let map = Dictionary(uniqueKeysWithValues: pages.map { ($0.id, $0) })
+        var cur: String? = targetId
+        while let id = cur {
+            if id == ancestorId { return true }
+            cur = map[id]?.parentId
+        }
+        return false
+    }
+
+    private static func nextSortOrder(_ pages: [NotebookPage], parentId: String?) -> Int {
+        (sortedChildren(pages, parentId: parentId).map(\.sortOrder).max() ?? -1) + 1
+    }
+
+    static func addPage(_ pages: [NotebookPage], parentId: String?, title: String = "Untitled") -> (pages: [NotebookPage], newId: String) {
+        var page = NotebookPage.new(title: title, sortOrder: nextSortOrder(pages, parentId: parentId))
+        page.parentId = parentId
+        return (pages + [page], page.id)
+    }
+
+    static func addGroup(_ pages: [NotebookPage], parentId: String?, title: String = "Untitled group") -> (pages: [NotebookPage], newId: String) {
+        var group = NotebookPage.new(title: title, sortOrder: nextSortOrder(pages, parentId: parentId))
+        group.parentId = parentId
+        group.kind = "group"
+        return (pages + [group], group.id)
+    }
+
+    /// Delete a page or group along with all descendants.
+    static func delete(_ pages: [NotebookPage], pageId: String) -> [NotebookPage] {
+        var toRemove = Set<String>()
+        func walk(_ id: String) {
+            toRemove.insert(id)
+            for child in pages.filter({ $0.parentId == id }) {
+                walk(child.id)
+            }
+        }
+        walk(pageId)
+        return pages.filter { !toRemove.contains($0.id) }
+    }
+
+    static func rename(_ pages: [NotebookPage], pageId: String, title: String) -> [NotebookPage] {
+        pages.map { page in
+            var next = page
+            if page.id == pageId { next.title = title }
+            return next
+        }
+    }
+
+    static func updateContent(_ pages: [NotebookPage], pageId: String, contentMd: String) -> [NotebookPage] {
+        pages.map { page in
+            var next = page
+            if page.id == pageId { next.contentMd = contentMd }
+            return next
+        }
+    }
+
+    /// Move a page or group under `newParentId` (nil = top level), appended last. Nil on invalid move.
+    static func moveToParent(_ pages: [NotebookPage], pageId: String, newParentId: String?) -> [NotebookPage]? {
+        guard pageId != newParentId else { return nil }
+        if let newParentId, isUnderAncestor(pages, ancestorId: pageId, targetId: newParentId) {
+            return nil
+        }
+        guard pages.contains(where: { $0.id == pageId }) else { return nil }
+        let order = nextSortOrder(pages, parentId: newParentId)
+        return pages.map { page in
+            var next = page
+            if page.id == pageId {
+                next.parentId = newParentId
+                next.sortOrder = order
+            }
+            return next
+        }
+    }
+
+    /// Groups the page can be moved into (excludes self and own descendants).
+    static func groupMoveTargets(_ pages: [NotebookPage], pageId: String) -> [NotebookPage] {
+        pages
+            .filter { isGroup($0) && $0.id != pageId }
+            .filter { !isUnderAncestor(pages, ancestorId: pageId, targetId: $0.id) }
+            .sorted { pathLabel(pages, pageId: $0.id) < pathLabel(pages, pageId: $1.id) }
+    }
+
+    static func pathLabel(_ pages: [NotebookPage], pageId: String) -> String {
+        let map = Dictionary(uniqueKeysWithValues: pages.map { ($0.id, $0) })
+        var parts: [String] = []
+        var cur: String? = pageId
+        while let id = cur, let row = map[id] {
+            parts.insert(row.title.isEmpty ? "Untitled" : row.title, at: 0)
+            cur = row.parentId
+        }
+        return parts.joined(separator: " / ")
+    }
+}

--- a/clients/ios/Lextures/Features/Notebooks/.swiftlint.yml
+++ b/clients/ios/Lextures/Features/Notebooks/.swiftlint.yml
@@ -1,0 +1,4 @@
+# Notebook editor views are intentionally large single-file SwiftUI screens.
+type_body_length:
+  warning: 350
+  error: 750

--- a/clients/ios/Lextures/Features/Notebooks/NotebookContentView.swift
+++ b/clients/ios/Lextures/Features/Notebooks/NotebookContentView.swift
@@ -1,0 +1,252 @@
+import SwiftUI
+
+/// Rendered reading view for a notebook page: headings, lists, quotes, code,
+/// and interactive task checkboxes (parity with the web notebook editor output).
+struct NotebookContentView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    let markdown: String
+    var onToggleTask: (ParsedNotebookTask) -> Void
+    var onEditTaskDue: (ParsedNotebookTask) -> Void
+    var onEditDrawing: ((_ index: Int, _ elementsJson: String) -> Void)? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(NotebookMarkdown.parseBlocks(markdown)) { block in
+                blockView(block.kind)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func blockView(_ kind: NotebookBlockKind) -> some View {
+        switch kind {
+        case .heading(let level, let text):
+            inlineText(text)
+                .font(LexturesTheme.displayFont(level == 1 ? 26 : level == 2 ? 21 : 17))
+                .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                .padding(.top, level == 1 ? 6 : 2)
+
+        case .paragraph(let text):
+            inlineText(text)
+                .font(.subheadline)
+                .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                .lineSpacing(3)
+
+        case .bulletItem(let text):
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Circle()
+                    .fill(LexturesTheme.accent(for: colorScheme))
+                    .frame(width: 5, height: 5)
+                    .padding(.top, 6)
+                inlineText(text)
+                    .font(.subheadline)
+                    .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+            }
+            .padding(.leading, 4)
+
+        case .orderedItem(let number, let text):
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("\(number).")
+                    .font(.subheadline.weight(.semibold).monospacedDigit())
+                    .foregroundStyle(LexturesTheme.accent(for: colorScheme))
+                inlineText(text)
+                    .font(.subheadline)
+                    .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+            }
+            .padding(.leading, 4)
+
+        case .quote(let text):
+            HStack(alignment: .top, spacing: 10) {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(LexturesTheme.brandAmber)
+                    .frame(width: 3)
+                inlineText(text)
+                    .font(.subheadline.italic())
+                    .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+            }
+            .padding(.vertical, 2)
+
+        case .code(let text):
+            Text(text)
+                .font(.caption.monospaced())
+                .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(LexturesTheme.sceneBackground(for: colorScheme).opacity(colorScheme == .dark ? 0.6 : 1))
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .stroke(LexturesTheme.fieldBorder(for: colorScheme), lineWidth: 1)
+                )
+
+        case .divider:
+            Rectangle()
+                .fill(LexturesTheme.fieldBorder(for: colorScheme))
+                .frame(height: 1)
+                .padding(.vertical, 4)
+
+        case .task(let task):
+            taskRow(task)
+
+        case .image(let alt, let url):
+            imageBlock(alt: alt, url: url)
+
+        case .drawing(let index, let elementsJson):
+            NotebookDrawingBlockView(elementsJson: elementsJson) {
+                onEditDrawing?(index, elementsJson)
+            }
+        }
+    }
+
+    // MARK: - Tasks
+
+    private func taskRow(_ task: ParsedNotebookTask) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Button {
+                onToggleTask(task)
+            } label: {
+                Image(systemName: task.checked ? "checkmark.square.fill" : "square")
+                    .font(.system(size: 20))
+                    .foregroundStyle(
+                        task.checked
+                            ? LexturesTheme.accent(for: colorScheme)
+                            : LexturesTheme.textSecondary(for: colorScheme)
+                    )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(task.checked ? "Mark task incomplete" : "Mark task complete")
+
+            VStack(alignment: .leading, spacing: 3) {
+                inlineText(task.text.isEmpty ? "Untitled task" : task.text)
+                    .font(.subheadline)
+                    .strikethrough(task.checked, color: LexturesTheme.textSecondary(for: colorScheme))
+                    .foregroundStyle(
+                        task.checked
+                            ? LexturesTheme.textSecondary(for: colorScheme)
+                            : LexturesTheme.textPrimary(for: colorScheme)
+                    )
+
+                Button {
+                    onEditTaskDue(task)
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "calendar")
+                            .font(.caption2)
+                        Text(dueLabel(task))
+                            .font(.caption)
+                    }
+                    .foregroundStyle(dueColor(task))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Edit due date")
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(LexturesTheme.cardBackground(for: colorScheme))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(LexturesTheme.fieldBorder(for: colorScheme).opacity(0.9), lineWidth: 1)
+        )
+    }
+
+    private func dueLabel(_ task: ParsedNotebookTask) -> String {
+        guard let dueAt = task.dueAt, let date = LMSDates.parse(dueAt) else { return "Add due date" }
+        return "Due \(date.formatted(date: .abbreviated, time: .omitted))"
+    }
+
+    private func dueColor(_ task: ParsedNotebookTask) -> Color {
+        guard let dueAt = task.dueAt, let date = LMSDates.parse(dueAt) else {
+            return LexturesTheme.textSecondary(for: colorScheme).opacity(0.8)
+        }
+        if !task.checked, date < Date() {
+            return LexturesTheme.coral
+        }
+        return LexturesTheme.textSecondary(for: colorScheme)
+    }
+
+    // MARK: - Images
+
+    private func imageBlock(alt: String, url: String) -> some View {
+        AuthorizedNotebookImage(urlString: url, alt: alt)
+    }
+
+    // MARK: - Inline markdown (bold / italic / code / links)
+
+
+    private func inlineText(_ raw: String) -> Text {
+        if let attributed = try? AttributedString(
+            markdown: raw,
+            options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        ) {
+            return Text(attributed)
+        }
+        return Text(raw)
+    }
+}
+
+/// Notebook image loader. Web stores relative course-file paths (`/api/v1/...`) that need the
+/// bearer token (parity with web's authorized blob fetch), so `AsyncImage` can't be used.
+struct AuthorizedNotebookImage: View {
+    @Environment(AuthSession.self) private var session
+    @Environment(\.colorScheme) private var colorScheme
+    let urlString: String
+    let alt: String
+
+    @State private var image: UIImage?
+
+    private static let cache = NSCache<NSString, UIImage>()
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .accessibilityLabel(alt.isEmpty ? "Image" : alt)
+            } else {
+                HStack(spacing: 6) {
+                    Image(systemName: "photo")
+                    Text(alt.isEmpty ? "Image" : alt)
+                }
+                .font(.caption)
+                .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                .padding(12)
+            }
+        }
+        .task(id: urlString) { await load() }
+    }
+
+    private var resolvedURL: URL? {
+        if urlString.hasPrefix("/") {
+            return AppConfiguration.apiURL(path: urlString)
+        }
+        if let parsed = URL(string: urlString), parsed.scheme == "https" || parsed.scheme == "http" {
+            return parsed
+        }
+        return nil
+    }
+
+    private func load() async {
+        if let cached = Self.cache.object(forKey: urlString as NSString) {
+            image = cached
+            return
+        }
+        guard let url = resolvedURL else { return }
+        var request = URLRequest(url: url)
+        if let token = session.accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        guard
+            let (data, response) = try? await URLSession.shared.data(for: request),
+            (response as? HTTPURLResponse).map({ (200 ... 299).contains($0.statusCode) }) != false,
+            let loaded = UIImage(data: data)
+        else { return }
+        Self.cache.setObject(loaded, forKey: urlString as NSString)
+        image = loaded
+    }
+}

--- a/clients/ios/Lextures/Features/Notebooks/NotebookDrawingViews.swift
+++ b/clients/ios/Lextures/Features/Notebooks/NotebookDrawingViews.swift
@@ -1,0 +1,288 @@
+import SwiftUI
+
+/// Rendered whiteboard drawing in the notebook reading view; tap to edit.
+struct NotebookDrawingBlockView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    let elementsJson: String
+    var onTap: () -> Void
+
+    var body: some View {
+        let elements = NotebookDrawing.parseElements(elementsJson)
+        let content = NotebookDrawing.contentSize(elements)
+
+        Button(action: onTap) {
+            GeometryReader { geo in
+                let scale = min(geo.size.width / content.width, 1)
+                Canvas { context, _ in
+                    NotebookDrawing.draw(elements, in: context, scale: scale)
+                }
+            }
+            .aspectRatio(content.width / content.height, contentMode: .fit)
+            .frame(maxWidth: .infinity)
+            .overlay(alignment: .bottomTrailing) {
+                HStack(spacing: 4) {
+                    Image(systemName: "pencil.and.outline")
+                    Text(elements.isEmpty ? "Tap to draw" : "Edit drawing")
+                }
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(LexturesTheme.sceneBackground(for: colorScheme).opacity(0.85))
+                .clipShape(Capsule())
+                .padding(8)
+            }
+            .background(colorScheme == .dark ? Color(white: 0.12) : .white)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(LexturesTheme.fieldBorder(for: colorScheme), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Drawing — tap to edit")
+    }
+}
+
+/// Full-screen whiteboard editor: pen / line / rect / circle / triangle / eraser,
+/// the web palette and stroke widths, undo and clear (parity with web `/drawing`).
+struct NotebookDrawingEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+    let initialElementsJson: String
+    var onSave: (String) -> Void
+
+    private enum Tool: String, CaseIterable {
+        case pen, line, rect, circle, triangle, eraser
+
+        var icon: String {
+            switch self {
+            case .pen: "scribble"
+            case .line: "line.diagonal"
+            case .rect: "rectangle"
+            case .circle: "circle"
+            case .triangle: "triangle"
+            case .eraser: "eraser"
+            }
+        }
+    }
+
+    @State private var elements: [NotebookDrawEl] = []
+    @State private var undoStack: [[NotebookDrawEl]] = []
+    @State private var tool: Tool = .pen
+    @State private var color: String = NotebookDrawing.colors[0]
+    @State private var lineWidth: Double = NotebookDrawing.strokeWidths[1]
+    @State private var draftElement: NotebookDrawEl?
+    @State private var dragStart: CGPoint?
+    @State private var loaded = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                canvasArea
+                toolbar
+            }
+            .background(LexturesTheme.sceneBackground(for: colorScheme))
+            .navigationTitle("Drawing")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Save") {
+                        onSave(NotebookDrawing.serializeElements(elements))
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                }
+            }
+            .onAppear {
+                guard !loaded else { return }
+                loaded = true
+                elements = NotebookDrawing.parseElements(initialElementsJson)
+            }
+        }
+    }
+
+    // MARK: - Canvas
+
+    private var canvasArea: some View {
+        GeometryReader { geo in
+            let content = NotebookDrawing.contentSize(
+                elements,
+                minSize: CGSize(width: geo.size.width, height: geo.size.height)
+            )
+            let scale = min(geo.size.width / content.width, geo.size.height / content.height, 1)
+
+            Canvas { context, _ in
+                NotebookDrawing.draw(elements, in: context, scale: scale)
+                if let draftElement {
+                    NotebookDrawing.draw([draftElement], in: context, scale: scale)
+                }
+            }
+            .background(colorScheme == .dark ? Color(white: 0.12) : .white)
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        let point = CGPoint(x: value.location.x / scale, y: value.location.y / scale)
+                        handleDrag(to: point)
+                    }
+                    .onEnded { _ in commitDraft() }
+            )
+        }
+        .padding(12)
+    }
+
+    private func handleDrag(to point: CGPoint) {
+        if tool == .eraser {
+            let radius = max(lineWidth * 2, 12.0)
+            let next = elements.filter { !NotebookDrawing.hitTest($0, point: point, radius: radius) }
+            if next.count != elements.count {
+                pushUndo()
+                elements = next
+            }
+            return
+        }
+        let start = dragStart ?? point
+        if dragStart == nil { dragStart = point }
+        switch tool {
+        case .pen:
+            if case .stroke(let c, let w, var pts) = draftElement {
+                pts.append(point)
+                draftElement = .stroke(color: c, width: w, pts: pts)
+            } else {
+                draftElement = .stroke(color: color, width: lineWidth, pts: [point])
+            }
+        case .line:
+            draftElement = .line(color: color, width: lineWidth, x1: start.x, y1: start.y, x2: point.x, y2: point.y)
+        case .rect:
+            draftElement = .rect(
+                color: color, width: lineWidth,
+                x: min(start.x, point.x), y: min(start.y, point.y),
+                w: abs(point.x - start.x), h: abs(point.y - start.y)
+            )
+        case .circle:
+            draftElement = .circle(
+                color: color, width: lineWidth,
+                cx: (start.x + point.x) / 2, cy: (start.y + point.y) / 2,
+                rx: abs(point.x - start.x) / 2, ry: abs(point.y - start.y) / 2
+            )
+        case .triangle:
+            draftElement = .triangle(
+                color: color, width: lineWidth,
+                x1: (start.x + point.x) / 2, y1: min(start.y, point.y),
+                x2: start.x, y2: max(start.y, point.y),
+                x3: point.x, y3: max(start.y, point.y)
+            )
+        case .eraser:
+            break
+        }
+    }
+
+    private func commitDraft() {
+        dragStart = nil
+        guard let draftElement else { return }
+        pushUndo()
+        elements.append(draftElement)
+        self.draftElement = nil
+    }
+
+    private func pushUndo() {
+        undoStack.append(elements)
+        if undoStack.count > 50 { undoStack.removeFirst() }
+    }
+
+    // MARK: - Toolbar
+
+    private var toolbar: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 6) {
+                ForEach(Tool.allCases, id: \.rawValue) { item in
+                    toolButton(item)
+                }
+                Spacer()
+                Button {
+                    if let last = undoStack.popLast() { elements = last }
+                } label: {
+                    Image(systemName: "arrow.uturn.backward")
+                        .frame(width: 34, height: 34)
+                }
+                .disabled(undoStack.isEmpty)
+                Button(role: .destructive) {
+                    guard !elements.isEmpty else { return }
+                    pushUndo()
+                    elements = []
+                } label: {
+                    Image(systemName: "trash")
+                        .frame(width: 34, height: 34)
+                }
+                .disabled(elements.isEmpty)
+            }
+
+            HStack(spacing: 8) {
+                ForEach(NotebookDrawing.colors, id: \.self) { hex in
+                    Button {
+                        color = hex
+                    } label: {
+                        Circle()
+                            .fill(NotebookDrawing.color(from: hex))
+                            .frame(width: 24, height: 24)
+                            .overlay(
+                                Circle().stroke(
+                                    color == hex
+                                        ? LexturesTheme.accent(for: colorScheme)
+                                        : LexturesTheme.fieldBorder(for: colorScheme),
+                                    lineWidth: color == hex ? 2.5 : 1
+                                )
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Color \(hex)")
+                }
+                Spacer()
+                ForEach(NotebookDrawing.strokeWidths, id: \.self) { w in
+                    Button {
+                        lineWidth = w
+                    } label: {
+                        Circle()
+                            .fill(LexturesTheme.textPrimary(for: colorScheme))
+                            .frame(width: 6 + w * 1.5, height: 6 + w * 1.5)
+                            .frame(width: 28, height: 28)
+                            .background(
+                                Circle().fill(
+                                    lineWidth == w
+                                        ? LexturesTheme.accent(for: colorScheme).opacity(0.18)
+                                        : .clear
+                                )
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Stroke width \(Int(w))")
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(LexturesTheme.cardBackground(for: colorScheme))
+    }
+
+    private func toolButton(_ item: Tool) -> some View {
+        Button {
+            tool = item
+        } label: {
+            Image(systemName: item.icon)
+                .font(.subheadline)
+                .foregroundStyle(
+                    tool == item ? .white : LexturesTheme.textPrimary(for: colorScheme)
+                )
+                .frame(width: 34, height: 34)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(tool == item ? LexturesTheme.accent(for: colorScheme) : .clear)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(item.rawValue)
+    }
+}

--- a/clients/ios/Lextures/Features/Notebooks/NotebookDrawingViews.swift
+++ b/clients/ios/Lextures/Features/Notebooks/NotebookDrawingViews.swift
@@ -148,9 +148,9 @@ struct NotebookDrawingEditorView: View {
         if dragStart == nil { dragStart = point }
         switch tool {
         case .pen:
-            if case .stroke(let c, let w, var pts) = draftElement {
+            if case .stroke(let strokeColor, let strokeWidth, var pts) = draftElement {
                 pts.append(point)
-                draftElement = .stroke(color: c, width: w, pts: pts)
+                draftElement = .stroke(color: strokeColor, width: strokeWidth, pts: pts)
             } else {
                 draftElement = .stroke(color: color, width: lineWidth, pts: [point])
             }
@@ -159,8 +159,8 @@ struct NotebookDrawingEditorView: View {
         case .rect:
             draftElement = .rect(
                 color: color, width: lineWidth,
-                x: min(start.x, point.x), y: min(start.y, point.y),
-                w: abs(point.x - start.x), h: abs(point.y - start.y)
+                rectX: min(start.x, point.x), rectY: min(start.y, point.y),
+                rectWidth: abs(point.x - start.x), rectHeight: abs(point.y - start.y)
             )
         case .circle:
             draftElement = .circle(
@@ -241,24 +241,24 @@ struct NotebookDrawingEditorView: View {
                     .accessibilityLabel("Color \(hex)")
                 }
                 Spacer()
-                ForEach(NotebookDrawing.strokeWidths, id: \.self) { w in
+                ForEach(NotebookDrawing.strokeWidths, id: \.self) { strokeWidth in
                     Button {
-                        lineWidth = w
+                        lineWidth = strokeWidth
                     } label: {
                         Circle()
                             .fill(LexturesTheme.textPrimary(for: colorScheme))
-                            .frame(width: 6 + w * 1.5, height: 6 + w * 1.5)
+                            .frame(width: 6 + strokeWidth * 1.5, height: 6 + strokeWidth * 1.5)
                             .frame(width: 28, height: 28)
                             .background(
                                 Circle().fill(
-                                    lineWidth == w
+                                    lineWidth == strokeWidth
                                         ? LexturesTheme.accent(for: colorScheme).opacity(0.18)
                                         : .clear
                                 )
                             )
                     }
                     .buttonStyle(.plain)
-                    .accessibilityLabel("Stroke width \(Int(w))")
+                    .accessibilityLabel("Stroke width \(Int(strokeWidth))")
                 }
             }
         }

--- a/clients/ios/Lextures/Features/Notebooks/NotebookDrawingViews.swift
+++ b/clients/ios/Lextures/Features/Notebooks/NotebookDrawingViews.swift
@@ -155,25 +155,28 @@ struct NotebookDrawingEditorView: View {
                 draftElement = .stroke(color: color, width: lineWidth, pts: [point])
             }
         case .line:
-            draftElement = .line(color: color, width: lineWidth, x1: start.x, y1: start.y, x2: point.x, y2: point.y)
+            draftElement = .line(
+                color: color, width: lineWidth,
+                x1: Double(start.x), y1: Double(start.y), x2: Double(point.x), y2: Double(point.y)
+            )
         case .rect:
             draftElement = .rect(
                 color: color, width: lineWidth,
-                rectX: min(start.x, point.x), rectY: min(start.y, point.y),
-                rectWidth: abs(point.x - start.x), rectHeight: abs(point.y - start.y)
+                rectX: Double(min(start.x, point.x)), rectY: Double(min(start.y, point.y)),
+                rectWidth: Double(abs(point.x - start.x)), rectHeight: Double(abs(point.y - start.y))
             )
         case .circle:
             draftElement = .circle(
                 color: color, width: lineWidth,
-                cx: (start.x + point.x) / 2, cy: (start.y + point.y) / 2,
-                rx: abs(point.x - start.x) / 2, ry: abs(point.y - start.y) / 2
+                cx: Double(start.x + point.x) / 2.0, cy: Double(start.y + point.y) / 2.0,
+                rx: Double(abs(point.x - start.x)) / 2.0, ry: Double(abs(point.y - start.y)) / 2.0
             )
         case .triangle:
             draftElement = .triangle(
                 color: color, width: lineWidth,
-                x1: (start.x + point.x) / 2, y1: min(start.y, point.y),
-                x2: start.x, y2: max(start.y, point.y),
-                x3: point.x, y3: max(start.y, point.y)
+                x1: Double(start.x + point.x) / 2.0, y1: Double(min(start.y, point.y)),
+                x2: Double(start.x), y2: Double(max(start.y, point.y)),
+                x3: Double(point.x), y3: Double(max(start.y, point.y))
             )
         case .eraser:
             break

--- a/clients/ios/Lextures/Features/Notebooks/NotebookEditorSupportViews.swift
+++ b/clients/ios/Lextures/Features/Notebooks/NotebookEditorSupportViews.swift
@@ -1,0 +1,212 @@
+import SwiftUI
+
+/// One block row in edit mode: styled like the reading view, but editable in place.
+struct NotebookEditBlockRow: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Binding var block: NotebookEditBlock
+    let orderedNumber: Int
+    var focus: FocusState<UUID?>.Binding
+    var onTextChange: () -> Void
+    var onToggleTask: () -> Void
+    var onEditTaskDue: () -> Void
+    var onEditDrawing: () -> Void
+    var onDelete: () -> Void
+
+    var body: some View {
+        switch block.kind {
+        case .paragraph:
+            textField(font: .subheadline)
+
+        case .heading(let level):
+            textField(
+                font: LexturesTheme.displayFont(level == 1 ? 26 : level == 2 ? 21 : 17),
+                prompt: "Heading"
+            )
+
+        case .bullet:
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Circle()
+                    .fill(LexturesTheme.accent(for: colorScheme))
+                    .frame(width: 5, height: 5)
+                    .padding(.top, 6)
+                textField(font: .subheadline, prompt: "List item")
+            }
+            .padding(.leading, 4)
+
+        case .ordered:
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("\(orderedNumber).")
+                    .font(.subheadline.weight(.semibold).monospacedDigit())
+                    .foregroundStyle(LexturesTheme.accent(for: colorScheme))
+                textField(font: .subheadline, prompt: "List item")
+            }
+            .padding(.leading, 4)
+
+        case .quote:
+            HStack(alignment: .top, spacing: 10) {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(LexturesTheme.brandAmber)
+                    .frame(width: 3)
+                textField(font: .subheadline.italic(), prompt: "Quote")
+            }
+            .padding(.vertical, 2)
+
+        case .code:
+            TextField("Code", text: $block.text, axis: .vertical)
+                .font(.caption.monospaced())
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .focused(focus, equals: block.id)
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(LexturesTheme.sceneBackground(for: colorScheme).opacity(colorScheme == .dark ? 0.6 : 1))
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .stroke(LexturesTheme.fieldBorder(for: colorScheme), lineWidth: 1)
+                )
+
+        case .divider:
+            nonTextRow {
+                Rectangle()
+                    .fill(LexturesTheme.fieldBorder(for: colorScheme))
+                    .frame(height: 1)
+                    .padding(.vertical, 8)
+            }
+
+        case .task(_, let checked, let dueAt):
+            HStack(alignment: .top, spacing: 10) {
+                Button(action: onToggleTask) {
+                    Image(systemName: checked ? "checkmark.square.fill" : "square")
+                        .font(.system(size: 20))
+                        .foregroundStyle(
+                            checked
+                                ? LexturesTheme.accent(for: colorScheme)
+                                : LexturesTheme.textSecondary(for: colorScheme)
+                        )
+                }
+                .buttonStyle(.plain)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    textField(font: .subheadline, prompt: "Task")
+                    Button(action: onEditTaskDue) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "calendar")
+                                .font(.caption2)
+                            Text(dueLabel(dueAt))
+                                .font(.caption)
+                        }
+                        .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(10)
+            .background(LexturesTheme.cardBackground(for: colorScheme))
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(LexturesTheme.fieldBorder(for: colorScheme).opacity(0.9), lineWidth: 1)
+            )
+
+        case .image(let alt, let url):
+            nonTextRow {
+                AuthorizedNotebookImage(urlString: url, alt: alt)
+            }
+
+        case .drawing(let elementsJson):
+            nonTextRow {
+                NotebookDrawingBlockView(elementsJson: elementsJson, onTap: onEditDrawing)
+            }
+        }
+    }
+
+    private func textField(font: Font, prompt: String = "Write something…") -> some View {
+        TextField(prompt, text: $block.text, axis: .vertical)
+            .font(font)
+            .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+            .focused(focus, equals: block.id)
+            .onChange(of: block.text) {
+                onTextChange()
+            }
+    }
+
+    /// Non-text blocks get a small delete affordance since they can't be backspaced away.
+    private func nonTextRow(@ViewBuilder content: () -> some View) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            content()
+            Button(action: onDelete) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.subheadline)
+                    .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme).opacity(0.7))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Delete block")
+        }
+    }
+
+    private func dueLabel(_ dueAt: String?) -> String {
+        guard let dueAt, let date = LMSDates.parse(dueAt) else { return "Add due date" }
+        return "Due \(date.formatted(date: .abbreviated, time: .omitted))"
+    }
+}
+
+/// Due-date picker for a notebook task (set / change / remove).
+struct NotebookDueDateSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+    let task: ParsedNotebookTask
+    var onSave: (Date?) -> Void
+
+    @State private var date: Date = .now
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 12) {
+                if !task.text.isEmpty {
+                    Text(task.text)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                        .lineLimit(2)
+                        .padding(.horizontal, 20)
+                }
+
+                DatePicker("Due date", selection: $date, displayedComponents: .date)
+                    .datePickerStyle(.graphical)
+                    .tint(LexturesTheme.accent(for: colorScheme))
+                    .padding(.horizontal, 12)
+
+                if task.dueAt != nil {
+                    Button(role: .destructive) {
+                        onSave(nil)
+                        dismiss()
+                    } label: {
+                        Label("Remove due date", systemImage: "calendar.badge.minus")
+                            .font(.subheadline.weight(.semibold))
+                    }
+                    .padding(.bottom, 8)
+                }
+            }
+            .navigationTitle("Due date")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Save") {
+                        onSave(date)
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                    .tint(LexturesTheme.accent(for: colorScheme))
+                }
+            }
+            .onAppear {
+                if let dueAt = task.dueAt, let parsed = LMSDates.parse(dueAt) {
+                    date = parsed
+                }
+            }
+        }
+    }
+}

--- a/clients/ios/Lextures/Features/Notebooks/NotebookEditorView.swift
+++ b/clients/ios/Lextures/Features/Notebooks/NotebookEditorView.swift
@@ -55,7 +55,7 @@ struct NotebookEditorView: View {
 
     private var slashCommands: [NotebookSlashCommand] {
         guard let slashQuery else { return [] }
-        return NotebookMarkdown.filterCommands(query: slashQuery)
+        return NotebookSlashCommands.filter(query: slashQuery)
     }
 
     var body: some View {
@@ -329,10 +329,10 @@ struct NotebookEditorView: View {
     private func orderedNumber(for blockId: UUID) -> Int {
         guard let idx = blocks.firstIndex(where: { $0.id == blockId }) else { return 1 }
         var number = 1
-        var i = idx - 1
-        while i >= 0, blocks[i].kind.isOrdered {
+        var walkIndex = idx - 1
+        while walkIndex >= 0, blocks[walkIndex].kind.isOrdered {
             number += 1
-            i -= 1
+            walkIndex -= 1
         }
         return number
     }
@@ -432,7 +432,7 @@ struct NotebookEditorView: View {
 
     @ViewBuilder
     private func toolbarButton(_ commandId: String, label: String? = nil) -> some View {
-        if let command = NotebookMarkdown.slashCommands.first(where: { $0.id == commandId }) {
+        if let command = NotebookSlashCommands.all.first(where: { $0.id == commandId }) {
             Button {
                 applyCommand(command, clearSlash: false)
             } label: {
@@ -821,217 +821,6 @@ struct NotebookEditorView: View {
             try? await Task.sleep(nanoseconds: 1_500_000_000)
             guard !Task.isCancelled else { return }
             NotebookSync.push(store: store, courseCode: courseCode, accessToken: session.accessToken)
-        }
-    }
-}
-
-/// One block row in edit mode: styled like the reading view, but editable in place.
-private struct NotebookEditBlockRow: View {
-    @Environment(\.colorScheme) private var colorScheme
-    @Binding var block: NotebookEditBlock
-    let orderedNumber: Int
-    var focus: FocusState<UUID?>.Binding
-    var onTextChange: () -> Void
-    var onToggleTask: () -> Void
-    var onEditTaskDue: () -> Void
-    var onEditDrawing: () -> Void
-    var onDelete: () -> Void
-
-    var body: some View {
-        switch block.kind {
-        case .paragraph:
-            textField(font: .subheadline)
-
-        case .heading(let level):
-            textField(
-                font: LexturesTheme.displayFont(level == 1 ? 26 : level == 2 ? 21 : 17),
-                prompt: "Heading"
-            )
-
-        case .bullet:
-            HStack(alignment: .firstTextBaseline, spacing: 10) {
-                Circle()
-                    .fill(LexturesTheme.accent(for: colorScheme))
-                    .frame(width: 5, height: 5)
-                    .padding(.top, 6)
-                textField(font: .subheadline, prompt: "List item")
-            }
-            .padding(.leading, 4)
-
-        case .ordered:
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Text("\(orderedNumber).")
-                    .font(.subheadline.weight(.semibold).monospacedDigit())
-                    .foregroundStyle(LexturesTheme.accent(for: colorScheme))
-                textField(font: .subheadline, prompt: "List item")
-            }
-            .padding(.leading, 4)
-
-        case .quote:
-            HStack(alignment: .top, spacing: 10) {
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(LexturesTheme.brandAmber)
-                    .frame(width: 3)
-                textField(font: .subheadline.italic(), prompt: "Quote")
-            }
-            .padding(.vertical, 2)
-
-        case .code:
-            TextField("Code", text: $block.text, axis: .vertical)
-                .font(.caption.monospaced())
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .focused(focus, equals: block.id)
-                .padding(12)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(LexturesTheme.sceneBackground(for: colorScheme).opacity(colorScheme == .dark ? 0.6 : 1))
-                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .stroke(LexturesTheme.fieldBorder(for: colorScheme), lineWidth: 1)
-                )
-
-        case .divider:
-            nonTextRow {
-                Rectangle()
-                    .fill(LexturesTheme.fieldBorder(for: colorScheme))
-                    .frame(height: 1)
-                    .padding(.vertical, 8)
-            }
-
-        case .task(_, let checked, let dueAt):
-            HStack(alignment: .top, spacing: 10) {
-                Button(action: onToggleTask) {
-                    Image(systemName: checked ? "checkmark.square.fill" : "square")
-                        .font(.system(size: 20))
-                        .foregroundStyle(
-                            checked
-                                ? LexturesTheme.accent(for: colorScheme)
-                                : LexturesTheme.textSecondary(for: colorScheme)
-                        )
-                }
-                .buttonStyle(.plain)
-
-                VStack(alignment: .leading, spacing: 3) {
-                    textField(font: .subheadline, prompt: "Task")
-                    Button(action: onEditTaskDue) {
-                        HStack(spacing: 4) {
-                            Image(systemName: "calendar")
-                                .font(.caption2)
-                            Text(dueLabel(dueAt))
-                                .font(.caption)
-                        }
-                        .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            .padding(10)
-            .background(LexturesTheme.cardBackground(for: colorScheme))
-            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(LexturesTheme.fieldBorder(for: colorScheme).opacity(0.9), lineWidth: 1)
-            )
-
-        case .image(let alt, let url):
-            nonTextRow {
-                AuthorizedNotebookImage(urlString: url, alt: alt)
-            }
-
-        case .drawing(let elementsJson):
-            nonTextRow {
-                NotebookDrawingBlockView(elementsJson: elementsJson, onTap: onEditDrawing)
-            }
-        }
-    }
-
-    private func textField(font: Font, prompt: String = "Write something…") -> some View {
-        TextField(prompt, text: $block.text, axis: .vertical)
-            .font(font)
-            .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
-            .focused(focus, equals: block.id)
-            .onChange(of: block.text) {
-                onTextChange()
-            }
-    }
-
-    /// Non-text blocks get a small delete affordance since they can't be backspaced away.
-    private func nonTextRow(@ViewBuilder content: () -> some View) -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            content()
-            Button(action: onDelete) {
-                Image(systemName: "xmark.circle.fill")
-                    .font(.subheadline)
-                    .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme).opacity(0.7))
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Delete block")
-        }
-    }
-
-    private func dueLabel(_ dueAt: String?) -> String {
-        guard let dueAt, let date = LMSDates.parse(dueAt) else { return "Add due date" }
-        return "Due \(date.formatted(date: .abbreviated, time: .omitted))"
-    }
-}
-
-/// Due-date picker for a notebook task (set / change / remove).
-private struct NotebookDueDateSheet: View {
-    @Environment(\.dismiss) private var dismiss
-    @Environment(\.colorScheme) private var colorScheme
-    let task: ParsedNotebookTask
-    var onSave: (Date?) -> Void
-
-    @State private var date: Date = .now
-
-    var body: some View {
-        NavigationStack {
-            VStack(spacing: 12) {
-                if !task.text.isEmpty {
-                    Text(task.text)
-                        .font(.subheadline.weight(.medium))
-                        .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
-                        .lineLimit(2)
-                        .padding(.horizontal, 20)
-                }
-
-                DatePicker("Due date", selection: $date, displayedComponents: .date)
-                    .datePickerStyle(.graphical)
-                    .tint(LexturesTheme.accent(for: colorScheme))
-                    .padding(.horizontal, 12)
-
-                if task.dueAt != nil {
-                    Button(role: .destructive) {
-                        onSave(nil)
-                        dismiss()
-                    } label: {
-                        Label("Remove due date", systemImage: "calendar.badge.minus")
-                            .font(.subheadline.weight(.semibold))
-                    }
-                    .padding(.bottom, 8)
-                }
-            }
-            .navigationTitle("Due date")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel") { dismiss() }
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button("Save") {
-                        onSave(date)
-                        dismiss()
-                    }
-                    .fontWeight(.semibold)
-                    .tint(LexturesTheme.accent(for: colorScheme))
-                }
-            }
-            .onAppear {
-                if let dueAt = task.dueAt, let parsed = LMSDates.parse(dueAt) {
-                    date = parsed
-                }
-            }
         }
     }
 }

--- a/clients/ios/Lextures/Features/Notebooks/NotebookEditorView.swift
+++ b/clients/ios/Lextures/Features/Notebooks/NotebookEditorView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
-/// Markdown notebook editor with a page picker; saves to device-local storage as you type.
+/// Notebook page editor with a page tree, a rendered reading view (interactive tasks),
+/// and a WYSIWYG block edit mode with `/` commands + insert toolbar (parity with the web
+/// block editor — blocks stay rendered while editing, markdown is only the storage format).
 struct NotebookEditorView: View {
     @Environment(AuthSession.self) private var session
     @Environment(\.colorScheme) private var colorScheme
@@ -8,17 +10,52 @@ struct NotebookEditorView: View {
     let title: String
 
     @State private var notebook: CourseNotebook = .empty()
-    @State private var draft = ""
+    @State private var blocks: [NotebookEditBlock] = []
+    @State private var editing = false
+    @State private var showPages = false
     @State private var renamingPage = false
     @State private var renameText = ""
+    @State private var dueTask: ParsedNotebookTask?
     @State private var loaded = false
+    @State private var pushTask: Task<Void, Never>?
+    @State private var editingDrawing: EditingDrawing?
+    @FocusState private var focusedBlock: UUID?
+
+    /// Drawing being edited — from the reading view (by document index) or the
+    /// block editor (by block id).
+    private struct EditingDrawing: Identifiable {
+        let id = UUID()
+        let elementsJson: String
+        var readIndex: Int?
+        var blockId: UUID?
+    }
 
     private var store: NotebookStore {
         NotebookStore(accessToken: session.accessToken)
     }
 
     private var activePage: NotebookPage? {
-        notebook.pages.first { $0.id == notebook.activePageId } ?? notebook.pages.first
+        notebook.pages.first { $0.id == notebook.activePageId } ?? notebook.pages.first { $0.kind != "group" }
+    }
+
+    private var activeIsGroup: Bool {
+        activePage.map { NotebookTree.isGroup($0) } == true
+    }
+
+    /// `/query` typed at the start of the focused block opens the command menu (web parity).
+    private var slashQuery: String? {
+        guard editing, let focused = focusedBlock,
+              let block = blocks.first(where: { $0.id == focused }), block.isTextual,
+              block.text.hasPrefix("/")
+        else { return nil }
+        let query = String(block.text.dropFirst())
+        guard !query.contains(" "), !query.contains("\n"), query.count <= 24 else { return nil }
+        return query
+    }
+
+    private var slashCommands: [NotebookSlashCommand] {
+        guard let slashQuery else { return [] }
+        return NotebookMarkdown.filterCommands(query: slashQuery)
     }
 
     var body: some View {
@@ -26,28 +63,407 @@ struct NotebookEditorView: View {
             LexturesTheme.sceneBackground(for: colorScheme).ignoresSafeArea()
 
             VStack(spacing: 0) {
-                pageBar
+                pageHeader
 
-                TextEditor(text: $draft)
-                    .font(.body.monospaced())
-                    .scrollContentBackground(.hidden)
-                    .padding(12)
-                    .background(LexturesTheme.cardBackground(for: colorScheme))
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .stroke(LexturesTheme.fieldBorder(for: colorScheme).opacity(0.9), lineWidth: 1)
-                    )
-                    .padding(16)
-                    .onChange(of: draft) {
-                        saveDraft()
-                    }
+                if activeIsGroup {
+                    groupPanel
+                } else if editing {
+                    blockEditor
+                } else {
+                    readingView
+                }
             }
         }
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
+        .toolbar { toolbarContent }
+        .sheet(isPresented: $showPages) { pagesSheet }
+        .sheet(item: $editingDrawing) { drawing in
+            NotebookDrawingEditorView(initialElementsJson: drawing.elementsJson) { json in
+                saveDrawing(drawing, elementsJson: json)
+            }
+        }
+        .sheet(item: $dueTask) { task in
+            NotebookDueDateSheet(
+                task: task,
+                onSave: { date in setDueDate(taskId: task.id, date: date) }
+            )
+            .presentationDetents([.medium])
+        }
+        .alert("Rename page", isPresented: $renamingPage) {
+            TextField("Page title", text: $renameText)
+            Button("Save") { renameActivePage() }
+            Button("Cancel", role: .cancel) {}
+        }
+        .onAppear(perform: loadOnce)
+        .onChange(of: blocks) {
+            if editing { saveDraft() }
+        }
+        .onDisappear {
+            saveDraft()
+            if editing { syncAllTasks() }
+            // Leave the screen with the server current — skip the debounce.
+            pushTask?.cancel()
+            NotebookSync.push(store: store, courseCode: courseCode, accessToken: session.accessToken)
+        }
+    }
+
+    // MARK: - Header (current page → pages sheet)
+
+    private var pageHeader: some View {
+        HStack(spacing: 10) {
+            Button {
+                saveDraft()
+                showPages = true
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: activeIsGroup ? "folder.fill" : "doc.text")
+                        .font(.caption)
+                        .foregroundStyle(activeIsGroup ? LexturesTheme.brandAmber : LexturesTheme.accent(for: colorScheme))
+                    Text(headerTitle)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                        .lineLimit(1)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 9)
+                .background(LexturesTheme.cardBackground(for: colorScheme))
+                .clipShape(Capsule())
+                .overlay(Capsule().stroke(LexturesTheme.fieldBorder(for: colorScheme), lineWidth: 1))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Show pages")
+
+            Spacer()
+
+            if !editing, !activeIsGroup {
+                Button {
+                    startEditing()
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "pencil")
+                        Text("Edit")
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 9)
+                    .background(
+                        LinearGradient(
+                            colors: [LexturesTheme.primary, Color(hex: 0x17897B)],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    private var headerTitle: String {
+        guard let page = activePage else { return "Untitled" }
+        let path = NotebookTree.pathLabel(notebook.pages, pageId: page.id)
+        return path.isEmpty ? "Untitled" : path
+    }
+
+    // MARK: - Reading view
+
+    private var readingView: some View {
+        ScrollView {
+            if (activePage?.contentMd ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                emptyPageState
+            } else {
+                NotebookContentView(
+                    markdown: activePage?.contentMd ?? "",
+                    onToggleTask: { task in toggleTask(task) },
+                    onEditTaskDue: { task in dueTask = task },
+                    onEditDrawing: { index, elementsJson in
+                        editingDrawing = EditingDrawing(elementsJson: elementsJson, readIndex: index, blockId: nil)
+                    }
+                )
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(LexturesTheme.cardBackground(for: colorScheme))
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(LexturesTheme.fieldBorder(for: colorScheme).opacity(0.9), lineWidth: 1)
+                )
+                .padding(.horizontal, 16)
+                .padding(.bottom, 24)
+            }
+        }
+    }
+
+    private var emptyPageState: some View {
+        VStack(spacing: 14) {
+            Image(systemName: "square.and.pencil")
+                .font(.system(size: 34))
+                .foregroundStyle(LexturesTheme.accent(for: colorScheme).opacity(0.7))
+            Text("This page is empty")
+                .font(LexturesTheme.displayFont(19))
+                .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+            Text("Tap Edit to start writing. Type / on a new line for headings, tasks, drawings, and more.")
+                .font(.footnote)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+        }
+        .padding(.horizontal, 40)
+        .padding(.top, 80)
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Group panel (active "page" is a group)
+
+    private var groupPanel: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+                let children = NotebookTree.sortedChildren(notebook.pages, parentId: activePage?.id)
+                if children.isEmpty {
+                    Text("No pages in this group yet.")
+                        .font(.footnote)
+                        .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                        .padding(.top, 20)
+                        .frame(maxWidth: .infinity)
+                }
+                ForEach(children) { child in
+                    Button {
+                        selectPage(child.id)
+                    } label: {
+                        HStack(spacing: 10) {
+                            Image(systemName: NotebookTree.isGroup(child) ? "folder.fill" : "doc.text")
+                                .foregroundStyle(NotebookTree.isGroup(child) ? LexturesTheme.brandAmber : LexturesTheme.accent(for: colorScheme))
+                            Text(child.title.isEmpty ? "Untitled" : child.title)
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                        }
+                        .padding(14)
+                        .background(LexturesTheme.cardBackground(for: colorScheme))
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .stroke(LexturesTheme.fieldBorder(for: colorScheme), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Button {
+                    createPage(parentId: activePage?.id)
+                } label: {
+                    Label("New page in group", systemImage: "plus")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(LexturesTheme.accent(for: colorScheme))
+                }
+                .padding(.top, 4)
+            }
+            .padding(16)
+        }
+    }
+
+    // MARK: - Block editor
+
+    private var blockEditor: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach($blocks) { $block in
+                    NotebookEditBlockRow(
+                        block: $block,
+                        orderedNumber: orderedNumber(for: block.id),
+                        focus: $focusedBlock,
+                        onTextChange: { handleTextChange(block.id) },
+                        onToggleTask: { toggleTaskBlock(block.id) },
+                        onEditTaskDue: { editTaskDue(block.id) },
+                        onEditDrawing: {
+                            if case .drawing(let json) = block.kind {
+                                editingDrawing = EditingDrawing(elementsJson: json, readIndex: nil, blockId: block.id)
+                            }
+                        },
+                        onDelete: { deleteBlock(block.id) }
+                    )
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(LexturesTheme.cardBackground(for: colorScheme))
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(LexturesTheme.fieldBorder(for: colorScheme).opacity(0.9), lineWidth: 1)
+            )
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
+            .onTapGesture {
+                // Tap below the last block: focus it (or add a trailing paragraph).
+                if let last = blocks.last, last.isTextual {
+                    focusedBlock = last.id
+                } else {
+                    let block = NotebookEditBlock(kind: .paragraph)
+                    blocks.append(block)
+                    focusedBlock = block.id
+                }
+            }
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            VStack(spacing: 0) {
+                if !slashCommands.isEmpty {
+                    slashMenu
+                }
+                insertToolbar
+            }
+        }
+    }
+
+    /// Display number for an ordered block: its position within the current run.
+    private func orderedNumber(for blockId: UUID) -> Int {
+        guard let idx = blocks.firstIndex(where: { $0.id == blockId }) else { return 1 }
+        var number = 1
+        var i = idx - 1
+        while i >= 0, blocks[i].kind.isOrdered {
+            number += 1
+            i -= 1
+        }
+        return number
+    }
+
+    private var slashMenu: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                ForEach(slashCommands) { command in
+                    Button {
+                        applySlashCommand(command)
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: command.icon)
+                                .font(.subheadline)
+                                .foregroundStyle(LexturesTheme.accent(for: colorScheme))
+                                .frame(width: 26)
+                            VStack(alignment: .leading, spacing: 1) {
+                                Text(command.label)
+                                    .font(.subheadline.weight(.medium))
+                                    .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                                Text(command.detail)
+                                    .font(.caption2)
+                                    .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                            }
+                            Spacer()
+                        }
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .frame(maxHeight: 220)
+        .background(LexturesTheme.cardBackground(for: colorScheme))
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(LexturesTheme.fieldBorder(for: colorScheme), lineWidth: 1)
+        )
+        .shadow(color: LexturesTheme.cardShadow(for: colorScheme), radius: 14, y: 6)
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+    }
+
+    private var insertToolbar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 4) {
+                toolbarButton("heading1", label: "H1")
+                toolbarButton("heading2", label: "H2")
+                toolbarButton("heading3", label: "H3")
+                toolbarDividerLine
+                toolbarButton("task")
+                toolbarButton("drawing")
+                toolbarButton("bulletList")
+                toolbarButton("orderedList")
+                toolbarDividerLine
+                toolbarButton("blockquote")
+                toolbarButton("codeBlock")
+                toolbarButton("horizontalRule")
+                toolbarDividerLine
+                Button {
+                    if let focused = focusedBlock { deleteBlock(focused) }
+                } label: {
+                    Image(systemName: "trash")
+                        .font(.subheadline)
+                        .foregroundStyle(
+                            focusedBlock == nil
+                                ? LexturesTheme.textSecondary(for: colorScheme).opacity(0.5)
+                                : LexturesTheme.coral
+                        )
+                        .frame(width: 38, height: 34)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(focusedBlock == nil)
+                .accessibilityLabel("Delete block")
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+        }
+        .background(LexturesTheme.cardBackground(for: colorScheme))
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(LexturesTheme.fieldBorder(for: colorScheme))
+                .frame(height: 1)
+        }
+    }
+
+    private var toolbarDividerLine: some View {
+        Rectangle()
+            .fill(LexturesTheme.fieldBorder(for: colorScheme))
+            .frame(width: 1, height: 22)
+            .padding(.horizontal, 4)
+    }
+
+    @ViewBuilder
+    private func toolbarButton(_ commandId: String, label: String? = nil) -> some View {
+        if let command = NotebookMarkdown.slashCommands.first(where: { $0.id == commandId }) {
+            Button {
+                applyCommand(command, clearSlash: false)
+            } label: {
+                Group {
+                    if let label {
+                        Text(label)
+                            .font(.footnote.weight(.bold))
+                    } else {
+                        Image(systemName: command.icon)
+                            .font(.subheadline)
+                    }
+                }
+                .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                .frame(width: 38, height: 34)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(command.label)
+        }
+    }
+
+    // MARK: - Toolbar (navigation bar)
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            if editing {
+                Button("Done") { finishEditing() }
+                    .fontWeight(.semibold)
+                    .tint(LexturesTheme.accent(for: colorScheme))
+            } else {
                 Menu {
                     Button {
                         renameText = activePage?.title ?? ""
@@ -56,121 +472,566 @@ struct NotebookEditorView: View {
                         Label("Rename page", systemImage: "pencil")
                     }
                     Button {
-                        addPage()
+                        createPage(parentId: nil)
                     } label: {
                         Label("New page", systemImage: "plus")
                     }
-                    if notebook.pages.count > 1 {
-                        Button(role: .destructive) {
-                            deleteActivePage()
-                        } label: {
-                            Label("Delete page", systemImage: "trash")
-                        }
+                    Button {
+                        createGroup()
+                    } label: {
+                        Label("New group", systemImage: "folder.badge.plus")
                     }
                 } label: {
                     Image(systemName: "ellipsis.circle")
                 }
             }
         }
-        .alert("Rename page", isPresented: $renamingPage) {
-            TextField("Page title", text: $renameText)
-            Button("Save") { renameActivePage() }
-            Button("Cancel", role: .cancel) {}
-        }
-        .onAppear {
-            guard !loaded else { return }
-            loaded = true
-            var data = store.load(courseCode: courseCode)
-            if courseCode != NotebookStore.globalKey {
-                data.courseTitle = title
-            }
-            notebook = data
-            draft = activePage?.contentMd ?? ""
-        }
     }
 
-    private var pageBar: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                ForEach(notebook.pages.sorted { $0.sortOrder < $1.sortOrder }) { page in
-                    Button {
-                        selectPage(page)
-                    } label: {
-                        Text(page.title.isEmpty ? "Untitled" : page.title)
-                            .font(.caption.weight(page.id == activePage?.id ? .semibold : .regular))
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 7)
-                            .background(
-                                page.id == activePage?.id
-                                    ? LexturesTheme.primary.opacity(0.14)
-                                    : LexturesTheme.cardBackground(for: colorScheme)
-                            )
-                            .foregroundStyle(
-                                page.id == activePage?.id
-                                    ? LexturesTheme.primary
-                                    : LexturesTheme.textSecondary(for: colorScheme)
-                            )
-                            .clipShape(Capsule())
-                            .overlay(
-                                Capsule().stroke(
-                                    page.id == activePage?.id
-                                        ? LexturesTheme.primary.opacity(0.4)
-                                        : LexturesTheme.fieldBorder(for: colorScheme),
-                                    lineWidth: 1
-                                )
-                            )
-                    }
-                    .buttonStyle(.plain)
+    // MARK: - Pages sheet wiring
+
+    private var pagesSheet: some View {
+        NotebookPagesSheet(
+            pages: notebook.pages,
+            activePageId: activePage?.id,
+            onSelect: { selectPage($0) },
+            onCreatePage: { parentId in createPage(parentId: parentId) },
+            onCreateGroup: { createGroup() },
+            onRename: { pageId, title in
+                notebook.pages = NotebookTree.rename(notebook.pages, pageId: pageId, title: title)
+                persist()
+            },
+            onMove: { pageId, newParentId in
+                if let moved = NotebookTree.moveToParent(notebook.pages, pageId: pageId, newParentId: newParentId) {
+                    notebook.pages = moved
+                    persist()
                 }
+            },
+            onDelete: { pageId in deletePage(pageId) }
+        )
+        .presentationDetents([.medium, .large])
+    }
+
+    // MARK: - Page operations
+
+    private func loadOnce() {
+        guard !loaded else { return }
+        loaded = true
+        loadFromStore()
+        // Merge any newer server copy (e.g. written on web), then refresh once.
+        Task {
+            if await NotebookSync.pull(store: store, accessToken: session.accessToken) {
+                loadFromStore()
             }
-            .padding(.horizontal, 16)
-            .padding(.top, 12)
         }
     }
 
-    private func selectPage(_ page: NotebookPage) {
-        commitDraftToNotebook()
-        notebook.activePageId = page.id
-        draft = page.contentMd
-        store.save(courseCode: courseCode, notebook: notebook)
+    private func loadFromStore() {
+        var data = store.load(courseCode: courseCode)
+        if courseCode != NotebookStore.globalKey {
+            data.courseTitle = title
+        }
+        notebook = data
+        loadBlocks()
+        // Empty page → straight into edit mode so writing is one tap away.
+        if !activeIsGroup, pageIsEmpty {
+            editing = true
+        }
     }
 
-    private func addPage() {
-        commitDraftToNotebook()
-        let maxOrder = notebook.pages.map(\.sortOrder).max() ?? 0
-        let page = NotebookPage.new(title: "Untitled", sortOrder: maxOrder + 1)
-        notebook.pages.append(page)
-        notebook.activePageId = page.id
-        draft = ""
-        store.save(courseCode: courseCode, notebook: notebook)
+    private var pageIsEmpty: Bool {
+        (activePage?.contentMd ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    private func deleteActivePage() {
-        guard let active = activePage, notebook.pages.count > 1 else { return }
-        notebook.pages.removeAll { $0.id == active.id }
-        notebook.activePageId = notebook.pages.first?.id
-        draft = activePage?.contentMd ?? ""
-        store.save(courseCode: courseCode, notebook: notebook)
+    private func loadBlocks() {
+        blocks = NotebookMarkdown.editBlocks(from: activePage?.contentMd ?? "")
+    }
+
+    private func selectPage(_ pageId: String) {
+        saveDraft()
+        editing = false
+        notebook.activePageId = pageId
+        loadBlocks()
+        if !activeIsGroup, pageIsEmpty {
+            editing = true
+        }
+        persist()
+    }
+
+    private func createPage(parentId: String?) {
+        saveDraft()
+        let (pages, newId) = NotebookTree.addPage(notebook.pages, parentId: parentId)
+        notebook.pages = pages
+        notebook.activePageId = newId
+        loadBlocks()
+        editing = true
+        focusedBlock = blocks.first?.id
+        persist()
+    }
+
+    private func createGroup() {
+        saveDraft()
+        let (pages, _) = NotebookTree.addGroup(notebook.pages, parentId: nil, title: "New group")
+        notebook.pages = pages
+        persist()
+        showPages = true
+    }
+
+    private func deletePage(_ pageId: String) {
+        var pages = NotebookTree.delete(notebook.pages, pageId: pageId)
+        if !pages.contains(where: { !NotebookTree.isGroup($0) }) {
+            let (withPage, newId) = NotebookTree.addPage(pages, parentId: nil)
+            pages = withPage
+            notebook.activePageId = newId
+        }
+        notebook.pages = pages
+        if !notebook.pages.contains(where: { $0.id == notebook.activePageId }) {
+            notebook.activePageId = pages.first { !NotebookTree.isGroup($0) }?.id ?? pages.first?.id
+        }
+        loadBlocks()
+        editing = false
+        persist()
     }
 
     private func renameActivePage() {
         guard let active = activePage else { return }
         let name = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !name.isEmpty else { return }
-        if let idx = notebook.pages.firstIndex(where: { $0.id == active.id }) {
-            notebook.pages[idx].title = name
-            store.save(courseCode: courseCode, notebook: notebook)
+        notebook.pages = NotebookTree.rename(notebook.pages, pageId: active.id, title: name)
+        persist()
+    }
+
+    // MARK: - Editing & block operations
+
+    private func startEditing() {
+        loadBlocks()
+        editing = true
+        focusedBlock = blocks.last(where: { $0.isTextual })?.id
+    }
+
+    private func finishEditing() {
+        saveDraft()
+        editing = false
+        syncAllTasks()
+        focusedBlock = nil
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+
+    /// Newlines never live inside a text block (except code): a return splits the block,
+    /// continuing the list/task kind like the web editor does.
+    private func handleTextChange(_ blockId: UUID) {
+        guard let idx = blocks.firstIndex(where: { $0.id == blockId }) else { return }
+        let block = blocks[idx]
+        if case .code = block.kind { return }
+        guard block.text.contains("\n") else { return }
+
+        let parts = block.text.components(separatedBy: "\n")
+        let first = parts[0]
+        let rest = parts.dropFirst().joined(separator: " ")
+
+        // Return on an empty list/quote/task line exits the list back to a paragraph.
+        if first.isEmpty, rest.isEmpty, !isParagraphKind(block.kind) {
+            blocks[idx].kind = .paragraph
+            blocks[idx].text = ""
+            return
+        }
+
+        blocks[idx].text = first
+        let continuation: NotebookEditBlock.Kind
+        switch block.kind {
+        case .bullet: continuation = .bullet
+        case .ordered: continuation = .ordered
+        case .quote: continuation = .quote
+        case .task: continuation = .task(taskId: NotebookMarkdown.newTaskId(), checked: false, dueAt: nil)
+        default: continuation = .paragraph
+        }
+        let newBlock = NotebookEditBlock(kind: continuation, text: rest)
+        blocks.insert(newBlock, at: idx + 1)
+        focusedBlock = newBlock.id
+    }
+
+    private func isParagraphKind(_ kind: NotebookEditBlock.Kind) -> Bool {
+        if case .paragraph = kind { return true }
+        return false
+    }
+
+    private func applySlashCommand(_ command: NotebookSlashCommand) {
+        applyCommand(command, clearSlash: true)
+    }
+
+    /// Convert the focused block (text kinds) or insert after it (divider / drawing).
+    private func applyCommand(_ command: NotebookSlashCommand, clearSlash: Bool) {
+        var idx = blocks.firstIndex { $0.id == focusedBlock }
+        if idx == nil {
+            let block = NotebookEditBlock(kind: .paragraph)
+            blocks.append(block)
+            idx = blocks.count - 1
+        }
+        guard let idx else { return }
+        if clearSlash, blocks[idx].isTextual, blocks[idx].text.hasPrefix("/") {
+            blocks[idx].text = ""
+        }
+
+        switch command.id {
+        case "heading1": blocks[idx].kind = .heading(1)
+        case "heading2": blocks[idx].kind = .heading(2)
+        case "heading3": blocks[idx].kind = .heading(3)
+        case "bulletList": blocks[idx].kind = .bullet
+        case "orderedList": blocks[idx].kind = .ordered
+        case "blockquote": blocks[idx].kind = .quote
+        case "codeBlock": blocks[idx].kind = .code
+        case "task":
+            if case .task = blocks[idx].kind { break }
+            blocks[idx].kind = .task(taskId: NotebookMarkdown.newTaskId(), checked: false, dueAt: nil)
+        case "horizontalRule":
+            insertBlock(NotebookEditBlock(kind: .divider), after: idx)
+        case "drawing":
+            insertBlock(NotebookEditBlock(kind: .drawing(elementsJson: "[]")), after: idx)
+        default:
+            break
+        }
+        focusedBlock = blocks[min(idx, blocks.count - 1)].id
+    }
+
+    /// Insert a non-text block, followed by a paragraph to keep typing into.
+    private func insertBlock(_ block: NotebookEditBlock, after idx: Int) {
+        let paragraph = NotebookEditBlock(kind: .paragraph)
+        blocks.insert(block, at: idx + 1)
+        blocks.insert(paragraph, at: idx + 2)
+        focusedBlock = paragraph.id
+    }
+
+    private func deleteBlock(_ blockId: UUID) {
+        guard let idx = blocks.firstIndex(where: { $0.id == blockId }) else { return }
+        blocks.remove(at: idx)
+        if blocks.isEmpty {
+            blocks.append(NotebookEditBlock(kind: .paragraph))
+        }
+        focusedBlock = blocks[max(0, min(idx - 1, blocks.count - 1))].id
+    }
+
+    private func toggleTaskBlock(_ blockId: UUID) {
+        guard let idx = blocks.firstIndex(where: { $0.id == blockId }),
+              case .task(let taskId, let checked, let dueAt) = blocks[idx].kind
+        else { return }
+        blocks[idx].kind = .task(taskId: taskId, checked: !checked, dueAt: dueAt)
+        syncTask(ParsedNotebookTask(id: taskId, text: blocks[idx].text, checked: !checked, dueAt: dueAt))
+    }
+
+    private func editTaskDue(_ blockId: UUID) {
+        guard let block = blocks.first(where: { $0.id == blockId }),
+              case .task(let taskId, let checked, let dueAt) = block.kind
+        else { return }
+        dueTask = ParsedNotebookTask(id: taskId, text: block.text, checked: checked, dueAt: dueAt)
+    }
+
+    // MARK: - Tasks (reading view + due sheet)
+
+    private func toggleTask(_ task: ParsedNotebookTask) {
+        guard let active = activePage else { return }
+        let next = NotebookMarkdown.setTaskChecked(in: active.contentMd, taskId: task.id, checked: !task.checked)
+        updateActiveContent(next)
+        syncTask(ParsedNotebookTask(id: task.id, text: task.text, checked: !task.checked, dueAt: task.dueAt))
+    }
+
+    private func setDueDate(taskId: String, date: Date?) {
+        saveDraft()
+        guard let active = activePage else { return }
+        let dueAt = date.map { endOfDayISO($0) }
+        let next = NotebookMarkdown.setTaskDueAt(in: active.contentMd, taskId: taskId, dueAt: dueAt)
+        updateActiveContent(next)
+        if let task = NotebookMarkdown.parseTasks(in: next).first(where: { $0.id == taskId }) {
+            syncTask(task)
         }
     }
 
-    private func commitDraftToNotebook() {
-        guard let active = activePage,
-              let idx = notebook.pages.firstIndex(where: { $0.id == active.id }) else { return }
-        notebook.pages[idx].contentMd = draft
+    private func endOfDayISO(_ date: Date) -> String {
+        let start = Calendar.current.startOfDay(for: date)
+        let end = Calendar.current.date(byAdding: DateComponents(day: 1, second: -1), to: start) ?? date
+        return ISO8601DateFormatter().string(from: end)
     }
 
+    private func updateActiveContent(_ contentMd: String) {
+        guard let active = activePage else { return }
+        notebook.pages = NotebookTree.updateContent(notebook.pages, pageId: active.id, contentMd: contentMd)
+        loadBlocks()
+        persist()
+    }
+
+    // MARK: - Drawings
+
+    private func saveDrawing(_ drawing: EditingDrawing, elementsJson: String) {
+        if let blockId = drawing.blockId,
+           let idx = blocks.firstIndex(where: { $0.id == blockId }) {
+            blocks[idx].kind = .drawing(elementsJson: elementsJson)
+            saveDraft()
+            return
+        }
+        if let index = drawing.readIndex, let active = activePage {
+            let next = NotebookMarkdown.replaceDrawing(in: active.contentMd, index: index, elementsJson: elementsJson)
+            updateActiveContent(next)
+        }
+    }
+
+    /// Fire-and-forget dashboard sync (web parity: tasks also live server-side).
+    private func syncTask(_ task: ParsedNotebookTask) {
+        guard let token = session.accessToken, let pageId = activePage?.id else { return }
+        let body = LMSAPI.NotebookTaskUpsert(
+            id: task.id,
+            courseCode: courseCode,
+            notebookPageId: pageId,
+            taskText: task.text,
+            completed: task.checked,
+            dueAt: task.dueAt
+        )
+        Task { try? await LMSAPI.upsertNotebookTask(body, accessToken: token) }
+    }
+
+    private func syncAllTasks() {
+        guard let active = activePage else { return }
+        for task in NotebookMarkdown.parseTasks(in: active.contentMd) {
+            syncTask(task)
+        }
+    }
+
+    // MARK: - Persistence
+
     private func saveDraft() {
-        commitDraftToNotebook()
+        guard editing, let active = activePage, !NotebookTree.isGroup(active) else {
+            persist()
+            return
+        }
+        notebook.pages = NotebookTree.updateContent(
+            notebook.pages,
+            pageId: active.id,
+            contentMd: NotebookMarkdown.markdown(from: blocks)
+        )
+        persist()
+    }
+
+    private func persist() {
         store.save(courseCode: courseCode, notebook: notebook)
+        schedulePush()
+    }
+
+    /// Debounced server push so typing doesn't fire a request per keystroke.
+    private func schedulePush() {
+        pushTask?.cancel()
+        pushTask = Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            guard !Task.isCancelled else { return }
+            NotebookSync.push(store: store, courseCode: courseCode, accessToken: session.accessToken)
+        }
+    }
+}
+
+/// One block row in edit mode: styled like the reading view, but editable in place.
+private struct NotebookEditBlockRow: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Binding var block: NotebookEditBlock
+    let orderedNumber: Int
+    var focus: FocusState<UUID?>.Binding
+    var onTextChange: () -> Void
+    var onToggleTask: () -> Void
+    var onEditTaskDue: () -> Void
+    var onEditDrawing: () -> Void
+    var onDelete: () -> Void
+
+    var body: some View {
+        switch block.kind {
+        case .paragraph:
+            textField(font: .subheadline)
+
+        case .heading(let level):
+            textField(
+                font: LexturesTheme.displayFont(level == 1 ? 26 : level == 2 ? 21 : 17),
+                prompt: "Heading"
+            )
+
+        case .bullet:
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Circle()
+                    .fill(LexturesTheme.accent(for: colorScheme))
+                    .frame(width: 5, height: 5)
+                    .padding(.top, 6)
+                textField(font: .subheadline, prompt: "List item")
+            }
+            .padding(.leading, 4)
+
+        case .ordered:
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("\(orderedNumber).")
+                    .font(.subheadline.weight(.semibold).monospacedDigit())
+                    .foregroundStyle(LexturesTheme.accent(for: colorScheme))
+                textField(font: .subheadline, prompt: "List item")
+            }
+            .padding(.leading, 4)
+
+        case .quote:
+            HStack(alignment: .top, spacing: 10) {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(LexturesTheme.brandAmber)
+                    .frame(width: 3)
+                textField(font: .subheadline.italic(), prompt: "Quote")
+            }
+            .padding(.vertical, 2)
+
+        case .code:
+            TextField("Code", text: $block.text, axis: .vertical)
+                .font(.caption.monospaced())
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .focused(focus, equals: block.id)
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(LexturesTheme.sceneBackground(for: colorScheme).opacity(colorScheme == .dark ? 0.6 : 1))
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .stroke(LexturesTheme.fieldBorder(for: colorScheme), lineWidth: 1)
+                )
+
+        case .divider:
+            nonTextRow {
+                Rectangle()
+                    .fill(LexturesTheme.fieldBorder(for: colorScheme))
+                    .frame(height: 1)
+                    .padding(.vertical, 8)
+            }
+
+        case .task(_, let checked, let dueAt):
+            HStack(alignment: .top, spacing: 10) {
+                Button(action: onToggleTask) {
+                    Image(systemName: checked ? "checkmark.square.fill" : "square")
+                        .font(.system(size: 20))
+                        .foregroundStyle(
+                            checked
+                                ? LexturesTheme.accent(for: colorScheme)
+                                : LexturesTheme.textSecondary(for: colorScheme)
+                        )
+                }
+                .buttonStyle(.plain)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    textField(font: .subheadline, prompt: "Task")
+                    Button(action: onEditTaskDue) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "calendar")
+                                .font(.caption2)
+                            Text(dueLabel(dueAt))
+                                .font(.caption)
+                        }
+                        .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(10)
+            .background(LexturesTheme.cardBackground(for: colorScheme))
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(LexturesTheme.fieldBorder(for: colorScheme).opacity(0.9), lineWidth: 1)
+            )
+
+        case .image(let alt, let url):
+            nonTextRow {
+                AuthorizedNotebookImage(urlString: url, alt: alt)
+            }
+
+        case .drawing(let elementsJson):
+            nonTextRow {
+                NotebookDrawingBlockView(elementsJson: elementsJson, onTap: onEditDrawing)
+            }
+        }
+    }
+
+    private func textField(font: Font, prompt: String = "Write something…") -> some View {
+        TextField(prompt, text: $block.text, axis: .vertical)
+            .font(font)
+            .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+            .focused(focus, equals: block.id)
+            .onChange(of: block.text) {
+                onTextChange()
+            }
+    }
+
+    /// Non-text blocks get a small delete affordance since they can't be backspaced away.
+    private func nonTextRow(@ViewBuilder content: () -> some View) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            content()
+            Button(action: onDelete) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.subheadline)
+                    .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme).opacity(0.7))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Delete block")
+        }
+    }
+
+    private func dueLabel(_ dueAt: String?) -> String {
+        guard let dueAt, let date = LMSDates.parse(dueAt) else { return "Add due date" }
+        return "Due \(date.formatted(date: .abbreviated, time: .omitted))"
+    }
+}
+
+/// Due-date picker for a notebook task (set / change / remove).
+private struct NotebookDueDateSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+    let task: ParsedNotebookTask
+    var onSave: (Date?) -> Void
+
+    @State private var date: Date = .now
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 12) {
+                if !task.text.isEmpty {
+                    Text(task.text)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                        .lineLimit(2)
+                        .padding(.horizontal, 20)
+                }
+
+                DatePicker("Due date", selection: $date, displayedComponents: .date)
+                    .datePickerStyle(.graphical)
+                    .tint(LexturesTheme.accent(for: colorScheme))
+                    .padding(.horizontal, 12)
+
+                if task.dueAt != nil {
+                    Button(role: .destructive) {
+                        onSave(nil)
+                        dismiss()
+                    } label: {
+                        Label("Remove due date", systemImage: "calendar.badge.minus")
+                            .font(.subheadline.weight(.semibold))
+                    }
+                    .padding(.bottom, 8)
+                }
+            }
+            .navigationTitle("Due date")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Save") {
+                        onSave(date)
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                    .tint(LexturesTheme.accent(for: colorScheme))
+                }
+            }
+            .onAppear {
+                if let dueAt = task.dueAt, let parsed = LMSDates.parse(dueAt) {
+                    date = parsed
+                }
+            }
+        }
     }
 }

--- a/clients/ios/Lextures/Features/Notebooks/NotebookPagesSheet.swift
+++ b/clients/ios/Lextures/Features/Notebooks/NotebookPagesSheet.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+
+/// Page tree for a notebook: groups with nested pages, plus create / rename / move / delete
+/// (parity with the web notebook sidebar).
+struct NotebookPagesSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+
+    let pages: [NotebookPage]
+    let activePageId: String?
+    var onSelect: (String) -> Void
+    var onCreatePage: (_ parentId: String?) -> Void
+    var onCreateGroup: () -> Void
+    var onRename: (_ pageId: String, _ title: String) -> Void
+    var onMove: (_ pageId: String, _ newParentId: String?) -> Void
+    var onDelete: (_ pageId: String) -> Void
+
+    @State private var renameTarget: NotebookPage?
+    @State private var renameText = ""
+    @State private var deleteTarget: NotebookPage?
+
+    private var rows: [NotebookTree.FlatRow] {
+        NotebookTree.flatten(pages)
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(rows) { row in
+                        pageRow(row)
+                    }
+                } footer: {
+                    Text("Pages live on this device. Use groups to organize related pages.")
+                        .font(.caption2)
+                }
+
+                Section {
+                    Button {
+                        onCreatePage(nil)
+                        dismiss()
+                    } label: {
+                        Label("New page", systemImage: "plus")
+                            .foregroundStyle(LexturesTheme.accent(for: colorScheme))
+                    }
+                    Button {
+                        onCreateGroup()
+                    } label: {
+                        Label("New group", systemImage: "folder.badge.plus")
+                            .foregroundStyle(LexturesTheme.accent(for: colorScheme))
+                    }
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(LexturesTheme.sceneBackground(for: colorScheme))
+            .navigationTitle("Pages")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .fontWeight(.semibold)
+                        .tint(LexturesTheme.accent(for: colorScheme))
+                }
+            }
+        }
+        .alert("Rename", isPresented: Binding(
+            get: { renameTarget != nil },
+            set: { if !$0 { renameTarget = nil } }
+        )) {
+            TextField("Title", text: $renameText)
+            Button("Save") {
+                if let target = renameTarget {
+                    let name = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !name.isEmpty { onRename(target.id, name) }
+                }
+                renameTarget = nil
+            }
+            Button("Cancel", role: .cancel) { renameTarget = nil }
+        }
+        .alert("Delete \"\(deleteTarget.map { $0.title.isEmpty ? "Untitled" : $0.title } ?? "")\"?", isPresented: Binding(
+            get: { deleteTarget != nil },
+            set: { if !$0 { deleteTarget = nil } }
+        )) {
+            Button("Delete", role: .destructive) {
+                if let target = deleteTarget { onDelete(target.id) }
+                deleteTarget = nil
+            }
+            Button("Cancel", role: .cancel) { deleteTarget = nil }
+        } message: {
+            Text(deleteTarget.map { NotebookTree.isGroup($0) } == true
+                ? "The group and everything inside it will be deleted."
+                : "This page and its notes will be deleted.")
+        }
+    }
+
+    private func pageRow(_ row: NotebookTree.FlatRow) -> some View {
+        let page = row.page
+        let isGroup = NotebookTree.isGroup(page)
+        let isActive = page.id == activePageId
+
+        return Button {
+            onSelect(page.id)
+            dismiss()
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: isGroup ? "folder.fill" : "doc.text")
+                    .font(.subheadline)
+                    .foregroundStyle(isGroup ? LexturesTheme.brandAmber : LexturesTheme.accent(for: colorScheme))
+                    .frame(width: 22)
+
+                Text(page.title.isEmpty ? "Untitled" : page.title)
+                    .font(.subheadline.weight(isActive ? .semibold : .regular))
+                    .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                    .lineLimit(1)
+
+                Spacer(minLength: 0)
+
+                if isActive {
+                    Image(systemName: "checkmark")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(LexturesTheme.accent(for: colorScheme))
+                }
+            }
+            .padding(.leading, CGFloat(row.depth) * 20)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .listRowBackground(
+            isActive
+                ? LexturesTheme.accent(for: colorScheme).opacity(0.10)
+                : LexturesTheme.cardBackground(for: colorScheme)
+        )
+        .contextMenu {
+            Button {
+                renameTarget = page
+                renameText = page.title
+            } label: {
+                Label("Rename", systemImage: "pencil")
+            }
+
+            if isGroup {
+                Button {
+                    onCreatePage(page.id)
+                    dismiss()
+                } label: {
+                    Label("New page inside", systemImage: "plus")
+                }
+            }
+
+            moveMenu(for: page)
+
+            if canDelete(page) {
+                Button(role: .destructive) {
+                    deleteTarget = page
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func moveMenu(for page: NotebookPage) -> some View {
+        let targets = NotebookTree.groupMoveTargets(pages, pageId: page.id)
+        Menu {
+            if page.parentId != nil {
+                Button {
+                    onMove(page.id, nil)
+                } label: {
+                    Label("Top level", systemImage: "arrow.up.to.line")
+                }
+            }
+            ForEach(targets.filter { $0.id != page.parentId }) { group in
+                Button {
+                    onMove(page.id, group.id)
+                } label: {
+                    Label(NotebookTree.pathLabel(pages, pageId: group.id), systemImage: "folder")
+                }
+            }
+        } label: {
+            Label("Move to…", systemImage: "arrow.turn.down.right")
+        }
+        .disabled(targets.filter { $0.id != page.parentId }.isEmpty && page.parentId == nil)
+    }
+
+    /// Keep at least one real page in the notebook.
+    private func canDelete(_ page: NotebookPage) -> Bool {
+        let remaining = NotebookTree.delete(pages, pageId: page.id)
+        return remaining.contains { !NotebookTree.isGroup($0) }
+    }
+}

--- a/clients/ios/Lextures/Features/Notebooks/NotebooksListView.swift
+++ b/clients/ios/Lextures/Features/Notebooks/NotebooksListView.swift
@@ -92,8 +92,8 @@ struct NotebooksListView: View {
                     Text(subtitle)
                         .font(.caption)
                         .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
-                    if let notebook, !notebook.previewText.isEmpty {
-                        Text(notebook.previewText)
+                    if let notebook, case let preview = NotebookMarkdown.previewText(notebook.previewText), !preview.isEmpty {
+                        Text(preview)
                             .font(.caption)
                             .lineLimit(2)
                             .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
@@ -125,6 +125,10 @@ struct NotebooksListView: View {
         guard let token = session.accessToken else { return }
         if loadedOnce && !force { return }
         loadedOnce = true
+        // Pull server notebooks first so web-created ones appear in the list.
+        if await NotebookSync.pull(store: store, accessToken: token) {
+            savedNotebooks = store.listCourseNotebooks()
+        }
         courses = (try? await LMSAPI.fetchCourses(accessToken: token)) ?? courses
     }
 }

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -4,8 +4,26 @@ Native iPhone app for Lextures (SwiftUI). Feature development mirrors the web ap
 
 ## Requirements
 
-- Xcode 16+ (iOS 17 deployment target)
+- Xcode 16+ (iOS 17 deployment target; Xcode 26 recommended for iOS 26/27 device betas)
 - Running Lextures API (see repo root [AGENTS.md](../../AGENTS.md))
+
+## iOS 26/27 device crash at launch (`OS_dispatch_mach_msg _setContext`)
+
+On physical devices running iOS 26 or 27 betas with Xcode 26 on macOS Tahoe, Xcode’s debugger (LLDB) can abort the app at launch with:
+
+```
+-[OS_dispatch_mach_msg _setContext:]: unrecognized selector sent to instance
+```
+
+This is a known toolchain/OS beta issue, not a bug in app logic. Try in order:
+
+1. **Run without the debugger** — select the **Lextures-Device** scheme (Debug executable is off) and Run on your iPhone. Breakpoints are disabled, but the app should launch.
+2. **Or** Edit Scheme → Run → Info → uncheck **Debug executable** on the normal **Lextures** scheme.
+3. **Or** build & run once, then launch Lextures from the home screen (tap the icon instead of using Xcode Run).
+4. **Refresh device symbols** — delete `~/Library/Developer/Xcode/iOS DeviceSupport/`, unplug/replug the iPhone, wait for “Preparing debugger support…”, then rebuild.
+5. **Update Xcode** to the latest Tahoe beta; Apple fixed related URLSession/Network launch crashes in later iOS 26 betas.
+
+The app warms up Network.framework in `AppDelegate` before any API calls to avoid a separate URLSession init crash on these OS versions.
 
 ## Open the project
 

--- a/clients/web/src/app.tsx
+++ b/clients/web/src/app.tsx
@@ -14,6 +14,7 @@ import CourseGroupsPage from './pages/lms/course-groups-page'
 import CourseGradebook from './pages/lms/course-gradebook'
 import CourseAtRiskPage from './pages/lms/course-at-risk'
 import StudentProgressPage from './pages/lms/student-progress-page'
+import CourseStudentReportsPage from './pages/lms/course-student-reports-page'
 import CourseMyGrades from './pages/lms/course-my-grades'
 import AdminAccommodationsPage from './pages/lms/admin-accommodations-page'
 import AccommodationAuditPage from './pages/lms/accommodation-audit-page'
@@ -200,6 +201,7 @@ export default function App() {
             <Route path="calendar" element={<CourseCalendarPage />} />
             <Route path="my-grades" element={<CourseMyGrades />} />
             <Route path="gradebook" element={<CourseGradebook />} />
+            <Route path="reports" element={<CourseStudentReportsPage />} />
             <Route path="at-risk" element={<CourseAtRiskPage />} />
             <Route path="event-log" element={<CourseEventLogPage />} />
             <Route path="students/:enrollmentId/progress" element={<StudentProgressPage />} />

--- a/clients/web/src/components/dashboard/grading-backlog-list.tsx
+++ b/clients/web/src/components/dashboard/grading-backlog-list.tsx
@@ -1,0 +1,64 @@
+import { Link } from 'react-router-dom'
+import { ClipboardCheck } from 'lucide-react'
+
+export type GradingBacklogItem = {
+  assignmentId: string
+  assignmentTitle: string
+  ungradedCount: number
+  courseCode?: string
+  courseTitle?: string
+}
+
+function hrefForAssignmentGrading(courseCode: string, assignmentId: string): string {
+  return `/courses/${encodeURIComponent(courseCode)}/modules/assignment/${encodeURIComponent(assignmentId)}?preview=submissions`
+}
+
+function formatUngradedCount(count: number): string {
+  return `${count} ungraded submission${count === 1 ? '' : 's'}`
+}
+
+type GradingBacklogListProps = {
+  items: GradingBacklogItem[]
+  /** Show course title above each assignment (global dashboard). */
+  showCourse?: boolean
+  emptyMessage?: string
+}
+
+export function GradingBacklogList({ items, showCourse = false, emptyMessage }: GradingBacklogListProps) {
+  if (items.length === 0) {
+    if (!emptyMessage) return null
+    return <p className="text-sm text-slate-500 dark:text-neutral-400">{emptyMessage}</p>
+  }
+
+  return (
+    <ul className="space-y-2">
+      {items.map((item) => {
+        const courseCode = item.courseCode
+        if (!courseCode) return null
+        return (
+          <li key={`${courseCode}-${item.assignmentId}`}>
+            <Link
+              to={hrefForAssignmentGrading(courseCode, item.assignmentId)}
+              className="flex items-start justify-between gap-3 rounded-xl border border-amber-100 bg-amber-50/60 px-3 py-2.5 text-sm transition hover:border-amber-200 hover:bg-amber-50 dark:border-amber-900/40 dark:bg-amber-950/30 dark:hover:border-amber-800 dark:hover:bg-amber-950/50"
+            >
+              <span className="min-w-0">
+                {showCourse && item.courseTitle ? (
+                  <span className="block text-xs font-medium text-slate-500 dark:text-neutral-400">
+                    {item.courseTitle}
+                  </span>
+                ) : null}
+                <span className="flex items-center gap-1.5 font-semibold text-slate-900 dark:text-neutral-100">
+                  <ClipboardCheck className="h-3.5 w-3.5 shrink-0 text-amber-700 dark:text-amber-300" aria-hidden />
+                  <span className="truncate">{item.assignmentTitle}</span>
+                </span>
+              </span>
+              <span className="shrink-0 rounded-full bg-amber-200/80 px-2 py-0.5 text-xs font-semibold text-amber-950 dark:bg-amber-900/60 dark:text-amber-50">
+                {formatUngradedCount(item.ungradedCount)}
+              </span>
+            </Link>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/clients/web/src/components/enrollment/enrollment-avatar.tsx
+++ b/clients/web/src/components/enrollment/enrollment-avatar.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+function hueFromString(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0
+  return Math.abs(h) % 360
+}
+
+function displayInitials(label: string): string {
+  const t = label.trim()
+  if (!t) return '?'
+  const parts = t.split(/\s+/).filter(Boolean)
+  if (parts.length >= 2) {
+    const a = parts[0][0] ?? ''
+    const b = parts[1][0] ?? ''
+    return (a + b).toUpperCase() || '?'
+  }
+  return t.slice(0, 2).toUpperCase() || '?'
+}
+
+export function EnrollmentAvatar({
+  userId,
+  name,
+  avatarUrl,
+  size = 'sm',
+  showPreview = true,
+}: {
+  userId: string
+  name: string
+  avatarUrl?: string | null
+  size?: 'sm' | 'md'
+  /** When false, hover does not open the enlarged preview (e.g. top-bar menu trigger). */
+  showPreview?: boolean
+}) {
+  const label = name.trim() || '—'
+  const resolvedAvatarUrl = avatarUrl?.trim() || ''
+  const [imageError, setImageError] = useState(false)
+  const [previewOpen, setPreviewOpen] = useState(false)
+  const [previewPos, setPreviewPos] = useState<{ top: number; left: number } | null>(null)
+  const avatarRef = useRef<HTMLSpanElement>(null)
+  const dim = size === 'md' ? 'h-10 w-10 text-sm' : 'h-8 w-8 text-xs'
+
+  useEffect(() => {
+    setImageError(false)
+  }, [resolvedAvatarUrl])
+
+  useLayoutEffect(() => {
+    if (!previewOpen || !avatarRef.current) {
+      return
+    }
+    const measure = () => {
+      if (!avatarRef.current) return
+      const rect = avatarRef.current.getBoundingClientRect()
+      setPreviewPos({
+        top: rect.top + rect.height / 2,
+        left: rect.right + 10,
+      })
+    }
+    measure()
+    window.addEventListener('scroll', measure, true)
+    window.addEventListener('resize', measure)
+    return () => {
+      window.removeEventListener('scroll', measure, true)
+      window.removeEventListener('resize', measure)
+    }
+  }, [previewOpen])
+
+  const initialsAvatar = (() => {
+    const h = hueFromString(userId.toLowerCase())
+    const h2 = (h + 48) % 360
+    return (
+      <div
+        className={`flex shrink-0 select-none items-center justify-center rounded-full font-semibold text-white shadow-sm ring-2 ring-white dark:ring-neutral-950 ${dim}`}
+        style={{ background: `linear-gradient(145deg, hsl(${h} 58% 48%), hsl(${h2} 52% 40%))` }}
+        aria-hidden
+      >
+        {displayInitials(label)}
+      </div>
+    )
+  })()
+
+  if (!resolvedAvatarUrl || imageError) {
+    return initialsAvatar
+  }
+
+  const openPreview = () => {
+    if (showPreview) setPreviewOpen(true)
+  }
+  const hidePreview = () => {
+    setPreviewOpen(false)
+    setPreviewPos(null)
+  }
+
+  return (
+    <span
+      ref={avatarRef}
+      className="inline-flex shrink-0"
+      onMouseEnter={openPreview}
+      onMouseLeave={hidePreview}
+      onFocusCapture={openPreview}
+      onBlurCapture={hidePreview}
+    >
+      <img
+        src={resolvedAvatarUrl}
+        alt=""
+        className={`rounded-full object-cover shadow-sm ring-2 ring-white dark:ring-neutral-950 ${dim}`}
+        onError={() => setImageError(true)}
+      />
+      {showPreview && previewOpen && previewPos
+        ? createPortal(
+            <div
+              role="tooltip"
+              style={{
+                top: previewPos.top,
+                left: previewPos.left,
+                transform: 'translateY(-50%)',
+              }}
+              className="pointer-events-none fixed z-[200] overflow-hidden rounded-2xl border border-slate-200 bg-white p-1 shadow-2xl ring-1 ring-slate-900/5 dark:border-neutral-700 dark:bg-neutral-900 dark:ring-white/10"
+            >
+              <img
+                src={resolvedAvatarUrl}
+                alt=""
+                className="h-32 w-32 rounded-xl object-cover"
+              />
+            </div>,
+            document.body,
+          )
+        : null}
+    </span>
+  )
+}

--- a/clients/web/src/components/layout/__tests__/top-bar-utils.test.ts
+++ b/clients/web/src/components/layout/__tests__/top-bar-utils.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { initialsFromName, profileName, shortcutHint } from '../top-bar-utils'
+import { initialsFromName, parseAccountProfile, profileName, shortcutHint } from '../top-bar-utils'
 
 describe('profileName', () => {
   it('returns Profile when profile is null', () => {
@@ -24,6 +24,34 @@ describe('profileName', () => {
       }),
     ).toBe('Display')
     expect(profileName({ email: 'e@mail.test' })).toBe('e@mail.test')
+  })
+})
+
+describe('parseAccountProfile', () => {
+  it('reads avatarUrl and snake_case avatar_url', () => {
+    expect(
+      parseAccountProfile({
+        email: 'a@b.com',
+        firstName: 'Ada',
+        avatarUrl: 'https://example.com/a.png',
+      }),
+    ).toEqual({
+      email: 'a@b.com',
+      displayName: null,
+      firstName: 'Ada',
+      lastName: null,
+      avatarUrl: 'https://example.com/a.png',
+    })
+    expect(
+      parseAccountProfile({
+        email: 'a@b.com',
+        avatar_url: ' data:image/png;base64,abc ',
+      })?.avatarUrl,
+    ).toBe('data:image/png;base64,abc')
+  })
+
+  it('returns null for missing email', () => {
+    expect(parseAccountProfile({ avatarUrl: 'https://x.test/a.png' })).toBeNull()
   })
 })
 

--- a/clients/web/src/components/layout/side-nav-course-links.tsx
+++ b/clients/web/src/components/layout/side-nav-course-links.tsx
@@ -2,6 +2,7 @@ import { useLocation } from 'react-router-dom'
 import {
   ArrowLeft,
   Award,
+  BarChart3,
   BookMarked,
   Calendar,
   ClipboardList,
@@ -28,6 +29,7 @@ import {
 import { atRiskFeatureEnabled, atRiskI18n } from '../../lib/at-risk-i18n'
 import {
   outcomesReportFeatureEnabled,
+  studentProgressFeatureEnabled,
   xapiEmissionFeatureEnabled,
 } from '../../lib/platform-features'
 import { useCourseNavFeatures } from '../../context/course-nav-features-context'
@@ -178,6 +180,11 @@ export function SideNavCourseLinks({ courseCode }: SideNavCourseLinksProps) {
       {canViewGradebook && (
         <SideNavLink to={`${base}/gradebook`} icon={<ClipboardList className="h-5 w-5" />}>
           Gradebook
+        </SideNavLink>
+      )}
+      {canViewGradebook && studentProgressFeatureEnabled() && (
+        <SideNavLink to={`${base}/reports`} icon={<BarChart3 className="h-5 w-5" />}>
+          Reports
         </SideNavLink>
       )}
       {canViewGradebook && atRiskFeatureEnabled() && (

--- a/clients/web/src/components/layout/top-bar-breadcrumbs.tsx
+++ b/clients/web/src/components/layout/top-bar-breadcrumbs.tsx
@@ -198,6 +198,9 @@ function staticCrumbsFromPathname(pathname: string, courseCode: string | null): 
   if (pathname === `${base}/gradebook`) {
     return [courseCrumb(courseCode, true), { key: 'gb', label: 'Gradebook' }]
   }
+  if (pathname === `${base}/reports`) {
+    return [courseCrumb(courseCode, true), { key: 'reports', label: 'Reports' }]
+  }
   if (pathname === `${base}/standards-gradebook`) {
     return [courseCrumb(courseCode, true), { key: 'sgb', label: 'Standards gradebook' }]
   }

--- a/clients/web/src/components/layout/top-bar-utils.ts
+++ b/clients/web/src/components/layout/top-bar-utils.ts
@@ -6,6 +6,28 @@ export type TopBarAccountProfile = {
   avatarUrl?: string | null
 }
 
+function readOptionalString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
+
+/** Normalizes GET/PATCH /api/v1/settings/account JSON for the top bar. */
+export function parseAccountProfile(raw: unknown): TopBarAccountProfile | null {
+  if (!raw || typeof raw !== 'object') return null
+  const o = raw as Record<string, unknown>
+  const email = readOptionalString(o.email)?.trim() ?? ''
+  if (!email) return null
+  const avatarCandidate =
+    readOptionalString(o.avatarUrl) ?? readOptionalString(o.avatar_url) ?? ''
+  const avatarUrl = avatarCandidate.trim() || null
+  return {
+    email,
+    displayName: readOptionalString(o.displayName) ?? readOptionalString(o.display_name),
+    firstName: readOptionalString(o.firstName) ?? readOptionalString(o.first_name),
+    lastName: readOptionalString(o.lastName) ?? readOptionalString(o.last_name),
+    avatarUrl,
+  }
+}
+
 export function profileName(profile: TopBarAccountProfile | null): string {
   if (!profile) return 'Profile'
   const first = profile.firstName?.trim() ?? ''

--- a/clients/web/src/components/layout/top-bar.tsx
+++ b/clients/web/src/components/layout/top-bar.tsx
@@ -6,13 +6,14 @@ import { AiTutorMenu } from '../tutor-panel'
 import { useCourseNavFeatures } from '../../context/course-nav-features-context'
 import { setCourseViewAs, useCourseViewAs } from '../../lib/course-view-as'
 import { apiUrl, authorizedFetch } from '../../lib/api'
+import { getJwtSubject } from '../../lib/auth'
 import { useViewerEnrollmentRoles } from '../../lib/use-viewer-enrollment-roles'
-
+import { EnrollmentAvatar } from '../enrollment/enrollment-avatar'
 
 import { clearSessionTokens, getRefreshToken } from '../../lib/session-tokens'
 import { applyUiTheme } from '../../lib/ui-theme'
 import {
-  initialsFromName,
+  parseAccountProfile,
   profileName,
   type TopBarAccountProfile,
 } from './top-bar-utils'
@@ -38,8 +39,7 @@ function UserMenu() {
         const res = await authorizedFetch('/api/v1/settings/account')
         const raw: unknown = await res.json().catch(() => ({}))
         if (!res.ok || cancelled) return
-        const data = raw as TopBarAccountProfile
-        setProfile(data)
+        setProfile(parseAccountProfile(raw))
       } catch {
         if (!cancelled) setProfile(null)
       }
@@ -91,7 +91,7 @@ function UserMenu() {
   }
 
   const name = profileName(profile)
-  const initials = initialsFromName(name)
+  const viewerId = getJwtSubject() ?? profile?.email ?? 'viewer'
 
   return (
     <div ref={rootRef} className="relative">
@@ -104,17 +104,12 @@ function UserMenu() {
         onClick={() => setOpen((o) => !o)}
         className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white py-1.5 ps-1.5 pe-2.5 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:border-neutral-500 dark:hover:bg-neutral-700"
       >
-        {profile?.avatarUrl ? (
-          <img
-            src={profile.avatarUrl}
-            alt=""
-            className="h-8 w-8 rounded-full border border-slate-200 object-cover dark:border-neutral-600"
-          />
-        ) : (
-          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-indigo-100 text-xs font-semibold text-indigo-700 dark:bg-neutral-700 dark:text-neutral-100">
-            {initials}
-          </span>
-        )}
+        <EnrollmentAvatar
+          userId={viewerId}
+          name={name}
+          avatarUrl={profile?.avatarUrl}
+          showPreview={false}
+        />
         <span className="hidden max-w-[10rem] truncate sm:inline">{name}</span>
         <ChevronDown
           className={`h-4 w-4 shrink-0 text-slate-500 transition dark:text-neutral-400 ${open ? 'rotate-180' : ''}`}

--- a/clients/web/src/lib/build-search-items.ts
+++ b/clients/web/src/lib/build-search-items.ts
@@ -9,6 +9,7 @@ import {
   atRiskFeatureEnabled,
   bookstoreIntegrationEnabled,
   outcomesReportFeatureEnabled,
+  studentProgressFeatureEnabled,
   xapiEmissionFeatureEnabled,
 } from './platform-features'
 import type { SearchCourseItem } from './search-api'
@@ -307,6 +308,13 @@ const coursePageDefs: CoursePageDef[] = [
     suffix: '/gradebook',
     title: 'Gradebook',
     hint: 'gradebook grades scores',
+    requiredPermission: courseGradebookViewPermission,
+  },
+  {
+    suffix: '/reports',
+    title: 'Reports',
+    hint: 'student reports progress dashboard',
+    whenPlatform: studentProgressFeatureEnabled,
     requiredPermission: courseGradebookViewPermission,
   },
   {

--- a/clients/web/src/lib/courses-api.ts
+++ b/clients/web/src/lib/courses-api.ts
@@ -5382,6 +5382,22 @@ export async function revealModuleAssignmentIdentities(
   }
 }
 
+export type GradingBacklogItemApi = {
+  assignmentId: string
+  assignmentTitle: string
+  ungradedCount: number
+}
+
+export async function fetchCourseGradingBacklog(courseCode: string): Promise<GradingBacklogItemApi[]> {
+  const res = await authorizedFetch(
+    `/api/v1/courses/${encodeURIComponent(courseCode)}/grading-backlog`,
+  )
+  const raw = await parseJson(res)
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  const o = raw as { items?: GradingBacklogItemApi[] }
+  return Array.isArray(o.items) ? o.items : []
+}
+
 export async function fetchModuleAssignmentSubmissions(
   courseCode: string,
   itemId: string,

--- a/clients/web/src/lib/student-notebook-storage.ts
+++ b/clients/web/src/lib/student-notebook-storage.ts
@@ -109,6 +109,30 @@ function emitChanged(): void {
   window.dispatchEvent(new Event(STUDENT_NOTEBOOKS_CHANGED))
 }
 
+/** Called after a local save so the sync layer can push to the server (set once at module init). */
+let notebookSavedListener: ((courseCode: string) => void) | null = null
+
+export function setNotebookSavedListener(fn: (courseCode: string) => void): void {
+  notebookSavedListener = fn
+}
+
+/** Course codes with a stored notebook on this device (includes the global key). */
+export function localNotebookCourseCodes(): string[] {
+  return Object.keys(readFile().notebooks)
+}
+
+/**
+ * Write a server copy verbatim (keeps the server `updatedAt`, does not trigger a push).
+ * Used by the sync layer when the server copy wins the last-write-wins merge.
+ */
+export function saveCourseNotebookFromServer(courseCode: string, raw: unknown): void {
+  const data = parseStoredNotebookRow(raw)
+  const file = readFile()
+  file.notebooks[courseCode] = data
+  writeFile(file)
+  emitChanged()
+}
+
 function normalizeActivePage(data: CourseNotebookStore): CourseNotebookStore {
   const first = data.pages[0]?.id ?? null
   const valid =
@@ -184,6 +208,7 @@ export function saveCourseNotebookStore(courseCode: string, data: CourseNotebook
   file.notebooks[courseCode] = next
   writeFile(file)
   emitChanged()
+  notebookSavedListener?.(courseCode)
 }
 
 /** Preview for My Notebooks: any non-empty markdown across pages. */

--- a/clients/web/src/lib/student-notebook-sync.ts
+++ b/clients/web/src/lib/student-notebook-sync.ts
@@ -1,0 +1,103 @@
+import { authorizedFetch } from './api'
+import { getAccessToken } from './auth'
+import {
+  loadCourseNotebook,
+  localNotebookCourseCodes,
+  saveCourseNotebookFromServer,
+  setNotebookSavedListener,
+} from './student-notebook-storage'
+
+/**
+ * Server sync for student notebooks (last-write-wins by `updatedAt`).
+ *
+ * Local storage stays the source of truth for the editor; this module pushes saves to the
+ * server (debounced per course) and pulls server copies on notebook page load so notebooks
+ * written on other devices (e.g. mobile) appear here.
+ */
+
+const PUSH_DEBOUNCE_MS = 1500
+
+type ServerNotebookEntry = {
+  courseCode: string
+  updatedAt: string
+  data: unknown
+}
+
+const pushTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+function signedIn(): boolean {
+  return Boolean(getAccessToken())
+}
+
+async function pushNow(courseCode: string): Promise<void> {
+  if (!signedIn()) return
+  const data = loadCourseNotebook(courseCode)
+  try {
+    await authorizedFetch(`/api/v1/me/notebooks?courseCode=${encodeURIComponent(courseCode)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+  } catch {
+    /* offline / transient — next save retries */
+  }
+}
+
+/** Debounced fire-and-forget push of one notebook to the server. */
+export function schedulePushStudentNotebook(courseCode: string): void {
+  const prev = pushTimers.get(courseCode)
+  if (prev) clearTimeout(prev)
+  pushTimers.set(
+    courseCode,
+    setTimeout(() => {
+      pushTimers.delete(courseCode)
+      void pushNow(courseCode)
+    }, PUSH_DEBOUNCE_MS),
+  )
+}
+
+function parseTime(iso: string | undefined): number {
+  const t = iso ? Date.parse(iso) : NaN
+  return Number.isFinite(t) ? t : 0
+}
+
+/**
+ * Pull server notebooks and merge into local storage. Server copy wins when newer;
+ * local notebooks that are newer or missing on the server are pushed back.
+ */
+export async function pullStudentNotebooks(): Promise<void> {
+  if (!signedIn()) return
+  let entries: ServerNotebookEntry[]
+  try {
+    const res = await authorizedFetch('/api/v1/me/notebooks')
+    if (!res.ok) return
+    const body = (await res.json()) as { notebooks?: ServerNotebookEntry[] }
+    entries = body.notebooks ?? []
+  } catch {
+    return
+  }
+  const localCodes = new Set(localNotebookCourseCodes())
+  const serverCodes = new Set<string>()
+  for (const entry of entries) {
+    if (!entry?.courseCode) continue
+    serverCodes.add(entry.courseCode)
+    if (!localCodes.has(entry.courseCode)) {
+      saveCourseNotebookFromServer(entry.courseCode, entry.data)
+      continue
+    }
+    const local = loadCourseNotebook(entry.courseCode)
+    const serverTime = parseTime(entry.updatedAt)
+    const localTime = parseTime(local.updatedAt)
+    if (serverTime > localTime) {
+      saveCourseNotebookFromServer(entry.courseCode, entry.data)
+    } else if (localTime > serverTime) {
+      void pushNow(entry.courseCode)
+    }
+  }
+  for (const code of localCodes) {
+    if (!serverCodes.has(code)) void pushNow(code)
+  }
+}
+
+// Every local save (all consumers go through saveCourseNotebookStore) schedules a push.
+setNotebookSavedListener(schedulePushStudentNotebook)

--- a/clients/web/src/lib/student-progress-api.ts
+++ b/clients/web/src/lib/student-progress-api.ts
@@ -6,6 +6,7 @@ export type StudentProgressSummary = {
   courseId: string
   studentUserId: string
   studentDisplayName: string
+  studentAvatarUrl?: string | null
   assignmentsSubmittedPct: number
   modulesViewedPct: number
   avgQuizScore?: number | null

--- a/clients/web/src/pages/lms/course-detail.tsx
+++ b/clients/web/src/pages/lms/course-detail.tsx
@@ -13,6 +13,7 @@ import { authorizedFetch } from '../../lib/api'
 import {
   courseGradebookViewPermission,
   fetchCourseGradebookGrid,
+  fetchCourseGradingBacklog,
   fetchCourseMyGrades,
   fetchCourseStructure,
   fetchEnrollmentDiagnostic,
@@ -44,6 +45,10 @@ import { CourseCalendar, type CourseCalendarAssignment } from './course-calendar
 import { formatDueShort } from '../../lib/course-calendar-utils'
 import { fetchCourseCatalogInfo, type CatalogSection } from '../../lib/catalog-api'
 import { usePlatformFeatures } from '../../context/platform-features-context'
+import {
+  GradingBacklogList,
+  type GradingBacklogItem,
+} from '../../components/dashboard/grading-backlog-list'
 
 function formatIsoDurationHuman(iso: string | null | undefined): string {
   if (!iso?.trim()) return '—'
@@ -209,6 +214,7 @@ export default function CourseDetail() {
   const [myGrades, setMyGrades] = useState<CourseMyGradesResponse | null>(null)
   const [announcement, setAnnouncement] = useState<AnnouncementPreview | null>(null)
   const [gradebookEmptyCells, setGradebookEmptyCells] = useState<number | null>(null)
+  const [gradingBacklog, setGradingBacklog] = useState<GradingBacklogItem[]>([])
 
   useEffect(() => {
     if (!courseCode || !ffCatalogIntegration) {
@@ -344,8 +350,27 @@ export default function CourseDetail() {
               if (!cancelled) setGradebookEmptyCells(null)
             }),
         )
+        tasks.push(
+          fetchCourseGradingBacklog(courseCode)
+            .then((items) => {
+              if (!cancelled) {
+                setGradingBacklog(
+                  items.map((item) => ({
+                    assignmentId: item.assignmentId,
+                    assignmentTitle: item.assignmentTitle,
+                    ungradedCount: item.ungradedCount,
+                    courseCode,
+                  })),
+                )
+              }
+            })
+            .catch(() => {
+              if (!cancelled) setGradingBacklog([])
+            }),
+        )
       } else if (!cancelled) {
         setGradebookEmptyCells(null)
+        setGradingBacklog([])
       }
 
       await Promise.all(tasks)
@@ -796,11 +821,23 @@ export default function CourseDetail() {
                         <LayoutDashboard className="h-5 w-5 shrink-0" aria-hidden />
                         <span className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Teaching</span>
                       </div>
-                      <p className="mt-2 text-sm text-slate-600 dark:text-neutral-400">
-                        {gradebookEmptyCells != null
-                          ? `${gradebookEmptyCells} empty grade cell${gradebookEmptyCells === 1 ? '' : 's'} in the gradebook.`
-                          : 'Open the gradebook to review submissions and scores.'}
-                      </p>
+                      {gradingBacklog.length > 0 ? (
+                        <div className="mt-3">
+                          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+                            Needs grading
+                          </p>
+                          <div className="mt-2">
+                            <GradingBacklogList items={gradingBacklog} />
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="mt-2 text-sm text-slate-600 dark:text-neutral-400">
+                          No ungraded assignment submissions right now.
+                          {gradebookEmptyCells != null && gradebookEmptyCells > 0
+                            ? ` ${gradebookEmptyCells} empty grade cell${gradebookEmptyCells === 1 ? '' : 's'} remain in the gradebook.`
+                            : ''}
+                        </p>
+                      )}
                       <div className="mt-4 flex flex-wrap gap-2">
                         <Link
                           to={`/courses/${encodeURIComponent(courseCode)}/gradebook`}

--- a/clients/web/src/pages/lms/course-enrollments.tsx
+++ b/clients/web/src/pages/lms/course-enrollments.tsx
@@ -42,6 +42,7 @@ import { readApiErrorMessage } from '../../lib/errors'
 import { formatTimeAgoFromIso } from '../../lib/format-time-ago'
 import { toast, toastSaveOk } from '../../lib/lms-toast'
 import { usePlatformFeatures } from '../../context/platform-features-context'
+import { EnrollmentAvatar } from '../../components/enrollment/enrollment-avatar'
 import { EnrollmentStateBadge } from '../../components/enrollment/enrollment-state-badge'
 import {
   patchEnrollmentState,
@@ -52,6 +53,7 @@ export type CourseEnrollment = {
   id: string
   userId: string
   displayName: string | null
+  avatarUrl?: string | null
   role: string
   roleDisplay?: string | null
   lastCourseAccessAt?: string | null
@@ -305,6 +307,12 @@ export default function CourseEnrollments() {
             : typeof o.display_name === 'string'
               ? o.display_name
               : null
+        const avatarUrl =
+          typeof o.avatarUrl === 'string'
+            ? o.avatarUrl
+            : typeof o.avatar_url === 'string'
+              ? o.avatar_url
+              : null
         const role = typeof o.role === 'string' ? o.role : 'student'
         const roleDisplay =
           typeof o.roleDisplay === 'string'
@@ -385,6 +393,7 @@ export default function CourseEnrollments() {
           id,
           userId,
           displayName,
+          avatarUrl,
           role,
           roleDisplay,
           lastCourseAccessAt,
@@ -1039,6 +1048,11 @@ export default function CourseEnrollments() {
                   >
                     <td className="px-4 py-3 font-medium text-slate-900">
                       <div className="flex flex-wrap items-center gap-2">
+                        <EnrollmentAvatar
+                          userId={e.userId}
+                          name={e.displayName?.trim() || '—'}
+                          avatarUrl={e.avatarUrl}
+                        />
                         {studentProgressFeatureEnabled() &&
                         courseCode &&
                         (er === 'student' || er === 'learner') ? (

--- a/clients/web/src/pages/lms/course-notebook-page.tsx
+++ b/clients/web/src/pages/lms/course-notebook-page.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../lib/course-notebook-tree'
 import { fetchCourse, uploadCourseFile } from '../../lib/courses-api'
 import { syncNotebookTasksFromMarkdown } from '../../lib/notebook-task-sync'
+import { pullStudentNotebooks } from '../../lib/student-notebook-sync'
 import {
   loadCourseNotebook,
   saveCourseNotebookStore,
@@ -82,6 +83,24 @@ export default function CourseNotebookPage() {
     const page = next.pages.find((p) => p.id === next.activePageId)
     setHeaderTitleDraft(page?.title ?? '')
   }, [courseCode, searchParams])
+
+  useEffect(() => {
+    if (!courseCode) return
+    let cancelled = false
+    const before = loadCourseNotebook(courseCode).updatedAt
+    void pullStudentNotebooks().then(() => {
+      if (cancelled) return
+      const pulled = loadCourseNotebook(courseCode)
+      if (pulled.updatedAt !== before) {
+        setData(pulled)
+        const page = pulled.pages.find((p) => p.id === pulled.activePageId)
+        setHeaderTitleDraft(page?.title ?? '')
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [courseCode])
 
   useEffect(() => {
     if (!courseCode) return

--- a/clients/web/src/pages/lms/course-student-reports-page.tsx
+++ b/clients/web/src/pages/lms/course-student-reports-page.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, Navigate, useParams } from 'react-router-dom'
+import { BarChart3, ChevronRight } from 'lucide-react'
+import { usePermissions } from '../../context/use-permissions'
+import { usePlatformFeatures } from '../../context/platform-features-context'
+import {
+  courseGradebookViewPermission,
+  fetchCourseEnrollmentsList,
+  type CourseEnrollmentRosterRow,
+} from '../../lib/courses-api'
+import { LmsPage } from './lms-page'
+
+function normEnrollmentRole(role: string): string {
+  return role.trim().toLowerCase()
+}
+
+function isStudentEnrollment(row: CourseEnrollmentRosterRow): boolean {
+  const role = normEnrollmentRole(row.role)
+  return role === 'student' || role === 'learner'
+}
+
+function studentDisplayName(row: CourseEnrollmentRosterRow): string {
+  return row.displayName?.trim() || '—'
+}
+
+export default function CourseStudentReportsPage() {
+  const { courseCode } = useParams<{ courseCode: string }>()
+  const { studentProgressEnabled, loading: featuresLoading } = usePlatformFeatures()
+  const { allows, loading: permLoading } = usePermissions()
+  const canViewGradebook =
+    !!courseCode && !permLoading && allows(courseGradebookViewPermission(courseCode))
+  const [students, setStudents] = useState<CourseEnrollmentRosterRow[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadStudents = useCallback(async () => {
+    if (!courseCode) return
+    setError(null)
+    try {
+      const rows = await fetchCourseEnrollmentsList(courseCode)
+      const filtered = rows
+        .filter(isStudentEnrollment)
+        .sort((a, b) =>
+          studentDisplayName(a).localeCompare(studentDisplayName(b), undefined, { sensitivity: 'base' }),
+        )
+      setStudents(filtered)
+    } catch (e: unknown) {
+      setStudents([])
+      setError(e instanceof Error ? e.message : 'Could not load students.')
+    }
+  }, [courseCode])
+
+  useEffect(() => {
+    if (!courseCode || !canViewGradebook) return
+    if (featuresLoading || !studentProgressEnabled) return
+    void loadStudents()
+  }, [canViewGradebook, courseCode, featuresLoading, loadStudents, studentProgressEnabled])
+
+  const sectionsEnabled = useMemo(
+    () => students?.some((s) => s.sectionCode?.trim()) ?? false,
+    [students],
+  )
+
+  if (!courseCode) {
+    return <Navigate to="/courses" replace />
+  }
+
+  if (featuresLoading || permLoading) {
+    return (
+      <LmsPage title="Reports">
+        <p className="mt-6 text-sm text-slate-500 dark:text-neutral-400">Loading…</p>
+      </LmsPage>
+    )
+  }
+
+  if (!studentProgressEnabled) {
+    return <Navigate to={`/courses/${encodeURIComponent(courseCode)}`} replace />
+  }
+
+  if (!canViewGradebook) {
+    return <Navigate to={`/courses/${encodeURIComponent(courseCode)}`} replace />
+  }
+
+  return (
+    <LmsPage
+      title="Reports"
+      titleContent={
+        <div className="min-w-0 flex-1">
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-neutral-100">
+            Reports
+          </h1>
+          <p className="mt-2 max-w-2xl text-xs text-slate-500 dark:text-neutral-400">
+            Student progress reports for course {courseCode}. Select a student to view their report.
+          </p>
+        </div>
+      }
+    >
+      {error ? (
+        <p className="mt-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-200">
+          {error}
+        </p>
+      ) : null}
+
+      {students === null && !error ? (
+        <p className="mt-8 text-sm text-slate-500 dark:text-neutral-400">Loading students…</p>
+      ) : null}
+
+      {students && students.length === 0 && !error ? (
+        <p className="mt-8 text-sm text-slate-500 dark:text-neutral-400">No students enrolled yet.</p>
+      ) : null}
+
+      {students && students.length > 0 ? (
+        <div className="mt-8 overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
+          <table className="w-full min-w-[16rem] text-start text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-neutral-700 dark:bg-neutral-800/60 dark:text-neutral-400">
+                <th className="px-4 py-3">Student</th>
+                {sectionsEnabled ? <th className="px-4 py-3">Section</th> : null}
+                <th className="px-2 py-3 text-end font-normal" aria-label="Actions" />
+              </tr>
+            </thead>
+            <tbody>
+              {students.map((student) => {
+                const reportPath = `/courses/${encodeURIComponent(courseCode)}/students/${encodeURIComponent(student.id)}/progress`
+                const name = studentDisplayName(student)
+                return (
+                  <tr
+                    key={student.id}
+                    className="group border-b border-slate-100 last:border-0 dark:border-neutral-800"
+                  >
+                    <td className="px-4 py-3 font-medium text-slate-900 dark:text-neutral-100">
+                      <Link
+                        to={reportPath}
+                        className="text-indigo-700 hover:underline dark:text-indigo-300"
+                      >
+                        {name}
+                      </Link>
+                    </td>
+                    {sectionsEnabled ? (
+                      <td className="px-4 py-3 text-slate-600 dark:text-neutral-400">
+                        {student.sectionCode?.trim()
+                          ? student.sectionName?.trim()
+                            ? `${student.sectionCode} (${student.sectionName})`
+                            : student.sectionCode
+                          : '—'}
+                      </td>
+                    ) : null}
+                    <td className="px-2 py-3 text-end align-middle">
+                      <Link
+                        to={reportPath}
+                        className="inline-flex items-center gap-1 rounded-lg px-2 py-1.5 text-sm font-medium text-indigo-700 opacity-0 transition hover:bg-indigo-50 group-hover:opacity-100 focus-visible:opacity-100 dark:text-indigo-300 dark:hover:bg-indigo-950/40"
+                        aria-label={`View report for ${name}`}
+                      >
+                        <BarChart3 className="h-4 w-4" aria-hidden />
+                        View report
+                        <ChevronRight className="h-4 w-4" aria-hidden />
+                      </Link>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </LmsPage>
+  )
+}

--- a/clients/web/src/pages/lms/dashboard.tsx
+++ b/clients/web/src/pages/lms/dashboard.tsx
@@ -25,6 +25,7 @@ import {
   courseGradebookViewPermission,
   fetchCourse,
   fetchCourseGradebookGrid,
+  fetchCourseGradingBacklog,
   fetchCourseMyGrades,
   fetchCourseStructure,
   fetchLearnerRecommendations,
@@ -52,6 +53,10 @@ import {
   type GradebookColumnForFinal,
 } from './gradebook/compute-course-final-percent'
 import { DashboardLoadingSkeleton } from '../../components/ui/lms-content-skeletons'
+import {
+  GradingBacklogList,
+  type GradingBacklogItem,
+} from '../../components/dashboard/grading-backlog-list'
 import { NotebookTasksCard } from '../../components/dashboard/notebook-tasks-card'
 import { EnrollmentStateBadge } from '../../components/enrollment/enrollment-state-badge'
 import type { EnrollmentState } from '../../lib/enrollment-state-api'
@@ -239,6 +244,7 @@ export default function Dashboard() {
     {
       course: CoursePublic
       emptyGradeCells: number | null
+      gradingBacklog: GradingBacklogItem[]
     }[]
   >([])
 
@@ -406,6 +412,7 @@ export default function Dashboard() {
         const tRows = await mapPool(staffCourses, 3, async (course) => {
           const code = course.courseCode
           let emptyGradeCells: number | null = null
+          let gradingBacklog: GradingBacklogItem[] = []
           if (allows(courseGradebookViewPermission(code))) {
             try {
               const grid = await fetchCourseGradebookGrid(code)
@@ -413,8 +420,20 @@ export default function Dashboard() {
             } catch {
               emptyGradeCells = null
             }
+            try {
+              const backlog = await fetchCourseGradingBacklog(code)
+              gradingBacklog = backlog.map((item) => ({
+                assignmentId: item.assignmentId,
+                assignmentTitle: item.assignmentTitle,
+                ungradedCount: item.ungradedCount,
+                courseCode: code,
+                courseTitle: course.title,
+              }))
+            } catch {
+              gradingBacklog = []
+            }
           }
-          return { course, emptyGradeCells }
+          return { course, emptyGradeCells, gradingBacklog }
         })
 
         if (detailGenRef.current !== gen) return
@@ -517,6 +536,14 @@ export default function Dashboard() {
 
   const anyStudentExperience = studentRows.length > 0
   const anyStaffExperience = staffRows.length > 0
+
+  const allGradingBacklog = useMemo(
+    () =>
+      staffRows
+        .flatMap((row) => row.gradingBacklog)
+        .sort((a, b) => b.ungradedCount - a.ungradedCount),
+    [staffRows],
+  )
 
   const showLoading = catalog === null || courses === null
 
@@ -1109,7 +1136,21 @@ export default function Dashboard() {
               </div>
 
               {!collapsedSections['teaching-overview'] && (
-                <div className="mt-4 grid gap-4 md:grid-cols-2">
+                <>
+                  {allGradingBacklog.length > 0 ? (
+                    <div className="mt-4 rounded-2xl border border-amber-100 bg-amber-50/50 p-5 shadow-sm dark:border-amber-900/40 dark:bg-amber-950/20">
+                      <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+                        Needs grading
+                      </h3>
+                      <p className="mt-1 text-xs text-slate-600 dark:text-neutral-400">
+                        Open SpeedGrader or grade submissions for assignments with ungraded work.
+                      </p>
+                      <div className="mt-3">
+                        <GradingBacklogList items={allGradingBacklog} showCourse />
+                      </div>
+                    </div>
+                  ) : null}
+                  <div className="mt-4 grid gap-4 md:grid-cols-2">
                   {staffRows.map((row) => {
                     const base = `/courses/${encodeURIComponent(row.course.courseCode)}`
                     return (
@@ -1128,6 +1169,20 @@ export default function Dashboard() {
                             {courseSectionSubtitle(row.course)}
                           </p>
                         ) : null}
+                        {row.gradingBacklog.length > 0 ? (
+                          <div className="mt-4">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+                              Ungraded submissions
+                            </p>
+                            <div className="mt-2">
+                              <GradingBacklogList items={row.gradingBacklog} />
+                            </div>
+                          </div>
+                        ) : (
+                          <p className="mt-4 text-sm text-slate-500 dark:text-neutral-400">
+                            No ungraded assignment submissions right now.
+                          </p>
+                        )}
                         <dl className="mt-4 space-y-3 text-sm">
                           <div className="flex justify-between gap-3">
                             <dt className="text-slate-500 dark:text-neutral-400">Gradebook gaps</dt>
@@ -1140,13 +1195,6 @@ export default function Dashboard() {
                                   <span className="font-normal text-slate-500 dark:text-neutral-400">empty cells</span>
                                 </>
                               )}
-                            </dd>
-                          </div>
-                          <div className="flex justify-between gap-3">
-                            <dt className="text-slate-500 dark:text-neutral-400">Quizzes in progress</dt>
-                            <dd className="text-end text-xs text-slate-500 dark:text-neutral-400">
-                              Live attempts appear in the gradebook after students submit or auto-submit. Open the quiz
-                              or gradebook to review.
                             </dd>
                           </div>
                         </dl>
@@ -1168,6 +1216,7 @@ export default function Dashboard() {
                     )
                   })}
                 </div>
+                </>
               )}
             </section>
           )}

--- a/clients/web/src/pages/lms/global-notebook-page.tsx
+++ b/clients/web/src/pages/lms/global-notebook-page.tsx
@@ -26,6 +26,7 @@ import {
   saveCourseNotebookStore,
   type CourseNotebookStore,
 } from '../../lib/student-notebook-storage'
+import { pullStudentNotebooks } from '../../lib/student-notebook-sync'
 import { NotebookGroupPanel } from '../../components/notebook/notebook-group-panel'
 import { NotebookPageActionsMenu } from '../../components/notebook/notebook-page-actions-menu'
 import { LmsPage } from './lms-page'
@@ -70,6 +71,23 @@ export default function GlobalNotebookPage() {
     const page = next.pages.find((p) => p.id === next.activePageId)
     setHeaderTitleDraft(page?.title ?? '')
   }, [searchParams])
+
+  useEffect(() => {
+    let cancelled = false
+    const before = loadCourseNotebook(GLOBAL_STUDENT_NOTEBOOK_KEY).updatedAt
+    void pullStudentNotebooks().then(() => {
+      if (cancelled) return
+      const pulled = loadCourseNotebook(GLOBAL_STUDENT_NOTEBOOK_KEY)
+      if (pulled.updatedAt !== before) {
+        setData(pulled)
+        const page = pulled.pages.find((p) => p.id === pulled.activePageId)
+        setHeaderTitleDraft(page?.title ?? '')
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
     return () => {

--- a/clients/web/src/pages/lms/my-notebooks-page.tsx
+++ b/clients/web/src/pages/lms/my-notebooks-page.tsx
@@ -17,6 +17,7 @@ import {
   listStudentCourseNotebooks,
   subscribeStudentNotebooks,
 } from '../../lib/student-notebook-storage'
+import { pullStudentNotebooks } from '../../lib/student-notebook-sync'
 import { ReadingFocusToggle } from '../../components/layout/reading-focus-toggle'
 import { AiDisclosureBanner } from '../../components/ai-disclosure-banner'
 import { LmsPage } from './lms-page'
@@ -63,6 +64,11 @@ export default function MyNotebooksPage() {
   useEffect(() => {
     return subscribeStudentNotebooks(refreshNotebooks)
   }, [refreshNotebooks])
+
+  // Server pull writes through storage, which notifies the subscription above.
+  useEffect(() => {
+    void pullStudentNotebooks()
+  }, [])
 
   useEffect(() => {
     let cancelled = false

--- a/clients/web/src/pages/lms/student-progress-page.tsx
+++ b/clients/web/src/pages/lms/student-progress-page.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useId, useMemo, useState } from 'react'
 import { Link, Navigate, useParams } from 'react-router-dom'
+import { EnrollmentAvatar } from '../../components/enrollment/enrollment-avatar'
 import { LmsPage } from './lms-page'
 import { fetchCourse } from '../../lib/courses-api'
 import { formatTimeAgoFromIso } from '../../lib/format-time-ago'
@@ -289,6 +290,7 @@ export default function StudentProgressPage() {
   }
 
   const title = isSelf ? studentProgressI18n.myProgressTitle : studentProgressI18n.progressTitle
+  const pageTitle = data?.summary.studentDisplayName ?? title
 
   if (featuresLoading) {
     return (
@@ -336,7 +338,22 @@ export default function StudentProgressPage() {
 
   return (
     <LmsPage
-      title={data?.summary.studentDisplayName ?? title}
+      title={pageTitle}
+      titleContent={
+        data ? (
+          <div className="flex items-center gap-3">
+            <EnrollmentAvatar
+              userId={data.summary.studentUserId}
+              name={data.summary.studentDisplayName}
+              avatarUrl={data.summary.studentAvatarUrl}
+              size="md"
+            />
+            <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-neutral-100">
+              {pageTitle}
+            </h1>
+          </div>
+        ) : undefined
+      }
       description={
         isSelf
           ? 'Track your assignment completion, quiz performance, and recent activity in this course.'

--- a/e2e/tests/student-progress.spec.ts
+++ b/e2e/tests/student-progress.spec.ts
@@ -67,6 +67,37 @@ test.describe('Student progress', () => {
     await expect(page.getByText(noteText)).toBeVisible({ timeout: 8000 })
   })
 
+  test('instructor opens student report from course reports page', async ({
+    coursePage: page,
+    seededCourse,
+  }) => {
+    const enrollmentId = await studentEnrollmentId(
+      seededCourse.instructorToken,
+      seededCourse.courseCode,
+    )
+    const apiProgress = `${apiBase}/api/v1/courses/${encodeURIComponent(seededCourse.courseCode)}/enrollments/${encodeURIComponent(enrollmentId)}/progress`
+    const probe = await page.request.get(apiProgress, {
+      headers: { Authorization: `Bearer ${seededCourse.instructorToken}` },
+    })
+    if (probe.status() === 404) {
+      test.skip(true, 'FEATURE_STUDENT_PROGRESS is disabled on the API')
+    }
+    expect(probe.ok()).toBeTruthy()
+
+    await page.goto(`/courses/${seededCourse.courseCode}/reports`)
+    await expect(page.getByRole('heading', { name: /^reports$/i })).toBeVisible()
+    await page.getByRole('link', { name: /e2e student/i }).first().click()
+
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/courses/${seededCourse.courseCode}/students/${enrollmentId}/progress`,
+      ),
+    )
+    await expect(page.getByText(/assignments submitted|modules viewed/i).first()).toBeVisible({
+      timeout: 15000,
+    })
+  })
+
   test('instructor opens student report from enrollments roster', async ({
     coursePage: page,
     seededCourse,

--- a/server/internal/httpserver/canvas_enrollment_import.go
+++ b/server/internal/httpserver/canvas_enrollment_import.go
@@ -2,8 +2,10 @@ package httpserver
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -18,10 +20,13 @@ import (
 	"github.com/lextures/lextures/server/internal/service/authservice"
 )
 
+const canvasAvatarMaxBytes = 512 << 10
+
 type canvasEnrollmentImportStats struct {
-	Enrolled       int
+	Enrolled        int
 	AccountsCreated int
-	SkippedNoEmail int
+	SkippedNoEmail  int
+	AvatarsImported int
 }
 
 func canvasUserDisplayName(u map[string]any, email string) string {
@@ -46,6 +51,7 @@ func canvasEnrollmentListQuery() url.Values {
 	q.Add("state[]", "invited")
 	q.Add("state[]", "creation_pending")
 	q.Add("include[]", "user")
+	q.Add("include[]", "avatar_url")
 	return q
 }
 
@@ -57,7 +63,7 @@ func canvasRosterEmailsByCanvasUserID(
 ) (map[int64]string, error) {
 	rows, err := canvasGetArrayPaginated(ctx, client, canvasBase, accessToken,
 		fmt.Sprintf("courses/%d/users", canvasCourseID),
-		url.Values{"include[]": []string{"email"}})
+		url.Values{"include[]": []string{"email", "avatar_url"}})
 	if err != nil {
 		return nil, err
 	}
@@ -72,6 +78,116 @@ func canvasRosterEmailsByCanvasUserID(
 		}
 	}
 	return out, nil
+}
+
+func canvasAvatarURLFromMaps(enrollment, canvasUser map[string]any) string {
+	for _, m := range []map[string]any{canvasUser, enrollment} {
+		if m == nil {
+			continue
+		}
+		if u := strings.TrimSpace(strAt(m, "avatar_url", "")); u != "" {
+			return u
+		}
+	}
+	return ""
+}
+
+func canvasImageBytesToDataURL(data []byte, contentType string) (string, error) {
+	ct := strings.TrimSpace(contentType)
+	if i := strings.Index(ct, ";"); i >= 0 {
+		ct = ct[:i]
+	}
+	ct = strings.ToLower(ct)
+	if !strings.HasPrefix(ct, "image/") {
+		return "", fmt.Errorf("avatar is not an image")
+	}
+	out := "data:" + ct + ";base64," + base64.StdEncoding.EncodeToString(data)
+	if len(out) > 2_000_000 {
+		return "", fmt.Errorf("avatar data url too large")
+	}
+	return out, nil
+}
+
+func canvasDownloadAvatarImage(
+	ctx context.Context,
+	client *http.Client,
+	downloadURL, accessToken string,
+) ([]byte, string, error) {
+	if client == nil || strings.TrimSpace(downloadURL) == "" {
+		return nil, "", fmt.Errorf("missing download client or url")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	if strings.TrimSpace(accessToken) != "" {
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, "", fmt.Errorf("download status %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, canvasAvatarMaxBytes+1))
+	if err != nil {
+		return nil, "", err
+	}
+	if len(data) > canvasAvatarMaxBytes {
+		return nil, "", fmt.Errorf("avatar too large")
+	}
+	ct := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if ct == "" {
+		ct = "image/jpeg"
+	}
+	return data, ct, nil
+}
+
+func canvasImportEnrollmentUserAvatar(
+	ctx context.Context,
+	tx pgx.Tx,
+	client *http.Client,
+	accessToken string,
+	userID uuid.UUID,
+	enrollment, canvasUser map[string]any,
+	stats *canvasEnrollmentImportStats,
+) error {
+	if tx == nil || userID == uuid.Nil {
+		return nil
+	}
+	var hasAvatar bool
+	if err := tx.QueryRow(ctx, `
+SELECT avatar_url IS NOT NULL AND TRIM(avatar_url) <> ''
+FROM "user".users
+WHERE id = $1
+`, userID).Scan(&hasAvatar); err != nil {
+		return err
+	}
+	if hasAvatar {
+		return nil
+	}
+	avatarURL := canvasAvatarURLFromMaps(enrollment, canvasUser)
+	if avatarURL == "" {
+		return nil
+	}
+	data, contentType, err := canvasDownloadAvatarImage(ctx, client, avatarURL, accessToken)
+	if err != nil || len(data) == 0 {
+		return nil
+	}
+	dataURL, err := canvasImageBytesToDataURL(data, contentType)
+	if err != nil {
+		return nil
+	}
+	updated, err := user.SetAvatarURLIfEmptyTx(ctx, tx, userID, dataURL)
+	if err != nil {
+		return err
+	}
+	if updated && stats != nil {
+		stats.AvatarsImported++
+	}
+	return nil
 }
 
 // canvasResolveLexturesUserForEnrollment finds or creates a Lextures user for a Canvas roster member.
@@ -131,6 +247,8 @@ func canvasFillGradeUserMap(
 	pool *pgxpool.Pool,
 	tx pgx.Tx,
 	orgID uuid.UUID,
+	client *http.Client,
+	accessToken string,
 	enrollmentRows []map[string]any,
 	rosterEmailByCanvasUID map[int64]string,
 	out map[int64]uuid.UUID,
@@ -158,6 +276,9 @@ func canvasFillGradeUserMap(
 		}
 		if userID != uuid.Nil {
 			out[canvasUID] = userID
+			if err := canvasImportEnrollmentUserAvatar(ctx, tx, client, accessToken, userID, e, u, stats); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/server/internal/httpserver/canvas_enrollment_import_test.go
+++ b/server/internal/httpserver/canvas_enrollment_import_test.go
@@ -1,0 +1,56 @@
+package httpserver
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCanvasAvatarURLFromMaps_prefersUserObject(t *testing.T) {
+	enrollment := map[string]any{"avatar_url": "https://canvas.example/enrollment.png"}
+	user := map[string]any{"avatar_url": "https://canvas.example/user.png"}
+	if got := canvasAvatarURLFromMaps(enrollment, user); got != "https://canvas.example/user.png" {
+		t.Fatalf("canvasAvatarURLFromMaps() = %q, want user avatar", got)
+	}
+}
+
+func TestCanvasAvatarURLFromMaps_fallsBackToEnrollment(t *testing.T) {
+	enrollment := map[string]any{"avatar_url": "https://canvas.example/enrollment.png"}
+	if got := canvasAvatarURLFromMaps(enrollment, nil); got != "https://canvas.example/enrollment.png" {
+		t.Fatalf("canvasAvatarURLFromMaps() = %q, want enrollment avatar", got)
+	}
+}
+
+func TestCanvasImageBytesToDataURL_encodesImage(t *testing.T) {
+	data := []byte{0xff, 0xd8, 0xff}
+	got, err := canvasImageBytesToDataURL(data, "image/jpeg")
+	if err != nil {
+		t.Fatalf("canvasImageBytesToDataURL: %v", err)
+	}
+	if !strings.HasPrefix(got, "data:image/jpeg;base64,") {
+		t.Fatalf("unexpected data url prefix: %q", got)
+	}
+}
+
+func TestCanvasImageBytesToDataURL_rejectsNonImage(t *testing.T) {
+	if _, err := canvasImageBytesToDataURL([]byte("x"), "text/plain"); err == nil {
+		t.Fatal("expected non-image content type to fail")
+	}
+}
+
+func TestCanvasEnrollmentListQuery_includesAvatarURL(t *testing.T) {
+	q := canvasEnrollmentListQuery()
+	includes := q["include[]"]
+	foundUser := false
+	foundAvatar := false
+	for _, v := range includes {
+		if v == "user" {
+			foundUser = true
+		}
+		if v == "avatar_url" {
+			foundAvatar = true
+		}
+	}
+	if !foundUser || !foundAvatar {
+		t.Fatalf("include[] = %v, want user and avatar_url", includes)
+	}
+}

--- a/server/internal/httpserver/canvas_import_ws.go
+++ b/server/internal/httpserver/canvas_import_ws.go
@@ -496,6 +496,9 @@ func (d Deps) runCanvasImport(
 			if userID == uuid.Nil {
 				continue
 			}
+			if err := canvasImportEnrollmentUserAvatar(ctx, tx, client, accessToken, userID, e, u, &enrollStats); err != nil {
+				return err
+			}
 			role := canvasEnrollmentTypeToRole(strAt(e, "type", ""))
 			if (include.Grades || include.Assignments) && canvasUID > 0 {
 				if canvasUserToLocal == nil {
@@ -510,6 +513,9 @@ func (d Deps) runCanvasImport(
 		msg := fmt.Sprintf("Applied %d enrollment(s) from Canvas.", enrollStats.Enrolled)
 		if enrollStats.AccountsCreated > 0 {
 			msg += fmt.Sprintf(" Created %d new Lextures account(s) from Canvas emails.", enrollStats.AccountsCreated)
+		}
+		if enrollStats.AvatarsImported > 0 {
+			msg += fmt.Sprintf(" Imported %d profile picture(s).", enrollStats.AvatarsImported)
 		}
 		if enrollStats.SkippedNoEmail > 0 {
 			msg += fmt.Sprintf(" Skipped %d without an email in Canvas.", enrollStats.SkippedNoEmail)
@@ -531,7 +537,7 @@ func (d Deps) runCanvasImport(
 			canvasUserToLocal = make(map[int64]uuid.UUID)
 		}
 		var gradeUserStats canvasEnrollmentImportStats
-		if err := canvasFillGradeUserMap(ctx, d.Pool, tx, orgID, enrollmentRows, rosterEmailByCanvasUID, canvasUserToLocal, &gradeUserStats); err != nil {
+		if err := canvasFillGradeUserMap(ctx, d.Pool, tx, orgID, client, accessToken, enrollmentRows, rosterEmailByCanvasUID, canvasUserToLocal, &gradeUserStats); err != nil {
 			return err
 		}
 		if !include.Enrollments && gradeUserStats.AccountsCreated > 0 {

--- a/server/internal/httpserver/courses_routes.go
+++ b/server/internal/httpserver/courses_routes.go
@@ -87,6 +87,7 @@ func (d Deps) registerCourseRoutes(r chi.Router) {
 	r.Post("/api/v1/courses/{course_code}/quizzes/{item_id}/markups", d.handleCreateQuizMarkup())
 	r.Delete("/api/v1/courses/{course_code}/quizzes/{item_id}/markups/{markup_id}", d.handleDeleteQuizMarkup())
 	r.Get("/api/v1/courses/{course_code}/assignments/{item_id}/markups", d.handleListAssignmentMarkups())
+	r.Get("/api/v1/courses/{course_code}/grading-backlog", d.handleCourseGradingBacklog())
 	r.Get("/api/v1/courses/{course_code}/assignments/{item_id}/submissions", d.handleListAssignmentSubmissions())
 	r.Get("/api/v1/courses/{course_code}/assignments/{item_id}/submissions/mine", d.handleGetMyAssignmentSubmission())
 	r.Get("/api/v1/courses/{course_code}/assignments/{item_id}/submissions/{submission_id}/originality", d.handleGetSubmissionOriginality())

--- a/server/internal/httpserver/grading_backlog_http.go
+++ b/server/internal/httpserver/grading_backlog_http.go
@@ -1,0 +1,72 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/courseroles"
+	"github.com/lextures/lextures/server/internal/repos/course"
+	"github.com/lextures/lextures/server/internal/repos/moduleassignmentsubmissions"
+)
+
+// handleCourseGradingBacklog is GET /api/v1/courses/{course_code}/grading-backlog.
+func (d Deps) handleCourseGradingBacklog() http.HandlerFunc {
+	type item struct {
+		AssignmentID    string `json:"assignmentId"`
+		AssignmentTitle string `json:"assignmentTitle"`
+		UngradedCount   int64  `json:"ungradedCount"`
+	}
+	type resp struct {
+		Items []item `json:"items"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet+","+http.MethodOptions)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		courseCode, viewer, ok := d.requireCourseAccess(w, r)
+		if !ok {
+			return
+		}
+
+		has, err := courseroles.UserHasPermission(r.Context(), d.Pool, viewer, "course:"+courseCode+":gradebook:view")
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")
+			return
+		}
+		if !has {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission to view the grading backlog.")
+			return
+		}
+		cid, err := course.GetIDByCourseCode(r.Context(), d.Pool, courseCode)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course.")
+			return
+		}
+		if cid == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+			return
+		}
+		rows, err := moduleassignmentsubmissions.ListUngradedCountsForCourse(r.Context(), d.Pool, *cid)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load grading backlog.")
+			return
+		}
+		items := make([]item, 0, len(rows))
+		for _, row := range rows {
+			items = append(items, item{
+				AssignmentID:    row.ModuleItemID.String(),
+				AssignmentTitle: row.Title,
+				UngradedCount:   row.UngradedCount,
+			})
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(resp{Items: items})
+	}
+}

--- a/server/internal/httpserver/grading_backlog_nodb_test.go
+++ b/server/internal/httpserver/grading_backlog_nodb_test.go
@@ -1,0 +1,51 @@
+package httpserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/lextures/lextures/server/internal/auth"
+)
+
+func gradingBacklogTestToken(t *testing.T, signer *auth.JWTSigner) string {
+	t.Helper()
+	tok, err := signer.Sign(context.Background(), "00000000-0000-0000-0000-000000000001", "u@test.invalid", "", "", nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return tok
+}
+
+func TestCourseGradingBacklog_Unauthenticated(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	d := Deps{Pool: nil, JWTSigner: signer}
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/courses/{course_code}/grading-backlog", d.handleCourseGradingBacklog())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/courses/CS101/grading-backlog", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestCourseGradingBacklog_NoDatabase(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	d := Deps{Pool: nil, JWTSigner: signer}
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/courses/{course_code}/grading-backlog", d.handleCourseGradingBacklog())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/courses/CS101/grading-backlog", nil)
+	req.Header.Set("Authorization", "Bearer "+gradingBacklogTestToken(t, signer))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+}

--- a/server/internal/httpserver/lms_dashboard.go
+++ b/server/internal/httpserver/lms_dashboard.go
@@ -673,6 +673,7 @@ func (d Deps) handleCourseEnrollmentsList() http.HandlerFunc {
 		ID             string  `json:"id"`
 		UserID         string  `json:"userId"`
 		DisplayName    *string `json:"displayName"`
+		AvatarURL      *string `json:"avatarUrl,omitempty"`
 		Role           string  `json:"role"`
 		RoleDisplay    *string `json:"roleDisplay,omitempty"`
 		SectionID      *string `json:"sectionId,omitempty"`
@@ -719,6 +720,7 @@ func (d Deps) handleCourseEnrollmentsList() http.HandlerFunc {
 				ID:          e.ID.String(),
 				UserID:      e.UserID.String(),
 				DisplayName: e.DisplayName,
+				AvatarURL:   e.AvatarURL,
 				Role:        e.Role,
 				RoleDisplay: e.RoleDisplay,
 			}

--- a/server/internal/httpserver/me.go
+++ b/server/internal/httpserver/me.go
@@ -208,6 +208,7 @@ func (d Deps) registerMeRoutes(r chi.Router) {
 	r.Post("/api/v1/me/notebooks/query", d.handleNotebookQuery())
 	r.Post("/api/v1/me/notebooks/flashcards", d.handleGenerateNotebookFlashcards())
 	d.registerNotebookTaskRoutes(r)
+	d.registerStudentNotebookRoutes(r)
 	r.Post("/api/v1/stt/transcribe", d.handlePostSTTTranscribe())
 	d.registerTTSRoutes(r)
 	d.registerSelfReflectionRoutes(r)

--- a/server/internal/httpserver/student_notebooks.go
+++ b/server/internal/httpserver/student_notebooks.go
@@ -1,0 +1,114 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/lextures/lextures/server/internal/apierr"
+	repo "github.com/lextures/lextures/server/internal/repos/studentnotebooks"
+)
+
+// maxNotebookBytes caps one notebook document (all pages of one course).
+const maxNotebookBytes = 2 << 20 // 2 MiB
+
+// The course code travels as a query parameter — a path segment would collide with the
+// sibling /api/v1/me/notebooks/query and /notebooks/flashcards routes.
+func (d Deps) registerStudentNotebookRoutes(r chi.Router) {
+	r.Get("/api/v1/me/notebooks", d.handleListStudentNotebooks())
+	r.Put("/api/v1/me/notebooks", d.handlePutStudentNotebook())
+}
+
+type studentNotebookJSON struct {
+	CourseCode string          `json:"courseCode"`
+	UpdatedAt  string          `json:"updatedAt"`
+	Data       json.RawMessage `json:"data"`
+}
+
+func studentNotebookToJSON(n repo.Notebook) studentNotebookJSON {
+	return studentNotebookJSON{
+		CourseCode: n.CourseCode,
+		UpdatedAt:  n.UpdatedAt.UTC().Format(time.RFC3339),
+		Data:       json.RawMessage(n.Data),
+	}
+}
+
+func (d Deps) handleListStudentNotebooks() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database not available.")
+			return
+		}
+		notebooks, err := repo.List(r.Context(), d.Pool, userID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not load notebooks.")
+			return
+		}
+		out := make([]studentNotebookJSON, 0, len(notebooks))
+		for _, n := range notebooks {
+			out = append(out, studentNotebookToJSON(n))
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{"notebooks": out})
+	}
+}
+
+// putStudentNotebookBody mirrors the client CourseNotebookStore (format v2). Pages are kept
+// as raw JSON so clients can evolve page fields without server churn; only the envelope is checked.
+type putStudentNotebookBody struct {
+	FormatVersion int               `json:"formatVersion"`
+	UpdatedAt     string            `json:"updatedAt"`
+	Pages         []json.RawMessage `json:"pages"`
+}
+
+func (d Deps) handlePutStudentNotebook() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database not available.")
+			return
+		}
+		courseCode := strings.TrimSpace(r.URL.Query().Get("courseCode"))
+		if courseCode == "" || len(courseCode) > 200 {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid course code.")
+			return
+		}
+		b, err := io.ReadAll(io.LimitReader(r.Body, maxNotebookBytes+1))
+		_ = r.Body.Close()
+		if err != nil || len(b) > maxNotebookBytes {
+			apierr.WriteJSON(w, http.StatusRequestEntityTooLarge, apierr.CodeInvalidInput, "Notebook is too large.")
+			return
+		}
+		var body putStudentNotebookBody
+		if err := json.Unmarshal(b, &body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		if body.FormatVersion != 2 || len(body.Pages) == 0 {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Expected a format v2 notebook with at least one page.")
+			return
+		}
+		updatedAt, perr := time.Parse(time.RFC3339, strings.TrimSpace(body.UpdatedAt))
+		if perr != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid updatedAt.")
+			return
+		}
+		saved, err := repo.Upsert(r.Context(), d.Pool, userID, courseCode, b, updatedAt)
+		if err != nil || saved == nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not save notebook.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(studentNotebookToJSON(*saved))
+	}
+}

--- a/server/internal/httpserver/student_notebooks_nodb_test.go
+++ b/server/internal/httpserver/student_notebooks_nodb_test.go
@@ -1,0 +1,53 @@
+package httpserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/auth"
+)
+
+func studentNotebooksTestToken(t *testing.T, signer *auth.JWTSigner) string {
+	t.Helper()
+	tok, err := signer.Sign(context.Background(), "00000000-0000-0000-0000-000000000001", "u@test.invalid", "", "", nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return tok
+}
+
+func TestStudentNotebooks_Unauthenticated_Returns401(t *testing.T) {
+	d := Deps{}
+	h := NewHandler(d)
+	cases := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/me/notebooks"},
+		{http.MethodPut, "/api/v1/me/notebooks?courseCode=CS101"},
+	}
+	for _, c := range cases {
+		r := httptest.NewRequest(c.method, c.path, strings.NewReader("{}"))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("%s %s: status=%d want 401", c.method, c.path, w.Code)
+		}
+	}
+}
+
+func TestStudentNotebooks_NoDB_Returns500(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	d := Deps{Pool: nil, JWTSigner: signer}
+	h := NewHandler(d)
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/me/notebooks", nil)
+	r.Header.Set("Authorization", "Bearer "+studentNotebooksTestToken(t, signer))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d want 500", w.Code)
+	}
+}

--- a/server/internal/httpserver/student_progress.go
+++ b/server/internal/httpserver/student_progress.go
@@ -174,8 +174,14 @@ func (d Deps) handleEnrollmentProgressGet() http.HandlerFunc {
 		}
 
 		displayName := "Student"
-		if u, _ := user.FindByID(ctx, d.Pool, en.UserID); u != nil && u.DisplayName != nil && strings.TrimSpace(*u.DisplayName) != "" {
-			displayName = strings.TrimSpace(*u.DisplayName)
+		var avatarURL *string
+		if u, _ := user.FindByID(ctx, d.Pool, en.UserID); u != nil {
+			if u.DisplayName != nil && strings.TrimSpace(*u.DisplayName) != "" {
+				displayName = strings.TrimSpace(*u.DisplayName)
+			}
+			if u.AvatarURL != nil && strings.TrimSpace(*u.AvatarURL) != "" {
+				avatarURL = u.AvatarURL
+			}
 		}
 
 		avgGrade, _ := stprog.AvgGradePercent(ctx, d.Pool, en.CourseID, en.UserID)
@@ -202,6 +208,7 @@ func (d Deps) handleEnrollmentProgressGet() http.HandlerFunc {
 			CourseID:                en.CourseID.String(),
 			StudentUserID:           en.UserID.String(),
 			StudentDisplayName:      displayName,
+			StudentAvatarURL:        avatarURL,
 			AssignmentsSubmittedPct: stprog.Pct(snap.AssignmentsSubmitted, snap.AssignmentsTotal),
 			ModulesViewedPct:        stprog.Pct(snap.ModuleViewsCount, snap.ModulesTotal),
 			AvgQuizScore:            avgQuiz,

--- a/server/internal/models/studentprogress/models.go
+++ b/server/internal/models/studentprogress/models.go
@@ -9,6 +9,7 @@ type Summary struct {
 	CourseID                string     `json:"courseId"`
 	StudentUserID           string     `json:"studentUserId"`
 	StudentDisplayName      string     `json:"studentDisplayName"`
+	StudentAvatarURL        *string    `json:"studentAvatarUrl,omitempty"`
 	AssignmentsSubmittedPct float64    `json:"assignmentsSubmittedPct"`
 	ModulesViewedPct        float64    `json:"modulesViewedPct"`
 	AvgQuizScore            *float64   `json:"avgQuizScore,omitempty"`

--- a/server/internal/repos/enrollment/list_roster.go
+++ b/server/internal/repos/enrollment/list_roster.go
@@ -15,6 +15,7 @@ type RosterRow struct {
 	ID               uuid.UUID
 	UserID           uuid.UUID
 	DisplayName      *string
+	AvatarURL        *string
 	Role             string
 	RoleDisplay      *string
 	SectionID        *uuid.UUID
@@ -32,6 +33,7 @@ SELECT
 	ce.id,
 	ce.user_id,
 	u.display_name,
+	u.avatar_url,
 	ce.role,
 	er.display_name,
 	ce.section_id,
@@ -70,19 +72,26 @@ ORDER BY
 	for rows.Next() {
 		var r RosterRow
 		var display sql.NullString
+		var avatar sql.NullString
 		var secID sql.NullString
 		var secCode, secName sql.NullString
 		var roleDisplay sql.NullString
 		var stateStr string
 		var stateChanged sql.NullTime
 		var stateReason sql.NullString
-		if err := rows.Scan(&r.ID, &r.UserID, &display, &r.Role, &roleDisplay, &secID, &secCode, &secName, &stateStr, &stateChanged, &stateReason); err != nil {
+		if err := rows.Scan(&r.ID, &r.UserID, &display, &avatar, &r.Role, &roleDisplay, &secID, &secCode, &secName, &stateStr, &stateChanged, &stateReason); err != nil {
 			return nil, err
 		}
 		if display.Valid {
 			s := display.String
 			if s != "" {
 				r.DisplayName = &s
+			}
+		}
+		if avatar.Valid {
+			s := avatar.String
+			if s != "" {
+				r.AvatarURL = &s
 			}
 		}
 		if roleDisplay.Valid && roleDisplay.String != "" {

--- a/server/internal/repos/moduleassignmentsubmissions/repo.go
+++ b/server/internal/repos/moduleassignmentsubmissions/repo.go
@@ -84,6 +84,42 @@ WHERE course_id = $1 AND id = $2
 	return s, err
 }
 
+// UngradedAssignmentCount is one assignment with at least one ungraded submission.
+type UngradedAssignmentCount struct {
+	ModuleItemID  uuid.UUID
+	Title         string
+	UngradedCount int64
+}
+
+// ListUngradedCountsForCourse returns assignments in a course that have ungraded submissions.
+func ListUngradedCountsForCourse(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) ([]UngradedAssignmentCount, error) {
+	rows, err := pool.Query(ctx, `
+SELECT si.id, si.title, COUNT(s.id)::bigint
+FROM course.course_structure_items si
+INNER JOIN course.module_assignment_submissions s
+	ON s.module_item_id = si.id AND s.course_id = $1
+LEFT JOIN course.course_grades g
+	ON g.module_item_id = s.module_item_id AND g.student_user_id = s.submitted_by
+WHERE si.course_id = $1 AND si.kind = 'assignment' AND g.student_user_id IS NULL
+GROUP BY si.id, si.title
+HAVING COUNT(s.id) > 0
+ORDER BY MIN(s.submitted_at) ASC, si.title ASC
+`, courseID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]UngradedAssignmentCount, 0)
+	for rows.Next() {
+		var row UngradedAssignmentCount
+		if err := rows.Scan(&row.ModuleItemID, &row.Title, &row.UngradedCount); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
 func CountUngradedForAssignment(ctx context.Context, pool *pgxpool.Pool, courseID, moduleItemID uuid.UUID) (int64, error) {
 	var n *int64
 	err := pool.QueryRow(ctx, `

--- a/server/internal/repos/studentnotebooks/repo.go
+++ b/server/internal/repos/studentnotebooks/repo.go
@@ -1,0 +1,77 @@
+// Package studentnotebooks persists learner notebook documents synced from clients.
+package studentnotebooks
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Notebook is one learner notebook document for a course (or the global key).
+type Notebook struct {
+	UserID     uuid.UUID
+	CourseCode string
+	Data       []byte // CourseNotebookStore JSON (format v2)
+	UpdatedAt  time.Time
+}
+
+// List returns all notebooks owned by userID.
+func List(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) ([]Notebook, error) {
+	rows, err := pool.Query(ctx, `
+SELECT user_id, course_code, data, updated_at
+FROM analytics.student_notebooks
+WHERE user_id = $1
+ORDER BY updated_at DESC
+`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Notebook
+	for rows.Next() {
+		var n Notebook
+		if err := rows.Scan(&n.UserID, &n.CourseCode, &n.Data, &n.UpdatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, n)
+	}
+	return out, rows.Err()
+}
+
+// Get returns one notebook, or nil when the learner has none for courseCode.
+func Get(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, courseCode string) (*Notebook, error) {
+	var n Notebook
+	err := pool.QueryRow(ctx, `
+SELECT user_id, course_code, data, updated_at
+FROM analytics.student_notebooks
+WHERE user_id = $1 AND course_code = $2
+`, userID, courseCode).Scan(&n.UserID, &n.CourseCode, &n.Data, &n.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &n, nil
+}
+
+// Upsert writes a notebook unless the stored copy is newer (last-write-wins by updatedAt).
+// It returns the row that is current after the call, so callers can hand back the winner.
+func Upsert(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, courseCode string, data []byte, updatedAt time.Time) (*Notebook, error) {
+	_, err := pool.Exec(ctx, `
+INSERT INTO analytics.student_notebooks (user_id, course_code, data, updated_at)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (user_id, course_code) DO UPDATE SET
+    data = EXCLUDED.data,
+    updated_at = EXCLUDED.updated_at
+WHERE analytics.student_notebooks.updated_at <= EXCLUDED.updated_at
+`, userID, courseCode, data, updatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return Get(ctx, pool, userID, courseCode)
+}

--- a/server/internal/repos/user/profile_update.go
+++ b/server/internal/repos/user/profile_update.go
@@ -3,11 +3,30 @@ package user
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// SetAvatarURLIfEmptyTx stores an avatar URL when the user does not already have one.
+func SetAvatarURLIfEmptyTx(ctx context.Context, tx pgx.Tx, userID uuid.UUID, avatarURL string) (bool, error) {
+	avatarURL = strings.TrimSpace(avatarURL)
+	if avatarURL == "" {
+		return false, nil
+	}
+	tag, err := tx.Exec(ctx, `
+UPDATE "user".users
+SET avatar_url = $2
+WHERE id = $1
+  AND (avatar_url IS NULL OR TRIM(avatar_url) = '')
+`, userID, avatarURL)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}
 
 // UpdateProfile patches account profile fields for one user.
 func UpdateProfile(

--- a/server/migrations/262_student_notebooks.sql
+++ b/server/migrations/262_student_notebooks.sql
@@ -1,0 +1,13 @@
+-- Student notebooks (markdown pages + groups), synced from web and mobile editors.
+-- One row per learner per course; course_code '__lextures_global__' is the learner-wide notebook.
+
+CREATE TABLE analytics.student_notebooks (
+    user_id     UUID NOT NULL REFERENCES "user".users (id) ON DELETE CASCADE,
+    course_code TEXT NOT NULL,
+    data        JSONB NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, course_code)
+);
+
+COMMENT ON TABLE analytics.student_notebooks IS
+    'Learner notebook documents (format v2: pages/groups with markdown content); last-write-wins sync across web and mobile clients.';


### PR DESCRIPTION
## Summary

- Add server-side student notebook persistence (`analytics.student_notebooks`, migration 262) with list/put APIs and last-write-wins sync across web, iOS, and Android clients.
- Upgrade mobile notebook editors to web parity: page tree, block-based markdown editing with slash commands, drawing pages, and notebook task integration.
- Add instructor-facing grading backlog (per-course and dashboard) and a course student reports page linking to individual learner progress views.
- Improve student progress, enrollment roster display (avatars), and Canvas enrollment import reliability with new tests.

## Test plan

- [ ] Run migration 262 and verify `GET/PUT /api/v1/me/notebooks` round-trips notebook JSON
- [ ] Edit a notebook on web, open on mobile (or vice versa), confirm pages/content sync with correct last-write-wins behavior
- [ ] Exercise mobile notebook editor: page tree, markdown blocks, drawing, and task checkboxes
- [ ] As instructor, confirm grading backlog appears on dashboard and course detail with correct ungraded counts
- [ ] Open course student reports page and navigate to individual student progress entries
- [ ] Run `go test ./... -count=1 -short -timeout=1m` in `server/`
- [ ] Run `npm run typecheck` and `npm run test` in `clients/web/`