### PR TITLE
feat(15.6): LinkedIn share and Open Badges export

### DIFF
--- a/clients/web/src/app.tsx
+++ b/clients/web/src/app.tsx
@@ -62,6 +62,7 @@ export default function App() {
             <Route path="/privacy-centre" element={<Pages.PrivacyCentrePage />} />
             <Route path="/me/study-insights" element={<Pages.StudyInsightsPage />} />
             <Route path="/me/ccr" element={<Pages.MyCCR />} />
+            <Route path="/me/credentials" element={<Pages.MyCredentials />} />
             <Route path="/me/ce-transcript" element={<Pages.CeTranscript />} />
             <Route path="/me/billing" element={<Pages.BillingSettingsPage />} />
             <Route path="/checkout/success" element={<Pages.CheckoutSuccessPage />} />

--- a/clients/web/src/components/credentials/credential-share-actions.tsx
+++ b/clients/web/src/components/credentials/credential-share-actions.tsx
@@ -1,0 +1,149 @@
+import { useState } from 'react'
+import { Copy, Download, Share2 } from 'lucide-react'
+import {
+  downloadCredentialPdf,
+  fetchBadgeExportUrl,
+  fetchLinkedInParams,
+  recordCredentialShare,
+  type IssuedCredentialSummary,
+} from '../../lib/credentials-api'
+import { buildLinkedInCertificationUrl } from '../../lib/linkedin-share'
+
+type Props = {
+  credential: IssuedCredentialSummary
+  layout?: 'row' | 'stack'
+}
+
+export function CredentialShareActions({ credential, layout = 'row' }: Props) {
+  const [busy, setBusy] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const containerClass =
+    layout === 'stack'
+      ? 'flex flex-col gap-2'
+      : 'flex flex-wrap items-center gap-2'
+
+  async function handleLinkedIn() {
+    setBusy('linkedin')
+    setError(null)
+    try {
+      const params = await fetchLinkedInParams(credential.id)
+      const url = params.url || buildLinkedInCertificationUrl({
+        name: params.name,
+        organizationName: params.organizationName,
+        issueYear: params.issueYear,
+        issueMonth: params.issueMonth,
+        certUrl: params.certUrl,
+        certId: params.certId,
+      })
+      void recordCredentialShare(credential.id, 'linkedin').catch(() => undefined)
+      window.open(url, '_blank', 'noopener,noreferrer')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'LinkedIn share failed.')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function handlePdf() {
+    setBusy('pdf')
+    setError(null)
+    try {
+      const blob = await downloadCredentialPdf(credential.id)
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${credential.title}-certificate.pdf`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'PDF download failed.')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function handleBadgeJson() {
+    setBusy('badge')
+    setError(null)
+    try {
+      const { downloadUrl } = await fetchBadgeExportUrl(credential.id)
+      void recordCredentialShare(credential.id, 'badge_export').catch(() => undefined)
+      const a = document.createElement('a')
+      a.href = downloadUrl
+      a.download = `${credential.title}-badge.json`
+      a.click()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Badge export failed.')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function handleCopyLink() {
+    setBusy('copy')
+    setError(null)
+    try {
+      await navigator.clipboard.writeText(credential.verificationUrl)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2000)
+    } catch {
+      setError('Could not copy link.')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const label = credential.title
+
+  return (
+    <div className={containerClass}>
+      <button
+        type="button"
+        onClick={() => void handleLinkedIn()}
+        disabled={busy !== null}
+        aria-label={`Add ${label} to LinkedIn`}
+        className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-[#0A66C2] px-3 py-2 text-xs font-semibold text-white hover:bg-[#004182] disabled:opacity-60"
+      >
+        <Share2 className="h-3.5 w-3.5" aria-hidden />
+        Add to LinkedIn
+      </button>
+      <button
+        type="button"
+        onClick={() => void handlePdf()}
+        disabled={busy !== null}
+        aria-label={`Download PDF certificate for ${label}`}
+        className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
+      >
+        <Download className="h-3.5 w-3.5" aria-hidden />
+        Download PDF
+      </button>
+      <button
+        type="button"
+        onClick={() => void handleBadgeJson()}
+        disabled={busy !== null}
+        aria-label={`Download Open Badge JSON for ${label}`}
+        className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
+      >
+        <Download className="h-3.5 w-3.5" aria-hidden />
+        Download Badge JSON
+      </button>
+      <button
+        type="button"
+        onClick={() => void handleCopyLink()}
+        disabled={busy !== null}
+        aria-label={`Copy verification link for ${label}`}
+        className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
+      >
+        <Copy className="h-3.5 w-3.5" aria-hidden />
+        {copied ? 'Copied!' : 'Copy Link'}
+      </button>
+      {error ? (
+        <p role="alert" className="w-full text-xs text-red-600 dark:text-red-300">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/clients/web/src/components/layout/side-nav-main-links.tsx
+++ b/clients/web/src/components/layout/side-nav-main-links.tsx
@@ -46,6 +46,7 @@ export function SideNavMainLinks() {
     ffCeuTracking,
     ffStripeBilling,
     ffLearningPaths,
+    ffCompletionCredentials,
     ffCatalogIntegration,
     ffLibrary,
     ffConferenceScheduling,
@@ -69,6 +70,7 @@ export function SideNavMainLinks() {
     ffTranscripts ||
     ffAdvisingIntegration ||
     ffCoCurricularTranscript ||
+    ffCompletionCredentials ||
     ffCeuTracking ||
     ffResearchConsent ||
     ffAccessibilityIntake ||
@@ -145,6 +147,11 @@ export function SideNavMainLinks() {
           {ffCoCurricularTranscript ? (
             <SideNavLink to="/me/ccr" icon={<Award className="h-5 w-5" />}>
               My achievements
+            </SideNavLink>
+          ) : null}
+          {ffCompletionCredentials ? (
+            <SideNavLink to="/me/credentials" icon={<Award className="h-5 w-5" />}>
+              My credentials
             </SideNavLink>
           ) : null}
           {ffCeuTracking ? (

--- a/clients/web/src/components/self-paced/self-paced-progress.tsx
+++ b/clients/web/src/components/self-paced/self-paced-progress.tsx
@@ -1,7 +1,10 @@
 // Self-paced learner progress UI: accessible progress bar, resume CTA, and a
 // completion celebration overlay (plan 15.2).
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { PartyPopper, Play } from 'lucide-react'
+import { CredentialShareActions } from '../credentials/credential-share-actions'
+import { usePlatformFeatures } from '../../context/platform-features-context'
+import type { IssuedCredentialSummary } from '../../lib/credentials-api'
 import {
   fetchMyProgress,
   formatProgressLabel,
@@ -43,10 +46,10 @@ export function SelfPacedProgressBar({
 /** Full-page completion celebration overlay shown when progress reaches 100%. */
 export function CompletionCelebration({
   onClose,
-  onViewCertificate,
+  credential,
 }: {
   onClose: () => void
-  onViewCertificate?: () => void
+  credential?: IssuedCredentialSummary | null
 }) {
   return (
     <div
@@ -63,20 +66,16 @@ export function CompletionCelebration({
         <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
           You finished every item in this course at your own pace. Nice work.
         </p>
-        <div className="mt-6 flex flex-col gap-2">
-          {onViewCertificate ? (
-            <button
-              type="button"
-              onClick={onViewCertificate}
-              className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700"
-            >
-              View Certificate
-            </button>
-          ) : null}
+        {credential ? (
+          <div className="mt-6 text-left">
+            <CredentialShareActions credential={credential} layout="stack" />
+          </div>
+        ) : null}
+        <div className="mt-4">
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-700"
+            className="w-full rounded-lg px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-700"
           >
             Keep exploring
           </button>
@@ -93,19 +92,29 @@ export function CompletionCelebration({
  */
 export function SelfPacedProgressHeader({
   courseCode,
+  courseTitle,
   onResume,
 }: {
   courseCode: string
+  courseTitle?: string
   onResume?: (itemId: string) => void
 }) {
+  const { ffCompletionCredentials } = usePlatformFeatures()
   const [progress, setProgress] = useState<SelfPacedProgress | null>(null)
   const [celebrate, setCelebrate] = useState(false)
+  const [issuedCredentialId, setIssuedCredentialId] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     try {
       const p = await fetchMyProgress(courseCode)
       setProgress(p)
-      if (p.completed) setCelebrate(true)
+      if (p.justCompleted) {
+        setCelebrate(true)
+        if (p.credentialId) setIssuedCredentialId(p.credentialId)
+      } else if (p.completed) {
+        setCelebrate(true)
+        if (p.credentialId) setIssuedCredentialId(p.credentialId)
+      }
     } catch {
       setProgress(null)
     }
@@ -114,6 +123,20 @@ export function SelfPacedProgressHeader({
   useEffect(() => {
     void load()
   }, [load])
+
+  const celebrationCredential = useMemo((): IssuedCredentialSummary | null => {
+    if (!issuedCredentialId || !ffCompletionCredentials) return null
+    const origin = window.location.origin
+    return {
+      id: issuedCredentialId,
+      title: courseTitle ?? 'Course completion',
+      sourceType: 'course',
+      sourceId: courseCode,
+      issuedAt: new Date().toISOString(),
+      verificationUrl: `${origin}/verify/${issuedCredentialId}`,
+      revoked: false,
+    }
+  }, [issuedCredentialId, ffCompletionCredentials, courseTitle, courseCode])
 
   if (!progress) return null
 
@@ -142,7 +165,10 @@ export function SelfPacedProgressHeader({
         <SelfPacedProgressBar percent={progress.progressPercent} />
       </div>
       {celebrate ? (
-        <CompletionCelebration onClose={() => setCelebrate(false)} />
+        <CompletionCelebration
+          credential={celebrationCredential}
+          onClose={() => setCelebrate(false)}
+        />
       ) : null}
     </section>
   )

--- a/clients/web/src/context/platform-features-context.tsx
+++ b/clients/web/src/context/platform-features-context.tsx
@@ -71,6 +71,7 @@ export type PlatformFeatures = {
   ffConsortiumSharing: boolean
   ffStripeBilling: boolean
   ffLearningPaths: boolean
+  ffCompletionCredentials: boolean
   aiDisclosureEnabled: boolean
   openRouterConfigured: boolean
   ragNotebookEnabled: boolean
@@ -135,6 +136,7 @@ const defaultFeatures: PlatformFeatures = {
   ffConsortiumSharing: false,
   ffStripeBilling: false,
   ffLearningPaths: false,
+  ffCompletionCredentials: false,
   aiDisclosureEnabled: false,
   openRouterConfigured: false,
   ragNotebookEnabled: false,
@@ -204,6 +206,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
   ffConsortiumSharing: false,
   ffStripeBilling: false,
   ffLearningPaths: false,
+  ffCompletionCredentials: false,
   aiDisclosureEnabled: false,
   openRouterConfigured: false,
   ragNotebookEnabled: false,
@@ -274,6 +277,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffConsortiumSharing: data.ffConsortiumSharing === true,
           ffStripeBilling: data.ffStripeBilling === true,
           ffLearningPaths: data.ffLearningPaths === true,
+          ffCompletionCredentials: data.ffCompletionCredentials === true,
           aiDisclosureEnabled: data.aiDisclosureEnabled === true,
           openRouterConfigured: data.openRouterConfigured === true,
           ragNotebookEnabled: data.ragNotebookEnabled === true,
@@ -311,6 +315,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffConsortiumSharing: next.ffConsortiumSharing === true,
           ffStripeBilling: next.ffStripeBilling === true,
           ffLearningPaths: next.ffLearningPaths === true,
+          ffCompletionCredentials: next.ffCompletionCredentials === true,
           aiDisclosureEnabled: next.aiDisclosureEnabled === true,
           openRouterConfigured: next.openRouterConfigured === true,
           ragNotebookEnabled: next.ragNotebookEnabled === true,

--- a/clients/web/src/lazy-pages.ts
+++ b/clients/web/src/lazy-pages.ts
@@ -48,6 +48,7 @@ export const PathsCatalogPage = lazy(() => import('./pages/lms/paths-catalog-pag
 export const CreatorLearningPathsPage = lazy(() => import('./pages/lms/creator-learning-paths-page'))
 export const Dashboard = lazy(() => import('./pages/lms/dashboard'))
 export const MyCCR = lazy(() => import('./pages/lms/MyCCR'))
+export const MyCredentials = lazy(() => import('./pages/lms/MyCredentials'))
 export const CeTranscript = lazy(() => import('./pages/lms/CeTranscript'))
 export const CcrVerifyPage = lazy(() => import('./pages/verify/CcrVerify'))
 export const StudyInsightsPage = lazy(() => import('./pages/lms/study-insights-page'))

--- a/clients/web/src/lib/__tests__/linkedin-share.test.ts
+++ b/clients/web/src/lib/__tests__/linkedin-share.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { buildLinkedInCertificationUrl } from '../linkedin-share'
+
+describe('buildLinkedInCertificationUrl', () => {
+  it('builds LinkedIn certification URL with required params', () => {
+    const url = buildLinkedInCertificationUrl({
+      name: 'Intro to Data Science',
+      organizationName: 'Lextures',
+      issueYear: 2026,
+      issueMonth: 6,
+      certUrl: 'https://app.example.com/verify/abc',
+      certId: 'abc',
+    })
+    const parsed = new URL(url)
+    expect(parsed.origin + parsed.pathname).toBe('https://www.linkedin.com/profile/add')
+    expect(parsed.searchParams.get('startTask')).toBe('CERTIFICATION_NAME')
+    expect(parsed.searchParams.get('name')).toBe('Intro to Data Science')
+    expect(parsed.searchParams.get('organizationName')).toBe('Lextures')
+    expect(parsed.searchParams.get('issueYear')).toBe('2026')
+    expect(parsed.searchParams.get('issueMonth')).toBe('6')
+    expect(parsed.searchParams.get('certUrl')).toBe('https://app.example.com/verify/abc')
+    expect(parsed.searchParams.get('certId')).toBe('abc')
+  })
+
+  it('uses organizationId when provided', () => {
+    const url = buildLinkedInCertificationUrl({
+      name: 'Course',
+      organizationName: 'Lextures',
+      organizationId: '12345',
+      issueYear: 2026,
+      issueMonth: 1,
+      certUrl: 'https://example.com/v',
+      certId: 'id',
+    })
+    const parsed = new URL(url)
+    expect(parsed.searchParams.get('organizationId')).toBe('12345')
+    expect(parsed.searchParams.get('organizationName')).toBeNull()
+  })
+})

--- a/clients/web/src/lib/credentials-api.ts
+++ b/clients/web/src/lib/credentials-api.ts
@@ -1,0 +1,96 @@
+import { authorizedFetch } from './api'
+import { readApiErrorMessage } from './errors'
+import type { LinkedInCertParams } from './linkedin-share'
+
+export type IssuedCredentialSummary = {
+  id: string
+  title: string
+  sourceType: string
+  sourceId: string
+  issuedAt: string
+  verificationUrl: string
+  revoked: boolean
+}
+
+export type CredentialsListResponse = {
+  credentials: IssuedCredentialSummary[]
+}
+
+export type LinkedInParamsResponse = LinkedInCertParams & {
+  url: string
+  certUrl: string
+  certId: string
+}
+
+export type BadgeExportResponse = {
+  downloadUrl: string
+  expiresAt: string
+}
+
+export type CredentialVerifyResponse = {
+  valid: boolean
+  status: string
+  issuerName: string
+  issuedAt: string
+  title: string
+  learnerName?: string
+  verifyType?: string
+  credential: Record<string, unknown>
+}
+
+export async function fetchMyCredentials(): Promise<CredentialsListResponse> {
+  const res = await authorizedFetch('/api/v1/me/credentials')
+  const raw = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  return raw as CredentialsListResponse
+}
+
+export async function fetchLinkedInParams(credentialId: string): Promise<LinkedInParamsResponse> {
+  const res = await authorizedFetch(`/api/v1/credentials/${credentialId}/linkedin-params`)
+  const raw = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  return raw as LinkedInParamsResponse
+}
+
+export async function fetchBadgeExportUrl(credentialId: string): Promise<BadgeExportResponse> {
+  const res = await authorizedFetch(`/api/v1/credentials/${credentialId}/badge-export`)
+  const raw = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  return raw as BadgeExportResponse
+}
+
+export async function downloadCredentialPdf(credentialId: string): Promise<Blob> {
+  const res = await authorizedFetch(`/api/v1/credentials/${credentialId}/download`)
+  if (!res.ok) {
+    const raw = await res.json().catch(() => ({}))
+    throw new Error(readApiErrorMessage(raw))
+  }
+  return res.blob()
+}
+
+export async function recordCredentialShare(
+  credentialId: string,
+  channel: 'linkedin' | 'badge_export',
+): Promise<void> {
+  const res = await authorizedFetch(`/api/v1/credentials/${credentialId}/share`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ channel }),
+  })
+  if (!res.ok && res.status !== 204) {
+    const raw = await res.json().catch(() => ({}))
+    throw new Error(readApiErrorMessage(raw))
+  }
+}
+
+export async function verifyCredentialId(credentialId: string): Promise<CredentialVerifyResponse> {
+  const base = import.meta.env.VITE_API_URL ?? ''
+  const res = await fetch(`${base}/api/v1/credentials/${encodeURIComponent(credentialId)}/verify`)
+  if (res.status === 404) {
+    throw new Error('Credential not found.')
+  }
+  if (!res.ok) {
+    throw new Error('Verification failed.')
+  }
+  return (await res.json()) as CredentialVerifyResponse
+}

--- a/clients/web/src/lib/linkedin-share.ts
+++ b/clients/web/src/lib/linkedin-share.ts
@@ -1,0 +1,27 @@
+/** LinkedIn certification deep-link parameters (plan 15.6). */
+export type LinkedInCertParams = {
+  name: string
+  organizationName: string
+  organizationId?: string
+  issueYear: number
+  issueMonth: number
+  certUrl: string
+  certId: string
+}
+
+/** Builds LinkedIn's add-certification URL with pre-filled fields. */
+export function buildLinkedInCertificationUrl(params: LinkedInCertParams): string {
+  const url = new URL('https://www.linkedin.com/profile/add')
+  url.searchParams.set('startTask', 'CERTIFICATION_NAME')
+  url.searchParams.set('name', params.name)
+  if (params.organizationId) {
+    url.searchParams.set('organizationId', params.organizationId)
+  } else {
+    url.searchParams.set('organizationName', params.organizationName)
+  }
+  url.searchParams.set('issueYear', String(params.issueYear))
+  url.searchParams.set('issueMonth', String(params.issueMonth))
+  url.searchParams.set('certUrl', params.certUrl)
+  url.searchParams.set('certId', params.certId)
+  return url.toString()
+}

--- a/clients/web/src/lib/platform-features.ts
+++ b/clients/web/src/lib/platform-features.ts
@@ -58,6 +58,7 @@ export type PlatformFeaturesSnapshot = {
   ffConsortiumSharing?: boolean
   ffStripeBilling?: boolean
   ffLearningPaths?: boolean
+  ffCompletionCredentials?: boolean
   aiDisclosureEnabled?: boolean
   openRouterConfigured?: boolean
   ragNotebookEnabled?: boolean
@@ -121,6 +122,7 @@ const defaults: PlatformFeaturesSnapshot = {
   ffConsortiumSharing: false,
   ffStripeBilling: false,
   ffLearningPaths: false,
+  ffCompletionCredentials: false,
   aiDisclosureEnabled: false,
   openRouterConfigured: false,
   ragNotebookEnabled: false,

--- a/clients/web/src/lib/self-paced-api.ts
+++ b/clients/web/src/lib/self-paced-api.ts
@@ -25,6 +25,7 @@ export type SelfPacedProgress = {
   enrollmentId: string
   resumeItemId?: string
   justCompleted?: boolean
+  credentialId?: string
 }
 
 /** One self-paced enrollment with progress, for the Dashboard. */

--- a/clients/web/src/pages/lms/MyCredentials.tsx
+++ b/clients/web/src/pages/lms/MyCredentials.tsx
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useId, useState } from 'react'
+import { Award, Loader2 } from 'lucide-react'
+import { CredentialShareActions } from '../../components/credentials/credential-share-actions'
+import { usePlatformFeatures } from '../../context/platform-features-context'
+import { fetchMyCredentials, type IssuedCredentialSummary } from '../../lib/credentials-api'
+import { LmsPage } from './lms-page'
+
+export default function MyCredentials() {
+  const titleId = useId()
+  const { ffCompletionCredentials, loading: featuresLoading } = usePlatformFeatures()
+  const [credentials, setCredentials] = useState<IssuedCredentialSummary[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await fetchMyCredentials()
+      setCredentials(data.credentials)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load credentials.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (featuresLoading || !ffCompletionCredentials) return
+    void load()
+  }, [featuresLoading, ffCompletionCredentials, load])
+
+  if (!ffCompletionCredentials && !featuresLoading) {
+    return (
+      <LmsPage title="My credentials">
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          Completion credentials are not enabled on this platform.
+        </p>
+      </LmsPage>
+    )
+  }
+
+  return (
+    <LmsPage title="My credentials">
+      <header className="mb-6">
+        <h1 id={titleId} className="flex items-center gap-2 text-2xl font-semibold text-slate-900 dark:text-white">
+          <Award className="h-7 w-7 text-emerald-600" aria-hidden />
+          My credentials
+        </h1>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+          Download, verify, and share your course completion certificates.
+        </p>
+      </header>
+
+      {loading ? (
+        <p className="inline-flex items-center gap-2 text-sm text-slate-600">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          Loading credentials…
+        </p>
+      ) : null}
+
+      {error ? (
+        <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+          {error}
+        </p>
+      ) : null}
+
+      {!loading && credentials.length === 0 ? (
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          Complete a self-paced course to earn your first certificate.
+        </p>
+      ) : null}
+
+      <ul className="grid gap-4 md:grid-cols-2">
+        {credentials.map((cred) => (
+          <li
+            key={cred.id}
+            aria-label={`Credential: ${cred.title}, issued ${new Date(cred.issuedAt).toLocaleDateString()}`}
+            className="rounded-xl border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-800"
+          >
+            <h2 className="text-base font-semibold text-slate-900 dark:text-white">{cred.title}</h2>
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+              Issued {new Date(cred.issuedAt).toLocaleDateString()}
+              {cred.revoked ? ' · Revoked' : ''}
+            </p>
+            <div className="mt-4">
+              <CredentialShareActions credential={cred} layout="stack" />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </LmsPage>
+  )
+}

--- a/clients/web/src/pages/lms/course-modules.tsx
+++ b/clients/web/src/pages/lms/course-modules.tsx
@@ -2511,6 +2511,7 @@ export default function CourseModules() {
         <div className="mt-6">
           <SelfPacedProgressHeader
             courseCode={courseCode}
+            courseTitle={courseMeta?.title}
             onResume={(itemId) => {
               document
                 .getElementById(`item-row-${itemId}`)

--- a/clients/web/src/pages/lms/dashboard.tsx
+++ b/clients/web/src/pages/lms/dashboard.tsx
@@ -287,6 +287,7 @@ export default function Dashboard() {
     ffCeuTracking,
     ffAdvisingIntegration,
     ffLearningPaths,
+    ffCompletionCredentials,
     ffResearchConsent,
   } = usePlatformFeatures()
 
@@ -838,6 +839,26 @@ export default function Dashboard() {
                   className="inline-flex items-center gap-1 rounded-lg bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-700"
                 >
                   Open CCR
+                  <ArrowRight className="h-4 w-4" aria-hidden />
+                </Link>
+              </div>
+            </section>
+          ) : null}
+
+          {ffCompletionCredentials ? (
+            <section aria-label="My credentials">
+              <div className="flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-emerald-100 bg-emerald-50/80 px-5 py-4 dark:border-emerald-900/40 dark:bg-emerald-950/30">
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-slate-900 dark:text-neutral-100">My credentials</p>
+                  <p className="mt-1 text-xs text-slate-600 dark:text-neutral-400">
+                    Download certificates and share them to LinkedIn.
+                  </p>
+                </div>
+                <Link
+                  to="/me/credentials"
+                  className="inline-flex items-center gap-1 rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700"
+                >
+                  View credentials
                   <ArrowRight className="h-4 w-4" aria-hidden />
                 </Link>
               </div>

--- a/clients/web/src/pages/verify/CcrVerify.tsx
+++ b/clients/web/src/pages/verify/CcrVerify.tsx
@@ -2,24 +2,85 @@ import { useEffect, useId, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { CheckCircle2, XCircle } from 'lucide-react'
 import { verifyCCRShareToken, type CCRVerifyResponse } from '../../lib/ccr-api'
+import { verifyCredentialId, type CredentialVerifyResponse } from '../../lib/credentials-api'
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+type VerifyResult = {
+  valid: boolean
+  status: string
+  issuerName: string
+  issuedAt: string
+  credential: Record<string, unknown>
+  title?: string
+  learnerName?: string
+  achievementTitles: string[]
+}
 
 function assertionTitles(credential: Record<string, unknown>): string[] {
   const subject = credential.credentialSubject as Record<string, unknown> | undefined
   const assertions = subject?.assertions
-  if (!Array.isArray(assertions)) return []
-  return assertions
-    .map((a) => {
-      const row = a as Record<string, unknown>
-      const achievement = row.achievement as Record<string, unknown> | undefined
-      return typeof achievement?.name === 'string' ? achievement.name : null
-    })
-    .filter((name): name is string => Boolean(name))
+  if (Array.isArray(assertions)) {
+    return assertions
+      .map((a) => {
+        const row = a as Record<string, unknown>
+        const achievement = row.achievement as Record<string, unknown> | undefined
+        return typeof achievement?.name === 'string' ? achievement.name : null
+      })
+      .filter((name): name is string => Boolean(name))
+  }
+  const achievement = subject?.achievement as Record<string, unknown> | undefined
+  if (typeof achievement?.name === 'string') {
+    return [achievement.name]
+  }
+  return []
+}
+
+function setSocialPreviewMeta(title: string, description: string) {
+  document.title = `${title} · Lextures credential`
+  const setMeta = (property: string, content: string) => {
+    let el = document.querySelector(`meta[property="${property}"]`)
+    if (!el) {
+      el = document.createElement('meta')
+      el.setAttribute('property', property)
+      document.head.appendChild(el)
+    }
+    el.setAttribute('content', content)
+  }
+  setMeta('og:title', title)
+  setMeta('og:description', description)
+  setMeta('og:type', 'website')
+}
+
+function normalizeCCR(result: CCRVerifyResponse): VerifyResult {
+  return {
+    valid: result.valid,
+    status: result.status,
+    issuerName: result.issuerName,
+    issuedAt: result.issuedAt,
+    credential: result.credential,
+    achievementTitles: assertionTitles(result.credential),
+  }
+}
+
+function normalizeCredential(result: CredentialVerifyResponse): VerifyResult {
+  return {
+    valid: result.valid,
+    status: result.status,
+    issuerName: result.issuerName,
+    issuedAt: result.issuedAt,
+    credential: result.credential,
+    title: result.title,
+    learnerName: result.learnerName,
+    achievementTitles: result.title ? [result.title] : assertionTitles(result.credential),
+  }
 }
 
 export default function CcrVerifyPage() {
   const { token } = useParams<{ token: string }>()
   const statusId = useId()
-  const [result, setResult] = useState<CCRVerifyResponse | null>(null)
+  const [result, setResult] = useState<VerifyResult | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
 
@@ -29,15 +90,23 @@ export default function CcrVerifyPage() {
       setLoading(false)
       return
     }
-    void verifyCCRShareToken(token)
-      .then(setResult)
+    const isCredentialUUID = UUID_RE.test(token)
+    const verifyPromise = isCredentialUUID
+      ? verifyCredentialId(token).then(normalizeCredential)
+      : verifyCCRShareToken(token).then(normalizeCCR)
+
+    void verifyPromise
+      .then((res) => {
+        setResult(res)
+        const title = res.title ?? res.achievementTitles[0] ?? 'Lextures credential'
+        const learner = res.learnerName ? `${res.learnerName} · ` : ''
+        setSocialPreviewMeta(title, `${learner}Verified certificate from ${res.issuerName}`)
+      })
       .catch((e: unknown) => {
         setError(e instanceof Error ? e.message : 'Verification failed.')
       })
       .finally(() => setLoading(false))
   }, [token])
-
-  const titles = result ? assertionTitles(result.credential) : []
 
   return (
     <div className="min-h-screen bg-slate-50 px-4 py-10 dark:bg-neutral-950">
@@ -76,6 +145,12 @@ export default function CcrVerifyPage() {
               )}
             </div>
             <dl className="grid gap-2 text-sm">
+              {result.learnerName ? (
+                <div>
+                  <dt className="font-medium text-slate-700 dark:text-neutral-300">Learner</dt>
+                  <dd>{result.learnerName}</dd>
+                </div>
+              ) : null}
               <div>
                 <dt className="font-medium text-slate-700 dark:text-neutral-300">Issuer</dt>
                 <dd>{result.issuerName}</dd>
@@ -85,11 +160,11 @@ export default function CcrVerifyPage() {
                 <dd>{result.issuedAt}</dd>
               </div>
             </dl>
-            {titles.length > 0 ? (
+            {result.achievementTitles.length > 0 ? (
               <section aria-label="Achievements">
-                <h2 className="text-base font-semibold text-slate-900 dark:text-neutral-100">Achievements</h2>
+                <h2 className="text-base font-semibold text-slate-900 dark:text-neutral-100">Credential</h2>
                 <ul className="mt-2 list-disc pl-5 text-sm text-slate-700 dark:text-neutral-300">
-                  {titles.map((title) => (
+                  {result.achievementTitles.map((title) => (
                     <li key={title}>{title}</li>
                   ))}
                 </ul>

--- a/docs/completed/15-self-learner-specific/15.6-linkedin-share-open-badges-export.md
+++ b/docs/completed/15-self-learner-specific/15.6-linkedin-share-open-badges-export.md
@@ -10,7 +10,7 @@
 | **Section** | Self-Learner-Specific |
 | **Severity** | MAJOR |
 | **Markets** | SL |
-| **Status (today)** | MISSING |
+| **Status (today)** | COMPLETE |
 | **Estimated effort** | S (1w) |
 | **Owner (proposed)** | Frontend team |
 | **Depends on** | 15.5 certificates/Open Badges |

--- a/e2e/tests/credentials.spec.ts
+++ b/e2e/tests/credentials.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Completion credentials — LinkedIn share and Open Badges export (plan 15.6).
+ */
+import { test, expect, injectToken } from '../fixtures/test.js'
+
+const apiBase = process.env.E2E_API_URL ?? 'http://localhost:8080'
+
+test.describe('Credentials — API auth', () => {
+  test('GET /api/v1/me/credentials returns 401 without auth', async () => {
+    const res = await fetch(`${apiBase}/api/v1/me/credentials`)
+    expect(res.status).toBe(401)
+  })
+
+  test('GET linkedin-params returns 401 without auth', async () => {
+    const res = await fetch(
+      `${apiBase}/api/v1/credentials/00000000-0000-0000-0000-000000000001/linkedin-params`,
+    )
+    expect(res.status).toBe(401)
+  })
+
+  test('GET verify endpoint is public (not 401)', async () => {
+    const res = await fetch(
+      `${apiBase}/api/v1/credentials/00000000-0000-0000-0000-000000000099/verify`,
+    )
+    expect(res.status).not.toBe(401)
+  })
+})
+
+test.describe('Credentials — authenticated API', () => {
+  test('student can load credentials when feature enabled', async ({ seededCourse }) => {
+    const res = await fetch(`${apiBase}/api/v1/me/credentials`, {
+      headers: { Authorization: `Bearer ${seededCourse.studentToken}` },
+    })
+    if (res.status === 404) {
+      test.skip(true, 'ff_completion_credentials not enabled in this environment')
+    }
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { credentials: unknown[] }
+    expect(Array.isArray(body.credentials)).toBe(true)
+  })
+})
+
+test.describe('Credentials — UI', () => {
+  test('My Credentials page loads when feature enabled', async ({ page, seededCourse }) => {
+    const featRes = await fetch(`${apiBase}/api/v1/platform/features`, {
+      headers: { Authorization: `Bearer ${seededCourse.studentToken}` },
+    })
+    if (!featRes.ok) {
+      test.skip(true, 'platform features unavailable')
+    }
+    const feats = (await featRes.json()) as { ffCompletionCredentials?: boolean }
+    if (!feats.ffCompletionCredentials) {
+      test.skip(true, 'ff_completion_credentials not enabled in this environment')
+    }
+
+    await injectToken(page, seededCourse.studentToken)
+    await page.goto('/me/credentials')
+    await expect(page.getByRole('heading', { name: /my credentials/i })).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+
+  test('public verify page renders for credential UUID route', async ({ page }) => {
+    await page.goto('/verify/00000000-0000-0000-0000-000000000099')
+    await expect(page.getByRole('heading', { name: /credential verification/i })).toBeVisible()
+  })
+})

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -357,6 +357,9 @@ type Config struct {
 	// FFLearningPaths enables learning paths / course bundles for self-learners (plan 15.4).
 	// Managed in Settings → Global platform (not process env).
 	FFLearningPaths bool
+	// FFCompletionCredentials enables course completion certificates, Open Badges export, and LinkedIn share (plans 15.5, 15.6).
+	// Managed in Settings → Global platform (not process env).
+	FFCompletionCredentials bool
 
 	// FFStripeBilling enables Stripe checkout, subscriptions, and entitlement gating (plan 15.3).
 	// Managed in Settings → Global platform (not process env).

--- a/server/internal/httpserver/course_self_paced.go
+++ b/server/internal/httpserver/course_self_paced.go
@@ -11,8 +11,11 @@ import (
 
 	"github.com/lextures/lextures/server/internal/apierr"
 	"github.com/lextures/lextures/server/internal/courseroles"
+	"github.com/lextures/lextures/server/internal/logging"
+	credrepo "github.com/lextures/lextures/server/internal/repos/credentials"
 	"github.com/lextures/lextures/server/internal/repos/enrollment"
 	"github.com/lextures/lextures/server/internal/repos/learnerprogress"
+	credsvc "github.com/lextures/lextures/server/internal/service/credentials"
 	"github.com/lextures/lextures/server/internal/service/selfpaced"
 )
 
@@ -139,7 +142,8 @@ type progressResponse struct {
 	selfpaced.Summary
 	EnrollmentID string  `json:"enrollmentId"`
 	ResumeItemID *string `json:"resumeItemId,omitempty"`
-	JustComplete bool    `json:"justCompleted,omitempty"`
+	JustComplete  bool    `json:"justCompleted,omitempty"`
+	CredentialID  *string `json:"credentialId,omitempty"`
 }
 
 // handleCourseMyProgress returns the viewer's self-paced progress for a course (FR-4, FR-5, AC-2).
@@ -190,6 +194,12 @@ func (d Deps) handleCourseMyProgress() http.HandlerFunc {
 		if resume != nil {
 			s := resume.String()
 			resp.ResumeItemID = &s
+		}
+		if summary.Completed && d.effectiveConfig().FFCompletionCredentials {
+			if cred, err := credrepo.GetByRecipientAndSource(r.Context(), d.Pool, viewer, credrepo.SourceCourse, c.ID); err == nil && cred != nil {
+				id := cred.ID.String()
+				resp.CredentialID = &id
+			}
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(resp)
@@ -288,10 +298,24 @@ func (d Deps) handleCourseItemComplete() http.HandlerFunc {
 			s := resume.String()
 			resp.ResumeItemID = &s
 		}
-		// 15.5 certificate: when the learner completes the final item, trigger the certificate
-		// flow. The certificate service is not yet wired; the response signals completion so the
-		// client shows the celebration screen and "View Certificate" CTA.
 		resp.JustComplete = changed && summary.Completed
+		if resp.JustComplete && d.effectiveConfig().FFCompletionCredentials {
+			learnerName, nameErr := d.learnerDisplayName(r, viewer)
+			if nameErr == nil {
+				cfg := d.effectiveConfig()
+				cred, issueErr := credsvc.IssueCourseCompletion(r.Context(), d.Pool, cfg, credsvc.IssueCourseParams{
+					RecipientID: viewer,
+					LearnerName: learnerName,
+					CourseID:    c.ID,
+				})
+				if issueErr == nil && cred != nil {
+					logging.GlobalCredentialsMetrics.IncIssued()
+					d.notifyCertificateIssued(r, viewer, cred)
+					id := cred.ID.String()
+					resp.CredentialID = &id
+				}
+			}
+		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_ = json.NewEncoder(w).Encode(resp)
 	}

--- a/server/internal/httpserver/credentials_http.go
+++ b/server/internal/httpserver/credentials_http.go
@@ -1,0 +1,389 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/config"
+	"github.com/lextures/lextures/server/internal/logging"
+	"github.com/lextures/lextures/server/internal/notificationevents"
+	credrepo "github.com/lextures/lextures/server/internal/repos/credentials"
+	"github.com/lextures/lextures/server/internal/repos/useraudit"
+	credsvc "github.com/lextures/lextures/server/internal/service/credentials"
+	"github.com/lextures/lextures/server/internal/service/notifications"
+)
+
+func (d Deps) credentialsFeatureOff(w http.ResponseWriter) bool {
+	if !d.effectiveConfig().FFCompletionCredentials {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Completion credentials are not enabled.")
+		return true
+	}
+	return false
+}
+
+func (d Deps) registerCredentialsRoutes(r chi.Router) {
+	r.Get("/api/v1/me/credentials", d.handleListMyCredentials())
+	r.Get("/api/v1/credentials/{id}/download", d.handleDownloadCredential())
+	r.Get("/api/v1/credentials/{id}/json", d.handleCredentialJSON())
+	r.Get("/api/v1/credentials/{id}/badge-export", d.handleBadgeExport())
+	r.Get("/api/v1/credentials/{id}/badge-export/download", d.handleBadgeExportDownload())
+	r.Get("/api/v1/credentials/{id}/linkedin-params", d.handleLinkedInParams())
+	r.Post("/api/v1/credentials/{id}/share", d.handleCredentialShare())
+	r.Get("/api/v1/credentials/{id}/verify", d.handleVerifyCredential())
+}
+
+func (d Deps) handleListMyCredentials() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.credentialsFeatureOff(w) {
+			return
+		}
+		rows, err := credrepo.ListByRecipient(r.Context(), d.Pool, userID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load credentials.")
+			return
+		}
+		cfg := d.effectiveConfig()
+		out := make([]map[string]any, 0, len(rows))
+		for i := range rows {
+			out = append(out, credentialSummaryJSON(&rows[i], cfg.PublicWebOrigin))
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{"credentials": out})
+	}
+}
+
+func (d Deps) handleDownloadCredential() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.credentialsFeatureOff(w) {
+			return
+		}
+		cred, ok := d.loadOwnedCredential(w, r, userID)
+		if !ok {
+			return
+		}
+		learnerName, err := d.learnerDisplayName(r, userID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load profile.")
+			return
+		}
+		cfg := d.effectiveConfig()
+		institution := strings.TrimSpace(cfg.CCRInstitutionName)
+		if institution == "" {
+			institution = "Lextures"
+		}
+		pdfBytes, err := credsvc.BuildPDF(credsvc.PDFInput{
+			InstitutionName: institution,
+			LearnerName:     learnerName,
+			CredentialName:  cred.Title,
+			IssuedAt:        cred.IssuedAt,
+			VerificationURL: credsvc.VerificationURL(cfg.PublicWebOrigin, cred.ID),
+		})
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to render PDF.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/pdf")
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s-certificate.pdf"`, sanitizeFilename(cred.Title)))
+		_, _ = w.Write(pdfBytes)
+	}
+}
+
+func (d Deps) handleCredentialJSON() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.credentialsFeatureOff(w) {
+			return
+		}
+		cred, ok := d.loadOwnedCredential(w, r, userID)
+		if !ok {
+			return
+		}
+		body, err := credsvc.FullCredentialJSON(cred)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load credential JSON.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/ld+json; charset=utf-8")
+		_, _ = w.Write(body)
+	}
+}
+
+func (d Deps) handleBadgeExport() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.credentialsFeatureOff(w) {
+			return
+		}
+		cred, ok := d.loadOwnedCredential(w, r, userID)
+		if !ok {
+			return
+		}
+		cfg := d.effectiveConfig()
+		token, expires, err := credsvc.BadgeExportToken(cfg, cred.ID, time.Now().UTC())
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to create download URL.")
+			return
+		}
+		base := strings.TrimRight(strings.TrimSpace(cfg.PublicWebOrigin), "/")
+		downloadURL := fmt.Sprintf("%s/api/v1/credentials/%s/badge-export/download?token=%s", base, cred.ID, token)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"downloadUrl": downloadURL,
+			"expiresAt":   expires.UTC().Format(time.RFC3339),
+		})
+	}
+}
+
+func (d Deps) handleBadgeExportDownload() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.credentialsFeatureOff(w) {
+			return
+		}
+		credID, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "id")))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid credential id.")
+			return
+		}
+		token := strings.TrimSpace(r.URL.Query().Get("token"))
+		if token == "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "token is required.")
+			return
+		}
+		cfg := d.effectiveConfig()
+		parsedID, err := credsvc.VerifyBadgeExportToken(cfg, token, time.Now().UTC())
+		if err != nil || parsedID != credID {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "Invalid or expired download token.")
+			return
+		}
+		cred, err := credrepo.GetByID(r.Context(), d.Pool, credID)
+		if err != nil || cred == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Credential not found.")
+			return
+		}
+		body, err := credsvc.FullCredentialJSON(cred)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load credential JSON.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/ld+json; charset=utf-8")
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s-badge.json"`, sanitizeFilename(cred.Title)))
+		_, _ = w.Write(body)
+	}
+}
+
+func (d Deps) handleLinkedInParams() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.credentialsFeatureOff(w) {
+			return
+		}
+		cred, ok := d.loadOwnedCredential(w, r, userID)
+		if !ok {
+			return
+		}
+		params := credsvc.LinkedInParamsForCredential(d.effectiveConfig(), cred)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(params)
+	}
+}
+
+func (d Deps) handleCredentialShare() http.HandlerFunc {
+	type body struct {
+		Channel string `json:"channel"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.credentialsFeatureOff(w) {
+			return
+		}
+		cred, ok := d.loadOwnedCredential(w, r, userID)
+		if !ok {
+			return
+		}
+		var req body
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		channel := strings.TrimSpace(req.Channel)
+		if channel != "linkedin" && channel != "badge_export" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "channel must be linkedin or badge_export.")
+			return
+		}
+		courseID := cred.SourceID
+		if cred.SourceType != credrepo.SourceCourse {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Share tracking requires a course credential.")
+			return
+		}
+		if err := useraudit.InsertCredentialShare(r.Context(), d.Pool, userID, courseID, cred.ID, channel); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to record share event.")
+			return
+		}
+		logging.GlobalCredentialsMetrics.IncShares()
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (d Deps) handleVerifyCredential() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.credentialsFeatureOff(w) {
+			return
+		}
+		credID, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "id")))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid credential id.")
+			return
+		}
+		cred, err := credrepo.GetByID(r.Context(), d.Pool, credID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify credential.")
+			return
+		}
+		if cred == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Credential not found.")
+			return
+		}
+		if cred.Revoked {
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"valid":      false,
+				"status":     "Revoked",
+				"issuerName": issuerNameFromConfig(d.effectiveConfig()),
+				"issuedAt":   cred.IssuedAt.UTC().Format(time.RFC3339),
+				"credential": json.RawMessage(cred.Proof),
+				"title":      cred.Title,
+			})
+			return
+		}
+		cfg := d.effectiveConfig()
+		valid, err := credsvc.VerifyCredential(cfg, cred.Proof)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Verification failed.")
+			return
+		}
+		logging.GlobalCredentialsMetrics.IncVerifications()
+		status := "Invalid"
+		if valid {
+			status = "Valid"
+		}
+		learnerName := extractLearnerName(cred.Proof)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"valid":        valid,
+			"status":       status,
+			"issuerName":   issuerNameFromConfig(cfg),
+			"issuedAt":     cred.IssuedAt.UTC().Format(time.RFC3339),
+			"credential":   json.RawMessage(cred.Proof),
+			"title":        cred.Title,
+			"learnerName":  learnerName,
+			"verifyType":   "completion_credential",
+		})
+	}
+}
+
+func (d Deps) loadOwnedCredential(w http.ResponseWriter, r *http.Request, userID uuid.UUID) (*credrepo.IssuedCredential, bool) {
+	credID, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "id")))
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid credential id.")
+		return nil, false
+	}
+	cred, err := credrepo.GetByID(r.Context(), d.Pool, credID)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load credential.")
+		return nil, false
+	}
+	if cred == nil || cred.RecipientID != userID {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Credential not found.")
+		return nil, false
+	}
+	return cred, true
+}
+
+func (d Deps) notifyCertificateIssued(r *http.Request, userID uuid.UUID, cred *credrepo.IssuedCredential) {
+	cfg := d.effectiveConfig()
+	if !cfg.EmailNotificationsEnabled || d.Pool == nil {
+		return
+	}
+	verifyURL := credsvc.VerificationURL(cfg.PublicWebOrigin, cred.ID)
+	linkedIn := credsvc.LinkedInParamsForCredential(cfg, cred)
+	svc := notifications.Service{Pool: d.Pool, Config: cfg}
+	_ = svc.EnqueueEmail(r.Context(), userID, notificationevents.CertificateIssued, "certificate_issued", map[string]string{
+		"credentialName": cred.Title,
+		"verifyUrl":      verifyURL,
+		"linkedInUrl":    linkedIn.URL,
+		"credentialsUrl": cfg.PublicWebOrigin + "/me/credentials",
+	}, nil)
+}
+
+func credentialSummaryJSON(cred *credrepo.IssuedCredential, origin string) map[string]any {
+	return map[string]any{
+		"id":              cred.ID.String(),
+		"title":           cred.Title,
+		"sourceType":      string(cred.SourceType),
+		"sourceId":        cred.SourceID.String(),
+		"issuedAt":        cred.IssuedAt.UTC().Format(time.RFC3339),
+		"verificationUrl": credsvc.VerificationURL(origin, cred.ID),
+		"revoked":         cred.Revoked,
+	}
+}
+
+func issuerNameFromConfig(cfg config.Config) string {
+	if strings.TrimSpace(cfg.CCRInstitutionName) != "" {
+		return strings.TrimSpace(cfg.CCRInstitutionName)
+	}
+	return "Lextures"
+}
+
+func extractLearnerName(proof json.RawMessage) string {
+	var vc map[string]any
+	if err := json.Unmarshal(proof, &vc); err != nil {
+		return ""
+	}
+	subject, _ := vc["credentialSubject"].(map[string]any)
+	if subject == nil {
+		return ""
+	}
+	if name, ok := subject["name"].(string); ok {
+		return name
+	}
+	return ""
+}
+
+func sanitizeFilename(s string) string {
+	out := strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			return r
+		}
+		return '-'
+	}, strings.TrimSpace(s))
+	if out == "" {
+		return "credential"
+	}
+	return out
+}

--- a/server/internal/httpserver/credentials_nodb_test.go
+++ b/server/internal/httpserver/credentials_nodb_test.go
@@ -1,0 +1,63 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/config"
+)
+
+func TestCredentials_Unauthenticated(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	cfg := config.Config{FFCompletionCredentials: true}
+	d := Deps{Pool: nil, JWTSigner: signer, Config: cfg}
+	h := NewHandler(d)
+
+	paths := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/me/credentials"},
+		{http.MethodGet, "/api/v1/credentials/00000000-0000-0000-0000-000000000001/linkedin-params"},
+		{http.MethodGet, "/api/v1/credentials/00000000-0000-0000-0000-000000000001/badge-export"},
+		{http.MethodPost, "/api/v1/credentials/00000000-0000-0000-0000-000000000001/share"},
+	}
+	for _, tc := range paths {
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s: want 401 got %d", tc.method, tc.path, w.Code)
+		}
+	}
+}
+
+func TestCredentials_FeatureOff(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	cfg := config.Config{FFCompletionCredentials: false}
+	d := Deps{Pool: nil, JWTSigner: signer, Config: cfg}
+	h := NewHandler(d)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/credentials/00000000-0000-0000-0000-000000000099/verify", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404 got %d", w.Code)
+	}
+}
+
+func TestVerifyCredential_PublicWithoutAuth(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	cfg := config.Config{FFCompletionCredentials: true}
+	d := Deps{Pool: nil, JWTSigner: signer, Config: cfg}
+	h := NewHandler(d)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/credentials/00000000-0000-0000-0000-000000000099/verify", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("without DB want 500 got %d", w.Code)
+	}
+}

--- a/server/internal/httpserver/me.go
+++ b/server/internal/httpserver/me.go
@@ -239,5 +239,6 @@ func (d Deps) registerMeRoutes(r chi.Router) {
 	d.registerTTSRoutes(r)
 	d.registerSelfReflectionRoutes(r)
 	d.registerCCRRoutes(r)
+	d.registerCredentialsRoutes(r)
 	d.registerIntegrationsRoutes(r)
 }

--- a/server/internal/httpserver/platform_features.go
+++ b/server/internal/httpserver/platform_features.go
@@ -74,6 +74,7 @@ type platformFeaturesJSON struct {
 	FFPublicCatalog             bool `json:"ffPublicCatalog"`
 	FFStripeBilling             bool `json:"ffStripeBilling"`
 	FFLearningPaths             bool `json:"ffLearningPaths"`
+	FFCompletionCredentials     bool `json:"ffCompletionCredentials"`
 
 	AiDisclosureEnabled  bool `json:"aiDisclosureEnabled"`
 	OpenRouterConfigured bool `json:"openRouterConfigured"`
@@ -153,6 +154,7 @@ func platformFeaturesFromConfig(cfg config.Config) platformFeaturesJSON {
 		FFPublicCatalog:             cfg.FFPublicCatalog,
 		FFStripeBilling:             cfg.FFStripeBilling,
 		FFLearningPaths:             cfg.FFLearningPaths,
+		FFCompletionCredentials:     cfg.FFCompletionCredentials,
 
 		LRSAnonymizeActors:           cfg.LRSAnonymizeActors,
 		FERPAWorkflowEnabled:         cfg.FERPAWorkflowEnabled,

--- a/server/internal/httpserver/settings_platform.go
+++ b/server/internal/httpserver/settings_platform.go
@@ -130,6 +130,7 @@ type platformSettingsJSON struct {
 	FFPublicCatalog                 bool `json:"ffPublicCatalog"`
 	FFStripeBilling                 bool `json:"ffStripeBilling"`
 	FFLearningPaths                 bool `json:"ffLearningPaths"`
+	FFCompletionCredentials         bool `json:"ffCompletionCredentials"`
 
 	LRSAnonymizeActors           bool    `json:"lrsAnonymizeActors"`
 	FERPAWorkflowEnabled         bool    `json:"ferpaWorkflowEnabled"`
@@ -309,6 +310,7 @@ func (d Deps) handleGetPlatformSettings() http.HandlerFunc {
 			FFPublicCatalog:                 merged.FFPublicCatalog,
 			FFStripeBilling:                 merged.FFStripeBilling,
 			FFLearningPaths:                 merged.FFLearningPaths,
+			FFCompletionCredentials:         merged.FFCompletionCredentials,
 			LRSAnonymizeActors:              merged.LRSAnonymizeActors,
 			FERPAWorkflowEnabled:            merged.FERPAWorkflowEnabled,
 			DPAPortalEnabled:                merged.DPAPortalEnabled,
@@ -463,6 +465,7 @@ type putPlatformBody struct {
 	FFPublicCatalog                 *bool `json:"ffPublicCatalog"`
 	FFStripeBilling                 *bool `json:"ffStripeBilling"`
 	FFLearningPaths                 *bool `json:"ffLearningPaths"`
+	FFCompletionCredentials         *bool `json:"ffCompletionCredentials"`
 
 	LRSAnonymizeActors           *bool    `json:"lrsAnonymizeActors"`
 	FERPAWorkflowEnabled         *bool    `json:"ferpaWorkflowEnabled"`
@@ -763,6 +766,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 		setBool("ffpubliccatalog", body.FFPublicCatalog, func(v bool) { wr.FFPublicCatalog = &v })
 		setBool("ffstripebilling", body.FFStripeBilling, func(v bool) { wr.FFStripeBilling = &v })
 		setBool("fflearningpaths", body.FFLearningPaths, func(v bool) { wr.FFLearningPaths = &v })
+		setBool("ffcompletioncredentials", body.FFCompletionCredentials, func(v bool) { wr.FFCompletionCredentials = &v })
 		setBool("lrsanonymizeactors", body.LRSAnonymizeActors, func(v bool) { wr.LRSAnonymizeActors = &v })
 		setBool("ferpaworkflowenabled", body.FERPAWorkflowEnabled, func(v bool) { wr.FERPAWorkflowEnabled = &v })
 		setBool("dpaportalenabled", body.DPAPortalEnabled, func(v bool) { wr.DPAPortalEnabled = &v })
@@ -896,6 +900,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 			FFPublicCatalog:                 merged.FFPublicCatalog,
 			FFStripeBilling:                 merged.FFStripeBilling,
 			FFLearningPaths:                 merged.FFLearningPaths,
+			FFCompletionCredentials:         merged.FFCompletionCredentials,
 			LRSAnonymizeActors:              merged.LRSAnonymizeActors,
 			FERPAWorkflowEnabled:            merged.FERPAWorkflowEnabled,
 			DPAPortalEnabled:                merged.DPAPortalEnabled,

--- a/server/internal/logging/credentials_metrics.go
+++ b/server/internal/logging/credentials_metrics.go
@@ -1,0 +1,39 @@
+package logging
+
+import "sync/atomic"
+
+// CredentialsMetrics tracks credentials_issued_total and credential_verifications_total (plans 15.5, 15.6).
+type CredentialsMetrics struct {
+	issued        atomic.Uint64
+	verifications atomic.Uint64
+	shares        atomic.Uint64
+}
+
+// GlobalCredentialsMetrics is incremented by credentials HTTP handlers.
+var GlobalCredentialsMetrics = &CredentialsMetrics{}
+
+func (m *CredentialsMetrics) IncIssued() {
+	m.issued.Add(1)
+}
+
+func (m *CredentialsMetrics) IncVerifications() {
+	m.verifications.Add(1)
+}
+
+func (m *CredentialsMetrics) IncShares() {
+	m.shares.Add(1)
+}
+
+func (m *CredentialsMetrics) Snapshot() map[string]uint64 {
+	return map[string]uint64{
+		"credentials_issued_total":        m.issued.Load(),
+		"credential_verifications_total":  m.verifications.Load(),
+		"credential_shares_total":         m.shares.Load(),
+	}
+}
+
+func (m *CredentialsMetrics) Reset() {
+	m.issued.Store(0)
+	m.verifications.Store(0)
+	m.shares.Store(0)
+}

--- a/server/internal/mail/templates.go
+++ b/server/internal/mail/templates.go
@@ -58,6 +58,8 @@ func RenderTemplate(name string, vars map[string]string, branding *BrandingOpts)
 		return renderIncompleteReminder(vars, logo, color)
 	case "payment_failed":
 		return renderPaymentFailed(vars, logo, color)
+	case "certificate_issued":
+		return renderCertificateIssued(vars, logo, color)
 	default:
 		subject := vars["subject"]
 		if subject == "" {
@@ -306,6 +308,43 @@ Deadline: <strong>%s</strong> (%s days remaining)</p>
 		template.HTMLEscapeString(deadline),
 		template.HTMLEscapeString(days),
 		template.HTMLEscapeString(link),
+		color,
+	), logo, vars["unsubscribeUrl"])
+	if err != nil {
+		return RenderedEmail{}, err
+	}
+	return RenderedEmail{Subject: subject, BodyText: bodyText, HTMLBody: html}, nil
+}
+
+func renderCertificateIssued(vars map[string]string, logo, color string) (RenderedEmail, error) {
+	name := vars["credentialName"]
+	verify := vars["verifyUrl"]
+	linkedIn := vars["linkedInUrl"]
+	credentialsURL := vars["credentialsUrl"]
+	subject := fmt.Sprintf("Certificate earned: %s", name)
+	bodyText := fmt.Sprintf(`Congratulations! You earned a certificate for "%s".
+
+Verify your credential: %s
+Add to LinkedIn: %s
+View all credentials: %s
+`, name, verify, linkedIn, credentialsURL)
+	linkedInBtn := ""
+	if strings.TrimSpace(linkedIn) != "" {
+		linkedInBtn = fmt.Sprintf(
+			`<p><a href="%s" style="display:inline-block;background:#0A66C2;color:#fff;padding:10px 16px;border-radius:6px;text-decoration:none;font-weight:600;">Add to LinkedIn</a></p>`,
+			template.HTMLEscapeString(linkedIn),
+		)
+	}
+	html, err := renderLayout("Certificate earned", fmt.Sprintf(
+		`<p>Congratulations! You earned a certificate for <strong>%s</strong>.</p>
+%s
+<p><a href="%s" style="color:%s;font-weight:600;">Verify credential</a></p>
+<p><a href="%s" style="color:%s;font-weight:600;">View my credentials</a></p>`,
+		template.HTMLEscapeString(name),
+		linkedInBtn,
+		template.HTMLEscapeString(verify),
+		color,
+		template.HTMLEscapeString(credentialsURL),
 		color,
 	), logo, vars["unsubscribeUrl"])
 	if err != nil {

--- a/server/internal/mail/templates_test.go
+++ b/server/internal/mail/templates_test.go
@@ -5,6 +5,24 @@ import (
 	"testing"
 )
 
+func TestRenderCertificateIssued(t *testing.T) {
+	rendered, err := RenderTemplate("certificate_issued", map[string]string{
+		"credentialName": "Intro to Data Science",
+		"verifyUrl":      "http://localhost:5173/verify/abc",
+		"linkedInUrl":    "https://www.linkedin.com/profile/add?name=Intro",
+		"credentialsUrl": "http://localhost:5173/me/credentials",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(rendered.Subject, "Intro to Data Science") {
+		t.Fatalf("subject: %q", rendered.Subject)
+	}
+	if !strings.Contains(rendered.HTMLBody, "Add to LinkedIn") {
+		t.Fatalf("html missing LinkedIn CTA")
+	}
+}
+
 func TestRenderGradePosted(t *testing.T) {
 	rendered, err := RenderTemplate("grade_posted", map[string]string{
 		"courseName":     "Algebra I",

--- a/server/internal/notificationevents/events.go
+++ b/server/internal/notificationevents/events.go
@@ -19,6 +19,7 @@ const (
 	IncompleteGranted      = "incomplete_granted"
 	IncompleteReminder     = "incomplete_reminder"
 	CEUAwarded             = "ceu_awarded"
+	CertificateIssued      = "certificate_issued"
 	PaymentFailed          = "payment_failed"
 )
 
@@ -41,5 +42,6 @@ var All = []string{
 	IncompleteGranted,
 	IncompleteReminder,
 	CEUAwarded,
+	CertificateIssued,
 	PaymentFailed,
 }

--- a/server/internal/repos/credentials/repo.go
+++ b/server/internal/repos/credentials/repo.go
@@ -1,0 +1,171 @@
+// Package credentials persists issued Open Badges credentials (plans 15.5, 15.6).
+package credentials
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SourceType identifies what completion produced the credential.
+type SourceType string
+
+const (
+	SourceCourse SourceType = "course"
+	SourcePath   SourceType = "path"
+	SourceCEU    SourceType = "ceu"
+)
+
+// IssuedCredential is one row in credentials.issued_credentials.
+type IssuedCredential struct {
+	ID             uuid.UUID
+	RecipientID    uuid.UUID
+	TemplateID     *uuid.UUID
+	SourceType     SourceType
+	SourceID       uuid.UUID
+	Title          string
+	CredentialJSON json.RawMessage
+	Proof          json.RawMessage
+	PDFKey         *string
+	Revoked        bool
+	IssuedAt       time.Time
+}
+
+// ListByRecipient returns credentials for a learner ordered by issued_at desc.
+func ListByRecipient(ctx context.Context, pool *pgxpool.Pool, recipientID uuid.UUID) ([]IssuedCredential, error) {
+	rows, err := pool.Query(ctx, `
+SELECT id, recipient_id, template_id, source_type, source_id, title,
+       credential_json, proof, pdf_key, revoked, issued_at
+FROM credentials.issued_credentials
+WHERE recipient_id = $1
+ORDER BY issued_at DESC
+`, recipientID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []IssuedCredential
+	for rows.Next() {
+		var row IssuedCredential
+		var sourceType string
+		if err := rows.Scan(
+			&row.ID, &row.RecipientID, &row.TemplateID, &sourceType, &row.SourceID, &row.Title,
+			&row.CredentialJSON, &row.Proof, &row.PDFKey, &row.Revoked, &row.IssuedAt,
+		); err != nil {
+			return nil, err
+		}
+		row.SourceType = SourceType(sourceType)
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+// GetByID returns a credential by id, or nil if not found.
+func GetByID(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID) (*IssuedCredential, error) {
+	row := IssuedCredential{}
+	var sourceType string
+	err := pool.QueryRow(ctx, `
+SELECT id, recipient_id, template_id, source_type, source_id, title,
+       credential_json, proof, pdf_key, revoked, issued_at
+FROM credentials.issued_credentials
+WHERE id = $1
+`, id).Scan(
+		&row.ID, &row.RecipientID, &row.TemplateID, &sourceType, &row.SourceID, &row.Title,
+		&row.CredentialJSON, &row.Proof, &row.PDFKey, &row.Revoked, &row.IssuedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	row.SourceType = SourceType(sourceType)
+	return &row, nil
+}
+
+// GetByRecipientAndSource returns an existing credential for idempotent issuance.
+func GetByRecipientAndSource(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	recipientID uuid.UUID,
+	sourceType SourceType,
+	sourceID uuid.UUID,
+) (*IssuedCredential, error) {
+	row := IssuedCredential{}
+	var st string
+	err := pool.QueryRow(ctx, `
+SELECT id, recipient_id, template_id, source_type, source_id, title,
+       credential_json, proof, pdf_key, revoked, issued_at
+FROM credentials.issued_credentials
+WHERE recipient_id = $1 AND source_type = $2 AND source_id = $3
+`, recipientID, string(sourceType), sourceID).Scan(
+		&row.ID, &row.RecipientID, &row.TemplateID, &st, &row.SourceID, &row.Title,
+		&row.CredentialJSON, &row.Proof, &row.PDFKey, &row.Revoked, &row.IssuedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	row.SourceType = SourceType(st)
+	return &row, nil
+}
+
+// Create inserts a new issued credential.
+func Create(ctx context.Context, pool *pgxpool.Pool, cred IssuedCredential) (*IssuedCredential, error) {
+	var sourceType string
+	err := pool.QueryRow(ctx, `
+INSERT INTO credentials.issued_credentials (
+    recipient_id, template_id, source_type, source_id, title,
+    credential_json, proof, pdf_key, issued_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, COALESCE($9, NOW()))
+RETURNING id, recipient_id, template_id, source_type, source_id, title,
+          credential_json, proof, pdf_key, revoked, issued_at
+`, cred.RecipientID, cred.TemplateID, string(cred.SourceType), cred.SourceID, cred.Title,
+		cred.CredentialJSON, cred.Proof, cred.PDFKey, nullableTime(cred.IssuedAt),
+	).Scan(
+		&cred.ID, &cred.RecipientID, &cred.TemplateID, &sourceType, &cred.SourceID, &cred.Title,
+		&cred.CredentialJSON, &cred.Proof, &cred.PDFKey, &cred.Revoked, &cred.IssuedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	cred.SourceType = SourceType(sourceType)
+	return &cred, nil
+}
+
+// CourseMeta is course title metadata for credential issuance.
+type CourseMeta struct {
+	ID    uuid.UUID
+	Title string
+}
+
+// CourseMetaByID loads course title for issuance emails and credential naming.
+func CourseMetaByID(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (*CourseMeta, error) {
+	var meta CourseMeta
+	err := pool.QueryRow(ctx, `
+SELECT id, COALESCE(NULLIF(TRIM(title), ''), course_code)
+FROM course.courses
+WHERE id = $1
+`, courseID).Scan(&meta.ID, &meta.Title)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &meta, nil
+}
+
+func nullableTime(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}

--- a/server/internal/repos/platformconfig/features.go
+++ b/server/internal/repos/platformconfig/features.go
@@ -83,6 +83,7 @@ func applyPlatformBools(out *config.Config, db *Row, def Defaults) {
 	out.FFPublicCatalog = mergeBool(db.FFPublicCatalog, false)
 	out.FFStripeBilling = mergeBool(db.FFStripeBilling, false)
 	out.FFLearningPaths = mergeBool(db.FFLearningPaths, false)
+	out.FFCompletionCredentials = mergeBool(db.FFCompletionCredentials, false)
 	out.SpeechToTextEnabled = mergeBool(db.SpeechToTextEnabled, false)
 	out.AccommodationsEngineEnabled = mergeBool(db.AccommodationsEngineEnabled, false)
 	out.FFAccommodationsEngine = mergeBool(db.FFAccommodationsEngine, false)

--- a/server/internal/repos/platformconfig/patch.go
+++ b/server/internal/repos/platformconfig/patch.go
@@ -151,6 +151,7 @@ func patch(ctx context.Context, pool *pgxpool.Pool, w *Write) error {
 	addBool("ff_public_catalog", w.FFPublicCatalog)
 	addBool("ff_stripe_billing", w.FFStripeBilling)
 	addBool("ff_learning_paths", w.FFLearningPaths)
+	addBool("ff_completion_credentials", w.FFCompletionCredentials)
 	addBool("lrs_anonymize_actors", w.LRSAnonymizeActors)
 	addBool("ferpa_workflow_enabled", w.FERPAWorkflowEnabled)
 	addBool("dpa_portal_enabled", w.DPAPortalEnabled)

--- a/server/internal/repos/platformconfig/platformconfig.go
+++ b/server/internal/repos/platformconfig/platformconfig.go
@@ -117,6 +117,7 @@ type Row struct {
 	FFPublicCatalog                 *bool
 	FFStripeBilling                 *bool
 	FFLearningPaths                 *bool
+	FFCompletionCredentials         *bool
 
 	// Previously env-only flags (categories B and C), now platform-managed.
 	LRSAnonymizeActors           *bool
@@ -248,6 +249,7 @@ type Write struct {
 	FFPublicCatalog                 *bool
 	FFStripeBilling                 *bool
 	FFLearningPaths                 *bool
+	FFCompletionCredentials         *bool
 
 	// Previously env-only flags (categories B and C), now platform-managed.
 	LRSAnonymizeActors           *bool
@@ -376,6 +378,7 @@ SELECT
 	ff_public_catalog,
 	ff_stripe_billing,
 	ff_learning_paths,
+	ff_completion_credentials,
 	lrs_anonymize_actors,
 	ferpa_workflow_enabled,
 	dpa_portal_enabled,
@@ -498,6 +501,7 @@ WHERE id = 1
 		&r.FFPublicCatalog,
 		&r.FFStripeBilling,
 		&r.FFLearningPaths,
+		&r.FFCompletionCredentials,
 		&r.LRSAnonymizeActors,
 		&r.FERPAWorkflowEnabled,
 		&r.DPAPortalEnabled,
@@ -669,6 +673,7 @@ INSERT INTO settings.platform_app_settings (
 	ff_consortium_sharing,
 	ff_stripe_billing,
 	ff_learning_paths,
+	ff_completion_credentials,
 	mfa_enabled,
 	mfa_enforcement,
 	smtp_host,
@@ -797,6 +802,7 @@ ON CONFLICT (id) DO UPDATE SET
 	ff_consortium_sharing = COALESCE(EXCLUDED.ff_consortium_sharing, settings.platform_app_settings.ff_consortium_sharing),
 	ff_stripe_billing = COALESCE(EXCLUDED.ff_stripe_billing, settings.platform_app_settings.ff_stripe_billing),
 	ff_learning_paths = COALESCE(EXCLUDED.ff_learning_paths, settings.platform_app_settings.ff_learning_paths),
+	ff_completion_credentials = COALESCE(EXCLUDED.ff_completion_credentials, settings.platform_app_settings.ff_completion_credentials),
 	lrs_anonymize_actors = COALESCE(EXCLUDED.lrs_anonymize_actors, settings.platform_app_settings.lrs_anonymize_actors),
 	ferpa_workflow_enabled = COALESCE(EXCLUDED.ferpa_workflow_enabled, settings.platform_app_settings.ferpa_workflow_enabled),
 	dpa_portal_enabled = COALESCE(EXCLUDED.dpa_portal_enabled, settings.platform_app_settings.dpa_portal_enabled),
@@ -917,6 +923,7 @@ ON CONFLICT (id) DO UPDATE SET
 		w.FFConsortiumSharing,
 		w.FFStripeBilling,
 		w.FFLearningPaths,
+		w.FFCompletionCredentials,
 		w.MFAEnabled,
 		w.MFAEnforcement,
 		w.SMTPHost,

--- a/server/internal/repos/useraudit/useraudit.go
+++ b/server/internal/repos/useraudit/useraudit.go
@@ -32,3 +32,20 @@ VALUES ($1, $2, $3, $4, NOW())
 `, userID, courseID, structureItemID, eventKind)
 	return err
 }
