### PR TITLE
docs: mark 14.16 accessibility services intake as completed

### DIFF
--- a/docs/completed/14-higher-ed-specific/14.16-accessibility-services-intake.md
+++ b/docs/completed/14-higher-ed-specific/14.16-accessibility-services-intake.md
@@ -1,6 +1,6 @@
 # 14.16 — Accessibility Services Intake Workflow
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §14.
+> Implementation plan (done 2026). Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §14.
 
 ## Metadata
 
@@ -10,11 +10,21 @@
 | **Section** | Higher-Education-Specific |
 | **Severity** | MAJOR |
 | **Markets** | HE |
-| **Status (today)** | MISSING |
+| **Status (today)** | IMPLEMENTED |
 | **Estimated effort** | M (2–4w) |
 | **Owner (proposed)** | Full-stack team |
 | **Depends on** | 2.11 accommodations, 5.9 roles |
 | **Unblocks** | None |
+
+## Implementation (2026)
+
+- **Feature flag** — `ff_accessibility_intake` on platform settings (default off). Gated in `server/internal/httpserver/accessibility_http.go` and the web `usePlatformFeatures()` context.
+- **Migration** — `server/migrations/271_accessibility_services.sql`: `accessibility.accommodation_profiles` table and `accommodation_type` enum; links to propagated `course.student_accommodations` override rows (2.11).
+- **Backend** — `server/internal/repos/accessibilityprofiles/`: profile CRUD, affected-course lookup, instructor resolution. `server/internal/service/accessibility/`: type → override mapping, global propagation via `Apply`/`Deactivate`, instructor notification letter (no disability disclosure), `accommodations_applied_total{type}` metric.
+- **Routes** — Coordinator CRUD at `/api/v1/accessibility/profiles` (+ `GET/PATCH` by id, `POST .../notify-instructors`); student self-service at `/api/v1/me/accommodation-profiles`. Authorization reuses the existing 2.11 `global:user:accommodations:manage` permission (Accessibility Coordinator + Global Admin roles). Instructors get 403 on profile endpoints (AC-4); roster uses per-enrollment `GET /api/v1/enrollments/{id}/accommodation-summary` (boolean flag only).
+- **Frontend** — `clients/web/src/pages/admin/accessibility-services.tsx` (coordinator intake: student search, WCAG-labelled checkboxes with `aria-describedby`, multiplier confirmation); `clients/web/src/pages/lms/my-accommodations.tsx` (student view of active profiles + affected courses); shield indicator on `clients/web/src/pages/lms/course-enrollments.tsx`; API client in `clients/web/src/lib/accessibility-api.ts`.
+- **Tests** — Go unit (`server/internal/service/accessibility/accessibility_test.go`), HTTP auth/feature-gate (`accessibility_nodb_test.go`), web API unit tests, Playwright e2e (`e2e/tests/accessibility-intake.spec.ts` covering AC-1..AC-5).
+- **Deferred from original plan** — Bulk roster accommodations endpoint (`GET /courses/:id/roster/accommodations`); per-enrollment summary used instead. SIS disability-module sync, mid-term expiry instructor alerts, and course-scoped profiles (open questions §18).
 
 ---
 
@@ -77,7 +87,7 @@ University accessibility services offices (also called disability resource cente
 
 ## 8. Data Model
 
-Migration `089_accessibility_services.sql`:
+Migration `271_accessibility_services.sql`:
 ```sql
 CREATE TYPE accommodation_type AS ENUM (
   'extended_time_1_5x', 'extended_time_2x', 'separate_testing',
@@ -104,20 +114,20 @@ CREATE INDEX idx_accommodation_profiles_student ON accommodation_profiles(studen
 
 ```
 POST/GET/PATCH /api/v1/accessibility/profiles         -- coordinator CRUD
-GET            /api/v1/me/accommodations               -- student reads own profile
-GET            /api/v1/courses/:id/roster/accommodations -- instructor: Boolean flags only
+GET            /api/v1/me/accommodation-profiles       -- student reads own profile
+GET            /api/v1/enrollments/{id}/accommodation-summary -- instructor: Boolean flags only
 POST           /api/v1/accessibility/profiles/:id/notify-instructors -- send notification email
 ```
 
 ## 10. UI / UX
 
 New pages in admin area:
-- `clients/web/src/pages/admin/AccessibilityServices.tsx` — student lookup + profile management.
+- `clients/web/src/pages/admin/accessibility-services.tsx` — student lookup + profile management.
 - Profile form: student search, accommodation type checkboxes, date range, custom time multiplier.
 
-Student-facing: section in `clients/web/src/pages/lms/Settings.tsx` — "My Accommodations" list.
+Student-facing: `clients/web/src/pages/lms/my-accommodations.tsx` — "My Accommodations" list.
 
-Instructor-facing: `clients/web/src/pages/lms/CourseEnrollments.tsx` — accommodation indicator (shield icon, no detail).
+Instructor-facing: `clients/web/src/pages/lms/course-enrollments.tsx` — accommodation indicator (shield icon, no detail).
 
 States: profile form loading; success toast on create; no-accommodation empty state.
 Accessibility: accommodation type checkboxes have descriptive labels; form errors use `aria-describedby`.
@@ -176,7 +186,7 @@ Not applicable.
 
 ## 19. References
 
-- Existing files: `server/internal/authz/authz.go`, `server/internal/httpserver/course_*.go`, `server/migrations/063_module_assignment_delivery_settings.sql`, `clients/web/src/pages/lms/CourseEnrollments.tsx`, `clients/web/src/pages/lms/Settings.tsx`.
+- Existing files: `server/internal/authz/authz.go`, `server/internal/httpserver/course_*.go`, `server/migrations/063_module_assignment_delivery_settings.sql`, `clients/web/src/pages/lms/course-enrollments.tsx`, `clients/web/src/pages/lms/my-accommodations.tsx`.
 - ADA Title II requirements for higher education.
 - Section 504 Rehabilitation Act accommodation obligations.
 - FERPA guidance on disability records access.


### PR DESCRIPTION
## Summary
- Moves plan 14.16 from `docs/plan/` to `docs/completed/` now that the feature shipped in #280.
- Updates status to IMPLEMENTED and adds an implementation summary documenting migration, API routes, UI pages, tests, and deferred items.

## Test plan
- [x] Go unit tests: `go test ./internal/service/accessibility/... ./internal/httpserver/... -run Accessibility`
- [x] Web unit tests: `npm run test -- src/lib/__tests__/accessibility-api.test.ts`
- [x] Feature already covered by `e2e/tests/accessibility-intake.spec.ts` (merged in #280)


Made with [Cursor](https://cursor.com)