### PR TITLE
feat: AI usage logging, reports dashboard, and runtime notebook AI flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,5 @@
 # Set before the first human user registers. If unset, use bootstrap-admin after signup (see docs/getting-started.md).
 BOOTSTRAP_ADMIN_EMAIL=you@yourdomain.com
 
-# Optional: AI features (OpenRouter)
-# OPEN_ROUTER_API_KEY=
-
 # Optional: override API URL baked into the web image (default http://localhost:8080)
 # VITE_API_URL=http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Open-source learning platform for running courses end to end: structured modules
 | **Web app**       | React 19, Vite, TypeScript, Tailwind CSS v4, React Router, TipTap, Vitest |
 | **API**           | Go 1.25, Chi, pgx, Argon2id passwords, JWT access tokens                  |
 | **Data**          | PostgreSQL 16                                                             |
-| **AI (optional)** | OpenRouter API (`OPEN_ROUTER_API_KEY` / `OPENROUTER_API_KEY`)             |
+| **AI (optional)** | OpenRouter API key in **Settings → Intelligence → Models** (platform DB)   |
 
 
 For architecture notes (Compose port layout, dev vs prod web, testing conventions), see [docs/ARCH.md](docs/ARCH.md).

--- a/clients/web/src/components/command-palette/command-palette-dialog.tsx
+++ b/clients/web/src/components/command-palette/command-palette-dialog.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react'
 import { useCourseNavFeatures } from '../../context/course-nav-features-context'
 import { usePermissions } from '../../context/use-permissions'