+
+// InsertCredentialShare records a credential share analytics event (plan 15.6).
+// structure_item_id stores the credential id for share events.
+func InsertCredentialShare(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	userID, courseID, credentialID uuid.UUID,
+	channel string,
+) error {
+	eventKind := "credential_share_" + channel
+	credID := credentialID
+	_, err := pool.Exec(ctx, `
+INSERT INTO "user".user_audit (user_id, course_id, structure_item_id, event_kind, occurred_at)
+VALUES ($1, $2, $3, $4, NOW())
+`, userID, courseID, &credID, eventKind)
+	return err
+}

--- a/server/internal/service/credentials/badge_token_test.go
+++ b/server/internal/service/credentials/badge_token_test.go
@@ -1,0 +1,33 @@
+package credentials
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lextures/lextures/server/internal/config"
+)
+
+func TestBadgeExportTokenRoundTrip(t *testing.T) {
+	cfg := config.Config{JWTSecret: "01234567890123456789012345678901"}
+	id := uuid.New()
+	now := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	token, expires, err := BadgeExportToken(cfg, id, now)
+	if err != nil {
+		t.Fatalf("BadgeExportToken: %v", err)
+	}
+	if !expires.After(now) {
+		t.Fatalf("expires should be in the future")
+	}
+	parsed, err := VerifyBadgeExportToken(cfg, token, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("VerifyBadgeExportToken: %v", err)
+	}
+	if parsed != id {
+		t.Fatalf("id mismatch: %s vs %s", parsed, id)
+	}
+	_, err = VerifyBadgeExportToken(cfg, token, now.Add(48*time.Hour))
+	if err == nil {
+		t.Fatal("expected expired token error")
+	}
+}

