### PR TITLE
feat: accessibility services intake workflow (14.16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,8 +244,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
+        shardIndex: [1, 2, 3, 4, 5]
+        shardTotal: [5]
     env:
       E2E_USE_DOCKER: "0"
       E2E_DATABASE_URL: postgres://e2e:e2e@localhost:5432/e2e?sslmode=disable

--- a/clients/web/src/app.tsx
+++ b/clients/web/src/app.tsx
@@ -101,6 +101,8 @@ import GradeSubmissionStatus from './pages/admin/grade-submission-status'
 import AcademicCalendarAdminPage from './pages/admin/academic-calendar'
 import ConsentStudiesAdminPage from './pages/admin/consent-studies'
 import ResearchStudiesPage from './pages/lms/research-studies'
+import AccessibilityServicesPage from './pages/admin/accessibility-services'
+import MyAccommodationsPage from './pages/lms/my-accommodations'
 import CourseEvaluation from './pages/lms/CourseEvaluation'
 import CourseEvaluationResults from './pages/lms/CourseEvaluationResults'
 import EvaluationTemplates from './pages/admin/EvaluationTemplates'
@@ -169,6 +171,7 @@ export default function App() {
           <Route path="/transcripts" element={<TranscriptsPage />} />
           <Route path="/advising-notes" element={<AdvisingNotesPage />} />
           <Route path="/me/research-studies" element={<ResearchStudiesPage />} />
+          <Route path="/me/accommodations" element={<MyAccommodationsPage />} />
           <Route path="/parent" element={<ParentDashboard />} />
           <Route path="/parent/conferences" element={<ConferenceBooking />} />
           <Route path="/conferences/availability" element={<ConferenceAvailabilitySetup />} />
@@ -259,6 +262,7 @@ export default function App() {
           <Route path="/admin/incompletes" element={<IncompletesAdminPage />} />
           <Route path="/admin/academic-calendar" element={<AcademicCalendarAdminPage />} />
           <Route path="/admin/consent-studies" element={<ConsentStudiesAdminPage />} />
+          <Route path="/admin/accessibility" element={<AccessibilityServicesPage />} />
           <Route path="/admin/evaluations/templates" element={<EvaluationTemplates />} />
           <Route path="/admin/evaluations/report" element={<EvaluationReport />} />
           <Route path="/reports" element={<Reports />} />

--- a/clients/web/src/components/layout/side-nav-main-links.tsx
+++ b/clients/web/src/components/layout/side-nav-main-links.tsx
@@ -26,7 +26,14 @@ import { SideNavLink } from './side-nav-link'
 export function SideNavMainLinks() {
   const unreadInboxCount = useInboxUnreadCount()
   const { allows, loading: permLoading } = usePermissions()
-  const { accommodationsEngineEnabled, ffEportfolio, ffTranscripts, ffAdvisingIntegration, ffResearchConsent } =
+  const {
+    accommodationsEngineEnabled,
+    ffEportfolio,
+    ffTranscripts,
+    ffAdvisingIntegration,
+    ffResearchConsent,
+    ffAccessibilityIntake,
+  } =
     usePlatformFeatures()
 
   const canViewReports = !permLoading && allows(PERM_REPORTS_VIEW)
@@ -76,6 +83,11 @@ export function SideNavMainLinks() {
       {ffResearchConsent ? (
         <SideNavLink to="/me/research-studies" icon={<ShieldCheck className="h-5 w-5" />}>
           Research studies
+        </SideNavLink>
+      ) : null}
+      {ffAccessibilityIntake ? (
+        <SideNavLink to="/me/accommodations" icon={<ShieldCheck className="h-5 w-5" />}>
+          My accommodations
         </SideNavLink>
       ) : null}
       <SideNavLink to="/calendar" icon={<Calendar className="h-5 w-5" />}>

--- a/clients/web/src/components/layout/side-nav-settings-links.tsx
+++ b/clients/web/src/components/layout/side-nav-settings-links.tsx
@@ -44,7 +44,13 @@ export function SideNavSettingsLinks() {
   const canOrgRoles =
     !permLoading && (allows(PERM_TENANT_ORG_ROLES_MANAGE) || allows(PERM_TENANT_ORG_ROLES_VIEW))
   const { scimEnabled: platformScimEnabled } = usePlatformScimEnabled(canManageRbac)
-  const { ffBookstoreIntegration, ffTranscripts, ffAdvisingIntegration, ffResearchConsent } = usePlatformFeatures()
+  const {
+    ffBookstoreIntegration,
+    ffTranscripts,
+    ffAdvisingIntegration,
+    ffResearchConsent,
+    ffAccessibilityIntake,
+  } = usePlatformFeatures()
   const location = useLocation()
   const view = settingsViewFromPathname(location.pathname)
   const aiSectionActive = view === 'ai-models' || view === 'ai-prompts'
@@ -186,6 +192,17 @@ export function SideNavSettingsLinks() {
                   icon={<ShieldCheck className="h-5 w-5" />}
                 >
                   Research consent
+                </SideNavLink>
+              )}
+              {ffAccessibilityIntake && (
+                <SideNavLink
+                  to="/admin/accessibility"
+                  className={() =>
+                    location.pathname === '/admin/accessibility' ? sideNavActiveClass : ''
+                  }
+                  icon={<ShieldCheck className="h-5 w-5" />}
+                >
+                  Accessibility services
                 </SideNavLink>
               )}
               {ffBookstoreIntegration && (

--- a/clients/web/src/components/settings/platform-feature-definitions.ts
+++ b/clients/web/src/components/settings/platform-feature-definitions.ts
@@ -79,6 +79,12 @@ const PLATFORM_FEATURE_DEFINITIONS_UNSORTED: PlatformFeatureDefinition[] = [
       'IRB consent studies: present consent forms to students, record decisions, and gate research data export to consenting participants.',
   },
   {
+    key: 'ffAccessibilityIntake',
+    label: 'Accessibility services intake',
+    description:
+      'Accommodation profiles managed by accessibility coordinators, propagated automatically to assessment overrides; instructors see only that an accommodation is active.',
+  },
+  {
     key: 'ffCoCurricularTranscript',
     label: 'Co-curricular transcript (CLR)',
     description:

--- a/clients/web/src/components/settings/platform-settings-panel.tsx
+++ b/clients/web/src/components/settings/platform-settings-panel.tsx
@@ -61,6 +61,7 @@ function emptyForm(): PlatformSettingsPayload {
     ffTranscripts: false,
     ffAdvisingIntegration: false,
     ffResearchConsent: false,
+    ffAccessibilityIntake: false,
     translationMemoryEnabled: false,
     storageQuotasEnabled: false,
     avScanningEnabled: false,

--- a/clients/web/src/components/settings/platform-settings-types.ts
+++ b/clients/web/src/components/settings/platform-settings-types.ts
@@ -39,6 +39,7 @@ export type PlatformSettingsPayload = {
   ffTranscripts: boolean
   ffAdvisingIntegration: boolean
   ffResearchConsent: boolean
+  ffAccessibilityIntake: boolean
   translationMemoryEnabled: boolean
   storageQuotasEnabled: boolean
   avScanningEnabled: boolean

--- a/clients/web/src/context/platform-features-context.tsx
+++ b/clients/web/src/context/platform-features-context.tsx
@@ -66,6 +66,7 @@ export type PlatformFeatures = {
   ffTranscripts: boolean
   ffAdvisingIntegration: boolean
   ffResearchConsent: boolean
+  ffAccessibilityIntake: boolean
   loading: boolean
   refresh: () => Promise<void>
 }
@@ -122,6 +123,7 @@ const defaultFeatures: PlatformFeatures = {
   ffTranscripts: false,
   ffAdvisingIntegration: false,
   ffResearchConsent: false,
+  ffAccessibilityIntake: false,
   loading: true,
   refresh: async () => {},
 }
@@ -183,6 +185,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
     ffTranscripts: false,
     ffAdvisingIntegration: false,
     ffResearchConsent: false,
+    ffAccessibilityIntake: false,
   })
   const [loading, setLoading] = useState(true)
 
@@ -245,6 +248,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffTranscripts: data.ffTranscripts === true,
           ffAdvisingIntegration: data.ffAdvisingIntegration === true,
           ffResearchConsent: data.ffResearchConsent === true,
+          ffAccessibilityIntake: data.ffAccessibilityIntake === true,
         }
         setFeatures({
           ...next,
@@ -274,6 +278,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffTranscripts: next.ffTranscripts === true,
           ffAdvisingIntegration: next.ffAdvisingIntegration === true,
           ffResearchConsent: next.ffResearchConsent === true,
+          ffAccessibilityIntake: next.ffAccessibilityIntake === true,
         })
         setPlatformFeaturesSnapshot(next)
       }

--- a/clients/web/src/lib/__tests__/accessibility-api.test.ts
+++ b/clients/web/src/lib/__tests__/accessibility-api.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  accommodationLabel,
+  createAccommodationProfile,
+  fetchAccommodationProfiles,
+  fetchMyAccommodations,
+  notifyInstructors,
+  updateAccommodationProfile,
+} from '../accessibility-api'
+
+vi.mock('../api', () => ({
+  authorizedFetch: vi.fn(),
+}))
+
+vi.mock('../errors', () => ({
+  readApiErrorMessage: (raw: Record<string, unknown>) => (raw?.message as string) ?? '',
+}))
+
+import { authorizedFetch } from '../api'
+
+const mockFetch = authorizedFetch as unknown as ReturnType<typeof vi.fn>
+
+describe('accommodationLabel', () => {
+  it('maps known types to friendly labels', () => {
+    expect(accommodationLabel('extended_time_1_5x')).toBe('1.5x Extended Time')
+    expect(accommodationLabel('bogus')).toBe('bogus')
+  })
+})
+
+describe('fetchAccommodationProfiles', () => {
+  beforeEach(() => mockFetch.mockReset())
+
+  it('returns the profiles array', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ profiles: [{ id: 'p1', labels: ['1.5x Extended Time'] }] }),
+    })
+    const res = await fetchAccommodationProfiles()
+    expect(res).toHaveLength(1)
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/accessibility/profiles')
+  })
+
+  it('throws on error response', async () => {
+    mockFetch.mockResolvedValue({ ok: false, json: async () => ({}) })
+    await expect(fetchAccommodationProfiles()).rejects.toThrow()
+  })
+})
+
+describe('createAccommodationProfile', () => {
+  beforeEach(() => mockFetch.mockReset())
+
+  it('posts the profile payload', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ profile: { id: 'p1', studentId: 's1' } }),
+    })
+    const prof = await createAccommodationProfile({
+      studentId: 's1',
+      accommodations: ['extended_time_1_5x'],
+    })
+    expect(prof.id).toBe('p1')
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/accessibility/profiles', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ studentId: 's1', accommodations: ['extended_time_1_5x'] }),
+    })
+  })
+
+  it('surfaces server error messages', async () => {
+    mockFetch.mockResolvedValue({ ok: false, json: async () => ({ message: 'bad input' }) })
+    await expect(
+      createAccommodationProfile({ studentId: 's1', accommodations: [] }),
+    ).rejects.toThrow('bad input')
+  })
+})
+
+describe('updateAccommodationProfile', () => {
+  beforeEach(() => mockFetch.mockReset())
+
+  it('patches isActive', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ profile: { id: 'p1', isActive: false } }),
+    })
+    const prof = await updateAccommodationProfile('p1', { isActive: false })
+    expect(prof.isActive).toBe(false)
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/accessibility/profiles/p1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isActive: false }),
+    })
+  })
+})
+
+describe('notifyInstructors', () => {
+  beforeEach(() => mockFetch.mockReset())
+
+  it('returns the notify result', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ notifiedInstructorCount: 2, letter: 'Dear Instructor' }),
+    })
+    const res = await notifyInstructors('p1')
+    expect(res.notifiedInstructorCount).toBe(2)
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/accessibility/profiles/p1/notify-instructors', {
+      method: 'POST',
+    })
+  })
+})
+
+describe('fetchMyAccommodations', () => {
+  beforeEach(() => mockFetch.mockReset())
+
+  it('returns profiles and affected courses', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        profiles: [{ id: 'p1' }],
+        affectedCourses: [{ courseId: 'c1', courseCode: 'C-ABC123', title: 'Bio' }],
+      }),
+    })
+    const res = await fetchMyAccommodations()
+    expect(res.profiles).toHaveLength(1)
+    expect(res.affectedCourses[0].courseCode).toBe('C-ABC123')
+  })
+})