+import { usePlatformFeatures } from '../../context/platform-features-context'
 import { usePlatformScimEnabled } from '../../hooks/use-platform-scim-enabled'
 import { PERM_RBAC_MANAGE } from '../../lib/rbac-api'
 import {
@@ -75,10 +76,14 @@ export function CommandPaletteDialog() {
   const location = useLocation()
   const { allows } = usePermissions()
   const canManageRbac = allows(PERM_RBAC_MANAGE)
+  const { ragNotebookEnabled } = usePlatformFeatures()
   const { scimEnabled } = usePlatformScimEnabled(canManageRbac)
   const globalSearchOptions = useMemo(
-    () => ({ scimEnabled: canManageRbac && scimEnabled }),
-    [canManageRbac, scimEnabled],
+    () => ({
+      scimEnabled: canManageRbac && scimEnabled,
+      ragNotebookEnabled,
+    }),
+    [canManageRbac, scimEnabled, ragNotebookEnabled],
   )
   const navFeatures = useCourseNavFeatures()
   const inputRef = useRef<HTMLInputElement>(null)

--- a/clients/web/src/components/layout/__tests__/side-nav-main-links.test.tsx
+++ b/clients/web/src/components/layout/__tests__/side-nav-main-links.test.tsx
@@ -8,6 +8,7 @@ import { SideNavMainLinks } from '../side-nav-main-links'
 const platformFeaturesMock = vi.fn(() => ({
   accommodationsEngineEnabled: false,
   ffEportfolio: false,
+  ragNotebookEnabled: true,
 }))
 
 vi.mock('../../../context/use-inbox-unread', () => ({
@@ -30,6 +31,7 @@ describe('SideNavMainLinks', () => {
     platformFeaturesMock.mockReturnValue({
       accommodationsEngineEnabled: false,
       ffEportfolio: false,
+      ragNotebookEnabled: true,
     })
   })
 
@@ -49,10 +51,29 @@ describe('SideNavMainLinks', () => {
     expect(screen.queryByRole('link', { name: /^my portfolio$/i })).not.toBeInTheDocument()
   })
 
+  it('hides Ask AI when notebook AI is disabled', () => {
+    platformFeaturesMock.mockReturnValue({
+      accommodationsEngineEnabled: false,
+      ffEportfolio: false,
+      ragNotebookEnabled: false,
+    })
+
+    render(
+      <MemoryRouter>
+        <ShellNavProvider>
+          <SideNavMainLinks />
+        </ShellNavProvider>
+      </MemoryRouter>,
+    )
+
+    expect(screen.queryByRole('link', { name: /^ask ai$/i })).not.toBeInTheDocument()
+  })
+
   it('shows My Portfolio when ePortfolio is enabled', () => {
     platformFeaturesMock.mockReturnValue({
       accommodationsEngineEnabled: false,
       ffEportfolio: true,
+      ragNotebookEnabled: true,
     })
 
     render(

--- a/clients/web/src/components/layout/__tests__/side-nav-path-utils.test.ts
+++ b/clients/web/src/components/layout/__tests__/side-nav-path-utils.test.ts
@@ -9,6 +9,7 @@ describe('settingsViewFromPathname', () => {
   it('detects AI routes before generic tab match', () => {
     expect(settingsViewFromPathname('/settings/ai/models')).toBe('ai-models')
     expect(settingsViewFromPathname('/settings/ai/system-prompts')).toBe('ai-prompts')
+    expect(settingsViewFromPathname('/settings/ai/reports')).toBe('ai-reports')
   })
 
   it('maps top-level settings tabs', () => {

--- a/clients/web/src/components/layout/side-nav-link.tsx
+++ b/clients/web/src/components/layout/side-nav-link.tsx
@@ -1,16 +1,29 @@
 import { type ReactNode } from 'react'
 import { NavLink, type NavLinkProps } from 'react-router-dom'
-import { sideNavActiveClass, sideNavLinkClass } from './side-nav-styles'
+import {
+  sideNavActiveClass,
+  sideNavLinkClass,
+  sideNavSubActiveClass,
+  sideNavSubLinkClass,
+} from './side-nav-styles'
 import { useShellNav } from './use-shell-nav'
 import { SideNavTooltip } from './side-nav-tooltip'
 
 interface SideNavLinkProps extends NavLinkProps {
-  icon: ReactNode
+  icon?: ReactNode
   children: ReactNode
   badge?: ReactNode
+  nested?: boolean
 }
 
-export function SideNavLink({ icon, children, badge, className, ...props }: SideNavLinkProps) {
+export function SideNavLink({
+  icon,
+  children,
+  badge,
+  nested = false,
+  className,
+  ...props
+}: SideNavLinkProps) {
   const { sideNavCollapsed } = useShellNav()
 
   const label = typeof children === 'string' ? children : ''
@@ -21,14 +34,21 @@ export function SideNavLink({ icon, children, badge, className, ...props }: Side
         {...props}
         className={(navProps) => {
           const baseClass = typeof className === 'function' ? className(navProps) : className
-          const activeClass = navProps.isActive ? sideNavActiveClass : ''
+          const activeClass = navProps.isActive
+            ? nested
+              ? sideNavSubActiveClass
+              : sideNavActiveClass
+            : ''
           const collapseClass = sideNavCollapsed ? 'justify-center' : ''
-          return `${sideNavLinkClass} ${activeClass} ${collapseClass} ${baseClass || ''}`
+          const linkClass = nested ? sideNavSubLinkClass : sideNavLinkClass
+          return `${linkClass} ${activeClass} ${collapseClass} ${baseClass || ''}`
         }}
       >
-        <span className="flex h-5 w-5 shrink-0 items-center justify-center text-current opacity-90">
-          {icon}
-        </span>
+        {!nested && (
+          <span className="flex h-5 w-5 shrink-0 items-center justify-center text-current opacity-90">
+            {icon}
+          </span>
+        )}
         {!sideNavCollapsed && (
           <span className="flex min-w-0 flex-1 items-center justify-between gap-2">
             <span className="truncate">{children}</span>

--- a/clients/web/src/components/layout/side-nav-main-links.tsx
+++ b/clients/web/src/components/layout/side-nav-main-links.tsx
@@ -49,6 +49,7 @@ export function SideNavMainLinks() {
     ffCatalogIntegration,
     ffLibrary,
     ffConferenceScheduling,
+    ragNotebookEnabled,
   } = usePlatformFeatures()
 
   const canViewReports = !permLoading && allows(PERM_REPORTS_VIEW)
@@ -86,9 +87,11 @@ export function SideNavMainLinks() {
       </SideNavLink>
 
       <SideNavSectionLabel first>Learning</SideNavSectionLabel>
-      <SideNavLink to="/ai" icon={<Bot className="h-5 w-5" />}>
-        Ask AI
-      </SideNavLink>
+      {ragNotebookEnabled ? (
+        <SideNavLink to="/ai" icon={<Bot className="h-5 w-5" />}>
+          Ask AI
+        </SideNavLink>
+      ) : null}
       <SideNavLink to="/review" icon={<RotateCcw className="h-5 w-5" />}>
         Review practice
       </SideNavLink>

--- a/clients/web/src/components/layout/side-nav-path-utils.ts
+++ b/clients/web/src/components/layout/side-nav-path-utils.ts
@@ -3,6 +3,7 @@ import { matchPath } from 'react-router-dom'
 export type SettingsNavView =
   | 'ai-models'
   | 'ai-prompts'
+  | 'ai-reports'
   | 'account'
   | 'notifications'
   | 'integrations'
@@ -22,6 +23,7 @@ export type SettingsNavView =
 
 export function settingsViewFromPathname(pathname: string): SettingsNavView {
   if (pathname.startsWith('/settings/ai/system-prompts')) return 'ai-prompts'
+  if (pathname.startsWith('/settings/ai/reports')) return 'ai-reports'
   if (pathname.startsWith('/settings/ai/models')) return 'ai-models'
   const m = matchPath({ path: '/settings/:tab', end: true }, pathname)
   const raw = m?.params.tab

--- a/clients/web/src/components/layout/side-nav-settings-links.tsx
+++ b/clients/web/src/components/layout/side-nav-settings-links.tsx
@@ -60,7 +60,7 @@ export function SideNavSettingsLinks() {
   } = usePlatformFeatures()
   const location = useLocation()
   const view = settingsViewFromPathname(location.pathname)
-  const aiSectionActive = view === 'ai-models' || view === 'ai-prompts'
+  const aiSectionActive = view === 'ai-models' || view === 'ai-prompts' || view === 'ai-reports'
   const [aiOpen, setAiOpen] = useState(() => location.pathname.startsWith('/settings/ai'))
 
   useEffect(() => {
@@ -277,7 +277,11 @@ export function SideNavSettingsLinks() {
                   onClick={() => setAiOpen((o) => !o)}
                   className={`${sideNavLinkClass} ${
                     sideNavCollapsed ? 'justify-center' : ''
-                  } ${aiSectionActive ? sideNavActiveClass : 'text-slate-500'}`}
+                  } ${
+                    aiOpen || aiSectionActive
+                      ? 'text-slate-900 dark:text-neutral-50'
+                      : 'text-slate-500 dark:text-neutral-400'
+                  }`}
                   aria-expanded={aiOpen}
                   title={sideNavCollapsed ? 'Intelligence' : undefined}
                 >
@@ -303,20 +307,15 @@ export function SideNavSettingsLinks() {
                     }`}
                   >
                     <div className="min-h-0 overflow-hidden">
-                      <div className="flex flex-col gap-0.5 border-s border-slate-200/80 ps-2 dark:border-neutral-600/80">
-                        <SideNavLink
-                          to="/settings/ai/models"
-                          className={() => (view === 'ai-models' ? sideNavActiveClass : '')}
-                          icon={null}
-                        >
+                      <div className="flex flex-col gap-0.5 pb-0.5">
+                        <SideNavLink to="/settings/ai/models" nested>
                           Models
                         </SideNavLink>
-                        <SideNavLink
-                          to="/settings/ai/system-prompts"
-                          className={() => (view === 'ai-prompts' ? sideNavActiveClass : '')}
-                          icon={null}
-                        >
+                        <SideNavLink to="/settings/ai/system-prompts" nested>
                           System Prompts
+                        </SideNavLink>
+                        <SideNavLink to="/settings/ai/reports" nested>
+                          Reports
                         </SideNavLink>
                       </div>
                     </div>

--- a/clients/web/src/components/layout/side-nav-styles.ts
+++ b/clients/web/src/components/layout/side-nav-styles.ts
@@ -3,3 +3,9 @@ export const sideNavLinkClass =
 
 export const sideNavActiveClass =
   'bg-white !text-slate-900 shadow-sm ring-1 ring-black/[0.05] dark:bg-neutral-800 dark:!text-neutral-50 dark:shadow-none dark:ring-1 dark:ring-inset dark:ring-white/10'
+
+export const sideNavSubLinkClass =
+  'relative flex w-full items-center rounded-lg py-2 ps-11 pe-3 text-sm font-medium text-slate-600 transition-colors hover:bg-white/60 hover:text-slate-900 dark:text-neutral-400 dark:hover:bg-neutral-800/60 dark:hover:text-neutral-50'
+
+export const sideNavSubActiveClass =
+  'bg-white/90 !text-slate-900 dark:bg-neutral-800/90 dark:!text-neutral-50'

--- a/clients/web/src/components/layout/top-bar-breadcrumbs.tsx
+++ b/clients/web/src/components/layout/top-bar-breadcrumbs.tsx
@@ -65,6 +65,8 @@ function settingsSubLabel(view: ReturnType<typeof settingsViewFromPathname>): st
       return 'Models'
     case 'ai-prompts':
       return 'System Prompts'
+    case 'ai-reports':
+      return 'Reports'
     case 'lti-tools':
       return 'LTI tools'
     case 'platform':

--- a/clients/web/src/components/notebook/notebook-page-actions-menu.tsx
+++ b/clients/web/src/components/notebook/notebook-page-actions-menu.tsx
@@ -17,6 +17,7 @@ export type NotebookPageActionsMenuProps = {
   onMoveToGroup: (pageId: string, groupId: string) => void
   onMoveToRoot: (pageId: string) => void
   onFlashcards: () => void
+  flashcardsEnabled?: boolean
 }
 
 export function NotebookPageActionsMenu({
@@ -29,6 +30,7 @@ export function NotebookPageActionsMenu({
   onMoveToGroup,
   onMoveToRoot,
   onFlashcards,
+  flashcardsEnabled = true,
 }: NotebookPageActionsMenuProps) {
   const [moveOpen, setMoveOpen] = useState(false)
   const moveTargets = useMemo(
@@ -62,22 +64,26 @@ export function NotebookPageActionsMenu({
           role="menu"
           className="absolute right-0 top-full z-20 mt-1 w-56 rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-neutral-700 dark:bg-neutral-900"
         >
-          <button
-            type="button"
-            role="menuitem"
-            onClick={() => {
-              closeAll()
-              onFlashcards()
-            }}
-            className="flex w-full items-center gap-2 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
-          >
-            <Sparkles className="h-4 w-4 text-indigo-500" aria-hidden />
-            Create Flash Cards
-          </button>
+          {flashcardsEnabled ? (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                closeAll()
+                onFlashcards()
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
+            >
+              <Sparkles className="h-4 w-4 text-indigo-500" aria-hidden />
+              Create Flash Cards
+            </button>
+          ) : null}
 
           {moveTargets.length > 0 || canMoveToRoot ? (
             <>
-              <div className="my-1 border-t border-slate-100 dark:border-neutral-800" role="separator" />
+              {flashcardsEnabled ? (
+                <div className="my-1 border-t border-slate-100 dark:border-neutral-800" role="separator" />
+              ) : null}
               <div className="relative">
                 <button
                   type="button"

--- a/clients/web/src/components/settings/ai-reports-panel.tsx
+++ b/clients/web/src/components/settings/ai-reports-panel.tsx
@@ -1,0 +1,303 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { formatDateTime, formatNumber } from '../../lib/format'
+import {
+  aiFeatureLabel,
+  aiReportsUtcRange,
+  fetchAIReports,
+  type AIReportsPayload,
+  type AIReportsPreset,
+} from '../../lib/ai-reports-api'
+
+const PRESETS: { id: AIReportsPreset; label: string }[] = [
+  { id: '24h', label: '24 hours' },
+  { id: '7d', label: '7 days' },
+  { id: '30d', label: '30 days' },
+  { id: '90d', label: '90 days' },
+]
+
+function formatUsd(value: number): string {
+  if (!Number.isFinite(value) || value === 0) return '$0.00'
+  if (value < 0.01) return `$${value.toFixed(4)}`
+  return `$${value.toFixed(2)}`
+}
+
+function formatRange(from: string, to: string): string {
+  const opts: Intl.DateTimeFormatOptions = { dateStyle: 'medium', timeStyle: 'short' }
+  return `${formatDateTime(new Date(from), opts)} → ${formatDateTime(new Date(to), opts)}`
+}
+
+function SummaryCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white px-4 py-3 dark:border-neutral-700 dark:bg-neutral-900">
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">{label}</p>
+      <p className="mt-1 text-xl font-semibold tabular-nums text-slate-900 dark:text-neutral-100">{value}</p>
+    </div>
+  )
+}
+
+export function AiReportsPanel() {
+  const [preset, setPreset] = useState<AIReportsPreset>('24h')
+  const [feature, setFeature] = useState('')
+  const [userQuery, setUserQuery] = useState('')
+  const [courseCode, setCourseCode] = useState('')
+  const [report, setReport] = useState<AIReportsPayload | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    const range = aiReportsUtcRange(preset)
+    try {
+      const data = await fetchAIReports({
+        ...range,
+        feature: feature.trim() || undefined,
+        userQuery: userQuery.trim() || undefined,
+        courseCode: courseCode.trim() || undefined,
+      })
+      setReport(data)
+    } catch (e) {
+      setReport(null)
+      setError(e instanceof Error ? e.message : 'Could not load AI reports.')
+    } finally {
+      setLoading(false)
+    }
+  }, [preset, feature, userQuery, courseCode])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const featureOptions = useMemo(() => {
+    const keys = new Set<string>()
+    for (const row of report?.cost.byFeature ?? []) keys.add(row.feature)
+    return Array.from(keys).sort()
+  }, [report])
+
+  return (
+    <div>
+      <h2 className="text-base font-semibold text-slate-900 dark:text-neutral-100">Reports</h2>
+      <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+        Platform-wide OpenRouter spend and usage. Data is recorded from successful AI calls after this
+        feature ships.
+      </p>
+
+      <div className="mt-6 flex flex-wrap items-center gap-2">
+        {PRESETS.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => setPreset(p.id)}
+            className={`rounded-xl border px-3 py-2 text-sm font-semibold shadow-sm transition ${
+              preset === p.id
+                ? 'border-indigo-300 bg-indigo-50 text-indigo-900 dark:border-indigo-500/50 dark:bg-indigo-950/60 dark:text-indigo-100'
+                : 'border-slate-200 bg-white text-slate-700 hover:border-indigo-200 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200'
+            }`}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+
+      {report && (
+        <p className="mt-3 text-xs text-slate-500 dark:text-neutral-400">
+          Window: {formatRange(report.range.from, report.range.to)}
+        </p>
+      )}
+
+      {loading && <p className="mt-6 text-sm text-slate-500">Loading…</p>}
+      {error && (
+        <p className="mt-6 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-100">
+          {error}
+        </p>
+      )}
+
+      {!loading && report && (
+        <div className="mt-8 space-y-10">
+          <section aria-labelledby="ai-cost-heading">
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <h3 id="ai-cost-heading" className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+                AI cost
+              </h3>
+              <label className="text-sm text-slate-600 dark:text-neutral-300">
+                <span className="sr-only">Filter by feature</span>
+                <select
+                  value={feature}
+                  onChange={(e) => setFeature(e.target.value)}
+                  className="rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-sm dark:border-neutral-600 dark:bg-neutral-800"
+                >
+                  <option value="">All features</option>
+                  {featureOptions.map((f) => (
+                    <option key={f} value={f}>
+                      {aiFeatureLabel(f)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <div className="mt-4 grid gap-3 sm:grid-cols-3">
+              <SummaryCard label="Total cost" value={formatUsd(report.cost.summary.totalCostUsd)} />
+              <SummaryCard label="API calls" value={formatNumber(report.cost.summary.totalCalls)} />
+              <SummaryCard label="Tokens" value={formatNumber(report.cost.summary.totalTokens)} />
+            </div>
+
+            {report.cost.byDay.length > 0 && (
+              <div className="mt-5 overflow-x-auto rounded-xl border border-slate-200 dark:border-neutral-700">
+                <table className="min-w-full text-left text-sm">
+                  <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500 dark:bg-neutral-800/80 dark:text-neutral-400">
+                    <tr>
+                      <th className="px-4 py-2.5 font-semibold">Day (UTC)</th>
+                      <th className="px-4 py-2.5 font-semibold">Cost</th>
+                      <th className="px-4 py-2.5 font-semibold">Calls</th>
+                      <th className="px-4 py-2.5 font-semibold">Tokens</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100 dark:divide-neutral-800">
+                    {report.cost.byDay.map((row) => (
+                      <tr key={row.day}>
+                        <td className="px-4 py-2.5 text-slate-800 dark:text-neutral-200">{row.day}</td>
+                        <td className="px-4 py-2.5 tabular-nums">{formatUsd(row.costUsd)}</td>
+                        <td className="px-4 py-2.5 tabular-nums">{formatNumber(row.calls)}</td>
+                        <td className="px-4 py-2.5 tabular-nums">{formatNumber(row.tokens)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {report.cost.byFeature.length > 0 && (
+              <div className="mt-5 overflow-x-auto rounded-xl border border-slate-200 dark:border-neutral-700">
+                <table className="min-w-full text-left text-sm">
+                  <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500 dark:bg-neutral-800/80 dark:text-neutral-400">
+                    <tr>
+                      <th className="px-4 py-2.5 font-semibold">Feature</th>
+                      <th className="px-4 py-2.5 font-semibold">Cost</th>
+                      <th className="px-4 py-2.5 font-semibold">Calls</th>
+                      <th className="px-4 py-2.5 font-semibold">Tokens</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100 dark:divide-neutral-800">
+                    {report.cost.byFeature.map((row) => (
+                      <tr key={row.feature}>
+                        <td className="px-4 py-2.5 text-slate-800 dark:text-neutral-200">
+                          {aiFeatureLabel(row.feature)}
+                        </td>
+                        <td className="px-4 py-2.5 tabular-nums">{formatUsd(row.costUsd)}</td>
+                        <td className="px-4 py-2.5 tabular-nums">{formatNumber(row.calls)}</td>
+                        <td className="px-4 py-2.5 tabular-nums">{formatNumber(row.tokens)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {report.cost.summary.totalCalls === 0 && (
+              <p className="mt-4 text-sm text-slate-500 dark:text-neutral-400">
+                No AI usage recorded in this window.
+              </p>
+            )}
+          </section>
+
+          <section aria-labelledby="ai-by-user-heading">
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <h3 id="ai-by-user-heading" className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+                AI usage by user
+              </h3>
+              <label className="flex min-w-[12rem] flex-1 flex-col text-sm text-slate-600 dark:text-neutral-300 sm:max-w-xs">
+                <span className="mb-1 text-xs font-medium">Search user</span>
+                <input
+                  type="search"
+                  value={userQuery}
+                  onChange={(e) => setUserQuery(e.target.value)}
+                  placeholder="Email or name"
+                  className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-neutral-600 dark:bg-neutral-800"
+                />
+              </label>
+            </div>
+
+            {report.byUser.length > 0 ? (
+              <div className="mt-4 overflow-x-auto rounded-xl border border-slate-200 dark:border-neutral-700">
+                <table className="min-w-full text-left text-sm">
+                  <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500 dark:bg-neutral-800/80 dark:text-neutral-400">
+                    <tr>
+                      <th className="px-4 py-2.5 font-semibold">User</th>
+                      <th className="px-4 py-2.5 font-semibold">Calls</th>
+                      <th className="px-4 py-2.5 font-semibold">Tokens</th>
+                      <th className="px-4 py-2.5 font-semibold">Cost</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100 dark:divide-neutral-800">
+                    {report.byUser.map((row) => (
+                      <tr key={row.userId}>
+                        <td className="px-4 py-2.5">
+                          <div className="font-medium text-slate-900 dark:text-neutral-100">{row.displayName}</div>
+                          <div className="text-xs text-slate-500 dark:text-neutral-400">{row.email}</div>
+                        </td>
+                        <td className="px-4 py-2.5 tabular-nums">{formatNumber(row.calls)}</td>
+                        <td className="px-4 py-2.5 tabular-nums">{formatNumber(row.totalTokens)}</td>
+                        <td className="px-4 py-2.5 tabular-nums">{formatUsd(row.costUsd)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="mt-4 text-sm text-slate-500 dark:text-neutral-400">No user usage in this window.</p>
+            )}
+          </section>
+
+          <section aria-labelledby="ai-by-course-heading">
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <h3 id="ai-by-course-heading" className="text-sm font-semibold text-slate-900 dark:text-neutral-100">
+                AI usage by course
+              </h3>
+              <label className="flex min-w-[12rem] flex-1 flex-col text-sm text-slate-600 dark:text-neutral-300 sm:max-w-xs">
+                <span className="mb-1 text-xs font-medium">Search course</span>
+                <input
+                  type="search"
+                  value={courseCode}
+                  onChange={(e) => setCourseCode(e.target.value)}
+                  placeholder="Course code or title"
+                  className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-neutral-600 dark:bg-neutral-800"
+                />
+              </label>
+            </div>
+
+            {report.byCourse.length > 0 ? (
+              <div className="mt-4 overflow-x-auto rounded-xl border border-slate-200 dark:border-neutral-700">
+                <table className="min-w-full text-left text-sm">
+                  <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500 dark:bg-neutral-800/80 dark:text-neutral-400">
+                    <tr>
+                      <th className="px-4 py-2.5 font-semibold">Course</th>
+                      <th className="px-4 py-2.5 font-semibold">Calls</th>
+                      <th className="px-4 py-2.5 font-semibold">Tokens</th>
+                      <th className="px-4 py-2.5 font-semibold">Cost</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100 dark:divide-neutral-800">
+                    {report.byCourse.map((row) => (
+                      <tr key={row.courseId}>
+                        <td className="px-4 py-2.5">
+                          <div className="font-medium text-slate-900 dark:text-neutral-100">{row.title}</div>
+                          <div className="text-xs text-slate-500 dark:text-neutral-400">{row.courseCode}</div>
+                        </td>
+                        <td className="px-4 py-2.5 tabular-nums">{formatNumber(row.calls)}</td>
+                        <td className="px-4 py-2.5 tabular-nums">{formatNumber(row.totalTokens)}</td>
+                        <td className="px-4 py-2.5 tabular-nums">{formatUsd(row.costUsd)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="mt-4 text-sm text-slate-500 dark:text-neutral-400">No course usage in this window.</p>
+            )}
+          </section>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/clients/web/src/components/settings/platform-settings-panel.tsx
+++ b/clients/web/src/components/settings/platform-settings-panel.tsx
@@ -23,7 +23,6 @@ function normalizePlatformPayload(data: PlatformSettingsPayload) {
 
 function emptyForm(): PlatformSettingsPayload {
   return {
-    openRouterApiKey: '',
     samlSsoEnabled: false,
     samlPublicBaseUrl: '',
     samlSpEntityId: '',
@@ -79,7 +78,6 @@ function emptyForm(): PlatformSettingsPayload {
     smtpUser: '',
     smtpPassword: '',
     sources: {
-      openRouterApiKey: 'environment',
       samlSsoEnabled: 'environment',
       samlPublicBaseUrl: 'environment',
       samlSpEntityId: 'environment',
@@ -271,27 +269,6 @@ export function PlatformSettingsPanel() {
         }
       }
 
-      maybe(
-        'openRouterApiKey',
-        baseline.openRouterApiKey,
-        form.openRouterApiKey,
-        () => {
-          const v = form.openRouterApiKey.trim()
-          if (v && v !== PLATFORM_SECRET_PLACEHOLDER) {
-            body.openRouterApiKey = v
-          }
-        },
-      )
-
-      if (
-        baseline.sources.openRouterApiKey === 'database' &&
-        form.openRouterApiKey.trim() === '' &&
-        baseline.openRouterApiKey !== form.openRouterApiKey
-      ) {
-        mask.push('clearOpenRouterApiKey')
-        body.clearOpenRouterApiKey = true
-      }
-
       maybe('samlSsoEnabled', baseline.samlSsoEnabled, form.samlSsoEnabled, () => {
         body.samlSsoEnabled = form.samlSsoEnabled
       })
@@ -457,24 +434,6 @@ export function PlatformSettingsPanel() {
               />
             </div>
           </div>
-        </section>
-
-        <section>
-          <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">AI — OpenRouter</h3>
-          <p className="mt-1 text-xs text-slate-500 dark:text-neutral-400">
-            Used for AI generation (models list, notebook RAG, etc.). Leave unchanged to keep the current key.
-          </p>
-          <label className="mt-4 block text-sm font-medium text-slate-700 dark:text-neutral-200">
-            API key {sourceBadge(form.sources.openRouterApiKey)}
-          </label>
-          <input
-            type="password"
-            autoComplete="off"
-            value={form.openRouterApiKey}
-            onChange={(e) => update('openRouterApiKey', e.target.value)}
-            placeholder={PLATFORM_SECRET_PLACEHOLDER}
-            className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 font-mono text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
-          />
         </section>
 
         <section>

--- a/clients/web/src/components/settings/platform-settings-types.ts
+++ b/clients/web/src/components/settings/platform-settings-types.ts
@@ -1,7 +1,6 @@
 export type FieldSource = 'environment' | 'database' | 'default'
 
 export type PlatformSettingsPayload = {
-  openRouterApiKey: string
   samlSsoEnabled: boolean
   samlPublicBaseUrl: string
   samlSpEntityId: string
@@ -57,7 +56,6 @@ export type PlatformSettingsPayload = {
   smtpUser: string
   smtpPassword: string
   sources: {
-    openRouterApiKey: FieldSource
     samlSsoEnabled: FieldSource
     samlPublicBaseUrl: FieldSource
     samlSpEntityId: FieldSource

--- a/clients/web/src/context/platform-features-context.tsx
+++ b/clients/web/src/context/platform-features-context.tsx
@@ -71,6 +71,9 @@ export type PlatformFeatures = {
   ffConsortiumSharing: boolean
   ffStripeBilling: boolean
   ffLearningPaths: boolean
+  aiDisclosureEnabled: boolean
+  openRouterConfigured: boolean
+  ragNotebookEnabled: boolean
   loading: boolean
   refresh: () => Promise<void>
 }
@@ -132,6 +135,9 @@ const defaultFeatures: PlatformFeatures = {
   ffConsortiumSharing: false,
   ffStripeBilling: false,
   ffLearningPaths: false,
+  aiDisclosureEnabled: false,
+  openRouterConfigured: false,
+  ragNotebookEnabled: false,
   loading: true,
   refresh: async () => {},
 }
@@ -198,6 +204,9 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
   ffConsortiumSharing: false,
   ffStripeBilling: false,
   ffLearningPaths: false,
+  aiDisclosureEnabled: false,
+  openRouterConfigured: false,
+  ragNotebookEnabled: false,
   })
   const [loading, setLoading] = useState(true)
 
@@ -265,6 +274,9 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffConsortiumSharing: data.ffConsortiumSharing === true,
           ffStripeBilling: data.ffStripeBilling === true,
           ffLearningPaths: data.ffLearningPaths === true,
+          aiDisclosureEnabled: data.aiDisclosureEnabled === true,
+          openRouterConfigured: data.openRouterConfigured === true,
+          ragNotebookEnabled: data.ragNotebookEnabled === true,
         }
         setFeatures({
           ...next,
@@ -299,6 +311,9 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffConsortiumSharing: next.ffConsortiumSharing === true,
           ffStripeBilling: next.ffStripeBilling === true,
           ffLearningPaths: next.ffLearningPaths === true,
+          aiDisclosureEnabled: next.aiDisclosureEnabled === true,
+          openRouterConfigured: next.openRouterConfigured === true,
+          ragNotebookEnabled: next.ragNotebookEnabled === true,
         })
         setPlatformFeaturesSnapshot(next)
       }

--- a/clients/web/src/lib/__tests__/build-search-items.test.ts
+++ b/clients/web/src/lib/__tests__/build-search-items.test.ts
@@ -55,8 +55,8 @@ describe('buildSearchItems', () => {
     expect(enc?.path).toBe('/courses/a%2Fb')
   })
 
-  it('includes Ask AI as a global shortcut for every user', () => {
-    const items = buildSearchItems([], [], allowsNone)
+  it('includes Ask AI when notebook AI is enabled', () => {
+    const items = buildSearchItems([], [], allowsNone, { ragNotebookEnabled: true })
     const ask = items.find((i) => i.id === 'global:ask-ai')
     expect(ask).toMatchObject({
       group: 'ai',
@@ -64,6 +64,11 @@ describe('buildSearchItems', () => {
       title: 'Ask AI',
     })
     expect(ask?.haystack).toContain('ask ai')
+  })
+
+  it('omits Ask AI when notebook AI is disabled', () => {
+    const items = buildSearchItems([], [], allowsNone)
+    expect(items.some((i) => i.id === 'global:ask-ai')).toBe(false)
   })
 
   it('adds global page entries for every user', () => {
@@ -85,6 +90,7 @@ describe('buildSearchItems', () => {
     expect(items.some((i) => i.path === '/settings/cloud-providers')).toBe(true)
     expect(items.some((i) => i.path === '/settings/ai/models')).toBe(true)
     expect(items.some((i) => i.path === '/settings/ai/system-prompts')).toBe(true)
+    expect(items.some((i) => i.path === '/settings/ai/reports')).toBe(true)
   })
 
   it('matches system settings by title (e.g. Global platform)', () => {

--- a/clients/web/src/lib/ai-reports-api.ts
+++ b/clients/web/src/lib/ai-reports-api.ts
@@ -1,0 +1,84 @@
+import { authorizedFetch } from './api'
+import { readApiErrorMessage } from './errors'
+
+export type AIReportsPayload = {
+  range: { from: string; to: string }
+  cost: {
+    summary: {
+      totalCostUsd: number
+      totalCalls: number
+      totalTokens: number
+    }
+    byDay: { day: string; costUsd: number; calls: number; tokens: number }[]
+    byFeature: { feature: string; costUsd: number; calls: number; tokens: number }[]
+  }
+  byUser: {
+    userId: string
+    email: string
+    displayName: string
+    calls: number
+    promptTokens: number
+    completionTokens: number
+    totalTokens: number
+    costUsd: number
+  }[]
+  byCourse: {
+    courseId: string
+    courseCode: string
+    title: string
+    calls: number
+    totalTokens: number
+    costUsd: number
+  }[]
+}
+
+export type AIReportsQuery = {
+  from?: string
+  to?: string
+  feature?: string
+  userQuery?: string
+  courseCode?: string
+}
+
+/** GET `/api/v1/settings/ai/reports` — requires global admin (PERM_RBAC_MANAGE). */
+export async function fetchAIReports(params: AIReportsQuery): Promise<AIReportsPayload> {
+  const search = new URLSearchParams()
+  if (params.from) search.set('from', params.from)
+  if (params.to) search.set('to', params.to)
+  if (params.feature) search.set('feature', params.feature)
+  if (params.userQuery) search.set('userQuery', params.userQuery)
+  if (params.courseCode) search.set('courseCode', params.courseCode)
+  const qs = search.toString()
+  const res = await authorizedFetch(`/api/v1/settings/ai/reports${qs ? `?${qs}` : ''}`)
+  const raw: unknown = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  return raw as AIReportsPayload
+}
+
+export type AIReportsPreset = '24h' | '7d' | '30d' | '90d'
+
+export function aiReportsUtcRange(preset: AIReportsPreset): { from: string; to: string } {
+  const to = new Date()
+  const from = new Date(to)
+  const hours =
+    preset === '24h' ? 24 : preset === '7d' ? 7 * 24 : preset === '30d' ? 30 * 24 : 90 * 24
+  from.setTime(from.getTime() - hours * 60 * 60 * 1000)
+  return { from: from.toISOString(), to: to.toISOString() }
+}
+
+export const AI_FEATURE_LABELS: Record<string, string> = {
+  ai_tutor: 'AI Tutor',
+  rag_notebook: 'Notebook AI',
+  syllabus_generation: 'Syllabus generation',
+  translation: 'Translation',
+  quiz_generation: 'Quiz generation',
+  reading_level_simplification: 'Reading level',
+  content_translation: 'Content translation',
+  alt_text_suggestion: 'Alt text',
+  vibe_generation: 'Vibe activities',
+  unknown: 'Unknown',
+}
+
+export function aiFeatureLabel(feature: string): string {
+  return AI_FEATURE_LABELS[feature] ?? feature.replaceAll('_', ' ')
+}

--- a/clients/web/src/lib/build-search-items.ts
+++ b/clients/web/src/lib/build-search-items.ts
@@ -66,6 +66,8 @@ export type SearchListItem = {
 export type GlobalSearchBuildOptions = {
   /** Effective platform SCIM flag (Settings → Global platform). */
   scimEnabled?: boolean
+  /** Notebook RAG / Ask AI when platform AI and OpenRouter are configured. */
+  ragNotebookEnabled?: boolean
 }
 
 type SearchPageDef = { title: string; subtitle: string; path: string; hint: string }
@@ -103,16 +105,17 @@ export function buildGlobalSearchItems(
   allows: (perm: string) => boolean,
   options: GlobalSearchBuildOptions = {},
 ): SearchListItem[] {
-  const items: SearchListItem[] = [
-    {
+  const items: SearchListItem[] = []
+  if (options.ragNotebookEnabled) {
+    items.push({
       id: 'global:ask-ai',
       group: 'ai',
       title: 'Ask AI',
       subtitle: 'Ask the AI any question you have permissions to',
       path: '/ai',
       haystack: 'ask ai assistant tutor help chat questions',
-    },
-  ]
+    })
+  }
 
   const globalPages: SearchPageDef[] = [
     { title: 'Dashboard', subtitle: 'Home', path: '/', hint: 'dashboard home' },
@@ -246,7 +249,7 @@ export function buildGlobalSearchItems(
         title: 'Global platform',
         subtitle: 'System settings',
         path: '/settings/platform',
-        hint: 'openrouter saml feature flags lti oneroster platform environment database admin',
+        hint: 'saml feature flags lti oneroster platform environment database admin',
       },
       {
         title: 'Organizations',
@@ -258,13 +261,19 @@ export function buildGlobalSearchItems(
         title: 'AI models',
         subtitle: 'System settings',
         path: '/settings/ai/models',
-        hint: 'ai intelligence openrouter models',
+        hint: 'ai intelligence openrouter api key models',
       },
       {
         title: 'System prompts',
         subtitle: 'System settings',
         path: '/settings/ai/system-prompts',
         hint: 'system prompts ai configuration admin intelligence',
+      },
+      {
+        title: 'AI reports',
+        subtitle: 'System settings',
+        path: '/settings/ai/reports',
+        hint: 'ai intelligence usage cost reports openrouter',
       },
     ]
     for (const g of systemPages) {

--- a/clients/web/src/lib/platform-features.ts
+++ b/clients/web/src/lib/platform-features.ts
@@ -58,6 +58,9 @@ export type PlatformFeaturesSnapshot = {
   ffConsortiumSharing?: boolean
   ffStripeBilling?: boolean
   ffLearningPaths?: boolean
+  aiDisclosureEnabled?: boolean
+  openRouterConfigured?: boolean
+  ragNotebookEnabled?: boolean
 }
 
 const defaults: PlatformFeaturesSnapshot = {
@@ -118,6 +121,9 @@ const defaults: PlatformFeaturesSnapshot = {
   ffConsortiumSharing: false,
   ffStripeBilling: false,
   ffLearningPaths: false,
+  aiDisclosureEnabled: false,
+  openRouterConfigured: false,
+  ragNotebookEnabled: false,
 }
 
 let loaded = false
@@ -275,6 +281,15 @@ export function eportfolioFeatureEnabled(): boolean {
 
 export function incompleteGradeWorkflowFeatureEnabled(): boolean {
   return loaded && snapshot.ffIncompleteGradeWorkflow === true
+}
+
+/** Notebook RAG + flashcards when platform AI is on, OpenRouter is configured, and tenant policy allows it. */
+export function ragNotebookAiEnabled(s?: PlatformFeaturesSnapshot): boolean {
+  const snap = s ?? snapshot
+  if (!s && !loaded) {
+    return false
+  }
+  return snap.ragNotebookEnabled === true
 }
 
 /** True when GET/PATCH /api/v1/me/reading-preferences is available (matches server readingPreferencesEnabled). */

--- a/clients/web/src/pages/lms/ask-ai-page.tsx
+++ b/clients/web/src/pages/lms/ask-ai-page.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, Navigate, useSearchParams } from 'react-router-dom'
+import { usePlatformFeatures } from '../../context/platform-features-context'
 import { Sparkles } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -30,6 +31,7 @@ type NotebookRagResponse = {
 }
 
 export default function AskAiPage() {
+  const { ragNotebookEnabled, loading: featuresLoading } = usePlatformFeatures()
   const [searchParams] = useSearchParams()
   const qParam = searchParams.get('q')?.trim() ?? ''
 
@@ -177,6 +179,10 @@ export default function AskAiPage() {
       setAskLoading(false)
     }
   }, [askText, hasNotes, notebooksForRag])
+
+  if (!featuresLoading && !ragNotebookEnabled) {
+    return <Navigate to="/" replace />
+  }
 
   return (
     <LmsPage

--- a/clients/web/src/pages/lms/course-notebook-page.tsx
+++ b/clients/web/src/pages/lms/course-notebook-page.tsx
@@ -4,6 +4,7 @@ import { Navigate, useParams, useSearchParams } from 'react-router-dom'
 import { ConfirmDialog } from '../../components/confirm-dialog'
 import { ReadingFocusToggle } from '../../components/layout/reading-focus-toggle'
 import { useCourseNavFeatures } from '../../context/course-nav-features-context'
+import { usePlatformFeatures } from '../../context/platform-features-context'
 import { MarkdownBodyEditor } from '../../components/editor/block-editor/markdown-body-editor'
 import { CourseNotebookSidebar } from '../../components/notebook/course-notebook-sidebar'
 import { FlashcardsModal } from '../../components/notebook/flashcards-modal'
@@ -36,6 +37,7 @@ export default function CourseNotebookPage() {
   const [searchParams] = useSearchParams()
   const { notebookEnabled: courseNotebookEnabled, loading: courseFeatureFlagsLoading } =
     useCourseNavFeatures()
+  const { ragNotebookEnabled } = usePlatformFeatures()
   const [data, setData] = useState<CourseNotebookStore | null>(null)
   const [courseTitle, setCourseTitle] = useState<string | null>(null)
   const [loadError, setLoadError] = useState<string | null>(null)
@@ -408,6 +410,7 @@ export default function CourseNotebookPage() {
                     onMoveToGroup={onMovePageToGroup}
                     onMoveToRoot={onMovePageToRoot}
                     onFlashcards={() => setFlashcardsOpen(true)}
+                    flashcardsEnabled={ragNotebookEnabled}
                   />
                 </div>
                 <div className="mx-auto min-h-0 w-full max-w-[72ch] flex-1 overflow-y-auto px-4 py-4 text-[1.0625rem] leading-relaxed md:px-6 md:py-5">
@@ -465,12 +468,14 @@ export default function CourseNotebookPage() {
         }}
       />
 
-      <FlashcardsModal
-        open={flashcardsOpen}
-        notes={activePage?.contentMd ?? ''}
-        pageTitle={activePage?.title ?? ''}
-        onClose={() => setFlashcardsOpen(false)}
-      />
+      {ragNotebookEnabled ? (
+        <FlashcardsModal
+          open={flashcardsOpen}
+          notes={activePage?.contentMd ?? ''}
+          pageTitle={activePage?.title ?? ''}
+          onClose={() => setFlashcardsOpen(false)}
+        />
+      ) : null}
     </LmsPage>
   )
 }

--- a/clients/web/src/pages/lms/global-notebook-page.tsx
+++ b/clients/web/src/pages/lms/global-notebook-page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'react-router-dom'
 
 import { ConfirmDialog } from '../../components/confirm-dialog'
 import { ReadingFocusToggle } from '../../components/layout/reading-focus-toggle'
+import { usePlatformFeatures } from '../../context/platform-features-context'
 import { MarkdownBodyEditor } from '../../components/editor/block-editor/markdown-body-editor'
 import { CourseNotebookSidebar } from '../../components/notebook/course-notebook-sidebar'
 import { FlashcardsModal } from '../../components/notebook/flashcards-modal'
@@ -34,6 +35,7 @@ import { LmsPage } from './lms-page'
 const CONTENT_SAVE_MS = 500
 
 export default function GlobalNotebookPage() {
+  const { ragNotebookEnabled } = usePlatformFeatures()
   const [searchParams] = useSearchParams()
   const [data, setData] = useState<CourseNotebookStore | null>(null)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
@@ -364,6 +366,7 @@ export default function GlobalNotebookPage() {
                     onMoveToGroup={onMovePageToGroup}
                     onMoveToRoot={onMovePageToRoot}
                     onFlashcards={() => setFlashcardsOpen(true)}
+                    flashcardsEnabled={ragNotebookEnabled}
                   />
                 </div>
                 <div className="mx-auto min-h-0 w-full max-w-[72ch] flex-1 overflow-y-auto px-4 py-4 text-[1.0625rem] leading-relaxed md:px-6 md:py-5">
@@ -421,12 +424,14 @@ export default function GlobalNotebookPage() {
         }}
       />
 
-      <FlashcardsModal
-        open={flashcardsOpen}
-        notes={activePage?.contentMd ?? ''}
-        pageTitle={activePage?.title ?? ''}
-        onClose={() => setFlashcardsOpen(false)}
-      />
+      {ragNotebookEnabled ? (
+        <FlashcardsModal
+          open={flashcardsOpen}
+          notes={activePage?.contentMd ?? ''}
+          pageTitle={activePage?.title ?? ''}
+          onClose={() => setFlashcardsOpen(false)}
+        />
+      ) : null}
     </LmsPage>
   )
 }

--- a/clients/web/src/pages/lms/my-notebooks-page.tsx
+++ b/clients/web/src/pages/lms/my-notebooks-page.tsx
@@ -20,6 +20,7 @@ import {
 import { pullStudentNotebooks } from '../../lib/student-notebook-sync'
 import { ReadingFocusToggle } from '../../components/layout/reading-focus-toggle'
 import { AiDisclosureBanner } from '../../components/ai-disclosure-banner'
+import { usePlatformFeatures } from '../../context/platform-features-context'
 import { LmsPage } from './lms-page'
 
 function snippet(text: string, max = 140): string {
@@ -40,6 +41,7 @@ type NotebookRagResponse = {
 }
 
 export default function MyNotebooksPage() {
+  const { ragNotebookEnabled } = usePlatformFeatures()
   const [courses, setCourses] = useState<CoursePublic[] | null>(null)
   const [coursesError, setCoursesError] = useState<string | null>(null)
   const [notebookVersion, setNotebookVersion] = useState(0)
@@ -242,7 +244,7 @@ export default function MyNotebooksPage() {
             </div>
           </div>
 
-          {!askCardOpen ? (
+          {ragNotebookEnabled && !askCardOpen ? (
             <button
               type="button"
               onClick={() => setAskCardOpen(true)}
@@ -262,7 +264,7 @@ export default function MyNotebooksPage() {
                 </span>
               </span>
             </button>
-          ) : (
+          ) : ragNotebookEnabled ? (
             <div className="rounded-2xl border border-indigo-200/90 bg-gradient-to-b from-indigo-50/80 to-white p-4 shadow-sm dark:border-indigo-500/25 dark:from-indigo-950/40 dark:to-neutral-950 sm:p-5">
               <AiDisclosureBanner featureKey="rag_notebook" modelLabel="Claude 3.5 Sonnet" />
               <div className="flex items-start gap-3">
@@ -329,9 +331,9 @@ export default function MyNotebooksPage() {
                 </div>
               </div>
             </div>
-          )}
+          ) : null}
 
-          {ragResult && (
+          {ragNotebookEnabled && ragResult && (
             <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-neutral-700 dark:bg-neutral-950 sm:p-5">
               <h2 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Answer</h2>
               <article className="mt-3 text-sm leading-relaxed text-slate-700 dark:text-neutral-200 [&_a]:text-indigo-600 [&_a]:underline dark:[&_a]:text-indigo-400 [&_li]:my-0.5 [&_ol]:my-2 [&_p]:my-2 [&_ul]:my-2">

--- a/clients/web/src/pages/lms/settings.tsx
+++ b/clients/web/src/pages/lms/settings.tsx
@@ -40,11 +40,13 @@ import { IntegrationsMcpPanel } from '../../components/settings/integrations-mcp
 import { NotificationPreferencesPanel } from '../../components/settings/notification-preferences-panel'
 import { AiProcessingSettingsPanel } from '../../components/settings/ai-processing-settings-panel'
 import { AiGovernancePanel } from '../../components/settings/ai-governance-panel'
+import { AiReportsPanel } from '../../components/settings/ai-reports-panel'
 import { LmsPage } from './lms-page'
 import OrgBranding from './admin/org-branding'
 import { FALLBACK_IMAGE_MODEL_OPTIONS, FALLBACK_TEXT_MODEL_OPTIONS } from '../../lib/ai-models'
 import { apiUrl, authorizedFetch } from '../../lib/api'
 import { readApiErrorMessage } from '../../lib/errors'
+import { PLATFORM_SECRET_PLACEHOLDER } from '../../lib/platform-settings'
 import { passwordStrengthEnglish, passwordStrengthKey, type PasswordStrengthKey } from '../../lib/password-strength'
 import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
 import { applyUiTheme, parseUiTheme, type UiTheme } from '../../lib/ui-theme'
@@ -211,6 +213,8 @@ export default function Settings() {
   const [modelsConfigured, setModelsConfigured] = useState(false)
   const [modelsError, setModelsError] = useState<string | null>(null)
   const [modelsRefreshing, setModelsRefreshing] = useState(false)
+  const [openRouterApiKey, setOpenRouterApiKey] = useState('')
+  const [openRouterApiKeyBaseline, setOpenRouterApiKeyBaseline] = useState('')
 
   const [accountLoading, setAccountLoading] = useState(false)
   const [accountSaving, setAccountSaving] = useState(false)
@@ -333,11 +337,17 @@ export default function Settings() {
             courseSetupModelId?: string
             notebookFlashcardsModelId?: string
             vibeActivityModelId?: string
+            openRouterApiKey?: string
           }
           if (!cancelled && data.imageModelId) setImageModelId(data.imageModelId)
           if (!cancelled && data.courseSetupModelId) setCourseSetupModelId(data.courseSetupModelId)
           if (!cancelled && data.notebookFlashcardsModelId) setNotebookFlashcardsModelId(data.notebookFlashcardsModelId)
           if (!cancelled && data.vibeActivityModelId) setVibeActivityModelId(data.vibeActivityModelId)
+          if (!cancelled) {
+            const key = data.openRouterApiKey ?? ''
+            setOpenRouterApiKey(key)
+            setOpenRouterApiKeyBaseline(key)
+          }
         }
         if (!cancelled) await loadModels()
       } catch {
@@ -364,15 +374,32 @@ export default function Settings() {
     setAiMessage(null)
     setAiError(null)
     try {
+      const body: Record<string, unknown> = {
+        imageModelId,
+        courseSetupModelId,
+        notebookFlashcardsModelId,
+        vibeActivityModelId,
+      }
+      const keyTrimmed = openRouterApiKey.trim()
+      const keyBaselineTrimmed = openRouterApiKeyBaseline.trim()
+      if (keyTrimmed !== keyBaselineTrimmed) {
+        const v = keyTrimmed
+        if (v && v !== PLATFORM_SECRET_PLACEHOLDER) {
+          body.openRouterApiKey = v
+        }
+        if (
+          keyBaselineTrimmed === PLATFORM_SECRET_PLACEHOLDER &&
+          v === '' &&
+          openRouterApiKey !== openRouterApiKeyBaseline
+        ) {
+          body.clearOpenRouterApiKey = true
+        }
+      }
+
       const res = await authorizedFetch('/api/v1/settings/ai', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          imageModelId,
-          courseSetupModelId,
-          notebookFlashcardsModelId,
-          vibeActivityModelId,
-        }),
+        body: JSON.stringify(body),
       })
       const raw: unknown = await res.json().catch(() => ({}))
       if (!res.ok) {
@@ -384,13 +411,19 @@ export default function Settings() {
         courseSetupModelId?: string
         notebookFlashcardsModelId?: string
         vibeActivityModelId?: string
+        openRouterApiKey?: string
       }
       if (data.imageModelId) setImageModelId(data.imageModelId)
       if (data.courseSetupModelId) setCourseSetupModelId(data.courseSetupModelId)
       if (data.notebookFlashcardsModelId) setNotebookFlashcardsModelId(data.notebookFlashcardsModelId)
       if (data.vibeActivityModelId) setVibeActivityModelId(data.vibeActivityModelId)
+      if (data.openRouterApiKey !== undefined) {
+        setOpenRouterApiKey(data.openRouterApiKey)
+        setOpenRouterApiKeyBaseline(data.openRouterApiKey)
+      }
       setAiMessage('Saved.')
-      toastSaveOk('AI defaults saved')
+      toastSaveOk('AI settings saved')
+      await loadModels()
     } catch {
       setAiError('Could not save settings.')
       toastMutationError('Could not save AI settings.')
@@ -918,6 +951,8 @@ export default function Settings() {
               ? 'max-w-3xl'
             : activeView === 'ai-prompts'
               ? 'max-w-3xl'
+              : activeView === 'ai-reports'
+                ? 'max-w-4xl'
               : 'max-w-xl'
         }`}
       >
@@ -935,8 +970,8 @@ export default function Settings() {
               >
                 OpenRouter&apos;s models API
               </a>{' '}
-              (text-capable and image-capable models). Generation still requires an API key on the
-              server.
+              (text-capable and image-capable models). Generation requires an OpenRouter API key
+              configured below.
             </p>
 
             {aiLoading && <p className="mt-4 text-sm text-slate-500">Loading…</p>}
@@ -947,11 +982,8 @@ export default function Settings() {
             )}
 
             {!modelsConfigured && !aiLoading && (
-              <p className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
-                Configure an OpenRouter API key under{' '}
-                <span className="font-medium">Settings → Global platform</span>, or set{' '}
-                <code className="rounded bg-amber-100/80 px-1.5 py-0.5 font-mono text-xs">OPENROUTER_API_KEY</code> in the
-                server environment, so AI features can call OpenRouter.
+              <p className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
+                Add your OpenRouter API key below and save, so AI features can call OpenRouter.
               </p>
             )}
 
@@ -971,6 +1003,29 @@ export default function Settings() {
 
             {!aiLoading && (
               <form className="mt-6 space-y-5" onSubmit={onSaveAi}>
+                <div>
+                  <label
+                    htmlFor="openrouter-api-key"
+                    className="block text-sm font-medium text-slate-700 dark:text-neutral-200"
+                  >
+                    OpenRouter API key
+                  </label>
+                  <input
+                    id="openrouter-api-key"
+                    type="password"
+                    autoComplete="off"
+                    value={openRouterApiKey}
+                    onChange={(e) => setOpenRouterApiKey(e.target.value)}
+                    placeholder={PLATFORM_SECRET_PLACEHOLDER}
+                    disabled={aiSaving}
+                    className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 font-mono text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2 disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+                  />
+                  <p className="mt-1.5 text-xs text-slate-500 dark:text-neutral-400">
+                    Platform-wide key for AI generation. Leave unchanged to keep the current key; clear
+                    the field and save to remove it.
+                  </p>
+                </div>
+
                 <div>
                   <ImageModelPicker
                     id="course-setup-model"
@@ -1132,6 +1187,20 @@ export default function Settings() {
               )}
             </RequirePermission>
           </div>
+        )}
+
+        {activeView === 'ai-reports' && (
+          <RequirePermission
+            permission={PERM_RBAC_MANAGE}
+            fallback={
+              <p className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-neutral-600 dark:bg-neutral-800/50 dark:text-neutral-300">
+                You need permission to view AI reports (
+                <code className="font-mono text-xs">{PERM_RBAC_MANAGE}</code>).
+              </p>
+            }
+          >
+            <AiReportsPanel />
+          </RequirePermission>
         )}
 
         {activeView === 'account' && (

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -49,7 +49,6 @@ services:
       # Demo DB may retain checksums from migrations 120/135 after follow-up PR edits; align before migrate.
       MIGRATE_REPAIR_CHECKSUMS: "1"
       PORT: "8080"
-      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       COURSE_FILES_ROOT: /mnt/lextures-db/course-files
       RABBITMQ_URL: amqp://${RABBITMQ_USER:-studydrift}:${RABBITMQ_PASSWORD:-studydrift}@rabbitmq:5672/
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,6 @@ services:
       RUN_MIGRATIONS: "true"
       # Reconcile _sqlx_migrations checksums for listed idempotent migrations after SQL edits in dev.
       MIGRATE_REPAIR_CHECKSUMS: "1"
-      OPEN_ROUTER_API_KEY: ${OPEN_ROUTER_API_KEY:-}
       COURSE_FILES_ROOT: /var/course-files
       PORT: "8080"
       RABBITMQ_URL: amqp://studydrift:studydrift@rabbitmq:5672/

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ From the repository root:
    BOOTSTRAP_ADMIN_EMAIL=you@yourdomain.com
    ```
 
-   Optional: add `OPEN_ROUTER_API_KEY=...` for AI-related features.
+   Optional: configure an OpenRouter API key under **Settings → Intelligence → Models** for AI features.
 
 2. **Start the stack:**
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -23,8 +23,8 @@ RABBITMQ_URL=amqp://studydrift:studydrift@localhost:5672/
 COURSE_FILES_ROOT=data/course-files
 PUBLIC_WEB_ORIGIN=http://localhost:5173
 
-# API keys and integration credentials (prefer Settings → Global platform where supported)
-# OPENROUTER_API_KEY=
+# API keys and integration credentials (prefer Settings UI where supported)
+# OpenRouter API key: Settings → Intelligence → Models (stored in platform_app_settings)
 # PLATFORM_SECRETS_KEY=   # base64 32-byte AES key for encrypted SMTP password in DB (openssl rand -base64 32)
 # SMTP_HOST= SMTP_PORT=587 SMTP_USER= SMTP_PASSWORD= SMTP_FROM=
 

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -440,7 +440,8 @@ func Load() Config {
 
 		BootstrapAdminEmail: strings.ToLower(strings.TrimSpace(os.Getenv("BOOTSTRAP_ADMIN_EMAIL"))),
 
-		OpenRouterAPIKey: firstNonEmptyTrimmed("OPENROUTER_API_KEY", "OPEN_ROUTER_API_KEY"),
+		// OpenRouterAPIKey is loaded from settings.platform_app_settings (Settings → Intelligence → Models).
+		OpenRouterAPIKey: "",
 		CourseFilesRoot:  stringDefault(firstNonEmptyTrimmed("COURSE_FILES_ROOT"), "data/course-files"),
 
 		CanvasAllowedHostSuffixes:     canvasAllowedHostSuffixes(),

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -45,8 +45,7 @@ var configEnvKeys = []string{
 	"CLASSLINK_SSO_ENABLED",
 	"CLASSLINK_OIDC_CLIENT_ID",
 	"CLASSLINK_OIDC_CLIENT_SECRET",
-	"OPEN_ROUTER_API_KEY",
-	"OPENROUTER_API_KEY",
+
 	"ORIGINALITY_DETECTION_ENABLED",
 	"ORIGINALITY_STUB_EXTERNAL",
 	"PORT",
@@ -205,7 +204,6 @@ func TestJWTSecretAllowsInsecureFallback(t *testing.T) {
 
 func TestLoadTrimsAndUsesLegacyAliases(t *testing.T) {
 	baseEnv(t)
-	t.Setenv("OPEN_ROUTER_API_KEY", " api-key ")
 	t.Setenv("COURSE_FILES_ROOT", " /tmp/course-files ")
 	t.Setenv("CANVAS_ALLOWED_HOST_SUFFIXES", " *.Instructure.com, .canvas.example.edu, ")
 	t.Setenv("PUBLIC_WEB_ORIGIN", " https://app.example.edu/ ")
@@ -216,9 +214,6 @@ func TestLoadTrimsAndUsesLegacyAliases(t *testing.T) {
 	t.Setenv("SMTP_FROM", " no-reply@example.edu ")
 
 	c := Load()
-	if c.OpenRouterAPIKey != "api-key" {
-		t.Fatalf("OpenRouterAPIKey: %q", c.OpenRouterAPIKey)
-	}
 	if c.CourseFilesRoot != "/tmp/course-files" {
 		t.Fatalf("CourseFilesRoot: %q", c.CourseFilesRoot)
 	}

--- a/server/internal/httpserver/admin_nodb_test.go
+++ b/server/internal/httpserver/admin_nodb_test.go
@@ -51,6 +51,7 @@ func TestAdmin_SettingsAI_Unauthorized(t *testing.T) {
 		method string
 	}{
 		{"/api/v1/settings/ai", http.MethodGet},
+		{"/api/v1/settings/ai/reports", http.MethodGet},
 		{"/api/v1/settings/ai/models?kind=text", http.MethodGet},
 	} {
 		srr := httptest.NewRecorder()

--- a/server/internal/httpserver/ai_gateway.go
+++ b/server/internal/httpserver/ai_gateway.go
@@ -1,12 +1,17 @@
 package httpserver
 
 import (
+	"context"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/repos/aiusage"
+	"github.com/lextures/lextures/server/internal/repos/course"
 	"github.com/lextures/lextures/server/internal/repos/organization"
 	aigateway "github.com/lextures/lextures/server/internal/service/aigateway"
+	"github.com/lextures/lextures/server/internal/service/openrouter"
 )
 
 func (d Deps) aiGatewayConfig() aigateway.Config {
@@ -57,6 +62,38 @@ func (d Deps) enforceAIGateway(
 		return false
 	}
 	return true
+}
+
+// AIUsageMeta identifies who triggered an OpenRouter call for analytics.ai_usage_log.
+type AIUsageMeta struct {
+	UserID     uuid.UUID
+	CourseID   *uuid.UUID
+	CourseCode string
+	Feature    string
+	Model      string
+}
+
+// recordAIUsage appends token/cost usage for Intelligence reports (best-effort).
+func (d Deps) recordAIUsage(ctx context.Context, meta AIUsageMeta, usage openrouter.UsageInfo, succeeded bool) {
+	if d.Pool == nil || !usage.HasData() {
+		return
+	}
+	var userID *uuid.UUID
+	if meta.UserID != uuid.Nil {
+		uid := meta.UserID
+		userID = &uid
+	}
+	var courseID *uuid.UUID
+	if meta.CourseID != nil {
+		courseID = meta.CourseID
+	} else if code := strings.TrimSpace(meta.CourseCode); code != "" {
+		if row, err := course.GetPublicByCourseCode(ctx, d.Pool, code); err == nil && row != nil {
+			if cid, perr := uuid.Parse(row.ID); perr == nil {
+				courseID = &cid
+			}
+		}
+	}
+	_ = aiusage.Insert(ctx, d.Pool, aiusage.EntryFromUsage(userID, courseID, meta.Feature, meta.Model, usage, succeeded))
 }
 
 // logAIInferenceAllowed records a successful (non-blocked) inference after the external call completes.

--- a/server/internal/httpserver/ai_reports_range.go
+++ b/server/internal/httpserver/ai_reports_range.go
@@ -1,0 +1,45 @@
+package httpserver
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+const (
+	aiReportsDefaultRange = 24 * time.Hour
+	aiReportsMaxRangeDays = int64(366)
+)
+
+// parseAIReportsTimeRange resolves [from, to) for Intelligence AI reports (default: last 24 hours).
+func parseAIReportsTimeRange(q url.Values, now time.Time) (from, to time.Time, err error) {
+	to = now
+	if s := q.Get("to"); s != "" {
+		t, perr := time.Parse(time.RFC3339, s)
+		if perr != nil {
+			return time.Time{}, time.Time{}, errAIReportsTimeRangeInvalid()
+		}
+		to = t.UTC()
+	}
+	from = to.Add(-aiReportsDefaultRange)
+	if s := q.Get("from"); s != "" {
+		f, perr := time.Parse(time.RFC3339, s)
+		if perr != nil {
+			return time.Time{}, time.Time{}, errAIReportsTimeRangeInvalid()
+		}
+		from = f.UTC()
+	}
+	if !from.Before(to) {
+		return time.Time{}, time.Time{}, fmt.Errorf("`from` must be before `to`.")
+	}
+	sec := to.Unix() - from.Unix()
+	days := sec / 86400
+	if days > aiReportsMaxRangeDays {
+		return time.Time{}, time.Time{}, fmt.Errorf("Date range cannot exceed %d days.", aiReportsMaxRangeDays)
+	}
+	return from, to, nil
+}
+
+func errAIReportsTimeRangeInvalid() error {
+	return fmt.Errorf("Invalid `from` or `to`: use RFC 3339 (e.g. 2026-04-01T00:00:00Z).")
+}

--- a/server/internal/httpserver/ai_reports_range_test.go
+++ b/server/internal/httpserver/ai_reports_range_test.go
@@ -1,0 +1,38 @@
+package httpserver
+
+import (
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestParseAIReportsTimeRange_defaults24h(t *testing.T) {
+	now, err := time.Parse(time.RFC3339, "2026-06-16T12:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	from, to, err := parseAIReportsTimeRange(url.Values{}, now)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !to.Equal(now) {
+		t.Fatalf("to: got %v", to)
+	}
+	if got := to.Sub(from); got != 24*time.Hour {
+		t.Fatalf("from default 24h before to: from=%v to=%v sub=%v", from, to, got)
+	}
+}
+
+func TestParseAIReportsTimeRange_explicit(t *testing.T) {
+	now := time.Unix(0, 0).UTC()
+	v := url.Values{}
+	v.Set("from", "2026-01-01T00:00:00Z")
+	v.Set("to", "2026-01-20T00:00:00Z")
+	from, to, err := parseAIReportsTimeRange(v, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if from.Format(time.RFC3339) != "2026-01-01T00:00:00Z" || to.Format(time.RFC3339) != "2026-01-20T00:00:00Z" {
+		t.Fatalf("got from=%v to=%v", from, to)
+	}
+}

--- a/server/internal/httpserver/course_syllabus.go
+++ b/server/internal/httpserver/course_syllabus.go
@@ -206,7 +206,7 @@ func (d Deps) handleGenerateSyllabusSection() http.HandlerFunc {
 
 		or := d.openRouterClient()
 		if or == nil {
-			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "AI generation is not configured. Set an OpenRouter API key in Platform Settings.")
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "AI generation is not configured. Set an OpenRouter API key under Settings → Intelligence → Models.")
 			return
 		}
 
@@ -244,8 +244,11 @@ func (d Deps) handleGenerateSyllabusSection() http.HandlerFunc {
 			return
 		}
 		d.logAIInferenceAllowed(r, viewer, aigateway.FeatureSyllabusGeneration, model, promptMaterial, gwDec)
+		d.recordAIUsage(r.Context(), AIUsageMeta{
+			UserID: viewer, CourseCode: courseCode, Feature: aigateway.FeatureSyllabusGeneration, Model: model,
+		}, generated.Usage, true)
 
-		markdown := strings.TrimSpace(generated)
+		markdown := strings.TrimSpace(generated.Text)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(resp{Markdown: markdown})
 	}

--- a/server/internal/httpserver/course_translation.go
+++ b/server/internal/httpserver/course_translation.go
@@ -345,14 +345,14 @@ func (d Deps) handlePostCourseTranslationAIDraft() http.HandlerFunc {
 		if !d.enforceAIGateway(w, r, userID, aigateway.FeatureContentTranslation, courseTranslationAIModel, text) {
 			return
 		}
-		translated, _, err := callLLMTranslation(or, text, req.TargetLocale)
+		translated, _, _, err := callLLMTranslation(or, text, req.TargetLocale)
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusBadGateway, apierr.CodeInternal, "AI draft translation failed.")
 			return
 		}
 		var tTitle *string
 		if strings.TrimSpace(title) != "" {
-			tTitleStr, _, tErr := callLLMTranslation(or, strings.TrimSpace(title), req.TargetLocale)
+			tTitleStr, _, _, tErr := callLLMTranslation(or, strings.TrimSpace(title), req.TargetLocale)
 			if tErr == nil {
 				tTitle = &tTitleStr
 			}

--- a/server/internal/httpserver/me_notebook.go
+++ b/server/internal/httpserver/me_notebook.go
@@ -163,6 +163,9 @@ func (d Deps) handleGenerateNotebookFlashcards() http.HandlerFunc {
 		}
 
 		d.logAIInferenceAllowed(r, userID, aigateway.FeatureRAGNotebook, model, notes, gwDec)
+		d.recordAIUsage(r.Context(), AIUsageMeta{
+			UserID: userID, Feature: aigateway.FeatureRAGNotebook, Model: model,
+		}, completion.Usage, true)
 
 		// Parse output to ensure it is valid JSON matching our expected flashcards structure
 		var parsed struct {
@@ -173,7 +176,7 @@ func (d Deps) handleGenerateNotebookFlashcards() http.HandlerFunc {
 		}
 
 		// Sometimes AI outputs Markdown JSON blocks (e.g. ```json ... ```)
-		cleanCompletion := completion
+		cleanCompletion := completion.Text
 		if idx := strings.Index(cleanCompletion, "```json"); idx != -1 {
 			cleanCompletion = cleanCompletion[idx+7:]
 			if endIdx := strings.Index(cleanCompletion, "```"); endIdx != -1 {
@@ -183,7 +186,7 @@ func (d Deps) handleGenerateNotebookFlashcards() http.HandlerFunc {
 		cleanCompletion = strings.TrimSpace(cleanCompletion)
 
 		if err := json.Unmarshal([]byte(cleanCompletion), &parsed); err != nil {
-			apierr.WriteJSON(w, http.StatusBadGateway, apierr.CodeAiGenerationFailed, fmt.Sprintf("AI did not return valid JSON: %v. Raw response: %s", err, completion))
+			apierr.WriteJSON(w, http.StatusBadGateway, apierr.CodeAiGenerationFailed, fmt.Sprintf("AI did not return valid JSON: %v. Raw response: %s", err, completion.Text))
 			return
 		}
 

--- a/server/internal/httpserver/platform_features.go
+++ b/server/internal/httpserver/platform_features.go
@@ -1,10 +1,15 @@
 package httpserver
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/lextures/lextures/server/internal/config"
+	aidisclosurerepo "github.com/lextures/lextures/server/internal/repos/aidisclosure"
+	"github.com/lextures/lextures/server/internal/repos/organization"
+	aigateway "github.com/lextures/lextures/server/internal/service/aigateway"
 )
 
 type platformFeaturesJSON struct {
@@ -69,6 +74,10 @@ type platformFeaturesJSON struct {
 	FFPublicCatalog             bool `json:"ffPublicCatalog"`
 	FFStripeBilling             bool `json:"ffStripeBilling"`
 	FFLearningPaths             bool `json:"ffLearningPaths"`
+
+	AiDisclosureEnabled  bool `json:"aiDisclosureEnabled"`
+	OpenRouterConfigured bool `json:"openRouterConfigured"`
+	RagNotebookEnabled   bool `json:"ragNotebookEnabled"`
 
 	LRSAnonymizeActors           bool    `json:"lrsAnonymizeActors"`
 	FERPAWorkflowEnabled         bool    `json:"ferpaWorkflowEnabled"`
@@ -157,6 +166,28 @@ func platformFeaturesFromConfig(cfg config.Config) platformFeaturesJSON {
 	}
 }
 
+func (d Deps) effectiveRagNotebookEnabled(ctx context.Context, userID uuid.UUID) bool {
+	cfg := d.effectiveConfig()
+	if !cfg.AiDisclosureEnabled || d.openRouterClient() == nil {
+		return false
+	}
+	if d.Pool == nil {
+		return true
+	}
+	orgID, err := organization.OrgIDForUser(ctx, d.Pool, userID)
+	if err != nil {
+		return true
+	}
+	tc, err := aidisclosurerepo.GetTenantConfig(ctx, d.Pool, orgID)
+	if err != nil || tc == nil {
+		return true
+	}
+	if disabled, ok := tc.FeaturesEnabled[aigateway.FeatureRAGNotebook]; ok && !disabled {
+		return false
+	}
+	return true
+}
+
 // handleGetPlatformFeatures is GET /api/v1/platform/features (authenticated; read-only effective flags).
 func (d Deps) handleGetPlatformFeatures() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -165,10 +196,15 @@ func (d Deps) handleGetPlatformFeatures() http.HandlerFunc {
 			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 			return
 		}
-		if _, ok := d.meUserID(w, r); !ok {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
 			return
 		}
-		out := platformFeaturesFromConfig(d.effectiveConfig())
+		cfg := d.effectiveConfig()
+		out := platformFeaturesFromConfig(cfg)
+		out.AiDisclosureEnabled = cfg.AiDisclosureEnabled
+		out.OpenRouterConfigured = d.openRouterClient() != nil
+		out.RagNotebookEnabled = d.effectiveRagNotebookEnabled(r.Context(), userID)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(out)
 	}

--- a/server/internal/httpserver/rbac_settings.go
+++ b/server/internal/httpserver/rbac_settings.go
@@ -550,6 +550,7 @@ func (d Deps) registerSettingsRoutes(r chi.Router) {
 	r.Put("/api/v1/settings/timezone", d.handlePutSettingsTimezone())
 	r.Get("/api/v1/timezones", d.handleListTimezones())
 	r.Get("/api/v1/settings/ai/models", d.handleListAIModels())
+	r.Get("/api/v1/settings/ai/reports", d.handleGetSettingsAIReports())
 	r.Get("/api/v1/settings/ai", d.handleGetSettingsAI())
 	r.Put("/api/v1/settings/ai", d.handlePutSettingsAI())
 	r.Get("/api/v1/settings/platform", d.handleGetPlatformSettings())

--- a/server/internal/httpserver/report_cards_http.go
+++ b/server/internal/httpserver/report_cards_http.go
@@ -475,7 +475,7 @@ func (d Deps) handleAIReportCardComment() http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		_ = json.NewEncoder(w).Encode(map[string]any{"suggestion": strings.TrimSpace(suggestion)})
+		_ = json.NewEncoder(w).Encode(map[string]any{"suggestion": strings.TrimSpace(suggestion.Text)})
 	}
 }
 

--- a/server/internal/httpserver/settings_ai.go
+++ b/server/internal/httpserver/settings_ai.go
@@ -1,12 +1,14 @@
 package httpserver
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
 
 	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/repos/platformconfig"
 	"github.com/lextures/lextures/server/internal/repos/user"
 	"github.com/lextures/lextures/server/internal/service/openrouter"
 )
@@ -85,21 +87,25 @@ func (d Deps) handleGetSettingsAI() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load AI settings.")
 			return
 		}
+		cfg := d.effectiveConfig()
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"imageModelId":                img,
 			"courseSetupModelId":          course,
 			"notebookFlashcardsModelId":   flashcards,
 			"vibeActivityModelId":         vibe,
+			"openRouterApiKey":            maskSecret(cfg.OpenRouterAPIKey),
 		})
 	}
 }
 
 type putSettingsAIBody struct {
-	ImageModelID                string `json:"imageModelId"`
-	CourseSetupModelID          string `json:"courseSetupModelId"`
-	NotebookFlashcardsModelID   string `json:"notebookFlashcardsModelId"`
-	VibeActivityModelID         string `json:"vibeActivityModelId"`
+	ImageModelID                string  `json:"imageModelId"`
+	CourseSetupModelID          string  `json:"courseSetupModelId"`
+	NotebookFlashcardsModelID   string  `json:"notebookFlashcardsModelId"`
+	VibeActivityModelID         string  `json:"vibeActivityModelId"`
+	OpenRouterAPIKey            *string `json:"openRouterApiKey"`
+	ClearOpenRouterAPIKey       bool    `json:"clearOpenRouterApiKey"`
 }
 
 // handlePutSettingsAI is PUT /api/v1/settings/ai
@@ -143,17 +149,76 @@ func (d Deps) handlePutSettingsAI() http.HandlerFunc {
 		if vibe == "" {
 			vibe = user.DefaultVibeActivityModelID
 		}
+		if err := d.applyOpenRouterAPIKeyUpdate(r.Context(), in.OpenRouterAPIKey, in.ClearOpenRouterAPIKey); err != nil {
+			if err == errOpenRouterAPIKeyConflict {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Cannot set openRouterApiKey and clearOpenRouterApiKey together.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save OpenRouter API key.")
+			return
+		}
+
 		imgOut, courseOut, flashcardsOut, vibeOut, err := user.UpsertAISettings(r.Context(), d.Pool, uid, img, course, flashcards, vibe)
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save AI settings.")
 			return
 		}
+		cfg := d.effectiveConfig()
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"imageModelId":                imgOut,
 			"courseSetupModelId":          courseOut,
 			"notebookFlashcardsModelId":   flashcardsOut,
 			"vibeActivityModelId":         vibeOut,
+			"openRouterApiKey":            maskSecret(cfg.OpenRouterAPIKey),
 		})
 	}
+}
+
+var errOpenRouterAPIKeyConflict = errOpenRouterKeyConflict{}
+
+type errOpenRouterKeyConflict struct{}
+
+func (errOpenRouterKeyConflict) Error() string {
+	return "openrouter api key conflict"
+}
+
+func (d Deps) applyOpenRouterAPIKeyUpdate(ctx context.Context, key *string, clear bool) error {
+	if d.Pool == nil {
+		return nil
+	}
+	if key == nil && !clear {
+		return nil
+	}
+
+	wr := &platformconfig.Write{}
+	if key != nil {
+		s := strings.TrimSpace(*key)
+		if s != "" && s != placeholderSecretResponse {
+			wr.OpenRouterAPIKey = &s
+		}
+	}
+	if clear && wr.OpenRouterAPIKey != nil && strings.TrimSpace(*wr.OpenRouterAPIKey) != "" {
+		return errOpenRouterAPIKeyConflict
+	}
+	if clear {
+		if err := platformconfig.ClearOpenRouterAPIKey(ctx, d.Pool); err != nil {
+			return err
+		}
+	}
+	if wr.OpenRouterAPIKey == nil {
+		return nil
+	}
+	dbRow, err := platformconfig.Upsert(ctx, d.Pool, wr)
+	if err != nil {
+		return err
+	}
+	merged := platformconfig.Merge(d.Config, dbRow)
+	if err := merged.Validate(); err != nil {
+		return err
+	}
+	if d.Platform != nil {
+		d.Platform.Reload(merged)
+	}
+	return nil
 }

--- a/server/internal/httpserver/settings_ai_reports.go
+++ b/server/internal/httpserver/settings_ai_reports.go
@@ -1,0 +1,106 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/lextures/lextures/server/internal/apierr"
+	models "github.com/lextures/lextures/server/internal/models/aiusage"
+	"github.com/lextures/lextures/server/internal/repos/aiusage"
+)
+
+// handleGetSettingsAIReports is GET /api/v1/settings/ai/reports
+func (d Deps) handleGetSettingsAIReports() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet+","+http.MethodOptions)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+			return
+		}
+
+		from, to, err := parseAIReportsTimeRange(r.URL.Query(), timeNowUTC())
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+
+		q := r.URL.Query()
+		filters := aiusage.Filters{
+			From:       from,
+			To:         to,
+			Feature:    strings.TrimSpace(q.Get("feature")),
+			UserQuery:  strings.TrimSpace(q.Get("userQuery")),
+			CourseCode: strings.TrimSpace(q.Get("courseCode")),
+		}
+		if s := strings.TrimSpace(q.Get("userId")); s != "" {
+			uid, perr := uuid.Parse(s)
+			if perr != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid userId.")
+				return
+			}
+			filters.UserID = &uid
+		}
+		if s := strings.TrimSpace(q.Get("courseId")); s != "" {
+			cid, perr := uuid.Parse(s)
+			if perr != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid courseId.")
+				return
+			}
+			filters.CourseID = &cid
+		}
+
+		ctx := r.Context()
+		summary, err := aiusage.CostSummary(ctx, d.Pool, filters)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load AI cost report.")
+			return
+		}
+		byDay, err := aiusage.CostByDay(ctx, d.Pool, filters)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load AI cost report.")
+			return
+		}
+		byFeature, err := aiusage.CostByFeature(ctx, d.Pool, filters)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load AI cost report.")
+			return
+		}
+		byUser, err := aiusage.UsageByUser(ctx, d.Pool, filters, 50)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load AI usage by user.")
+			return
+		}
+		byCourse, err := aiusage.UsageByCourse(ctx, d.Pool, filters, 50)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load AI usage by course.")
+			return
+		}
+
+		out := models.ReportsPayload{
+			Range: models.DateRange{From: from, To: to},
+			Cost: models.CostReport{
+				Summary:   summary,
+				ByDay:     byDay,
+				ByFeature: byFeature,
+			},
+			ByUser:   byUser,
+			ByCourse: byCourse,
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}

--- a/server/internal/httpserver/settings_platform.go
+++ b/server/internal/httpserver/settings_platform.go
@@ -38,8 +38,6 @@ func smtpPasswordMasked(dbRow *platformconfig.Row, mergedPassword string) string
 }
 
 type platformSettingsJSON struct {
-	OpenRouterAPIKey string `json:"openRouterApiKey"`
-
 	SAMLSSOEnabled      bool   `json:"samlSsoEnabled"`
 	SAMLPublicBaseURL   string `json:"samlPublicBaseUrl"`
 	SAMLSPEntityID      string `json:"samlSpEntityId"`
@@ -165,8 +163,6 @@ type platformSettingsJSON struct {
 }
 
 type platformSourcesJSON struct {
-	OpenRouterAPIKey string `json:"openRouterApiKey"`
-
 	SAMLSSOEnabled      string `json:"samlSsoEnabled"`
 	SAMLPublicBaseURL   string `json:"samlPublicBaseUrl"`
 	SAMLSPEntityID      string `json:"samlSpEntityId"`
@@ -223,7 +219,6 @@ func (d Deps) handleGetPlatformSettings() http.HandlerFunc {
 		merged := platformconfig.Merge(d.Config, dbRow)
 		sources := platformconfig.ResolveSources(d.Config, dbRow)
 		out := platformSettingsJSON{
-			OpenRouterAPIKey:                maskSecret(merged.OpenRouterAPIKey),
 			SAMLSSOEnabled:                  merged.SAMLSSOEnabled,
 			SAMLPublicBaseURL:               merged.SAMLPublicBaseURL,
 			SAMLSPEntityID:                  merged.SAMLSPEntityID,
@@ -339,7 +334,6 @@ func (d Deps) handleGetPlatformSettings() http.HandlerFunc {
 			SMTPUser:                        merged.SMTPUser,
 			SMTPPassword:                    smtpPasswordMasked(dbRow, merged.SMTPPassword),
 			Sources: platformSourcesJSON{
-				OpenRouterAPIKey:            src(sources.OpenRouterAPIKey),
 				SAMLSSOEnabled:              src(sources.SAMLSSOEnabled),
 				SAMLPublicBaseURL:           src(sources.SAMLPublicBaseURL),
 				SAMLSPEntityID:              src(sources.SAMLSPEntityID),
@@ -372,9 +366,6 @@ func (d Deps) handleGetPlatformSettings() http.HandlerFunc {
 }
 
 type putPlatformBody struct {
-	OpenRouterAPIKey      *string `json:"openRouterApiKey"`
-	ClearOpenRouterAPIKey bool    `json:"clearOpenRouterApiKey"`
-
 	SAMLSSOEnabled      *bool   `json:"samlSsoEnabled"`
 	SAMLPublicBaseURL   *string `json:"samlPublicBaseUrl"`
 	SAMLSPEntityID      *string `json:"samlSpEntityId"`
@@ -530,13 +521,8 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 		}
 
 		wr := &platformconfig.Write{}
-		clearRouter := body.ClearOpenRouterAPIKey
 		clearSMTP := body.ClearSMTPPassword
 		if len(mask) > 0 {
-			clearRouter = false
-			if _, ok := mask["clearopenrouterapikey"]; ok {
-				clearRouter = true
-			}
 			clearSMTP = false
 			if _, ok := mask["clearsmtpassword"]; ok {
 				clearSMTP = true
@@ -554,24 +540,6 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 				}
 			}
 			apply()
-		}
-
-		set("openrouterapikey", body.OpenRouterAPIKey != nil, func() {
-			s := strings.TrimSpace(*body.OpenRouterAPIKey)
-			if s != "" && s != placeholderSecretResponse {
-				wr.OpenRouterAPIKey = &s
-			}
-		})
-
-		if clearRouter && wr.OpenRouterAPIKey != nil && strings.TrimSpace(*wr.OpenRouterAPIKey) != "" {
-			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Cannot set openRouterApiKey and clearOpenRouterApiKey together.")
-			return
-		}
-		if clearRouter {
-			if err := platformconfig.ClearOpenRouterAPIKey(r.Context(), d.Pool); err != nil {
-				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to clear OpenRouter override.")
-				return
-			}
 		}
 
 		smtpPortActive := len(mask) == 0
@@ -838,7 +806,6 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 
 		sources := platformconfig.ResolveSources(d.Config, dbRow)
 		out := platformSettingsJSON{
-			OpenRouterAPIKey:                maskSecret(merged.OpenRouterAPIKey),
 			SAMLSSOEnabled:                  merged.SAMLSSOEnabled,
 			SAMLPublicBaseURL:               merged.SAMLPublicBaseURL,
 			SAMLSPEntityID:                  merged.SAMLSPEntityID,
@@ -954,7 +921,6 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 			SMTPUser:                        merged.SMTPUser,
 			SMTPPassword:                    smtpPasswordMasked(dbRow, merged.SMTPPassword),
 			Sources: platformSourcesJSON{
-				OpenRouterAPIKey:            src(sources.OpenRouterAPIKey),
 				SAMLSSOEnabled:              src(sources.SAMLSSOEnabled),
 				SAMLPublicBaseURL:           src(sources.SAMLPublicBaseURL),
 				SAMLSPEntityID:              src(sources.SAMLSPEntityID),

--- a/server/internal/httpserver/structure_module_http.go
+++ b/server/internal/httpserver/structure_module_http.go
@@ -912,7 +912,7 @@ func (d Deps) handleGenerateVibeActivityHTML() http.HandlerFunc {
 
 		or := d.openRouterClient()
 		if or == nil {
-			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "AI generation is not configured. Set an OpenRouter API key in Platform Settings.")
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "AI generation is not configured. Set an OpenRouter API key under Settings → Intelligence → Models.")
 			return
 		}
 
@@ -945,8 +945,11 @@ func (d Deps) handleGenerateVibeActivityHTML() http.HandlerFunc {
 			return
 		}
 		d.logAIInferenceAllowed(r, viewer, aigateway.FeatureVibeGeneration, model, prompt, gwDec)
+		d.recordAIUsage(r.Context(), AIUsageMeta{
+			UserID: viewer, CourseCode: courseCode, Feature: aigateway.FeatureVibeGeneration, Model: model,
+		}, generated.Usage, true)
 
-		html := strings.TrimSpace(generated)
+		html := strings.TrimSpace(generated.Text)
 		// Strip accidental markdown code fences if the model wraps output
 		if strings.HasPrefix(html, "```") {
 			lines := strings.SplitN(html, "\n", 2)

--- a/server/internal/httpserver/translation.go
+++ b/server/internal/httpserver/translation.go
@@ -112,7 +112,7 @@ func (d Deps) handleTranslate() http.HandlerFunc {
 			OptInConfirmed: true,
 		}
 
-		translated, sourceLang, err := callLLMTranslation(or, req.Text, req.TargetLang)
+		translated, sourceLang, usage, err := callLLMTranslation(or, req.Text, req.TargetLang)
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Translation temporarily unavailable.")
 			return
@@ -120,6 +120,9 @@ func (d Deps) handleTranslate() http.HandlerFunc {
 
 		_ = translation.Store(ctx, d.Pool, req.ContentType, contentID, sourceLang, req.TargetLang, translated, translationProvider)
 		d.logAIInferenceAllowed(r, userID, aigateway.FeatureTranslation, translationModel, req.Text, gwDec)
+		d.recordAIUsage(r.Context(), AIUsageMeta{
+			UserID: userID, Feature: aigateway.FeatureTranslation, Model: translationModel,
+		}, usage, true)
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(translateResponse{
@@ -130,8 +133,8 @@ func (d Deps) handleTranslate() http.HandlerFunc {
 	}
 }
 
-// callLLMTranslation sends a translation request to the LLM and returns (translated, sourceLang, error).
-func callLLMTranslation(or *openrouter.Client, text, targetLang string) (string, string, error) {
+// callLLMTranslation sends a translation request to the LLM and returns (translated, sourceLang, usage, error).
+func callLLMTranslation(or *openrouter.Client, text, targetLang string) (string, string, openrouter.UsageInfo, error) {
 	langName := langCodeToName(targetLang)
 	prompt := fmt.Sprintf(
 		"Detect the source language of the following text and translate it to %s. "+
@@ -144,23 +147,23 @@ func callLLMTranslation(or *openrouter.Client, text, targetLang string) (string,
 		{Role: "user", Content: text},
 	}
 
-	cfg, err := or.ChatCompletion("openai/gpt-4o-mini", messages)
+	completion, err := or.ChatCompletion("openai/gpt-4o-mini", messages)
 	if err != nil {
-		return "", "", fmt.Errorf("llm call failed: %w", err)
+		return "", "", openrouter.UsageInfo{}, fmt.Errorf("llm call failed: %w", err)
 	}
 
 	var result struct {
 		SourceLang string `json:"source_lang"`
 		Translated string `json:"translated"`
 	}
-	if err := json.Unmarshal([]byte(cfg), &result); err != nil {
+	if err := json.Unmarshal([]byte(completion.Text), &result); err != nil {
 		// If LLM didn't produce valid JSON, treat entire response as the translation.
-		return strings.TrimSpace(cfg), "und", nil
+		return strings.TrimSpace(completion.Text), "und", completion.Usage, nil
 	}
 	if result.SourceLang == "" {
 		result.SourceLang = "und"
 	}
-	return result.Translated, result.SourceLang, nil
+	return result.Translated, result.SourceLang, completion.Usage, nil
 }
 
 // langCodeToName converts a BCP 47 language code to a human-readable name for the prompt.

--- a/server/internal/httpserver/tutor.go
+++ b/server/internal/httpserver/tutor.go
@@ -179,15 +179,18 @@ func (d Deps) handlePostTutorMessage() http.HandlerFunc {
 		})
 		if streamErr == nil {
 			d.logAIInferenceAllowed(r, userID, aigateway.FeatureAITutor, model, cleaned, gwDec)
+			d.recordAIUsage(ctx, AIUsageMeta{
+				UserID: userID, Feature: aigateway.FeatureAITutor, Model: model,
+			}, fullText.Usage, true)
 		}
 		if streamErr != nil {
 			tutorSSEError(w, flusher, "I'm having trouble right now. Please try again in a moment.")
 			return
 		}
 
-		estimated := estimateTutorTokens(cleaned + fullText)
+		estimated := estimateTutorTokens(cleaned + fullText.Text)
 		// Non-fatal: save response and update budget; if save fails the stream already sent.
-		_ = tutorrepo.AppendMessage(ctx, d.Pool, conv.ID, "assistant", fullText, estimated)
+		_ = tutorrepo.AppendMessage(ctx, d.Pool, conv.ID, "assistant", fullText.Text, estimated)
 		_ = tutorrepo.AddTokens(ctx, d.Pool, userID, orgID, estimated)
 
 		donePayload := fmt.Sprintf(`{"type":"done","conversationId":%q}`, conv.ID.String())

--- a/server/internal/models/aiusage/reports.go
+++ b/server/internal/models/aiusage/reports.go
@@ -1,0 +1,70 @@
+// Package aiusage holds JSON DTOs for Intelligence AI usage reports.
+package aiusage
+
+import "time"
+
+// ReportsPayload is GET /api/v1/settings/ai/reports.
+type ReportsPayload struct {
+	Range     DateRange         `json:"range"`
+	Cost      CostReport        `json:"cost"`
+	ByUser    []UserUsageRow    `json:"byUser"`
+	ByCourse  []CourseUsageRow  `json:"byCourse"`
+}
+
+// DateRange is the resolved query window (RFC 3339, UTC).
+type DateRange struct {
+	From time.Time `json:"from"`
+	To   time.Time `json:"to"`
+}
+
+// CostReport aggregates platform AI spend.
+type CostReport struct {
+	Summary   CostSummary      `json:"summary"`
+	ByDay     []DayCostBucket  `json:"byDay"`
+	ByFeature []FeatureCostRow `json:"byFeature"`
+}
+
+// CostSummary is headline totals.
+type CostSummary struct {
+	TotalCostUSD float64 `json:"totalCostUsd"`
+	TotalCalls   int64   `json:"totalCalls"`
+	TotalTokens  int64   `json:"totalTokens"`
+}
+
+// DayCostBucket is one UTC calendar day.
+type DayCostBucket struct {
+	Day     string  `json:"day"`
+	CostUSD float64 `json:"costUsd"`
+	Calls   int64   `json:"calls"`
+	Tokens  int64   `json:"tokens"`
+}
+
+// FeatureCostRow is spend for one AI feature key.
+type FeatureCostRow struct {
+	Feature string  `json:"feature"`
+	CostUSD float64 `json:"costUsd"`
+	Calls   int64   `json:"calls"`
+	Tokens  int64   `json:"tokens"`
+}
+
+// UserUsageRow is per-user rollup.
+type UserUsageRow struct {
+	UserID           string  `json:"userId"`
+	Email            string  `json:"email"`
+	DisplayName      string  `json:"displayName"`
+	Calls            int64   `json:"calls"`
+	PromptTokens     int64   `json:"promptTokens"`
+	CompletionTokens int64   `json:"completionTokens"`
+	TotalTokens      int64   `json:"totalTokens"`
+	CostUSD          float64 `json:"costUsd"`
+}
+
+// CourseUsageRow is per-course rollup.
+type CourseUsageRow struct {
+	CourseID   string  `json:"courseId"`
+	CourseCode string  `json:"courseCode"`
+	Title      string  `json:"title"`
+	Calls      int64   `json:"calls"`
+	TotalTokens int64  `json:"totalTokens"`
+	CostUSD    float64 `json:"costUsd"`
+}

--- a/server/internal/repos/aiusage/aiusage.go
+++ b/server/internal/repos/aiusage/aiusage.go
@@ -1,0 +1,65 @@
+// Package aiusage persists OpenRouter token/cost rows for Intelligence reports.
+package aiusage
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/lextures/lextures/server/internal/service/openrouter"
+)
+
+// Entry is one analytics.ai_usage_log row.
+type Entry struct {
+	UserID           *uuid.UUID
+	CourseID         *uuid.UUID
+	Feature          string
+	Model            string
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+	CostUSD          float64
+	Succeeded        bool
+}
+
+// Insert appends a usage row (best-effort; callers may ignore errors).
+func Insert(ctx context.Context, pool *pgxpool.Pool, e Entry) error {
+	if pool == nil {
+		return nil
+	}
+	feature := strings.TrimSpace(e.Feature)
+	if feature == "" {
+		feature = "unknown"
+	}
+	model := strings.TrimSpace(e.Model)
+	if model == "" {
+		model = "unknown"
+	}
+	total := e.TotalTokens
+	if total == 0 {
+		total = e.PromptTokens + e.CompletionTokens
+	}
+	_, err := pool.Exec(ctx, `
+INSERT INTO analytics.ai_usage_log
+  (user_id, course_id, feature, model, prompt_tokens, completion_tokens, total_tokens, cost_usd, succeeded)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+`, e.UserID, e.CourseID, feature, model, e.PromptTokens, e.CompletionTokens, total, e.CostUSD, e.Succeeded)
+	return err
+}
+
+// EntryFromUsage builds a log entry from an OpenRouter result.
+func EntryFromUsage(userID, courseID *uuid.UUID, feature, model string, usage openrouter.UsageInfo, succeeded bool) Entry {
+	return Entry{
+		UserID:           userID,
+		CourseID:         courseID,
+		Feature:          feature,
+		Model:            model,
+		PromptTokens:     usage.PromptTokens,
+		CompletionTokens: usage.CompletionTokens,
+		TotalTokens:      usage.TotalTokens,
+		CostUSD:          usage.CostUSD,
+		Succeeded:        succeeded,
+	}
+}

--- a/server/internal/repos/aiusage/reports.go
+++ b/server/internal/repos/aiusage/reports.go
@@ -1,0 +1,248 @@
+package aiusage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	models "github.com/lextures/lextures/server/internal/models/aiusage"
+)
+
+// Filters scopes report queries.
+type Filters struct {
+	From       time.Time
+	To         time.Time
+	Feature    string
+	UserID     *uuid.UUID
+	CourseID   *uuid.UUID
+	UserQuery  string
+	CourseCode string
+}
+
+func (f Filters) whereSQL(alias string) (string, []any) {
+	col := func(name string) string {
+		if alias == "" {
+			return name
+		}
+		return alias + "." + name
+	}
+	logRef := "analytics.ai_usage_log"
+	if alias != "" {
+		logRef = alias
+	}
+
+	clauses := []string{
+		col("created_at") + " >= $1",
+		col("created_at") + " < $2",
+		col("succeeded") + " = TRUE",
+	}
+	args := []any{f.From, f.To}
+	n := 3
+	if s := strings.TrimSpace(f.Feature); s != "" {
+		clauses = append(clauses, fmt.Sprintf("%s = $%d", col("feature"), n))
+		args = append(args, s)
+		n++
+	}
+	if f.UserID != nil {
+		clauses = append(clauses, fmt.Sprintf("%s = $%d", col("user_id"), n))
+		args = append(args, *f.UserID)
+		n++
+	}
+	if f.CourseID != nil {
+		clauses = append(clauses, fmt.Sprintf("%s = $%d", col("course_id"), n))
+		args = append(args, *f.CourseID)
+		n++
+	}
+	if q := strings.TrimSpace(f.UserQuery); q != "" {
+		pat := "%" + q + "%"
+		clauses = append(clauses, fmt.Sprintf(`EXISTS (
+  SELECT 1 FROM "user".users u
+   WHERE u.id = %s.user_id
+     AND (
+       u.email ILIKE $%d
+       OR COALESCE(u.display_name, '') ILIKE $%d
+       OR COALESCE(u.first_name, '') ILIKE $%d
+       OR COALESCE(u.last_name, '') ILIKE $%d
+     )
+)`, logRef, n, n, n, n))
+		args = append(args, pat)
+		n++
+	}
+	if code := strings.TrimSpace(f.CourseCode); code != "" {
+		pat := "%" + code + "%"
+		clauses = append(clauses, fmt.Sprintf(`EXISTS (
+  SELECT 1 FROM course.courses c
+   WHERE c.id = %s.course_id
+     AND (c.course_code ILIKE $%d OR c.title ILIKE $%d)
+)`, logRef, n, n))
+		args = append(args, pat)
+	}
+	return strings.Join(clauses, " AND "), args
+}
+
+// CostSummary aggregates spend over the window.
+func CostSummary(ctx context.Context, pool *pgxpool.Pool, f Filters) (models.CostSummary, error) {
+	where, args := f.whereSQL("")
+	var s models.CostSummary
+	err := pool.QueryRow(ctx, `
+SELECT
+  COALESCE(SUM(cost_usd), 0)::float8,
+  COUNT(*)::bigint,
+  COALESCE(SUM(total_tokens), 0)::bigint
+FROM analytics.ai_usage_log
+WHERE `+where, args...).Scan(&s.TotalCostUSD, &s.TotalCalls, &s.TotalTokens)
+	return s, err
+}
+
+// CostByDay returns UTC day buckets.
+func CostByDay(ctx context.Context, pool *pgxpool.Pool, f Filters) ([]models.DayCostBucket, error) {
+	where, args := f.whereSQL("")
+	rows, err := pool.Query(ctx, `
+SELECT
+  (date_trunc('day', created_at AT TIME ZONE 'UTC'))::date,
+  COALESCE(SUM(cost_usd), 0)::float8,
+  COUNT(*)::bigint,
+  COALESCE(SUM(total_tokens), 0)::bigint
+FROM analytics.ai_usage_log
+WHERE `+where+`
+GROUP BY 1
+ORDER BY 1 ASC
+`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanDayCost(rows)
+}
+
+func scanDayCost(rows pgx.Rows) ([]models.DayCostBucket, error) {
+	out := make([]models.DayCostBucket, 0)
+	for rows.Next() {
+		var d pgtype.Date
+		var b models.DayCostBucket
+		if err := rows.Scan(&d, &b.CostUSD, &b.Calls, &b.Tokens); err != nil {
+			return nil, err
+		}
+		if d.Valid {
+			t := d.Time.UTC()
+			b.Day = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC).Format("2006-01-02")
+		}
+		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+// CostByFeature returns spend grouped by feature.
+func CostByFeature(ctx context.Context, pool *pgxpool.Pool, f Filters) ([]models.FeatureCostRow, error) {
+	where, args := f.whereSQL("")
+	rows, err := pool.Query(ctx, `
+SELECT
+  feature,
+  COALESCE(SUM(cost_usd), 0)::float8,
+  COUNT(*)::bigint,
+  COALESCE(SUM(total_tokens), 0)::bigint
+FROM analytics.ai_usage_log
+WHERE `+where+`
+GROUP BY feature
+ORDER BY SUM(cost_usd) DESC, COUNT(*) DESC
+`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]models.FeatureCostRow, 0)
+	for rows.Next() {
+		var r models.FeatureCostRow
+		if err := rows.Scan(&r.Feature, &r.CostUSD, &r.Calls, &r.Tokens); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// UsageByUser returns top users by cost in the window.
+func UsageByUser(ctx context.Context, pool *pgxpool.Pool, f Filters, limit int) ([]models.UserUsageRow, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	where, args := f.whereSQL("l")
+	args = append(args, limit)
+	lim := len(args)
+	rows, err := pool.Query(ctx, `
+SELECT
+  u.id,
+  u.email,
+  COALESCE(NULLIF(TRIM(CONCAT_WS(' ', u.first_name, u.last_name)), ''), u.display_name, u.email),
+  COUNT(*)::bigint,
+  COALESCE(SUM(l.prompt_tokens), 0)::bigint,
+  COALESCE(SUM(l.completion_tokens), 0)::bigint,
+  COALESCE(SUM(l.total_tokens), 0)::bigint,
+  COALESCE(SUM(l.cost_usd), 0)::float8
+FROM analytics.ai_usage_log l
+INNER JOIN "user".users u ON u.id = l.user_id
+WHERE `+where+`
+GROUP BY u.id, u.email, u.first_name, u.last_name, u.display_name
+ORDER BY SUM(l.cost_usd) DESC, SUM(l.total_tokens) DESC
+LIMIT $`+fmt.Sprint(lim), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]models.UserUsageRow, 0)
+	for rows.Next() {
+		var id uuid.UUID
+		var r models.UserUsageRow
+		if err := rows.Scan(&id, &r.Email, &r.DisplayName, &r.Calls, &r.PromptTokens, &r.CompletionTokens, &r.TotalTokens, &r.CostUSD); err != nil {
+			return nil, err
+		}
+		r.UserID = id.String()
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// UsageByCourse returns top courses by cost in the window.
+func UsageByCourse(ctx context.Context, pool *pgxpool.Pool, f Filters, limit int) ([]models.CourseUsageRow, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	where, args := f.whereSQL("l")
+	args = append(args, limit)
+	lim := len(args)
+	rows, err := pool.Query(ctx, `
+SELECT
+  c.id,
+  c.course_code,
+  c.title,
+  COUNT(*)::bigint,
+  COALESCE(SUM(l.total_tokens), 0)::bigint,
+  COALESCE(SUM(l.cost_usd), 0)::float8
+FROM analytics.ai_usage_log l
+INNER JOIN course.courses c ON c.id = l.course_id
+WHERE `+where+`
+GROUP BY c.id, c.course_code, c.title
+ORDER BY SUM(l.cost_usd) DESC, SUM(l.total_tokens) DESC
+LIMIT $`+fmt.Sprint(lim), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]models.CourseUsageRow, 0)
+	for rows.Next() {
+		var id uuid.UUID
+		var r models.CourseUsageRow
+		if err := rows.Scan(&id, &r.CourseCode, &r.Title, &r.Calls, &r.TotalTokens, &r.CostUSD); err != nil {
+			return nil, err
+		}
+		r.CourseID = id.String()
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/server/internal/repos/aiusage/reports_test.go
+++ b/server/internal/repos/aiusage/reports_test.go
@@ -1,0 +1,34 @@
+package aiusage
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFilters_whereSQL_qualifiedForJoin(t *testing.T) {
+	from := time.Date(2026, 6, 16, 0, 0, 0, 0, time.UTC)
+	to := from.Add(24 * time.Hour)
+	where, args := (Filters{From: from, To: to}).whereSQL("l")
+	if !strings.Contains(where, "l.created_at >= $1") {
+		t.Fatalf("expected qualified created_at: %q", where)
+	}
+	if !strings.Contains(where, "l.succeeded = TRUE") {
+		t.Fatalf("expected qualified succeeded: %q", where)
+	}
+	if len(args) != 2 {
+		t.Fatalf("args: %d", len(args))
+	}
+}
+
+func TestFilters_whereSQL_unqualifiedForSingleTable(t *testing.T) {
+	from := time.Date(2026, 6, 16, 0, 0, 0, 0, time.UTC)
+	to := from.Add(24 * time.Hour)
+	where, _ := (Filters{From: from, To: to}).whereSQL("")
+	if strings.Contains(where, "l.") {
+		t.Fatalf("unexpected alias in single-table where: %q", where)
+	}
+	if !strings.Contains(where, "created_at >= $1") {
+		t.Fatalf("expected bare created_at: %q", where)
+	}
+}

--- a/server/internal/repos/platformconfig/defaults.go
+++ b/server/internal/repos/platformconfig/defaults.go
@@ -1,7 +1,8 @@
 package platformconfig
 
 // Defaults for platform boolean settings when the database column is NULL.
-// Secrets and integration endpoints still come from process environment.
+// Integration endpoints and some secrets still come from process environment.
+// OpenRouter API keys are stored in settings.platform_app_settings (Intelligence → Models).
 type Defaults struct {
 	BlindGradingEnabled         bool
 	GradePostingPoliciesEnabled bool

--- a/server/internal/repos/platformconfig/merge_test.go
+++ b/server/internal/repos/platformconfig/merge_test.go
@@ -8,16 +8,16 @@ import (
 	"github.com/lextures/lextures/server/internal/crypto/appsecrets"
 )
 
-func TestMerge_OpenRouterEmptyDBUsesEnv(t *testing.T) {
+func TestMerge_OpenRouterEmptyDBStaysEmpty(t *testing.T) {
 	env := config.Config{OpenRouterAPIKey: "env-key"}
 	db := Row{OpenRouterAPIKey: ptr("")}
 	got := Merge(env, &db)
-	if got.OpenRouterAPIKey != "env-key" {
-		t.Fatalf("OpenRouter: got %q want env", got.OpenRouterAPIKey)
+	if got.OpenRouterAPIKey != "" {
+		t.Fatalf("OpenRouter: got %q want empty (not loaded from env)", got.OpenRouterAPIKey)
 	}
 }
 
-func TestMerge_OpenRouterNonEmptyDBOverrides(t *testing.T) {
+func TestMerge_OpenRouterFromDB(t *testing.T) {
 	env := config.Config{OpenRouterAPIKey: "env-key"}
 	db := Row{OpenRouterAPIKey: ptr("db-key")}
 	got := Merge(env, &db)

--- a/server/internal/repos/platformconfig/platformconfig.go
+++ b/server/internal/repos/platformconfig/platformconfig.go
@@ -529,7 +529,7 @@ WHERE id = 1
 	return &r, nil
 }
 
-// ClearOpenRouterAPIKey removes the stored OpenRouter override so the environment key is used again.
+// ClearOpenRouterAPIKey removes the stored OpenRouter API key.
 func ClearOpenRouterAPIKey(ctx context.Context, pool *pgxpool.Pool) error {
 	_, err := pool.Exec(ctx, `
 UPDATE settings.platform_app_settings
@@ -949,6 +949,8 @@ ON CONFLICT (id) DO UPDATE SET
 // Merge applies platform settings from the database (booleans) and optional DB overrides for secrets/URLs.
 func Merge(env config.Config, db *Row) config.Config {
 	out := env
+	// OpenRouter is configured only via platform settings (Intelligence → Models), not process env.
+	out.OpenRouterAPIKey = ""
 	applyPlatformBools(&out, db, DefaultDefaults())
 	if db == nil {
 		return out
@@ -1048,7 +1050,7 @@ func ResolveSources(env config.Config, db *Row) Sources {
 	if db == nil {
 		return sourcesAllEnvironment(env)
 	}
-	s.OpenRouterAPIKey = sourceString(env.OpenRouterAPIKey, db.OpenRouterAPIKey)
+	s.OpenRouterAPIKey = sourceOpenRouterAPIKey(db.OpenRouterAPIKey)
 	s.SAMLSSOEnabled = sourceBoolDB(db.SAMLSSOEnabled)
 	s.SAMLPublicBaseURL = sourceString(env.SAMLPublicBaseURL, db.SAMLPublicBaseURL)
 	s.SAMLSPEntityID = sourceString(env.SAMLSPEntityID, db.SAMLSPEntityID)
@@ -1079,7 +1081,7 @@ func ResolveSources(env config.Config, db *Row) Sources {
 func sourcesAllEnvironment(env config.Config) Sources {
 	_ = env
 	return Sources{
-		OpenRouterAPIKey:            SourceEnvironment,
+		OpenRouterAPIKey:            SourceDefault,
 		SAMLSSOEnabled:              SourceDefault,
 		SAMLPublicBaseURL:           SourceEnvironment,
 		SAMLSPEntityID:              SourceEnvironment,
@@ -1126,6 +1128,13 @@ func sourceSMTPPasswordCiphertext(ciphertext []byte) Source {
 		return SourceDatabase
 	}
 	return SourceEnvironment
+}
+
+func sourceOpenRouterAPIKey(dbPtr *string) Source {
+	if dbPtr != nil && strings.TrimSpace(*dbPtr) != "" {
+		return SourceDatabase
+	}
+	return SourceDefault
 }
 
 func sourceString(envVal string, dbPtr *string) Source {

--- a/server/internal/service/alttextai/service.go
+++ b/server/internal/service/alttextai/service.go
@@ -37,7 +37,7 @@ func Suggest(client *openrouter.Client, model, imageURL, courseLanguage string) 
 	if err != nil {
 		return "", 0, err
 	}
-	suggestion := strings.TrimSpace(text)
+	suggestion := strings.TrimSpace(text.Text)
 	if suggestion == "" {
 		return "", 0, fmt.Errorf("alttextai: empty suggestion")
 	}

--- a/server/internal/service/coachingtips/generate.go
+++ b/server/internal/service/coachingtips/generate.go
@@ -38,14 +38,14 @@ func GenerateTip(ctx context.Context, pool *pgxpool.Pool, client *openrouter.Cli
 		{Role: "system", Content: systemPrompt},
 		{Role: "user", Content: userMsg},
 	})
-	if genErr != nil || strings.TrimSpace(text) == "" {
+	if genErr != nil || strings.TrimSpace(text.Text) == "" {
 		return PickFallback(weekSeed), contextLine, false, genErr
 	}
-	text = strings.TrimSpace(text)
-	if len(text) > 500 {
-		text = text[:500]
+	textStr := strings.TrimSpace(text.Text)
+	if len(textStr) > 500 {
+		textStr = textStr[:500]
 	}
-	return text, contextLine, true, nil
+	return textStr, contextLine, true, nil
 }
 
 // WeekOfMonday returns the Monday date for the week containing t.

--- a/server/internal/service/contentsimplificationai/service.go
+++ b/server/internal/service/contentsimplificationai/service.go
@@ -34,5 +34,5 @@ func Simplify(client *openrouter.Client, model, text string, targetGrade int) (s
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(out), nil
+	return strings.TrimSpace(out.Text), nil
 }

--- a/server/internal/service/notebookrag/notebookrag.go
+++ b/server/internal/service/notebookrag/notebookrag.go
@@ -314,7 +314,7 @@ func Answer(ctx context.Context, pool *pgxpool.Pool, or *openrouter.Client, user
 	if err != nil {
 		return Response{}, &GenerationError{Message: err.Error()}
 	}
-	answer := normalizeMarkdownOutput(text)
+	answer := normalizeMarkdownOutput(text.Text)
 	if answer == "" {
 		return Response{}, &GenerationError{Message: "The model returned an empty response."}
 	}

--- a/server/internal/service/openrouter/openrouter.go
+++ b/server/internal/service/openrouter/openrouter.go
@@ -63,13 +63,42 @@ type VisionMessage struct {
 	Content []ContentPart `json:"content"`
 }
 
+type chatCompletionResponse struct {
+	Choices []struct {
+		Message struct {
+			Content *string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+	Usage usagePayload `json:"usage"`
+}
+
+type usagePayload struct {
+	PromptTokens     int     `json:"prompt_tokens"`
+	CompletionTokens int     `json:"completion_tokens"`
+	TotalTokens      int     `json:"total_tokens"`
+	Cost             float64 `json:"cost"`
+}
+
+func usageFromPayload(u usagePayload) UsageInfo {
+	total := u.TotalTokens
+	if total == 0 {
+		total = u.PromptTokens + u.CompletionTokens
+	}
+	return UsageInfo{
+		PromptTokens:     u.PromptTokens,
+		CompletionTokens: u.CompletionTokens,
+		TotalTokens:      total,
+		CostUSD:          u.Cost,
+	}
+}
+
 // ChatCompletion sends a non-streaming chat request and returns the assistant text, if any.
-func (c *Client) ChatCompletion(model string, messages []Message) (string, error) {
+func (c *Client) ChatCompletion(model string, messages []Message) (ChatResult, error) {
 	if c == nil {
-		return "", fmt.Errorf("openrouter: nil client")
+		return ChatResult{}, fmt.Errorf("openrouter: nil client")
 	}
 	if c.apiKey == "" {
-		return "", fmt.Errorf("openrouter: missing API key")
+		return ChatResult{}, fmt.Errorf("openrouter: missing API key")
 	}
 	base := c.baseURL
 	if base == "" {
@@ -82,12 +111,12 @@ func (c *Client) ChatCompletion(model string, messages []Message) (string, error
 	}
 	buf, err := json.Marshal(body)
 	if err != nil {
-		return "", err
+		return ChatResult{}, err
 	}
 	u := base + "/chat/completions"
 	req, err := http.NewRequest(http.MethodPost, u, bytes.NewReader(buf))
 	if err != nil {
-		return "", err
+		return ChatResult{}, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
@@ -97,46 +126,41 @@ func (c *Client) ChatCompletion(model string, messages []Message) (string, error
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		return "", err
+		return ChatResult{}, err
 	}
 	defer func() { _ = res.Body.Close() }()
 	b, err := io.ReadAll(res.Body)
 	if err != nil {
-		return "", err
+		return ChatResult{}, err
 	}
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		msg := string(b)
 		if len(msg) > 2000 {
 			msg = msg[:2000]
 		}
-		return "", fmt.Errorf("openrouter: status %d: %s", res.StatusCode, msg)
+		return ChatResult{}, fmt.Errorf("openrouter: status %d: %s", res.StatusCode, msg)
 	}
-	var parsed struct {
-		Choices []struct {
-			Message struct {
-				Content *string `json:"content"`
-			} `json:"message"`
-		} `json:"choices"`
-	}
+	var parsed chatCompletionResponse
 	if err := json.Unmarshal(b, &parsed); err != nil {
-		return "", fmt.Errorf("openrouter: parse response: %w", err)
+		return ChatResult{}, fmt.Errorf("openrouter: parse response: %w", err)
 	}
 	if len(parsed.Choices) == 0 {
-		return "", fmt.Errorf("openrouter: no choices in response")
+		return ChatResult{}, fmt.Errorf("openrouter: no choices in response")
 	}
-	if parsed.Choices[0].Message.Content == nil {
-		return "", nil
+	out := ChatResult{Usage: usageFromPayload(parsed.Usage)}
+	if parsed.Choices[0].Message.Content != nil {
+		out.Text = *parsed.Choices[0].Message.Content
 	}
-	return *parsed.Choices[0].Message.Content, nil
+	return out, nil
 }
 
 // VisionCompletion sends a vision-capable chat request with one image URL.
-func (c *Client) VisionCompletion(model, systemPrompt, userText, imageURL string) (string, error) {
+func (c *Client) VisionCompletion(model, systemPrompt, userText, imageURL string) (ChatResult, error) {
 	if c == nil {
-		return "", fmt.Errorf("openrouter: nil client")
+		return ChatResult{}, fmt.Errorf("openrouter: nil client")
 	}
 	if c.apiKey == "" {
-		return "", fmt.Errorf("openrouter: missing API key")
+		return ChatResult{}, fmt.Errorf("openrouter: missing API key")
 	}
 	base := c.baseURL
 	if base == "" {
@@ -159,12 +183,12 @@ func (c *Client) VisionCompletion(model, systemPrompt, userText, imageURL string
 	}
 	buf, err := json.Marshal(body)
 	if err != nil {
-		return "", err
+		return ChatResult{}, err
 	}
 	u := base + "/chat/completions"
 	req, err := http.NewRequest(http.MethodPost, u, bytes.NewReader(buf))
 	if err != nil {
-		return "", err
+		return ChatResult{}, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
@@ -174,35 +198,30 @@ func (c *Client) VisionCompletion(model, systemPrompt, userText, imageURL string
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		return "", err
+		return ChatResult{}, err
 	}
 	defer func() { _ = res.Body.Close() }()
 	b, err := io.ReadAll(res.Body)
 	if err != nil {
-		return "", err
+		return ChatResult{}, err
 	}
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		msg := string(b)
 		if len(msg) > 2000 {
 			msg = msg[:2000]
 		}
-		return "", fmt.Errorf("openrouter: status %d: %s", res.StatusCode, msg)
+		return ChatResult{}, fmt.Errorf("openrouter: status %d: %s", res.StatusCode, msg)
 	}
-	var parsed struct {
-		Choices []struct {
-			Message struct {
-				Content *string `json:"content"`
-			} `json:"message"`
-		} `json:"choices"`
-	}
+	var parsed chatCompletionResponse
 	if err := json.Unmarshal(b, &parsed); err != nil {
-		return "", fmt.Errorf("openrouter: parse response: %w", err)
+		return ChatResult{}, fmt.Errorf("openrouter: parse response: %w", err)
 	}
 	if len(parsed.Choices) == 0 {
-		return "", fmt.Errorf("openrouter: no choices in response")
+		return ChatResult{}, fmt.Errorf("openrouter: no choices in response")
 	}
-	if parsed.Choices[0].Message.Content == nil {
-		return "", nil
+	out := ChatResult{Usage: usageFromPayload(parsed.Usage)}
+	if parsed.Choices[0].Message.Content != nil {
+		out.Text = *parsed.Choices[0].Message.Content
 	}
-	return *parsed.Choices[0].Message.Content, nil
+	return out, nil
 }

--- a/server/internal/service/openrouter/openrouter_test.go
+++ b/server/internal/service/openrouter/openrouter_test.go
@@ -19,8 +19,8 @@ func TestChatCompletion_OK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != "## Hi\n- one" {
-		t.Fatalf("content: %q", got)
+	if got.Text != "## Hi\n- one" {
+		t.Fatalf("content: %q", got.Text)
 	}
 }
 

--- a/server/internal/service/openrouter/stream.go
+++ b/server/internal/service/openrouter/stream.go
@@ -15,13 +15,13 @@ import (
 type ChunkHandler func(text string) error
 
 // ChatCompletionStream sends a streaming chat request to OpenRouter and calls onChunk for each
-// content delta. It returns the concatenated full response text.
-func (c *Client) ChatCompletionStream(model string, messages []Message, onChunk ChunkHandler) (string, error) {
+// content delta. It returns the concatenated full response text and any usage from the final chunk.
+func (c *Client) ChatCompletionStream(model string, messages []Message, onChunk ChunkHandler) (ChatResult, error) {
 	if c == nil {
-		return "", fmt.Errorf("openrouter: nil client")
+		return ChatResult{}, fmt.Errorf("openrouter: nil client")
 	}
 	if c.apiKey == "" {
-		return "", fmt.Errorf("openrouter: missing API key")
+		return ChatResult{}, fmt.Errorf("openrouter: missing API key")
 	}
 	base := c.baseURL
 	if base == "" {
@@ -34,11 +34,11 @@ func (c *Client) ChatCompletionStream(model string, messages []Message, onChunk 
 	}
 	buf, err := json.Marshal(body)
 	if err != nil {
-		return "", err
+		return ChatResult{}, err
 	}
 	req, err := http.NewRequest(http.MethodPost, base+"/chat/completions", bytes.NewReader(buf))
 	if err != nil {
-		return "", err
+		return ChatResult{}, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
@@ -48,7 +48,7 @@ func (c *Client) ChatCompletionStream(model string, messages []Message, onChunk 
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		return "", err
+		return ChatResult{}, err
 	}
 	defer func() { _ = res.Body.Close() }()
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
@@ -57,10 +57,11 @@ func (c *Client) ChatCompletionStream(model string, messages []Message, onChunk 
 		if len(msg) > 2000 {
 			msg = msg[:2000]
 		}
-		return "", fmt.Errorf("openrouter: status %d: %s", res.StatusCode, msg)
+		return ChatResult{}, fmt.Errorf("openrouter: status %d: %s", res.StatusCode, msg)
 	}
 
 	var sb strings.Builder
+	var usage UsageInfo
 	scanner := bufio.NewScanner(res.Body)
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -77,9 +78,13 @@ func (c *Client) ChatCompletionStream(model string, messages []Message, onChunk 
 					Content *string `json:"content"`
 				} `json:"delta"`
 			} `json:"choices"`
+			Usage usagePayload `json:"usage"`
 		}
 		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
 			continue
+		}
+		if u := usageFromPayload(chunk.Usage); u.HasData() {
+			usage = u
 		}
 		if len(chunk.Choices) == 0 {
 			continue
@@ -94,12 +99,12 @@ func (c *Client) ChatCompletionStream(model string, messages []Message, onChunk 
 		sb.WriteString(text)
 		if onChunk != nil {
 			if err := onChunk(text); err != nil {
-				return sb.String(), err
+				return ChatResult{Text: sb.String(), Usage: usage}, err
 			}
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return sb.String(), fmt.Errorf("openrouter: scan stream: %w", err)
+		return ChatResult{Text: sb.String(), Usage: usage}, fmt.Errorf("openrouter: scan stream: %w", err)
 	}
-	return sb.String(), nil
+	return ChatResult{Text: sb.String(), Usage: usage}, nil
 }

--- a/server/internal/service/openrouter/stream_test.go
+++ b/server/internal/service/openrouter/stream_test.go
@@ -27,8 +27,8 @@ func TestChatCompletionStream_OK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if full != "Hello world" {
-		t.Errorf("full text: %q", full)
+	if full.Text != "Hello world" {
+		t.Errorf("full text: %q", full.Text)
 	}
 	if len(got) != 3 {
 		t.Errorf("chunk count: %d", len(got))
@@ -78,7 +78,7 @@ func TestChatCompletionStream_IgnoresNonDataLines(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if full != "ok" {
-		t.Errorf("full: %q", full)
+	if full.Text != "ok" {
+		t.Errorf("full: %q", full.Text)
 	}
 }

--- a/server/internal/service/openrouter/usage.go
+++ b/server/internal/service/openrouter/usage.go
@@ -1,0 +1,20 @@
+package openrouter
+
+// UsageInfo is token and cost metadata from an OpenRouter chat completion response.
+type UsageInfo struct {
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+	CostUSD          float64
+}
+
+// HasData reports whether the provider returned any usage metadata.
+func (u UsageInfo) HasData() bool {
+	return u.TotalTokens > 0 || u.PromptTokens > 0 || u.CompletionTokens > 0 || u.CostUSD > 0
+}
+
+// ChatResult is the assistant text plus optional usage metadata.
+type ChatResult struct {
+	Text  string
+	Usage UsageInfo
+}

--- a/server/internal/service/plagiarism/provider.go
+++ b/server/internal/service/plagiarism/provider.go
@@ -70,7 +70,7 @@ func (p InternalAIProvider) Scan(ctx context.Context, text string) (ScanResult, 
 	if err != nil {
 		return ScanResult{}, err
 	}
-	score := parseScorePercent(out)
+	score := parseScorePercent(out.Text)
 	if score == nil {
 		return ScanResult{}, fmt.Errorf("internal ai: could not parse score")
 	}

--- a/server/migrations/281_ai_usage_logs.sql
+++ b/server/migrations/281_ai_usage_logs.sql
@@ -1,0 +1,31 @@
+-- AI token/cost usage for Intelligence → Reports (plan 19.14 foundation).
+CREATE TABLE IF NOT EXISTS analytics.ai_usage_log (
+    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    user_id           UUID REFERENCES "user".users(id) ON DELETE SET NULL,
+    course_id         UUID REFERENCES course.courses(id) ON DELETE SET NULL,
+    feature           TEXT NOT NULL DEFAULT 'unknown',
+    model             TEXT NOT NULL,
+    prompt_tokens     INT NOT NULL DEFAULT 0 CHECK (prompt_tokens >= 0),
+    completion_tokens INT NOT NULL DEFAULT 0 CHECK (completion_tokens >= 0),
+    total_tokens      INT NOT NULL DEFAULT 0 CHECK (total_tokens >= 0),
+    cost_usd          NUMERIC(14, 8) NOT NULL DEFAULT 0 CHECK (cost_usd >= 0),
+    succeeded         BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_usage_log_created_at
+    ON analytics.ai_usage_log (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ai_usage_log_user_created
+    ON analytics.ai_usage_log (user_id, created_at DESC)
+    WHERE user_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ai_usage_log_course_created
+    ON analytics.ai_usage_log (course_id, created_at DESC)
+    WHERE course_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ai_usage_log_feature_created
+    ON analytics.ai_usage_log (feature, created_at DESC);
+
+COMMENT ON TABLE analytics.ai_usage_log IS
+    'Per-call OpenRouter usage (tokens, estimated USD cost) for platform AI reports.';

--- a/www/src/docs/self-hosting.md
+++ b/www/src/docs/self-hosting.md
@@ -25,11 +25,7 @@ To make **your** account the platform administrator:
 BOOTSTRAP_ADMIN_EMAIL=you@yourdomain.com
 ```
 
-Optional, for AI features:
-
-```bash
-OPEN_ROUTER_API_KEY=sk-or-...
-```
+Optional, for AI features: after signing in as a global admin, open **Settings → Intelligence → Models** and save your OpenRouter API key there (stored in the platform database).
 
 You can copy from [`.env.example`](https://github.com/StudyDrift/lextures/blob/main/.env.example) in the repo.
 


### PR DESCRIPTION
## Summary

- Add per-call OpenRouter usage tracking (tokens + estimated USD cost) persisted to `analytics.ai_usage_log`, instrumented across AI gateway paths
- Add **Settings → Intelligence → Reports** with cost/token summaries, time-range presets, and filters (feature, user, course)
- Move notebook RAG and flashcard gating from `VITE_FEATURE_*` build vars to runtime platform features (`ragNotebookEnabled`, `openRouterConfigured`, `aiDisclosureEnabled`)
- Restructure Settings AI navigation and update env/docs examples

## Test plan

- [x] `go test ./internal/httpserver/... ./internal/repos/aiusage/... ./internal/service/openrouter/... -short`
- [x] `npm run typecheck` (clients/web)
- [ ] Manual: open Settings → Intelligence → Reports as Global Admin and verify summaries load
- [ ] Manual: confirm notebook RAG/flashcards respect platform feature flags without rebuild