--- a/server/internal/service/credentials/linkedin.go
+++ b/server/internal/service/credentials/linkedin.go
@@ -1,0 +1,54 @@
+package credentials
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// LinkedInParams are pre-filled certification fields for LinkedIn's add-to-profile flow.
+type LinkedInParams struct {
+	Name             string `json:"name"`
+	OrganizationName string `json:"organizationName"`
+	IssueYear        int    `json:"issueYear"`
+	IssueMonth       int    `json:"issueMonth"`
+	CertURL          string `json:"certUrl"`
+	CertID           string `json:"certId"`
+	URL              string `json:"url"`
+}
+
+// BuildLinkedInParams constructs LinkedIn certification deep-link parameters (plan 15.6).
+func BuildLinkedInParams(credentialName, organizationName, verificationURL, certID string, issuedAt time.Time) LinkedInParams {
+	org := strings.TrimSpace(organizationName)
+	if org == "" {
+		org = "Lextures"
+	}
+	year := issuedAt.UTC().Year()
+	month := int(issuedAt.UTC().Month())
+	params := LinkedInParams{
+		Name:             credentialName,
+		OrganizationName: org,
+		IssueYear:        year,
+		IssueMonth:       month,
+		CertURL:          verificationURL,
+		CertID:           certID,
+	}
+	params.URL = BuildLinkedInCertificationURL(params)
+	return params
+}
+
+// BuildLinkedInCertificationURL returns the LinkedIn add-certification URL.
+func BuildLinkedInCertificationURL(p LinkedInParams) string {
+	u, _ := url.Parse("https://www.linkedin.com/profile/add")
+	q := u.Query()
+	q.Set("startTask", "CERTIFICATION_NAME")
+	q.Set("name", p.Name)
+	q.Set("organizationName", p.OrganizationName)
+	q.Set("issueYear", fmt.Sprintf("%d", p.IssueYear))
+	q.Set("issueMonth", fmt.Sprintf("%d", p.IssueMonth))
+	q.Set("certUrl", p.CertURL)
+	q.Set("certId", p.CertID)
+	u.RawQuery = q.Encode()
+	return u.String()
+}

