### PR TITLE
Fix deploy failure: repair migration 279 checksum mismatch

### DIFF
--- a/server/internal/migrate/repair.go
+++ b/server/internal/migrate/repair.go
@@ -43,6 +43,8 @@ var demoChecksumRepairMigrations = []struct {
 	{268, "268_ff_ui_mode_column.sql"},
 	// Idempotent CREATE TABLE/INDEX IF NOT EXISTS; table may exist on DBs that applied billing SQL manually.
 	{278, "278_billing_stripe.sql"},
+	// Edited after apply in PR #288: extend billing.user_entitlements from 278 instead of recreating it.
+	{279, "279_learning_paths.sql"},
 }
 
 // repairDemoMigrationChecksums updates _sqlx_migrations when a listed version's stored


### PR DESCRIPTION
## Summary
- Adds migration 279 to the `MIGRATE_REPAIR_CHECKSUMS` allowlist so deploy can start when the demo DB has a stale checksum.
- Migration 279 was edited after apply in PR #288 (reworked to `ALTER billing.user_entitlements` from 278 instead of recreating the table); persistent deploy databases retained the old checksum and blocked startup.
## Test plan
- [ ] Deploy demo stack with `MIGRATE_REPAIR_CHECKSUMS=1` against a DB that already applied the pre-#288 version of migration 279
- [ ] Confirm server starts without `version 279 checksum mismatch` errors
- [ ] Confirm fresh databases still apply migrations 278 and 279 normally