--- a/clients/web/src/lib/accessibility-api.ts
+++ b/clients/web/src/lib/accessibility-api.ts
@@ -1,0 +1,132 @@
+import { authorizedFetch } from './api'
+import { readApiErrorMessage } from './errors'
+
+export type AccommodationType =
+  | 'extended_time_1_5x'
+  | 'extended_time_2x'
+  | 'separate_testing'
+  | 'alternate_format'
+  | 'screen_reader'
+  | 'speech_to_text'
+  | 'reduced_distraction'
+  | 'other'
+
+export const ACCOMMODATION_TYPES: { value: AccommodationType; label: string; description: string }[] = [
+  { value: 'extended_time_1_5x', label: '1.5x Extended Time', description: 'Quiz time limits multiplied by 1.5.' },
+  { value: 'extended_time_2x', label: '2.0x Extended Time', description: 'Quiz time limits doubled.' },
+  { value: 'separate_testing', label: 'Separate Testing', description: 'Flags a separate testing environment.' },
+  { value: 'alternate_format', label: 'Alternate Format', description: 'Alternate-format materials (e.g. braille, large print).' },
+  { value: 'screen_reader', label: 'Screen Reader', description: 'Enables text-to-speech / screen reader support.' },
+  { value: 'speech_to_text', label: 'Speech-to-Text', description: 'Enables speech-to-text input.' },
+  { value: 'reduced_distraction', label: 'Reduced Distraction', description: 'Reduced-distraction quiz interface.' },
+  { value: 'other', label: 'Other', description: 'Additional accommodation (no automatic enforcement).' },
+]
+
+export function accommodationLabel(type: string): string {
+  return ACCOMMODATION_TYPES.find((t) => t.value === type)?.label ?? type
+}
+
+export type AccommodationProfile = {
+  id: string
+  studentId: string
+  accommodations: AccommodationType[]
+  customParams: Record<string, unknown>
+  effectiveFrom: string
+  effectiveUntil?: string
+  labels: string[]
+  isActive: boolean
+  notifiedAt?: string
+  createdAt: string
+}
+
+export type AffectedCourse = {
+  courseId: string
+  courseCode: string
+  title: string
+}
+
+export type CreateProfileInput = {
+  studentId: string
+  accommodations: AccommodationType[]
+  customParams?: Record<string, unknown>
+  effectiveFrom?: string
+  effectiveUntil?: string
+}
+
+// --- coordinator / admin ---
+
+export async function fetchAccommodationProfiles(): Promise<AccommodationProfile[]> {
+  const res = await authorizedFetch('/api/v1/accessibility/profiles')
+  if (!res.ok) {
+    throw new Error('Could not load accommodation profiles.')
+  }
+  const data = (await res.json()) as { profiles?: AccommodationProfile[] }
+  return data.profiles ?? []
+}
+
+export async function createAccommodationProfile(input: CreateProfileInput): Promise<AccommodationProfile> {
+  const res = await authorizedFetch('/api/v1/accessibility/profiles', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  if (!res.ok) {
+    const raw = (await res.json().catch(() => ({}))) as Record<string, unknown>
+    throw new Error(readApiErrorMessage(raw) || 'Could not create accommodation profile.')
+  }
+  const data = (await res.json()) as { profile?: AccommodationProfile }
+  if (!data.profile) {
+    throw new Error('Unexpected response from server.')
+  }
+  return data.profile
+}
+
+export async function updateAccommodationProfile(
+  id: string,
+  patch: Partial<CreateProfileInput> & { isActive?: boolean },
+): Promise<AccommodationProfile> {
+  const res = await authorizedFetch(`/api/v1/accessibility/profiles/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  })
+  if (!res.ok) {
+    const raw = (await res.json().catch(() => ({}))) as Record<string, unknown>
+    throw new Error(readApiErrorMessage(raw) || 'Could not update accommodation profile.')
+  }
+  const data = (await res.json()) as { profile?: AccommodationProfile }
+  if (!data.profile) {
+    throw new Error('Unexpected response from server.')
+  }
+  return data.profile
+}
+
+export async function notifyInstructors(
+  id: string,
+): Promise<{ notifiedInstructorCount: number; letter: string }> {
+  const res = await authorizedFetch(`/api/v1/accessibility/profiles/${id}/notify-instructors`, {
+    method: 'POST',
+  })
+  if (!res.ok) {
+    const raw = (await res.json().catch(() => ({}))) as Record<string, unknown>
+    throw new Error(readApiErrorMessage(raw) || 'Could not notify instructors.')
+  }
+  return (await res.json()) as { notifiedInstructorCount: number; letter: string }
+}
+
+// --- student ---
+
+export async function fetchMyAccommodations(): Promise<{
+  profiles: AccommodationProfile[]
+  affectedCourses: AffectedCourse[]
+}> {
+  const res = await authorizedFetch('/api/v1/me/accommodation-profiles')
+  if (!res.ok) {
+    throw new Error('Could not load your accommodations.')
+  }
+  const data = (await res.json()) as {
+    profiles?: AccommodationProfile[]
+    affectedCourses?: AffectedCourse[]
+  }
+  return { profiles: data.profiles ?? [], affectedCourses: data.affectedCourses ?? [] }
+}

--- a/clients/web/src/lib/platform-features.ts
+++ b/clients/web/src/lib/platform-features.ts
@@ -53,6 +53,7 @@ export type PlatformFeaturesSnapshot = {
   ffTranscripts?: boolean
   ffAdvisingIntegration?: boolean
   ffResearchConsent?: boolean
+  ffAccessibilityIntake?: boolean
 }
 
 const defaults: PlatformFeaturesSnapshot = {
@@ -108,6 +109,7 @@ const defaults: PlatformFeaturesSnapshot = {
   ffTranscripts: false,
   ffAdvisingIntegration: false,
   ffResearchConsent: false,
+  ffAccessibilityIntake: false,
 }
 
 let loaded = false

--- a/clients/web/src/pages/admin/accessibility-services.tsx
+++ b/clients/web/src/pages/admin/accessibility-services.tsx
@@ -1,0 +1,381 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ShieldCheck } from 'lucide-react'
+import { usePlatformFeatures } from '../../context/platform-features-context'
+import {
+  ACCOMMODATION_TYPES,
+  createAccommodationProfile,
+  fetchAccommodationProfiles,
+  notifyInstructors,
+  updateAccommodationProfile,
+  type AccommodationProfile,
+  type AccommodationType,
+} from '../../lib/accessibility-api'
+import {
+  searchAccommodationUsers,
+  type AccommodationUserSearchHit,
+} from '../../lib/courses-api'
+import { formatDateTime } from '../../lib/format'
+
+function learnerLabel(u: AccommodationUserSearchHit): string {
+  const dn = u.displayName?.trim()
+  if (dn) return `${dn} (${u.email})`
+  const name = [u.firstName, u.lastName].filter(Boolean).join(' ').trim()
+  if (name) return `${name} (${u.email})`
+  return u.email
+}
+
+function CreateProfileForm({ onCreated }: { onCreated: () => void }) {
+  const [query, setQuery] = useState('')
+  const [hits, setHits] = useState<AccommodationUserSearchHit[]>([])
+  const [selected, setSelected] = useState<AccommodationUserSearchHit | null>(null)
+  const [types, setTypes] = useState<Set<AccommodationType>>(new Set())
+  const [timeMultiplier, setTimeMultiplier] = useState('')
+  const [effectiveFrom, setEffectiveFrom] = useState('')
+  const [effectiveUntil, setEffectiveUntil] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function search(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    try {
+      setHits(await searchAccommodationUsers(query))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not search learners.')
+    }
+  }
+
+  function toggleType(t: AccommodationType) {
+    setTypes((prev) => {
+      const next = new Set(prev)
+      if (next.has(t)) next.delete(t)
+      else next.add(t)
+      return next
+    })
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!selected) {
+      setError('Select a student first.')
+      return
+    }
+    if (types.size === 0) {
+      setError('Select at least one accommodation type.')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      const customParams: Record<string, unknown> = {}
+      const mult = Number.parseFloat(timeMultiplier)
+      if (!Number.isNaN(mult) && mult >= 1) customParams.timeMultiplier = mult
+      await createAccommodationProfile({
+        studentId: selected.id,
+        accommodations: Array.from(types),
+        customParams,
+        effectiveFrom: effectiveFrom || undefined,
+        effectiveUntil: effectiveUntil || undefined,
+      })
+      setSelected(null)
+      setQuery('')
+      setHits([])
+      setTypes(new Set())
+      setTimeMultiplier('')
+      setEffectiveFrom('')
+      setEffectiveUntil('')
+      onCreated()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not create profile.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section
+      aria-label="Create accommodation profile"
+      className="rounded-xl border border-slate-200 p-4 dark:border-neutral-800"
+    >
+      <h2 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">New accommodation profile</h2>
+
+      <form onSubmit={search} className="mt-3 flex flex-wrap gap-2">
+        <label className="sr-only" htmlFor="acc-student-search">
+          Search students by name, email, or campus id
+        </label>
+        <input
+          id="acc-student-search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search students by name, email, or campus id…"
+          className="min-w-0 flex-1 rounded-lg border border-slate-300 px-3 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+        />
+        <button
+          type="submit"
+          className="rounded-lg border border-slate-300 px-3 py-1.5 text-sm font-medium dark:border-neutral-700"
+        >
+          Search
+        </button>
+      </form>
+
+      {hits.length > 0 && !selected && (
+        <ul className="mt-2 space-y-1" aria-label="Search results">
+          {hits.map((hit) => (
+            <li key={hit.id}>
+              <button
+                type="button"
+                onClick={() => setSelected(hit)}
+                className="w-full rounded-lg border border-slate-200 px-3 py-1.5 text-start text-sm hover:bg-slate-50 dark:border-neutral-800 dark:hover:bg-neutral-900"
+              >
+                {learnerLabel(hit)}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {selected && (
+        <form onSubmit={submit} className="mt-3 space-y-3">
+          <p className="text-sm text-slate-700 dark:text-neutral-300">
+            Student: <span className="font-medium">{learnerLabel(selected)}</span>{' '}
+            <button
+              type="button"
+              onClick={() => setSelected(null)}
+              className="text-xs text-violet-600 underline"
+            >
+              change
+            </button>
+          </p>
+
+          <fieldset>
+            <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Accommodation types
+            </legend>
+            <div className="mt-2 grid gap-2 sm:grid-cols-2">
+              {ACCOMMODATION_TYPES.map((t) => (
+                <label key={t.value} className="flex items-start gap-2 text-sm" htmlFor={`acc-${t.value}`}>
+                  <input
+                    id={`acc-${t.value}`}
+                    type="checkbox"
+                    checked={types.has(t.value)}
+                    onChange={() => toggleType(t.value)}
+                    aria-describedby={`acc-${t.value}-desc`}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    <span className="font-medium text-slate-900 dark:text-neutral-100">{t.label}</span>
+                    <span id={`acc-${t.value}-desc`} className="block text-xs text-slate-500">
+                      {t.description}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            <label className="text-xs font-medium text-slate-600 dark:text-neutral-400">
+              Custom time multiplier
+              <input
+                type="number"
+                min="1"
+                step="0.25"
+                value={timeMultiplier}
+                onChange={(e) => setTimeMultiplier(e.target.value)}
+                placeholder="e.g. 1.5"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+              />
+            </label>
+            <label className="text-xs font-medium text-slate-600 dark:text-neutral-400">
+              Effective from
+              <input
+                type="date"
+                value={effectiveFrom}
+                onChange={(e) => setEffectiveFrom(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+              />
+            </label>
+            <label className="text-xs font-medium text-slate-600 dark:text-neutral-400">
+              Effective until
+              <input
+                type="date"
+                value={effectiveUntil}
+                onChange={(e) => setEffectiveUntil(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+              />
+            </label>
+          </div>
+
+          {timeMultiplier && Number.parseFloat(timeMultiplier) >= 1 && (
+            <p className="text-xs text-amber-700 dark:text-amber-500">
+              This will apply a {Number.parseFloat(timeMultiplier)}× time multiplier to all quizzes for this
+              student.
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-lg bg-violet-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+          >
+            {submitting ? 'Creating…' : 'Create profile'}
+          </button>
+        </form>
+      )}
+
+      {error && (
+        <p role="alert" className="mt-2 text-sm text-red-600 dark:text-red-400">
+          {error}
+        </p>
+      )}
+    </section>
+  )
+}
+
+function ProfileRow({ profile, onChanged }: { profile: AccommodationProfile; onChanged: () => void }) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+
+  async function deactivate() {
+    setBusy(true)
+    setError(null)
+    try {
+      await updateAccommodationProfile(profile.id, { isActive: false })
+      onChanged()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not deactivate profile.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function notify() {
+    setBusy(true)
+    setError(null)
+    setNotice(null)
+    try {
+      const res = await notifyInstructors(profile.id)
+      setNotice(`Notified ${res.notifiedInstructorCount} instructor(s).`)
+      onChanged()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not notify instructors.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <li className="rounded-xl border border-slate-200 p-4 dark:border-neutral-800">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-neutral-100">
+            <ShieldCheck className="h-4 w-4 text-violet-500" aria-hidden="true" />
+            <span className="font-mono">{profile.studentId.slice(0, 8)}</span>
+            <span className={profile.isActive ? 'text-emerald-600' : 'text-slate-400'}>
+              {profile.isActive ? 'Active' : 'Inactive'}
+            </span>
+          </p>
+          <p className="mt-1 text-xs text-slate-600 dark:text-neutral-400">{profile.labels.join(', ')}</p>
+          <p className="text-xs text-slate-500">
+            Effective {profile.effectiveFrom}
+            {profile.effectiveUntil ? ` – ${profile.effectiveUntil}` : ''}
+            {profile.notifiedAt ? ` · Notified ${formatDateTime(profile.notifiedAt)}` : ''}
+          </p>
+        </div>
+        {profile.isActive && (
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void notify()}
+              className="rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-medium disabled:opacity-50 dark:border-neutral-700"
+            >
+              Notify instructors
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void deactivate()}
+              className="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-900/40 dark:text-red-400"
+            >
+              Deactivate
+            </button>
+          </div>
+        )}
+      </div>
+      {notice && <p className="mt-2 text-xs text-emerald-700 dark:text-emerald-500">{notice}</p>}
+      {error && (
+        <p role="alert" className="mt-2 text-xs text-red-600 dark:text-red-400">
+          {error}
+        </p>
+      )}
+    </li>
+  )
+}
+
+export default function AccessibilityServicesPage() {
+  const { ffAccessibilityIntake, loading: featuresLoading } = usePlatformFeatures()
+  const [profiles, setProfiles] = useState<AccommodationProfile[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      setProfiles(await fetchAccommodationProfiles())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load profiles.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (featuresLoading || !ffAccessibilityIntake) {
+      setLoading(false)
+      return
+    }
+    void load()
+  }, [ffAccessibilityIntake, featuresLoading, load])
+
+  if (!ffAccessibilityIntake && !featuresLoading) {
+    return (
+      <div className="mx-auto max-w-4xl p-6">
+        <h1 className="mb-2 text-xl font-semibold">Accessibility services</h1>
+        <p className="text-sm text-slate-600">Accessibility services intake is not enabled for this platform.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      <div>
+        <h1 className="text-xl font-semibold">Accessibility services</h1>
+        <p className="mt-1 text-sm text-slate-600 dark:text-neutral-400">
+          Create accommodation profiles for students. Accommodations apply automatically to all of a
+          student's quizzes; disability documentation is never stored here (ADA / Section 504 / FERPA).
+        </p>
+      </div>
+
+      <CreateProfileForm onCreated={() => void load()} />
+
+      {error && (
+        <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+          {error}
+        </p>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-slate-500">Loading…</p>
+      ) : profiles.length === 0 ? (
+        <p className="text-sm text-slate-500">No accommodation profiles yet.</p>
+      ) : (
+        <ul className="space-y-3" aria-label="Accommodation profiles">
+          {profiles.map((p) => (
+            <ProfileRow key={p.id} profile={p} onChanged={() => void load()} />
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/clients/web/src/pages/lms/my-accommodations.tsx
+++ b/clients/web/src/pages/lms/my-accommodations.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react'
+import { ShieldCheck } from 'lucide-react'
+import { LmsPage } from './lms-page'
+import { usePlatformFeatures } from '../../context/platform-features-context'
+import {
+  fetchMyAccommodations,
+  type AccommodationProfile,
+  type AffectedCourse,
+} from '../../lib/accessibility-api'
+
+export default function MyAccommodationsPage() {
+  const { ffAccessibilityIntake, loading: featuresLoading } = usePlatformFeatures()
+  const [profiles, setProfiles] = useState<AccommodationProfile[]>([])
+  const [courses, setCourses] = useState<AffectedCourse[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (featuresLoading || !ffAccessibilityIntake) {
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    void fetchMyAccommodations()
+      .then((res) => {
+        if (cancelled) return
+        setProfiles(res.profiles)
+        setCourses(res.affectedCourses)
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Could not load your accommodations.')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [ffAccessibilityIntake, featuresLoading])
+
+  if (featuresLoading || loading) {
+    return (
+      <LmsPage title="My accommodations">
+        <p className="text-sm text-slate-500">Loading…</p>
+      </LmsPage>
+    )
+  }
+
+  if (!ffAccessibilityIntake) {
+    return (
+      <LmsPage title="My accommodations">
+        <p className="text-sm text-slate-600 dark:text-neutral-400">
+          Accessibility services are not enabled on this platform.
+        </p>
+      </LmsPage>
+    )
+  }
+
+  return (
+    <LmsPage title="My accommodations">
+      <p className="text-sm text-slate-600 dark:text-neutral-400">
+        These accommodations are configured by your accessibility services office and applied
+        automatically across your courses. Contact the office if anything looks incorrect.
+      </p>
+
+      {error && (
+        <p role="alert" className="mt-4 text-sm text-red-600 dark:text-red-400">
+          {error}
+        </p>
+      )}
+
+      {profiles.length === 0 ? (
+        <p className="mt-6 text-sm text-slate-500">You have no active accommodations.</p>
+      ) : (
+        <ul className="mt-6 space-y-3" aria-label="Active accommodations">
+          {profiles.map((p) => (
+            <li
+              key={p.id}
+              className="rounded-xl border border-slate-200 px-4 py-3 dark:border-neutral-800"
+            >
+              <p className="flex items-center gap-2 text-sm font-medium text-slate-900 dark:text-neutral-100">
+                <ShieldCheck className="h-4 w-4 text-violet-500" aria-hidden="true" />
+                {p.labels.join(', ')}
+              </p>
+              <p className="text-xs text-slate-500">
+                Effective {p.effectiveFrom}
+                {p.effectiveUntil ? ` – ${p.effectiveUntil}` : ''}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <section aria-label="Courses affected" className="mt-8">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+          Courses affected
+        </h2>
+        {courses.length === 0 ? (
+          <p className="mt-2 text-sm text-slate-500">You are not currently enrolled in any courses.</p>
+        ) : (
+          <ul className="mt-2 space-y-1">
+            {courses.map((c) => (
+              <li key={c.courseId} className="text-sm text-slate-700 dark:text-neutral-300">
+                <span className="font-mono text-xs text-slate-500">{c.courseCode}</span> — {c.title}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </LmsPage>
+  )
+}

--- a/e2e/tests/accessibility-intake.spec.ts
+++ b/e2e/tests/accessibility-intake.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * Accessibility services intake workflow (plan 14.16)
+ */
+import { test, expect } from '@playwright/test'
+import { apiSignup } from '../fixtures/api.js'
+
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:8080'
+const PASSWORD = 'E2eTestPass1!'
+
+function uid(prefix = 'acc') {
+  return `e2e-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+function uniqueEmail(prefix = 'acc') {
+  return `${uid(prefix)}@test.invalid`
+}
+function authHeaders(token: string) {
+  return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+}
+
+async function getAdminToken(): Promise<string> {
+  const adminEmail = process.env.E2E_ADMIN_EMAIL ?? 'admin@e2e.test'
+  const adminPassword = process.env.E2E_ADMIN_PASSWORD ?? PASSWORD
+  const loginRes = await fetch(`${API_BASE}/api/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: adminEmail, password: adminPassword }),
+  })
+  if (!loginRes.ok) {
+    await fetch(`${API_BASE}/api/v1/auth/signup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: adminEmail, password: adminPassword, display_name: 'E2E Admin' }),
+    })
+    const retry = await fetch(`${API_BASE}/api/v1/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: adminEmail, password: adminPassword }),
+    })
+    const { access_token } = (await retry.json()) as { access_token: string }
+    return access_token
+  }
+  const { access_token } = (await loginRes.json()) as { access_token: string }
+  return access_token
+}
+
+async function enableFeature(adminToken: string) {
+  const res = await fetch(`${API_BASE}/api/v1/settings/platform`, {
+    method: 'PUT',
+    headers: authHeaders(adminToken),
+    body: JSON.stringify({
+      ffAccessibilityIntake: true,
+      updateMask: ['ffAccessibilityIntake'],
+    }),
+  })
+  expect(res.ok).toBeTruthy()
+}
+
+async function myUserId(token: string): Promise<string> {
+  const res = await fetch(`${API_BASE}/api/v1/me`, { headers: authHeaders(token) })
+  expect(res.ok).toBeTruthy()
+  const { id } = (await res.json()) as { id: string }
+  return id
+}
+
+test('Accessibility intake: unauthenticated endpoints return 401', async () => {
+  const adminToken = await getAdminToken()
+  await enableFeature(adminToken)
+
+  const paths = [
+    '/api/v1/accessibility/profiles',
+    '/api/v1/me/accommodation-profiles',
+  ]
+  for (const path of paths) {
+    const res = await fetch(`${API_BASE}${path}`)
+    expect(res.status).toBe(401)
+  }
+})
+
+test('Accessibility intake: coordinator profile propagates extended time and deactivation removes it (AC-1, AC-3, AC-5)', async () => {
+  const adminToken = await getAdminToken()
+  await enableFeature(adminToken)
+
+  const student = await apiSignup({ email: uniqueEmail('student'), password: PASSWORD })
+  const studentId = await myUserId(student.access_token)
+
+  // Coordinator (admin) creates a 1.5x extended-time profile.
+  const createRes = await fetch(`${API_BASE}/api/v1/accessibility/profiles`, {
+    method: 'POST',
+    headers: authHeaders(adminToken),
+    body: JSON.stringify({
+      studentId,
+      accommodations: ['extended_time_1_5x', 'reduced_distraction'],
+    }),
+  })
+  expect(createRes.status).toBe(201)
+  const { profile } = (await createRes.json()) as { profile: { id: string; labels: string[] } }
+  expect(profile.labels).toContain('1.5x Extended Time')
+
+  // AC-3: student sees the profile and affected courses payload.
+  const mineRes = await fetch(`${API_BASE}/api/v1/me/accommodation-profiles`, {
+    headers: authHeaders(student.access_token),
+  })
+  expect(mineRes.ok).toBeTruthy()
+  const mine = (await mineRes.json()) as { profiles: { labels: string[] }[]; affectedCourses: unknown[] }
+  expect(mine.profiles.length).toBe(1)
+  expect(mine.profiles[0].labels).toContain('1.5x Extended Time')
+
+  // AC-1 proxy: the 2.11 engine now reports extended time for the student (global override).
+  const effRes = await fetch(`${API_BASE}/api/v1/me/accommodations`, {
+    headers: authHeaders(student.access_token),
+  })
+  expect(effRes.ok).toBeTruthy()
+  const eff = (await effRes.json()) as { accommodations: { hasExtendedTime: boolean }[] }
+  expect(eff.accommodations.some((a) => a.hasExtendedTime)).toBeTruthy()
+
+  // AC-5: deactivating the profile removes the override.
+  const patchRes = await fetch(`${API_BASE}/api/v1/accessibility/profiles/${profile.id}`, {
+    method: 'PATCH',
+    headers: authHeaders(adminToken),
+    body: JSON.stringify({ isActive: false }),
+  })
+  expect(patchRes.ok).toBeTruthy()
+
+  const effAfter = await fetch(`${API_BASE}/api/v1/me/accommodations`, {
+    headers: authHeaders(student.access_token),
+  })
+  const effAfterData = (await effAfter.json()) as { accommodations: { hasExtendedTime: boolean }[] }
+  expect(effAfterData.accommodations.some((a) => a.hasExtendedTime)).toBeFalsy()
+})
+
+test('Accessibility intake: instructor cannot read accommodation profiles (AC-4 / security)', async () => {
+  const adminToken = await getAdminToken()
+  await enableFeature(adminToken)
+
+  const student = await apiSignup({ email: uniqueEmail('s2'), password: PASSWORD })
+  const studentId = await myUserId(student.access_token)
+  const createRes = await fetch(`${API_BASE}/api/v1/accessibility/profiles`, {
+    method: 'POST',
+    headers: authHeaders(adminToken),
+    body: JSON.stringify({ studentId, accommodations: ['extended_time_2x'] }),
+  })
+  expect(createRes.status).toBe(201)
+  const { profile } = (await createRes.json()) as { profile: { id: string } }
+
+  // A non-privileged user (no accommodations:manage permission) is forbidden.
+  const other = await apiSignup({ email: uniqueEmail('instructor'), password: PASSWORD })
+  const forbidden = await fetch(`${API_BASE}/api/v1/accessibility/profiles/${profile.id}`, {
+    headers: authHeaders(other.access_token),
+  })
+  expect(forbidden.status).toBe(403)
+
+  const forbiddenList = await fetch(`${API_BASE}/api/v1/accessibility/profiles`, {
+    headers: authHeaders(other.access_token),
+  })
+  expect(forbiddenList.status).toBe(403)
+})
+
+test('Accessibility intake: instructor notification letter omits disability details (AC-2)', async () => {
+  const adminToken = await getAdminToken()
+  await enableFeature(adminToken)
+
+  const student = await apiSignup({ email: uniqueEmail('s3'), password: PASSWORD })
+  const studentId = await myUserId(student.access_token)
+  const createRes = await fetch(`${API_BASE}/api/v1/accessibility/profiles`, {
+    method: 'POST',
+    headers: authHeaders(adminToken),
+    body: JSON.stringify({ studentId, accommodations: ['extended_time_1_5x'] }),
+  })
+  expect(createRes.status).toBe(201)
+  const { profile } = (await createRes.json()) as { profile: { id: string } }
+
+  const notifyRes = await fetch(`${API_BASE}/api/v1/accessibility/profiles/${profile.id}/notify-instructors`, {
+    method: 'POST',
+    headers: authHeaders(adminToken),
+  })
+  expect(notifyRes.ok).toBeTruthy()
+  const notify = (await notifyRes.json()) as { letter: string; notifiedInstructorCount: number }
+  expect(notify.letter).toContain('1.5x Extended Time')
+  expect(notify.letter.toLowerCase()).not.toContain('diagnosis')
+})

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -338,6 +338,10 @@ type Config struct {
 	// FFResearchConsent enables research / IRB consent studies, consent prompts, and gated data export (plan 14.15).
 	// Managed in Settings → Global platform (not process env).
 	FFResearchConsent bool
+	// FFAccessibilityIntake enables the accessibility services intake workflow: coordinator
+	// accommodation profiles propagated to assessment overrides (plan 14.16).
+	// Managed in Settings → Global platform (not process env).
+	FFAccessibilityIntake bool
 
 	// Adaptive-learning platform gates (managed in Settings → Global platform; combined with
 	// the per-course flag at the callsite). Previously env-only service flags.

--- a/server/internal/httpserver/accessibility_http.go
+++ b/server/internal/httpserver/accessibility_http.go
@@ -1,0 +1,415 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/lextures/lextures/server/internal/apierr"
+	acmodel "github.com/lextures/lextures/server/internal/models/accommodations"
+	repo "github.com/lextures/lextures/server/internal/repos/accessibilityprofiles"
+	"github.com/lextures/lextures/server/internal/repos/organization"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+	"github.com/lextures/lextures/server/internal/repos/user"
+	svc "github.com/lextures/lextures/server/internal/service/accessibility"
+)
+
+const eventAccommodationActive = "accommodation_active"
+
+func (d Deps) accessibilityFeatureOff(w http.ResponseWriter) bool {
+	if !d.effectiveConfig().FFAccessibilityIntake {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Accessibility services intake is not enabled.")
+		return true
+	}
+	return false
+}
+
+func (d Deps) registerAccessibilityRoutes(r chi.Router) {
+	r.Post("/api/v1/accessibility/profiles", d.handleCreateAccommodationProfile())
+	r.Get("/api/v1/accessibility/profiles", d.handleListAccommodationProfiles())
+	r.Get("/api/v1/accessibility/profiles/{id}", d.handleGetAccommodationProfile())
+	r.Patch("/api/v1/accessibility/profiles/{id}", d.handleUpdateAccommodationProfile())
+	r.Post("/api/v1/accessibility/profiles/{id}/notify-instructors", d.handleNotifyInstructors())
+	r.Get("/api/v1/me/accommodation-profiles", d.handleMyAccommodationProfiles())
+}
+
+// accessibilityCoordinator authenticates and authorizes a coordinator/admin. The 2.11
+// permission (granted to the "Accessibility Coordinator" and "Global Admin" roles) governs
+// access — instructors and students fail with 403 (AC-4).
+func (d Deps) accessibilityCoordinator(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	userID, ok := d.meUserID(w, r)
+	if !ok {
+		return uuid.UUID{}, false
+	}
+	has, err := rbac.UserHasPermission(r.Context(), d.Pool, userID, acmodel.PermManage)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")
+		return uuid.UUID{}, false
+	}
+	if !has {
+		apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission for this action.")
+		return uuid.UUID{}, false
+	}
+	return userID, true
+}
+
+type profileJSON struct {
+	ID             string          `json:"id"`
+	StudentID      string          `json:"studentId"`
+	Accommodations []string        `json:"accommodations"`
+	CustomParams   json.RawMessage `json:"customParams"`
+	EffectiveFrom  string          `json:"effectiveFrom"`
+	EffectiveUntil *string         `json:"effectiveUntil,omitempty"`
+	Labels         []string        `json:"labels"`
+	IsActive       bool            `json:"isActive"`
+	NotifiedAt     *string         `json:"notifiedAt,omitempty"`
+	CreatedAt      string          `json:"createdAt"`
+}
+
+func profileToJSON(p repo.Profile) profileJSON {
+	out := profileJSON{
+		ID:             p.ID.String(),
+		StudentID:      p.StudentID.String(),
+		Accommodations: p.Accommodations,
+		CustomParams:   p.CustomParams,
+		EffectiveFrom:  p.EffectiveFrom.UTC().Format("2006-01-02"),
+		Labels:         svc.Labels(p.Accommodations),
+		IsActive:       p.IsActive,
+		CreatedAt:      p.CreatedAt.UTC().Format(time.RFC3339),
+	}
+	if len(out.CustomParams) == 0 {
+		out.CustomParams = json.RawMessage(`{}`)
+	}
+	if p.EffectiveUntil != nil {
+		s := p.EffectiveUntil.UTC().Format("2006-01-02")
+		out.EffectiveUntil = &s
+	}
+	if p.NotifiedAt != nil {
+		s := p.NotifiedAt.UTC().Format(time.RFC3339)
+		out.NotifiedAt = &s
+	}
+	return out
+}
+
+func parseAccDate(s string) (*time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, true
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return nil, false
+	}
+	return &t, true
+}
+
+func (d Deps) handleCreateAccommodationProfile() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.accessibilityFeatureOff(w) {
+			return
+		}
+		coordinatorID, ok := d.accessibilityCoordinator(w, r)
+		if !ok {
+			return
+		}
+		var body struct {
+			StudentID      string          `json:"studentId"`
+			Accommodations []string        `json:"accommodations"`
+			CustomParams   json.RawMessage `json:"customParams"`
+			EffectiveFrom  string          `json:"effectiveFrom"`
+			EffectiveUntil string          `json:"effectiveUntil"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		studentID, err := uuid.Parse(strings.TrimSpace(body.StudentID))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "A valid studentId is required.")
+			return
+		}
+		if !svc.ValidTypes(body.Accommodations) {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "accommodations must be a non-empty list of valid accommodation types.")
+			return
+		}
+		from, okFrom := parseAccDate(body.EffectiveFrom)
+		until, okUntil := parseAccDate(body.EffectiveUntil)
+		if !okFrom || !okUntil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Dates must be in YYYY-MM-DD format.")
+			return
+		}
+		orgID, err := organization.OrgIDForUser(r.Context(), d.Pool, studentID)
+		if err != nil || orgID == uuid.Nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Student organization not found.")
+			return
+		}
+		prof, err := repo.Create(r.Context(), d.Pool, repo.CreateInput{
+			StudentID:      studentID,
+			OrgID:          orgID,
+			Accommodations: body.Accommodations,
+			CustomParams:   body.CustomParams,
+			EffectiveFrom:  from,
+			EffectiveUntil: until,
+			CreatedBy:      coordinatorID,
+		})
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to create accommodation profile.")
+			return
+		}
+		// FR-3 / AC-1: propagate to the 2.11 override engine immediately.
+		if _, err := svc.Apply(r.Context(), d.Pool, prof.ID, studentID, prof.Accommodations, prof.CustomParams, from, until, coordinatorID); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Profile created but accommodation propagation failed.")
+			return
+		}
+		if reloaded, err := repo.Get(r.Context(), d.Pool, prof.ID); err == nil && reloaded != nil {
+			prof = reloaded
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{"profile": profileToJSON(*prof)})
+	}
+}
+
+func (d Deps) handleListAccommodationProfiles() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.accessibilityFeatureOff(w) {
+			return
+		}
+		coordinatorID, ok := d.accessibilityCoordinator(w, r)
+		if !ok {
+			return
+		}
+		orgID, err := organization.OrgIDForUser(r.Context(), d.Pool, coordinatorID)
+		if err != nil || orgID == uuid.Nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Organization not found.")
+			return
+		}
+		profiles, err := repo.ListForOrg(r.Context(), d.Pool, orgID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load accommodation profiles.")
+			return
+		}
+		out := make([]profileJSON, 0, len(profiles))
+		for i := range profiles {
+			out = append(out, profileToJSON(profiles[i]))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"profiles": out})
+	}
+}
+
+func (d Deps) handleGetAccommodationProfile() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.accessibilityFeatureOff(w) {
+			return
+		}
+		if _, ok := d.accessibilityCoordinator(w, r); !ok {
+			return
+		}
+		prof, ok := d.loadProfile(w, r)
+		if !ok {
+			return
+		}
+		courses, _ := repo.CoursesForStudent(r.Context(), d.Pool, prof.StudentID)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"profile":         profileToJSON(*prof),
+			"affectedCourses": affectedCoursesJSON(courses),
+		})
+	}
+}
+
+func (d Deps) handleUpdateAccommodationProfile() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.accessibilityFeatureOff(w) {
+			return
+		}
+		coordinatorID, ok := d.accessibilityCoordinator(w, r)
+		if !ok {
+			return
+		}
+		prof, ok := d.loadProfile(w, r)
+		if !ok {
+			return
+		}
+		var body struct {
+			Accommodations *[]string       `json:"accommodations"`
+			CustomParams   json.RawMessage `json:"customParams"`
+			EffectiveFrom  *string         `json:"effectiveFrom"`
+			EffectiveUntil *string         `json:"effectiveUntil"`
+			IsActive       *bool           `json:"isActive"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		patch := repo.UpdatePatch{CustomParams: body.CustomParams, IsActive: body.IsActive}
+		if body.Accommodations != nil {
+			if !svc.ValidTypes(*body.Accommodations) {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "accommodations must be a non-empty list of valid types.")
+				return
+			}
+			patch.Accommodations = body.Accommodations
+		}
+		if body.EffectiveFrom != nil {
+			from, okFrom := parseAccDate(*body.EffectiveFrom)
+			if !okFrom {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "effectiveFrom must be YYYY-MM-DD.")
+				return
+			}
+			patch.EffectiveFrom = from
+		}
+		if body.EffectiveUntil != nil {
+			until, okUntil := parseAccDate(*body.EffectiveUntil)
+			if !okUntil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "effectiveUntil must be YYYY-MM-DD.")
+				return
+			}
+			patch.EffectiveUntil = until
+		}
+
+		deactivating := body.IsActive != nil && !*body.IsActive && prof.IsActive
+		updated, err := repo.Update(r.Context(), d.Pool, prof.ID, patch)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to update accommodation profile.")
+			return
+		}
+		if updated == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Accommodation profile not found.")
+			return
+		}
+
+		switch {
+		case deactivating:
+			// AC-5: removing the profile removes the propagated override.
+			if err := svc.Deactivate(r.Context(), d.Pool, prof.StudentID, prof.AppliedID); err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to remove accommodation override.")
+				return
+			}
+			_ = repo.SetApplied(r.Context(), d.Pool, prof.ID, nil)
+		case updated.IsActive:
+			// Re-propagate: drop any prior override, then apply the updated settings.
+			_ = svc.Deactivate(r.Context(), d.Pool, prof.StudentID, prof.AppliedID)
+			if _, err := svc.Apply(r.Context(), d.Pool, updated.ID, updated.StudentID, updated.Accommodations, updated.CustomParams, ptrTime(updated.EffectiveFrom), updated.EffectiveUntil, coordinatorID); err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to re-apply accommodation override.")
+				return
+			}
+		}
+		if reloaded, err := repo.Get(r.Context(), d.Pool, updated.ID); err == nil && reloaded != nil {
+			updated = reloaded
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"profile": profileToJSON(*updated)})
+	}
+}
+
+func (d Deps) handleNotifyInstructors() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.accessibilityFeatureOff(w) {
+			return
+		}
+		if _, ok := d.accessibilityCoordinator(w, r); !ok {
+			return
+		}
+		prof, ok := d.loadProfile(w, r)
+		if !ok {
+			return
+		}
+		ctx := r.Context()
+		studentName := "the student"
+		if u, err := user.FindByID(ctx, d.Pool, prof.StudentID); err == nil && u != nil {
+			studentName = user.DisplayLabel(u.DisplayName, u.Email)
+		}
+		effDate := prof.EffectiveFrom.UTC().Format("2006-01-02")
+		letter := svc.RenderLetter(studentName, effDate, prof.Accommodations)
+
+		instructors, err := repo.InstructorIDsForStudent(ctx, d.Pool, prof.StudentID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to resolve instructors.")
+			return
+		}
+		orgID, _ := organization.OrgIDForUser(ctx, d.Pool, prof.StudentID)
+		var orgPtr *uuid.UUID
+		if orgID != uuid.Nil {
+			orgPtr = &orgID
+		}
+		ns := d.notificationsService()
+		vars := map[string]string{
+			"subject":     svc.LetterSubject(studentName),
+			"studentName": studentName,
+			"labels":      strings.Join(svc.Labels(prof.Accommodations), ", "),
+			"letter":      letter,
+		}
+		for _, id := range instructors {
+			if err := ns.EnqueueEmail(ctx, id, eventAccommodationActive, "accommodation_active", vars, orgPtr); err != nil {
+				slog.Warn("accessibility.notify_instructors", "err", err, "instructor_id", id)
+			}
+		}
+		if err := repo.MarkNotified(ctx, d.Pool, prof.ID); err != nil {
+			slog.Warn("accessibility.mark_notified", "err", err, "profile_id", prof.ID)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"notifiedInstructorCount": len(instructors),
+			"letter":                  letter,
+		})
+	}
+}
+
+func (d Deps) handleMyAccommodationProfiles() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.accessibilityFeatureOff(w) {
+			return
+		}
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		profiles, err := repo.ListActiveForStudent(r.Context(), d.Pool, userID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load your accommodations.")
+			return
+		}
+		courses, _ := repo.CoursesForStudent(r.Context(), d.Pool, userID)
+		out := make([]profileJSON, 0, len(profiles))
+		for i := range profiles {
+			out = append(out, profileToJSON(profiles[i]))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"profiles":        out,
+			"affectedCourses": affectedCoursesJSON(courses),
+		})
+	}
+}
+
+// loadProfile parses {id}, loads the profile, and enforces the feature gate already done
+// by the caller. Returns the profile or writes an error and reports false.
+func (d Deps) loadProfile(w http.ResponseWriter, r *http.Request) (*repo.Profile, bool) {
+	id, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "id")))
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid profile id.")
+		return nil, false
+	}
+	prof, err := repo.Get(r.Context(), d.Pool, id)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load accommodation profile.")
+		return nil, false
+	}
+	if prof == nil {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Accommodation profile not found.")
+		return nil, false
+	}
+	return prof, true
+}
+
+func affectedCoursesJSON(courses []repo.AffectedCourse) []map[string]string {
+	out := make([]map[string]string, 0, len(courses))
+	for _, c := range courses {
+		out = append(out, map[string]string{
+			"courseId":   c.CourseID.String(),
+			"courseCode": c.CourseCode,
+			"title":      c.Title,
+		})
+	}
+	return out
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }

--- a/server/internal/httpserver/accessibility_nodb_test.go
+++ b/server/internal/httpserver/accessibility_nodb_test.go
@@ -1,0 +1,63 @@
+package httpserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/config"
+)
+
+func accessibilityTestToken(t *testing.T, signer *auth.JWTSigner) string {
+	t.Helper()
+	tok, err := signer.Sign(context.Background(), "00000000-0000-0000-0000-000000000001", "u@test.invalid", "", "", nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return tok
+}
+
+func TestAccessibility_Unauthenticated(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	cfg := config.Config{FFAccessibilityIntake: true}
+	d := Deps{Pool: nil, JWTSigner: signer, Config: cfg}
+	h := NewHandler(d)
+
+	paths := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/v1/accessibility/profiles"},
+		{http.MethodGet, "/api/v1/accessibility/profiles"},
+		{http.MethodGet, "/api/v1/accessibility/profiles/00000000-0000-0000-0000-000000000002"},
+		{http.MethodPatch, "/api/v1/accessibility/profiles/00000000-0000-0000-0000-000000000002"},
+		{http.MethodPost, "/api/v1/accessibility/profiles/00000000-0000-0000-0000-000000000002/notify-instructors"},
+		{http.MethodGet, "/api/v1/me/accommodation-profiles"},
+	}
+	for _, tc := range paths {
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s: want 401 got %d", tc.method, tc.path, w.Code)
+		}
+	}
+}
+
+func TestAccessibility_FeatureOff(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	cfg := config.Config{FFAccessibilityIntake: false}
+	d := Deps{Pool: nil, JWTSigner: signer, Config: cfg}
+	h := NewHandler(d)
+
+	tok := accessibilityTestToken(t, signer)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/accommodation-profiles", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("feature off want 404 got %d", w.Code)
+	}
+}

--- a/server/internal/httpserver/platform_features.go
+++ b/server/internal/httpserver/platform_features.go
@@ -62,6 +62,7 @@ type platformFeaturesJSON struct {
 	FFTranscripts               bool `json:"ffTranscripts"`
 	FFAdvisingIntegration       bool `json:"ffAdvisingIntegration"`
 	FFResearchConsent           bool `json:"ffResearchConsent"`
+	FFAccessibilityIntake       bool `json:"ffAccessibilityIntake"`
 
 	LRSAnonymizeActors           bool    `json:"lrsAnonymizeActors"`
 	FERPAWorkflowEnabled         bool    `json:"ferpaWorkflowEnabled"`
@@ -130,6 +131,7 @@ func platformFeaturesFromConfig(cfg config.Config) platformFeaturesJSON {
 		FFTranscripts:               cfg.FFTranscripts,
 		FFAdvisingIntegration:       cfg.FFAdvisingIntegration,
 		FFResearchConsent:           cfg.FFResearchConsent,
+		FFAccessibilityIntake:       cfg.FFAccessibilityIntake,
 
 		LRSAnonymizeActors:           cfg.LRSAnonymizeActors,
 		FERPAWorkflowEnabled:         cfg.FERPAWorkflowEnabled,

--- a/server/internal/httpserver/server.go
+++ b/server/internal/httpserver/server.go
@@ -137,6 +137,7 @@ func NewHandler(d Deps) http.Handler {
 	d.registerTranscriptsRoutes(r)
 	d.registerAdvisingRoutes(r)
 	d.registerResearchConsentRoutes(r)
+	d.registerAccessibilityRoutes(r)
 	d.registerBroadcastRoutes(r)
 	d.registerClassroomSignalsRoutes(r)
 	d.registerConferenceRoutes(r)

--- a/server/internal/httpserver/settings_platform.go
+++ b/server/internal/httpserver/settings_platform.go
@@ -125,6 +125,7 @@ type platformSettingsJSON struct {
 	FFTranscripts                   bool `json:"ffTranscripts"`
 	FFAdvisingIntegration           bool `json:"ffAdvisingIntegration"`
 	FFResearchConsent               bool `json:"ffResearchConsent"`
+	FFAccessibilityIntake           bool `json:"ffAccessibilityIntake"`
 
 	LRSAnonymizeActors           bool    `json:"lrsAnonymizeActors"`
 	FERPAWorkflowEnabled         bool    `json:"ferpaWorkflowEnabled"`
@@ -300,6 +301,7 @@ func (d Deps) handleGetPlatformSettings() http.HandlerFunc {
 			FFTranscripts:                   merged.FFTranscripts,
 			FFAdvisingIntegration:           merged.FFAdvisingIntegration,
 			FFResearchConsent:               merged.FFResearchConsent,
+			FFAccessibilityIntake:           merged.FFAccessibilityIntake,
 			LRSAnonymizeActors:              merged.LRSAnonymizeActors,
 			FERPAWorkflowEnabled:            merged.FERPAWorkflowEnabled,
 			DPAPortalEnabled:                merged.DPAPortalEnabled,
@@ -451,6 +453,7 @@ type putPlatformBody struct {
 	FFTranscripts                   *bool `json:"ffTranscripts"`
 	FFAdvisingIntegration           *bool `json:"ffAdvisingIntegration"`
 	FFResearchConsent               *bool `json:"ffResearchConsent"`
+	FFAccessibilityIntake           *bool `json:"ffAccessibilityIntake"`
 
 	LRSAnonymizeActors           *bool    `json:"lrsAnonymizeActors"`
 	FERPAWorkflowEnabled         *bool    `json:"ferpaWorkflowEnabled"`
@@ -767,6 +770,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 		setBool("fftranscripts", body.FFTranscripts, func(v bool) { wr.FFTranscripts = &v })
 		setBool("ffadvisingintegration", body.FFAdvisingIntegration, func(v bool) { wr.FFAdvisingIntegration = &v })
 		setBool("ffresearchconsent", body.FFResearchConsent, func(v bool) { wr.FFResearchConsent = &v })
+		setBool("ffaccessibilityintake", body.FFAccessibilityIntake, func(v bool) { wr.FFAccessibilityIntake = &v })
 		setBool("lrsanonymizeactors", body.LRSAnonymizeActors, func(v bool) { wr.LRSAnonymizeActors = &v })
 		setBool("ferpaworkflowenabled", body.FERPAWorkflowEnabled, func(v bool) { wr.FERPAWorkflowEnabled = &v })
 		setBool("dpaportalenabled", body.DPAPortalEnabled, func(v bool) { wr.DPAPortalEnabled = &v })
@@ -894,6 +898,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 			FFTranscripts:                   merged.FFTranscripts,
 			FFAdvisingIntegration:           merged.FFAdvisingIntegration,
 			FFResearchConsent:               merged.FFResearchConsent,
+			FFAccessibilityIntake:           merged.FFAccessibilityIntake,
 			LRSAnonymizeActors:              merged.LRSAnonymizeActors,
 			FERPAWorkflowEnabled:            merged.FERPAWorkflowEnabled,
 			DPAPortalEnabled:                merged.DPAPortalEnabled,

--- a/server/internal/repos/accessibilityprofiles/repo.go
+++ b/server/internal/repos/accessibilityprofiles/repo.go
@@ -1,0 +1,247 @@
+// Package accessibilityprofiles stores accessibility-office accommodation profiles
+// (plan 14.16). Profiles are a coordinator-facing intake layer that propagates to the
+// 2.11 course.student_accommodations override engine.
+package accessibilityprofiles
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Profile is one accessibility.accommodation_profiles row.
+type Profile struct {
+	ID             uuid.UUID       `json:"id"`
+	StudentID      uuid.UUID       `json:"studentId"`
+	OrgID          uuid.UUID       `json:"orgId"`
+	Accommodations []string        `json:"accommodations"`
+	CustomParams   json.RawMessage `json:"customParams"`
+	EffectiveFrom  time.Time       `json:"effectiveFrom"`
+	EffectiveUntil *time.Time      `json:"effectiveUntil,omitempty"`
+	AppliedID      *uuid.UUID      `json:"-"`
+	NotifiedAt     *time.Time      `json:"notifiedAt,omitempty"`
+	CreatedBy      uuid.UUID       `json:"createdBy"`
+	IsActive       bool            `json:"isActive"`
+	CreatedAt      time.Time       `json:"createdAt"`
+	UpdatedAt      time.Time       `json:"updatedAt"`
+}
+
+const selectCols = `
+    id, student_id, org_id, accommodations::text[], custom_params,
+    effective_from, effective_until, applied_accommodation_id, notified_at,
+    created_by, is_active, created_at, updated_at`
+
+func scanProfile(row pgx.Row) (*Profile, error) {
+	var p Profile
+	var params []byte
+	if err := row.Scan(
+		&p.ID, &p.StudentID, &p.OrgID, &p.Accommodations, &params,
+		&p.EffectiveFrom, &p.EffectiveUntil, &p.AppliedID, &p.NotifiedAt,
+		&p.CreatedBy, &p.IsActive, &p.CreatedAt, &p.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	if len(params) == 0 {
+		params = []byte(`{}`)
+	}
+	p.CustomParams = json.RawMessage(params)
+	return &p, nil
+}
+
+// CreateInput is the payload for a new profile.
+type CreateInput struct {
+	StudentID      uuid.UUID
+	OrgID          uuid.UUID
+	Accommodations []string
+	CustomParams   json.RawMessage
+	EffectiveFrom  *time.Time
+	EffectiveUntil *time.Time
+	CreatedBy      uuid.UUID
+}
+
+// Create inserts a new active accommodation profile.
+func Create(ctx context.Context, pool *pgxpool.Pool, in CreateInput) (*Profile, error) {
+	params := in.CustomParams
+	if len(params) == 0 {
+		params = json.RawMessage(`{}`)
+	}
+	const q = `
+INSERT INTO accessibility.accommodation_profiles
+    (student_id, org_id, accommodations, custom_params, effective_from, effective_until, created_by)
+VALUES ($1, $2, $3::text[]::accessibility.accommodation_type[], $4::jsonb,
+        COALESCE($5::date, CURRENT_DATE), $6::date, $7)
+RETURNING` + selectCols
+	row := pool.QueryRow(ctx, q,
+		in.StudentID, in.OrgID, in.Accommodations, []byte(params),
+		in.EffectiveFrom, in.EffectiveUntil, in.CreatedBy,
+	)
+	return scanProfile(row)
+}
+
+// Get returns a single profile by id, or (nil, nil) if not found.
+func Get(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID) (*Profile, error) {
+	p, err := scanProfile(pool.QueryRow(ctx, `SELECT`+selectCols+`
+FROM accessibility.accommodation_profiles WHERE id = $1`, id))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return p, err
+}
+
+// ListForOrg returns all profiles in an org, newest first.
+func ListForOrg(ctx context.Context, pool *pgxpool.Pool, orgID uuid.UUID) ([]Profile, error) {
+	rows, err := pool.Query(ctx, `SELECT`+selectCols+`
+FROM accessibility.accommodation_profiles WHERE org_id = $1
+ORDER BY is_active DESC, created_at DESC`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return collect(rows)
+}
+
+// ListActiveForStudent returns the student's own active profiles, newest first.
+func ListActiveForStudent(ctx context.Context, pool *pgxpool.Pool, studentID uuid.UUID) ([]Profile, error) {
+	rows, err := pool.Query(ctx, `SELECT`+selectCols+`
+FROM accessibility.accommodation_profiles
+WHERE student_id = $1 AND is_active = TRUE
+ORDER BY created_at DESC`, studentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return collect(rows)
+}
+
+func collect(rows pgx.Rows) ([]Profile, error) {
+	var out []Profile
+	for rows.Next() {
+		p, err := scanProfile(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *p)
+	}
+	return out, rows.Err()
+}
+
+// UpdatePatch carries optional updates for a profile.
+type UpdatePatch struct {
+	Accommodations *[]string
+	CustomParams   json.RawMessage
+	EffectiveFrom  *time.Time
+	EffectiveUntil *time.Time
+	IsActive       *bool
+}
+
+// Update applies a partial patch and returns the updated profile.
+func Update(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID, patch UpdatePatch) (*Profile, error) {
+	const q = `
+UPDATE accessibility.accommodation_profiles SET
+    accommodations  = COALESCE($2::text[]::accessibility.accommodation_type[], accommodations),
+    custom_params   = COALESCE($3::jsonb, custom_params),
+    effective_from  = COALESCE($4::date, effective_from),
+    effective_until = CASE WHEN $5::boolean THEN $6::date ELSE effective_until END,
+    is_active       = COALESCE($7::boolean, is_active),
+    updated_at      = NOW()
+WHERE id = $1
+RETURNING` + selectCols
+	var acc *[]string = patch.Accommodations
+	var params []byte
+	if len(patch.CustomParams) > 0 {
+		params = []byte(patch.CustomParams)
+	}
+	row := pool.QueryRow(ctx, q,
+		id, acc, params, patch.EffectiveFrom,
+		patch.EffectiveUntil != nil, patch.EffectiveUntil,
+		patch.IsActive,
+	)
+	p, err := scanProfile(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return p, err
+}
+
+// SetApplied records the propagated student_accommodations row id on the profile.
+func SetApplied(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID, appliedID *uuid.UUID) error {
+	_, err := pool.Exec(ctx, `
+UPDATE accessibility.accommodation_profiles
+SET applied_accommodation_id = $2, updated_at = NOW()
+WHERE id = $1`, id, appliedID)
+	return err
+}
+
+// MarkNotified stamps notified_at = NOW() on the profile.
+func MarkNotified(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID) error {
+	_, err := pool.Exec(ctx, `
+UPDATE accessibility.accommodation_profiles
+SET notified_at = NOW(), updated_at = NOW()
+WHERE id = $1`, id)
+	return err
+}
+
+// AffectedCourse is a course a student is enrolled in (FR-5 / notification targeting).
+type AffectedCourse struct {
+	CourseID   uuid.UUID
+	CourseCode string
+	Title      string
+}
+
+// CoursesForStudent lists the active-enrollment courses for a student (used to show
+// "courses affected" and to find instructors to notify).
+func CoursesForStudent(ctx context.Context, pool *pgxpool.Pool, studentID uuid.UUID) ([]AffectedCourse, error) {
+	rows, err := pool.Query(ctx, `
+SELECT DISTINCT c.id, c.course_code, c.title
+FROM course.course_enrollments e
+JOIN course.courses c ON c.id = e.course_id
+WHERE e.user_id = $1
+  AND e.role = 'student'
+  AND e.active
+ORDER BY c.course_code`, studentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AffectedCourse
+	for rows.Next() {
+		var a AffectedCourse
+		if err := rows.Scan(&a.CourseID, &a.CourseCode, &a.Title); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// InstructorIDsForStudent returns distinct teaching-staff user ids across the
+// student's enrolled courses (FR-4 notification recipients).
+func InstructorIDsForStudent(ctx context.Context, pool *pgxpool.Pool, studentID uuid.UUID) ([]uuid.UUID, error) {
+	rows, err := pool.Query(ctx, `
+SELECT DISTINCT staff.user_id
+FROM course.course_enrollments stu
+JOIN course.course_enrollments staff ON staff.course_id = stu.course_id
+WHERE stu.user_id = $1
+  AND stu.role = 'student'
+  AND stu.active
+  AND staff.role IN ('owner', 'teacher', 'instructor')
+  AND staff.active`, studentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}

--- a/server/internal/repos/accessibilityprofiles/repo.go
+++ b/server/internal/repos/accessibilityprofiles/repo.go
@@ -151,13 +151,12 @@ UPDATE accessibility.accommodation_profiles SET
     updated_at      = NOW()
 WHERE id = $1
 RETURNING` + selectCols
-	var acc *[]string = patch.Accommodations
 	var params []byte
 	if len(patch.CustomParams) > 0 {
 		params = []byte(patch.CustomParams)
 	}
 	row := pool.QueryRow(ctx, q,
-		id, acc, params, patch.EffectiveFrom,
+		id, patch.Accommodations, params, patch.EffectiveFrom,
 		patch.EffectiveUntil != nil, patch.EffectiveUntil,
 		patch.IsActive,
 	)

--- a/server/internal/repos/platformconfig/features.go
+++ b/server/internal/repos/platformconfig/features.go
@@ -76,6 +76,7 @@ func applyPlatformBools(out *config.Config, db *Row, def Defaults) {
 	out.FFTranscripts = mergeBool(db.FFTranscripts, false)
 	out.FFAdvisingIntegration = mergeBool(db.FFAdvisingIntegration, false)
 	out.FFResearchConsent = mergeBool(db.FFResearchConsent, false)
+	out.FFAccessibilityIntake = mergeBool(db.FFAccessibilityIntake, false)
 	out.SpeechToTextEnabled = mergeBool(db.SpeechToTextEnabled, false)
 	out.AccommodationsEngineEnabled = mergeBool(db.AccommodationsEngineEnabled, false)
 	out.FFAccommodationsEngine = mergeBool(db.FFAccommodationsEngine, false)

--- a/server/internal/repos/platformconfig/patch.go
+++ b/server/internal/repos/platformconfig/patch.go
@@ -144,6 +144,7 @@ func patch(ctx context.Context, pool *pgxpool.Pool, w *Write) error {
 	addBool("ff_transcripts", w.FFTranscripts)
 	addBool("ff_advising_integration", w.FFAdvisingIntegration)
 	addBool("ff_research_consent", w.FFResearchConsent)
+	addBool("ff_accessibility_intake", w.FFAccessibilityIntake)
 	addBool("lrs_anonymize_actors", w.LRSAnonymizeActors)
 	addBool("ferpa_workflow_enabled", w.FERPAWorkflowEnabled)
 	addBool("dpa_portal_enabled", w.DPAPortalEnabled)

--- a/server/internal/repos/platformconfig/platformconfig.go
+++ b/server/internal/repos/platformconfig/platformconfig.go
@@ -110,6 +110,7 @@ type Row struct {
 	FFTranscripts                   *bool
 	FFAdvisingIntegration           *bool
 	FFResearchConsent               *bool
+	FFAccessibilityIntake           *bool
 
 	// Previously env-only flags (categories B and C), now platform-managed.
 	LRSAnonymizeActors           *bool
@@ -234,6 +235,7 @@ type Write struct {
 	FFTranscripts                   *bool
 	FFAdvisingIntegration           *bool
 	FFResearchConsent               *bool
+	FFAccessibilityIntake           *bool
 
 	// Previously env-only flags (categories B and C), now platform-managed.
 	LRSAnonymizeActors           *bool
@@ -355,6 +357,7 @@ SELECT
 	ff_transcripts,
 	ff_advising_integration,
 	ff_research_consent,
+	ff_accessibility_intake,
 	lrs_anonymize_actors,
 	ferpa_workflow_enabled,
 	dpa_portal_enabled,
@@ -470,6 +473,7 @@ WHERE id = 1
 		&r.FFTranscripts,
 		&r.FFAdvisingIntegration,
 		&r.FFResearchConsent,
+		&r.FFAccessibilityIntake,
 		&r.LRSAnonymizeActors,
 		&r.FERPAWorkflowEnabled,
 		&r.DPAPortalEnabled,
@@ -636,6 +640,7 @@ INSERT INTO settings.platform_app_settings (
 	ff_transcripts,
 	ff_advising_integration,
 	ff_research_consent,
+	ff_accessibility_intake,
 	mfa_enabled,
 	mfa_enforcement,
 	smtp_host,
@@ -662,7 +667,7 @@ INSERT INTO settings.platform_app_settings (
 	$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18,
 	$19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40,
 	$41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, $66, $67, $68, $69, $70, $71, $72, $73, $74, $75, $76, $77, $78, $79, $80, $81, $82, $83, $84, $85, $86, $87, $88, $89, $90, $91, $92, $93, $94, $95,
-	$96, $97, $98, $99, $100, $101, $102, $103, $104, $105, $106, $107, $108, $109,
+	$96, $97, $98, $99, $100, $101, $102, $103, $104, $105, $106, $107, $108, $109, $110,
 	NOW()
 )
 ON CONFLICT (id) DO UPDATE SET
@@ -757,6 +762,7 @@ ON CONFLICT (id) DO UPDATE SET
 	ff_transcripts = COALESCE(EXCLUDED.ff_transcripts, settings.platform_app_settings.ff_transcripts),
 	ff_advising_integration = COALESCE(EXCLUDED.ff_advising_integration, settings.platform_app_settings.ff_advising_integration),
 	ff_research_consent = COALESCE(EXCLUDED.ff_research_consent, settings.platform_app_settings.ff_research_consent),
+	ff_accessibility_intake = COALESCE(EXCLUDED.ff_accessibility_intake, settings.platform_app_settings.ff_accessibility_intake),
 	lrs_anonymize_actors = COALESCE(EXCLUDED.lrs_anonymize_actors, settings.platform_app_settings.lrs_anonymize_actors),
 	ferpa_workflow_enabled = COALESCE(EXCLUDED.ferpa_workflow_enabled, settings.platform_app_settings.ferpa_workflow_enabled),
 	dpa_portal_enabled = COALESCE(EXCLUDED.dpa_portal_enabled, settings.platform_app_settings.dpa_portal_enabled),
@@ -870,6 +876,7 @@ ON CONFLICT (id) DO UPDATE SET
 		w.FFTranscripts,
 		w.FFAdvisingIntegration,
 		w.FFResearchConsent,
+		w.FFAccessibilityIntake,
 		w.MFAEnabled,
 		w.MFAEnforcement,
 		w.SMTPHost,

--- a/server/internal/service/accessibility/accessibility_test.go
+++ b/server/internal/service/accessibility/accessibility_test.go
@@ -1,0 +1,70 @@
+package accessibility
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestBuildWrite_ExtendedTimePresets(t *testing.T) {
+	w := BuildWrite([]string{TypeExtendedTime15}, nil)
+	if w.TimeMultiplier != 1.5 {
+		t.Fatalf("1.5x preset: want 1.5 got %v", w.TimeMultiplier)
+	}
+	w = BuildWrite([]string{TypeExtendedTime2}, nil)
+	if w.TimeMultiplier != 2.0 {
+		t.Fatalf("2x preset: want 2.0 got %v", w.TimeMultiplier)
+	}
+}
+
+func TestBuildWrite_CustomMultiplierWins(t *testing.T) {
+	w := BuildWrite([]string{TypeExtendedTime15}, json.RawMessage(`{"timeMultiplier":1.75}`))
+	if w.TimeMultiplier != 1.75 {
+		t.Fatalf("custom multiplier: want 1.75 got %v", w.TimeMultiplier)
+	}
+}
+
+func TestBuildWrite_FlagsAndFormat(t *testing.T) {
+	w := BuildWrite(
+		[]string{TypeSeparateTesting, TypeScreenReader, TypeSpeechToText, TypeReducedDistract, TypeAlternateFormat},
+		json.RawMessage(`{"alternateFormat":"braille"}`),
+	)
+	if !w.SeparateSetting || !w.TTSEnabled || !w.SpeechToTextEnabled || !w.ReducedDistraction {
+		t.Fatalf("expected all flags set: %+v", w)
+	}
+	if w.AlternativeFormat == nil || *w.AlternativeFormat != "braille" {
+		t.Fatalf("alternate format: want braille got %v", w.AlternativeFormat)
+	}
+	if w.TimeMultiplier != 1.0 {
+		t.Fatalf("no extended time: want 1.0 got %v", w.TimeMultiplier)
+	}
+}
+
+func TestValidTypes(t *testing.T) {
+	if ValidTypes(nil) {
+		t.Fatal("empty should be invalid")
+	}
+	if !ValidTypes([]string{TypeExtendedTime15, TypeOther}) {
+		t.Fatal("valid list rejected")
+	}
+	if ValidTypes([]string{"bogus"}) {
+		t.Fatal("bogus type accepted")
+	}
+}
+
+func TestRenderLetter_NoDisabilityDisclosure(t *testing.T) {
+	letter := RenderLetter("Jordan Lee", "2026-06-14", []string{TypeExtendedTime15})
+	if !strings.Contains(letter, "Jordan Lee") {
+		t.Fatal("letter missing student name")
+	}
+	if !strings.Contains(letter, "1.5x Extended Time") {
+		t.Fatal("letter missing accommodation label")
+	}
+	for _, banned := range []string{"disability", "diagnosis", "diagnos", "medical"} {
+		// The letter explicitly states it does not disclose the disability; ensure no
+		// diagnosis-style wording leaks beyond that single reassurance sentence.
+		if strings.Count(strings.ToLower(letter), banned) > 1 {
+			t.Fatalf("letter appears to reference %q more than the reassurance line", banned)
+		}
+	}
+}

--- a/server/internal/service/accessibility/apply.go
+++ b/server/internal/service/accessibility/apply.go
@@ -1,0 +1,52 @@
+package accessibility
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	repo "github.com/lextures/lextures/server/internal/repos/accessibilityprofiles"
+	stac "github.com/lextures/lextures/server/internal/repos/studentaccommodations"
+)
+
+// Apply propagates an active profile to the 2.11 override engine by creating a global
+// (course_id NULL) student_accommodations row for the student, which the quiz delivery
+// layer already resolves for every enrolled course (AC-1). It records the created row id
+// back on the profile so deactivation can remove exactly that override (AC-5).
+//
+// coordinatorID is stamped as created_by on the override row.
+func Apply(
+	ctx context.Context, pool *pgxpool.Pool,
+	profileID, studentID uuid.UUID,
+	types []string, params json.RawMessage,
+	effectiveFrom, effectiveUntil *time.Time,
+	coordinatorID uuid.UUID,
+) (*stac.Row, error) {
+	w := BuildWrite(types, params)
+	w.EffectiveFrom = effectiveFrom
+	w.EffectiveUntil = effectiveUntil
+
+	row, err := stac.InsertRow(ctx, pool, studentID, nil, w, coordinatorID)
+	if err != nil {
+		return nil, err
+	}
+	if err := repo.SetApplied(ctx, pool, profileID, &row.ID); err != nil {
+		return nil, err
+	}
+	for _, t := range types {
+		RecordApplied(t)
+	}
+	return row, nil
+}
+
+// Deactivate removes the propagated override for a profile (soft-deletes the
+// student_accommodations row), so standard limits resume on the next attempt (AC-5).
+func Deactivate(ctx context.Context, pool *pgxpool.Pool, studentID uuid.UUID, appliedID *uuid.UUID) error {
+	if appliedID == nil {
+		return nil
+	}
+	_, err := stac.DeleteRow(ctx, pool, *appliedID, studentID)
+	return err
+}

--- a/server/internal/service/accessibility/letter.go
+++ b/server/internal/service/accessibility/letter.go
@@ -1,0 +1,71 @@
+package accessibility
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// typeLabels are the externalised, instructor-facing accommodation names. They never
+// reference the underlying disability or diagnosis (FR-4, ADA/Section 504 need-to-know).
+var typeLabels = map[string]string{
+	TypeExtendedTime15:  "1.5x Extended Time",
+	TypeExtendedTime2:   "2.0x Extended Time",
+	TypeSeparateTesting: "Separate Testing Environment",
+	TypeAlternateFormat: "Alternate Format Materials",
+	TypeScreenReader:    "Screen Reader Support",
+	TypeSpeechToText:    "Speech-to-Text",
+	TypeReducedDistract: "Reduced-Distraction Setting",
+	TypeOther:           "Additional Accommodation",
+}
+
+// Label returns the instructor-facing label for an accommodation type.
+func Label(t string) string {
+	if l, ok := typeLabels[t]; ok {
+		return l
+	}
+	return t
+}
+
+// Labels returns instructor-facing labels for a list of types, de-duplicated and sorted.
+func Labels(types []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(types))
+	for _, t := range types {
+		l := Label(t)
+		if _, dup := seen[l]; dup {
+			continue
+		}
+		seen[l] = struct{}{}
+		out = append(out, l)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// LetterSubject is the instructor notification subject line.
+func LetterSubject(studentName string) string {
+	return fmt.Sprintf("Accommodation notice for %s", studentName)
+}
+
+// RenderLetter produces the FR-7 instructor notification letter body. It discloses only
+// the accommodation labels and effective date — never the disability (AC-2). effectiveDate
+// is a display string (e.g. "2026-06-14"); pass "" to omit.
+func RenderLetter(studentName, effectiveDate string, types []string) string {
+	labels := Labels(types)
+	var b strings.Builder
+	fmt.Fprintf(&b, "Dear Instructor,\n\n")
+	fmt.Fprintf(&b, "The accessibility services office has approved the following accommodation(s) "+
+		"for %s, a student enrolled in your course:\n\n", studentName)
+	for _, l := range labels {
+		fmt.Fprintf(&b, "  • %s\n", l)
+	}
+	if effectiveDate != "" {
+		fmt.Fprintf(&b, "\nEffective date: %s\n", effectiveDate)
+	}
+	fmt.Fprintf(&b, "\nThese accommodations are applied automatically by the learning platform; no "+
+		"action is required on your part. This notice intentionally does not disclose the nature of "+
+		"the student's disability, in accordance with ADA, Section 504, and FERPA.\n\n")
+	fmt.Fprintf(&b, "Please contact the accessibility services office with any questions.\n")
+	return b.String()
+}

--- a/server/internal/service/accessibility/metrics.go
+++ b/server/internal/service/accessibility/metrics.go
@@ -1,0 +1,31 @@
+package accessibility
+
+import (
+	"expvar"
+	"sync"
+)
+
+// accommodations_applied_total{type} (NFR Observability).
+var (
+	appliedMu    sync.Mutex
+	appliedCount = map[string]uint64{}
+)
+
+func init() {
+	expvar.Publish("accommodations_applied_total", expvar.Func(func() any {
+		appliedMu.Lock()
+		defer appliedMu.Unlock()
+		out := make(map[string]uint64, len(appliedCount))
+		for k, v := range appliedCount {
+			out[k] = v
+		}
+		return out
+	}))
+}
+
+// RecordApplied increments accommodations_applied_total for an accommodation type.
+func RecordApplied(accommodationType string) {
+	appliedMu.Lock()
+	appliedCount[accommodationType]++
+	appliedMu.Unlock()
+}

--- a/server/internal/service/accessibility/types.go
+++ b/server/internal/service/accessibility/types.go
@@ -1,0 +1,106 @@
+// Package accessibility is application logic for the accessibility services intake
+// workflow (plan 14.16): it maps coordinator-managed accommodation profiles onto the
+// 2.11 student_accommodations override engine and renders instructor notification letters.
+package accessibility
+
+import (
+	"encoding/json"
+
+	stac "github.com/lextures/lextures/server/internal/repos/studentaccommodations"
+)
+
+// Accommodation type values (mirror the accessibility.accommodation_type enum).
+const (
+	TypeExtendedTime15  = "extended_time_1_5x"
+	TypeExtendedTime2   = "extended_time_2x"
+	TypeSeparateTesting = "separate_testing"
+	TypeAlternateFormat = "alternate_format"
+	TypeScreenReader    = "screen_reader"
+	TypeSpeechToText    = "speech_to_text"
+	TypeReducedDistract = "reduced_distraction"
+	TypeOther           = "other"
+)
+
+var validTypes = map[string]struct{}{
+	TypeExtendedTime15:  {},
+	TypeExtendedTime2:   {},
+	TypeSeparateTesting: {},
+	TypeAlternateFormat: {},
+	TypeScreenReader:    {},
+	TypeSpeechToText:    {},
+	TypeReducedDistract: {},
+	TypeOther:           {},
+}
+
+// ValidType reports whether t is a recognized accommodation type.
+func ValidType(t string) bool {
+	_, ok := validTypes[t]
+	return ok
+}
+
+// ValidTypes reports whether every entry is recognized and the slice is non-empty.
+func ValidTypes(types []string) bool {
+	if len(types) == 0 {
+		return false
+	}
+	for _, t := range types {
+		if !ValidType(t) {
+			return false
+		}
+	}
+	return true
+}
+
+// customParams is the parsed shape of accommodation_profiles.custom_params.
+type customParams struct {
+	TimeMultiplier  float64 `json:"timeMultiplier"`
+	AlternateFormat string  `json:"alternateFormat"`
+}
+
+// BuildWrite translates an accommodation type list plus custom params into a 2.11
+// student_accommodations override payload (FR-3). The resulting row is the operational
+// projection of the profile; no disability information is carried across.
+func BuildWrite(types []string, rawParams json.RawMessage) stac.AccommodationWrite {
+	var p customParams
+	if len(rawParams) > 0 {
+		_ = json.Unmarshal(rawParams, &p)
+	}
+	w := stac.AccommodationWrite{TimeMultiplier: 1.0}
+	for _, t := range types {
+		switch t {
+		case TypeExtendedTime15:
+			w.TimeMultiplier = maxF(w.TimeMultiplier, 1.5)
+		case TypeExtendedTime2:
+			w.TimeMultiplier = maxF(w.TimeMultiplier, 2.0)
+		case TypeSeparateTesting:
+			w.SeparateSetting = true
+		case TypeAlternateFormat:
+			fmtStr := p.AlternateFormat
+			if fmtStr == "" {
+				fmtStr = "alternate"
+			}
+			w.AlternativeFormat = &fmtStr
+		case TypeScreenReader:
+			w.TTSEnabled = true
+		case TypeSpeechToText:
+			w.SpeechToTextEnabled = true
+		case TypeReducedDistract:
+			w.ReducedDistraction = true
+		case TypeOther:
+			// No operational projection; recorded on the profile for coordinator reference.
+		}
+	}
+	// An explicit coordinator-set multiplier overrides the preset (Risk: wrong multiplier
+	// is mitigated by an explicit confirmation in the UI, but the value still wins here).
+	if p.TimeMultiplier >= 1.0 {
+		w.TimeMultiplier = p.TimeMultiplier
+	}
+	return w
+}
+
+func maxF(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/server/migrations/271_accessibility_services.sql
+++ b/server/migrations/271_accessibility_services.sql
@@ -1,0 +1,54 @@
+-- Accessibility services intake (plan 14.16): accessibility-office accommodation profiles
+-- that propagate to the 2.11 student_accommodations override engine. Disability documentation
+-- itself is NOT stored here (it lives in the SIS/disability-office system); only operational
+-- accommodation settings (ADA Title II / Section 504 / FERPA need-to-know).
+
+CREATE SCHEMA IF NOT EXISTS accessibility;
+
+CREATE TYPE accessibility.accommodation_type AS ENUM (
+    'extended_time_1_5x',
+    'extended_time_2x',
+    'separate_testing',
+    'alternate_format',
+    'screen_reader',
+    'speech_to_text',
+    'reduced_distraction',
+    'other'
+);
+
+CREATE TABLE accessibility.accommodation_profiles (
+    id                       UUID PRIMARY KEY DEFAULT gen_random_uuid (),
+    student_id               UUID NOT NULL REFERENCES "user".users (id) ON DELETE CASCADE,
+    org_id                   UUID NOT NULL REFERENCES tenant.organizations (id) ON DELETE CASCADE,
+    accommodations           accessibility.accommodation_type[] NOT NULL,
+    custom_params            JSONB NOT NULL DEFAULT '{}'::jsonb, -- {"timeMultiplier": 1.5, "alternateFormat": "braille"}
+    effective_from           DATE NOT NULL DEFAULT CURRENT_DATE,
+    effective_until          DATE,
+    -- Link to the propagated course.student_accommodations override row (2.11). NULL until applied.
+    applied_accommodation_id UUID REFERENCES course.student_accommodations (id) ON DELETE SET NULL,
+    notified_at              TIMESTAMPTZ,
+    created_by               UUID NOT NULL REFERENCES "user".users (id) ON DELETE RESTRICT,
+    is_active                BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- FR-5/AC-3: fast lookup of a student's active profiles.
+CREATE INDEX idx_accommodation_profiles_student ON accessibility.accommodation_profiles (student_id)
+WHERE
+    is_active = TRUE;
+
+CREATE INDEX idx_accommodation_profiles_org ON accessibility.accommodation_profiles (org_id, is_active);
+
+COMMENT ON TABLE accessibility.accommodation_profiles IS
+    'Accessibility-office accommodation profiles (plan 14.16). Disability documentation lives in the SIS, not here; only operational settings are stored (ADA/Section 504/FERPA need-to-know).';
+
+-- Platform feature flag (default off; managed in Settings -> Global platform).
+ALTER TABLE settings.platform_app_settings
+ADD COLUMN IF NOT EXISTS ff_accessibility_intake BOOLEAN;
+
+COMMENT ON COLUMN settings.platform_app_settings.ff_accessibility_intake IS
+    'Enables accessibility services intake: coordinator accommodation profiles propagated to assessments (plan 14.16).';
+
+-- Coordinator capability reuses the existing 2.11 permission (global:user:accommodations:manage),
+-- already granted to the "Accessibility Coordinator" and "Global Admin" roles in migration 077.


### PR DESCRIPTION
## What & why

Implements plan [14.16 — Accessibility Services Intake](docs/plan/14-higher-ed-specific/14.16-accessibility-services-intake.md): a coordinator-managed accommodation intake that propagates into the **existing 2.11 accommodation override engine**, so a student's quizzes auto-apply extended time across all their courses without instructor intervention. Disability documentation is never stored (ADA / Section 504 / FERPA need-to-know).

Also splits the Playwright e2e CI job into **5 shards** (was 4) for faster runs.

## Backend

- **Migration 271** — `accessibility` schema + `accommodation_profiles` table and `accommodation_type` enum; `ff_accessibility_intake` platform flag. Reuses the existing 2.11 `global:user:accommodations:manage` permission (already granted to the *Accessibility Coordinator* and *Global Admin* roles in migration 077) rather than adding a new role.
- **repos/accessibilityprofiles** — profile CRUD plus affected-course and instructor-lookup queries against `course.course_enrollments`.
- **service/accessibility** — accommodation-type → `student_accommodations` override mapping, propagation to a global override row, deactivation cleanup, the FR-7 instructor notification letter (no disability disclosure), and the `accommodations_applied_total{type}` metric.
- **httpserver/accessibility_http** — coordinator CRUD, student `/me/accommodation-profiles`, and `notify-instructors`; gated by the feature flag and permission. Instructors/students hit the profile endpoints → **403** (AC-4).
- Feature flag wired through `config`, `platformconfig` (struct/select/scan/insert/upsert), settings, and the `platform_features` endpoint.

## Frontend

- `accessibility-api` client, admin **Accessibility Services** page (student search, WCAG-labelled accommodation checkboxes with `aria-describedby`, time-multiplier confirmation copy), student **My accommodations** page, nav links, routes, and the platform feature toggle.

## Tests

- Go unit (type mapping, letter redaction), http nodb auth/feature-gate, web API unit test, and Playwright e2e covering AC-1 through AC-5.
- Verified locally: `go build ./...`, `go vet ./...`, new Go tests, `tsc --noEmit`, web build, `npm run lint`, `i18n:check`, e2e `tsc`.

## Reviewer notes

- The e2e flow assumes the `E2E_ADMIN_EMAIL` account carries the Global Admin role (and thus the accommodations permission) — same assumption the 14.15 suite makes. If that account is provisioned without it in CI, the coordinator-path tests would 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)