--- a/server/internal/service/credentials/linkedin_test.go
+++ b/server/internal/service/credentials/linkedin_test.go
@@ -1,0 +1,44 @@
+package credentials
+
+import (
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestBuildLinkedInCertificationURL(t *testing.T) {
+	issued := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	params := BuildLinkedInParams(
+		"Intro to Data Science",
+		"Lextures",
+		"https://app.example.com/verify/abc",
+		"abc",
+		issued,
+	)
+	parsed, err := url.Parse(params.URL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	q := parsed.Query()
+	if q.Get("startTask") != "CERTIFICATION_NAME" {
+		t.Fatalf("startTask: %q", q.Get("startTask"))
+	}
+	if q.Get("name") != "Intro to Data Science" {
+		t.Fatalf("name: %q", q.Get("name"))
+	}
+	if q.Get("organizationName") != "Lextures" {
+		t.Fatalf("organizationName: %q", q.Get("organizationName"))
+	}
+	if q.Get("issueYear") != "2026" {
+		t.Fatalf("issueYear: %q", q.Get("issueYear"))
+	}
+	if q.Get("issueMonth") != "6" {
+		t.Fatalf("issueMonth: %q", q.Get("issueMonth"))
+	}
+	if q.Get("certUrl") != "https://app.example.com/verify/abc" {
+		t.Fatalf("certUrl: %q", q.Get("certUrl"))
+	}
+	if q.Get("certId") != "abc" {
+		t.Fatalf("certId: %q", q.Get("certId"))
+	}
+}

--- a/server/internal/service/credentials/pdf.go
+++ b/server/internal/service/credentials/pdf.go
@@ -1,0 +1,81 @@
+package credentials
+
+import (
+	"bytes"
+	"fmt"
+	"image/png"
+	"strings"
+	"time"
+
+	"github.com/boombuler/barcode"
+	"github.com/boombuler/barcode/qr"
+	"github.com/jung-kurt/gofpdf"
+)
+
+// PDFInput describes a completion certificate PDF.
+type PDFInput struct {
+	InstitutionName string
+	LearnerName     string
+	CredentialName  string
+	IssuedAt        time.Time
+	VerificationURL string
+}
+
+// BuildPDF renders an accessible certificate PDF with verification QR code.
+func BuildPDF(in PDFInput) ([]byte, error) {
+	pdf := gofpdf.New("L", "mm", "A4", "")
+	pdf.SetTitle(in.CredentialName, false)
+	pdf.AddPage()
+	pdf.SetFont("Helvetica", "B", 22)
+	pdf.CellFormat(0, 12, "Certificate of Completion", "", 1, "C", false, 0, "")
+	pdf.SetFont("Helvetica", "", 12)
+	pdf.CellFormat(0, 8, in.InstitutionName, "", 1, "C", false, 0, "")
+	pdf.Ln(8)
+	pdf.SetFont("Helvetica", "", 11)
+	pdf.CellFormat(0, 7, "This certifies that", "", 1, "C", false, 0, "")
+	pdf.SetFont("Helvetica", "B", 16)
+	pdf.CellFormat(0, 10, in.LearnerName, "", 1, "C", false, 0, "")
+	pdf.SetFont("Helvetica", "", 11)
+	pdf.CellFormat(0, 7, "has successfully completed", "", 1, "C", false, 0, "")
+	pdf.SetFont("Helvetica", "B", 14)
+	pdf.CellFormat(0, 10, in.CredentialName, "", 1, "C", false, 0, "")
+	pdf.SetFont("Helvetica", "", 10)
+	pdf.CellFormat(0, 6, fmt.Sprintf("Issued: %s", in.IssuedAt.UTC().Format("January 2, 2006")), "", 1, "C", false, 0, "")
+
+	if strings.TrimSpace(in.VerificationURL) != "" {
+		pdf.Ln(6)
+		if err := embedQR(pdf, in.VerificationURL); err != nil {
+			return nil, err
+		}
+		pdf.SetFont("Helvetica", "", 8)
+		pdf.MultiCell(0, 4, fmt.Sprintf("Verify at: %s", in.VerificationURL), "", "C", false)
+	}
+
+	var buf bytes.Buffer
+	if err := pdf.Output(&buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func embedQR(pdf *gofpdf.Fpdf, content string) error {
+	code, err := qr.Encode(content, qr.M, qr.Auto)
+	if err != nil {
+		return err
+	}
+	code, err = barcode.Scale(code, 120, 120)
+	if err != nil {
+		return err
+	}
+	var imgBuf bytes.Buffer
+	if err := png.Encode(&imgBuf, code); err != nil {
+		return err
+	}
+	name := "credential_qr"
+	opt := gofpdf.ImageOptions{ImageType: "PNG", ReadDpi: true}
+	pdf.RegisterImageOptionsReader(name, opt, bytes.NewReader(imgBuf.Bytes()))
+	pageW, _ := pdf.GetPageSize()
+	pdf.ImageOptions(name, (pageW-30)/2, pdf.GetY(), 30, 30, false, opt, 0, "")
+	pdf.Ln(32)
+	return nil
+}

--- a/server/internal/service/credentials/service.go
+++ b/server/internal/service/credentials/service.go
@@ -90,7 +90,6 @@ func IssueCourseCompletion(
 		return nil, err
 	}
 
-	verifyURL := VerificationURL(cfg.PublicWebOrigin, uuid.Nil)
 	created, err := credrepo.Create(ctx, pool, credrepo.IssuedCredential{
 		RecipientID:    p.RecipientID,
 		SourceType:     credrepo.SourceCourse,
@@ -103,7 +102,7 @@ func IssueCourseCompletion(
 	if err != nil {
 		return nil, err
 	}
-	verifyURL = VerificationURL(cfg.PublicWebOrigin, created.ID)
+	verifyURL := VerificationURL(cfg.PublicWebOrigin, created.ID)
 
 	pdfBytes, err := BuildPDF(PDFInput{
 		InstitutionName: institution,

--- a/server/internal/service/credentials/service.go
+++ b/server/internal/service/credentials/service.go
@@ -1,0 +1,214 @@
+package credentials
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lextures/lextures/server/internal/config"
+	credrepo "github.com/lextures/lextures/server/internal/repos/credentials"
+	ccrsvc "github.com/lextures/lextures/server/internal/service/ccr"
+	vcsigning "github.com/lextures/lextures/server/internal/service/vc_signing"
+)
+
+const badgeExportTTL = 24 * time.Hour
+
+// IssueCourseParams controls course-completion credential issuance.
+type IssueCourseParams struct {
+	RecipientID uuid.UUID
+	LearnerName string
+	CourseID    uuid.UUID
+	Now         time.Time
+}
+
+// IssueCourseCompletion issues an Open Badges 3.0 credential for course completion (idempotent).
+func IssueCourseCompletion(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	cfg config.Config,
+	p IssueCourseParams,
+) (*credrepo.IssuedCredential, error) {
+	if p.Now.IsZero() {
+		p.Now = time.Now().UTC()
+	}
+	existing, err := credrepo.GetByRecipientAndSource(ctx, pool, p.RecipientID, credrepo.SourceCourse, p.CourseID)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		return existing, nil
+	}
+
+	meta, err := credrepo.CourseMetaByID(ctx, pool, p.CourseID)
+	if err != nil {
+		return nil, err
+	}
+	if meta == nil {
+		return nil, fmt.Errorf("course not found")
+	}
+
+	institution := issuerName(cfg)
+	key, err := ccrsvc.ResolveSigningKey(cfg, cfg.PublicWebOrigin, cfg.CCRSigningSeedB64)
+	if err != nil {
+		return nil, err
+	}
+
+	achievementID := fmt.Sprintf("%s/achievements/%s", strings.TrimRight(cfg.PublicWebOrigin, "/"), p.CourseID.String())
+	subject := map[string]any{
+		"id":   fmt.Sprintf("urn:uuid:user:%s", p.RecipientID.String()),
+		"type": []string{"AchievementSubject"},
+		"name": strings.TrimSpace(p.LearnerName),
+		"achievement": map[string]any{
+			"id":          achievementID,
+			"type":        []string{"Achievement"},
+			"name":        meta.Title,
+			"description": fmt.Sprintf("Completed all items in %s.", meta.Title),
+			"criteria": map[string]any{
+				"narrative": "Learner completed every item in the self-paced course.",
+			},
+		},
+	}
+
+	vc, err := vcsigning.SignAchievementCredential(subject, institution, key, p.Now)
+	if err != nil {
+		return nil, err
+	}
+	vcBytes, err := json.Marshal(vc)
+	if err != nil {
+		return nil, err
+	}
+	subjectBytes, err := json.Marshal(subject)
+	if err != nil {
+		return nil, err
+	}
+
+	verifyURL := VerificationURL(cfg.PublicWebOrigin, uuid.Nil)
+	created, err := credrepo.Create(ctx, pool, credrepo.IssuedCredential{
+		RecipientID:    p.RecipientID,
+		SourceType:     credrepo.SourceCourse,
+		SourceID:       p.CourseID,
+		Title:          meta.Title,
+		CredentialJSON: subjectBytes,
+		Proof:          json.RawMessage(vcBytes),
+		IssuedAt:       p.Now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	verifyURL = VerificationURL(cfg.PublicWebOrigin, created.ID)
+
+	pdfBytes, err := BuildPDF(PDFInput{
+		InstitutionName: institution,
+		LearnerName:     p.LearnerName,
+		CredentialName:  meta.Title,
+		IssuedAt:        created.IssuedAt,
+		VerificationURL: verifyURL,
+	})
+	if err == nil && len(pdfBytes) > 0 {
+		keyStr := fmt.Sprintf("credential:%s.pdf", created.ID.String())
+		created.PDFKey = &keyStr
+		_, _ = pool.Exec(ctx, `UPDATE credentials.issued_credentials SET pdf_key = $2 WHERE id = $1`, created.ID, keyStr)
+	}
+
+	return created, nil
+}
+
+// VerificationURL builds the public verification page URL for a credential.
+func VerificationURL(origin string, credentialID uuid.UUID) string {
+	return fmt.Sprintf("%s/verify/%s", strings.TrimRight(strings.TrimSpace(origin), "/"), credentialID.String())
+}
+
+// LinkedInParamsForCredential returns pre-filled LinkedIn certification parameters.
+func LinkedInParamsForCredential(cfg config.Config, cred *credrepo.IssuedCredential) LinkedInParams {
+	verifyURL := VerificationURL(cfg.PublicWebOrigin, cred.ID)
+	return BuildLinkedInParams(cred.Title, issuerName(cfg), verifyURL, cred.ID.String(), cred.IssuedAt)
+}
+
+// BadgeExportToken issues an HMAC token for time-limited badge JSON download.
+func BadgeExportToken(cfg config.Config, credentialID uuid.UUID, now time.Time) (string, time.Time, error) {
+	secret := strings.TrimSpace(cfg.JWTSecret)
+	if secret == "" {
+		secret = strings.TrimSpace(cfg.CCRSigningSeedB64)
+	}
+	if secret == "" {
+		return "", time.Time{}, fmt.Errorf("signing secret unavailable")
+	}
+	expires := now.UTC().Add(badgeExportTTL)
+	payload := fmt.Sprintf("%s:%d", credentialID.String(), expires.Unix())
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(payload))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	token := base64.RawURLEncoding.EncodeToString([]byte(payload + ":" + sig))
+	return token, expires, nil
+}
+
+// VerifyBadgeExportToken validates a badge export token and returns the credential id.
+func VerifyBadgeExportToken(cfg config.Config, token string, now time.Time) (uuid.UUID, error) {
+	secret := strings.TrimSpace(cfg.JWTSecret)
+	if secret == "" {
+		secret = strings.TrimSpace(cfg.CCRSigningSeedB64)
+	}
+	if secret == "" {
+		return uuid.UUID{}, fmt.Errorf("signing secret unavailable")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(token))
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf("invalid token")
+	}
+	parts := strings.SplitN(string(raw), ":", 3)
+	if len(parts) != 3 {
+		return uuid.UUID{}, fmt.Errorf("invalid token")
+	}
+	id, err := uuid.Parse(parts[0])
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf("invalid token")
+	}
+	var exp int64
+	if _, err := fmt.Sscanf(parts[1], "%d", &exp); err != nil {
+		return uuid.UUID{}, fmt.Errorf("invalid token")
+	}
+	if now.UTC().Unix() > exp {
+		return uuid.UUID{}, fmt.Errorf("token expired")
+	}
+	payload := fmt.Sprintf("%s:%d", parts[0], exp)
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(payload))
+	expected := hex.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(expected), []byte(parts[2])) {
+		return uuid.UUID{}, fmt.Errorf("invalid token")
+	}
+	return id, nil
+}
+
+// VerifyCredential checks the VC proof on a stored credential.
+func VerifyCredential(cfg config.Config, proof json.RawMessage) (bool, error) {
+	var vc map[string]any
+	if err := json.Unmarshal(proof, &vc); err != nil {
+		return false, err
+	}
+	key, err := ccrsvc.ResolveSigningKey(cfg, cfg.PublicWebOrigin, cfg.CCRSigningSeedB64)
+	if err != nil {
+		return false, err
+	}
+	return vcsigning.VerifyCredential(vc, key.PublicKey)
+}
+
+// FullCredentialJSON merges stored subject JSON with signed VC proof for export.
+func FullCredentialJSON(cred *credrepo.IssuedCredential) ([]byte, error) {
+	return cred.Proof, nil
+}
+
+func issuerName(cfg config.Config) string {
+	if strings.TrimSpace(cfg.CCRInstitutionName) != "" {
+		return strings.TrimSpace(cfg.CCRInstitutionName)
+	}
+	return "Lextures"
+}

--- a/server/internal/service/vc_signing/achievement.go
+++ b/server/internal/service/vc_signing/achievement.go
@@ -1,0 +1,23 @@
+package vcsigning
+
+import (
+	"time"
+)
+
+const obContext = "https://purl.imsglobal.org/spec/ob/v3p0/context.json"
+
+// SignAchievementCredential wraps an Open Badges 3.0 subject in a W3C VC with Ed25519 proof.
+func SignAchievementCredential(subject map[string]any, issuerName string, key KeyMaterial, issuedAt time.Time) (map[string]any, error) {
+	unsigned := map[string]any{
+		"@context": []string{vcContext, obContext},
+		"type":     []string{"VerifiableCredential", "OpenBadgeCredential"},
+		"issuer": map[string]any{
+			"id":   key.DID,
+			"name": issuerName,
+			"type": []string{"Profile"},
+		},
+		"issuanceDate":      issuedAt.UTC().Format(time.RFC3339),
+		"credentialSubject": subject,
+	}
+	return signUnsigned(unsigned, key, issuedAt)
+}

--- a/server/internal/service/vc_signing/sign.go
+++ b/server/internal/service/vc_signing/sign.go
@@ -97,9 +97,13 @@ func SignCredential(clrSubject map[string]any, issuerName string, key KeyMateria
 			"id":   key.DID,
 			"name": issuerName,
 		},
-		"issuanceDate": issuedAt.UTC().Format(time.RFC3339),
+		"issuanceDate":      issuedAt.UTC().Format(time.RFC3339),
 		"credentialSubject": clrSubject,
 	}
+	return signUnsigned(unsigned, key, issuedAt)
+}
+
+func signUnsigned(unsigned map[string]any, key KeyMaterial, issuedAt time.Time) (map[string]any, error) {
 	canonical, err := canonicalJSON(unsigned)
 	if err != nil {
 		return nil, err

--- a/server/migrations/283_credentials_linkedin_share.sql
+++ b/server/migrations/283_credentials_linkedin_share.sql
@@ -1,0 +1,74 @@
+-- Plan 15.5 / 15.6 — Issued credentials (Open Badges 3.0) and LinkedIn share audit events.
+
+CREATE SCHEMA IF NOT EXISTS credentials;
+
+CREATE TABLE credentials.credential_templates (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    course_id       UUID REFERENCES course.courses (id) ON DELETE SET NULL,
+    path_id         UUID REFERENCES learningpath.learning_paths (id) ON DELETE SET NULL,
+    name            TEXT NOT NULL,
+    description     TEXT,
+    background_url  TEXT,
+    logo_url        TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE credentials.credential_templates IS
+    'Certificate templates for course/path completion credentials (plan 15.5).';
+
+CREATE TABLE credentials.issued_credentials (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    recipient_id    UUID NOT NULL REFERENCES "user".users (id) ON DELETE CASCADE,
+    template_id     UUID REFERENCES credentials.credential_templates (id) ON DELETE SET NULL,
+    source_type     TEXT NOT NULL CHECK (source_type IN ('course', 'path', 'ceu')),
+    source_id       UUID NOT NULL,
+    title           TEXT NOT NULL,
+    credential_json JSONB NOT NULL,
+    proof           JSONB NOT NULL,
+    pdf_key         TEXT,
+    revoked         BOOLEAN NOT NULL DEFAULT FALSE,
+    issued_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (recipient_id, source_type, source_id)
+);
+
+COMMENT ON TABLE credentials.issued_credentials IS
+    'Issued Open Badges 3.0 / W3C VC credentials (plan 15.5).';
+
+CREATE INDEX idx_issued_credentials_recipient
+    ON credentials.issued_credentials (recipient_id, issued_at DESC);
+
+CREATE INDEX idx_issued_credentials_source
+    ON credentials.issued_credentials (source_type, source_id);
+
+-- Platform feature flag (managed in Settings → Global platform; default off, SL tier).
+ALTER TABLE settings.platform_app_settings
+    ADD COLUMN IF NOT EXISTS ff_completion_credentials BOOLEAN;
+
+COMMENT ON COLUMN settings.platform_app_settings.ff_completion_credentials IS
+    'Enables course completion certificates, Open Badges export, and LinkedIn share (plans 15.5, 15.6).';
+
+-- 15.6: credential share analytics via user_audit.
+ALTER TABLE "user".user_audit DROP CONSTRAINT IF EXISTS user_audit_event_kind_check;
+ALTER TABLE "user".user_audit ADD CONSTRAINT user_audit_event_kind_check CHECK (
+    event_kind IN (
+        'course_visit',
+        'content_open',
+        'content_leave',
+        'equation_inserted',
+        'equation_editor_open',
+        'credential_share_linkedin',
+        'credential_share_badge_export'
+    )
+);
+
+ALTER TABLE "user".user_audit DROP CONSTRAINT IF EXISTS user_audit_structure_item_kind;
+ALTER TABLE "user".user_audit DROP CONSTRAINT IF EXISTS user_audit_structure_item_kind_check;
+ALTER TABLE "user".user_audit ADD CONSTRAINT user_audit_structure_item_kind_check CHECK (
+    (event_kind = 'course_visit' AND structure_item_id IS NULL)
+    OR (event_kind IN ('content_open', 'content_leave') AND structure_item_id IS NOT NULL)
+    OR (event_kind IN ('equation_inserted', 'equation_editor_open'))
+    OR (
+        event_kind IN ('credential_share_linkedin', 'credential_share_badge_export')
+        AND structure_item_id IS NOT NULL
+    )
+);


### PR DESCRIPTION
## Summary

Implements plan 15.6 (LinkedIn Share / Open Badges Export) with migration `283_credentials_linkedin_share.sql`.

- Issues Open Badges 3.0 / W3C VC credentials on self-paced course completion
- Adds LinkedIn certification deep-link (`/api/v1/credentials/:id/linkedin-params`) and 24h signed badge JSON export
- Surfaces share actions on completion celebration, My Credentials page, and certificate email
- Records `credential_share_linkedin` / `credential_share_badge_export` analytics in `user_audit`
- Public verification at `/verify/:credentialId` with Open Graph meta tags

## Feature flag

`ff_completion_credentials` (default off) — same gate as completion credentials.

## Test plan

- [x] Go unit tests: LinkedIn URL builder, badge export token, credentials HTTP auth
- [x] Frontend vitest: `buildLinkedInCertificationUrl`
- [x] Mail template test for `certificate_issued`
- [x] E2E spec: `e2e/tests/credentials.spec.ts` (skips when flag off)