### PR TITLE
15.8 — Affiliate / creator revenue share

### DIFF
--- a/clients/web/src/app.tsx
+++ b/clients/web/src/app.tsx
@@ -66,6 +66,7 @@ export default function App() {
             <Route path="/me/credentials" element={<Pages.MyCredentials />} />
             <Route path="/me/ce-transcript" element={<Pages.CeTranscript />} />
             <Route path="/me/billing" element={<Pages.BillingSettingsPage />} />
+            <Route path="/me/creator/earnings" element={<Pages.CreatorEarningsPage />} />
             <Route path="/checkout/success" element={<Pages.CheckoutSuccessPage />} />
             <Route path="/checkout/cancel" element={<Pages.CheckoutCancelPage />} />
             <Route path="/transcripts" element={<Pages.TranscriptsPage />} />

--- a/clients/web/src/components/layout/side-nav-main-links.tsx
+++ b/clients/web/src/components/layout/side-nav-main-links.tsx
@@ -7,6 +7,7 @@ import {
   Bot,
   Calendar,
   CreditCard,
+  DollarSign,
   FileText,
   FolderOpen,
   GraduationCap,
@@ -45,6 +46,7 @@ export function SideNavMainLinks() {
     ffCoCurricularTranscript,
     ffCeuTracking,
     ffStripeBilling,
+    ffRevenueShare,
     ffLearningPaths,
     ffCompletionCredentials,
     ffCatalogIntegration,
@@ -74,7 +76,8 @@ export function SideNavMainLinks() {
     ffCeuTracking ||
     ffResearchConsent ||
     ffAccessibilityIntake ||
-    ffStripeBilling
+    ffStripeBilling ||
+    ffRevenueShare
 
   return (
     <>
@@ -172,6 +175,11 @@ export function SideNavMainLinks() {
           {ffStripeBilling ? (
             <SideNavLink to="/me/billing" icon={<CreditCard className="h-5 w-5" />}>
               Billing
+            </SideNavLink>
+          ) : null}
+          {ffRevenueShare ? (
+            <SideNavLink to="/me/creator/earnings" icon={<DollarSign className="h-5 w-5" />}>
+              Creator earnings
             </SideNavLink>
           ) : null}
         </>

--- a/clients/web/src/components/settings/platform-feature-definitions.ts
+++ b/clients/web/src/components/settings/platform-feature-definitions.ts
@@ -109,6 +109,12 @@ const PLATFORM_FEATURE_DEFINITIONS_UNSORTED: PlatformFeatureDefinition[] = [
       'Stripe Checkout for course purchases and subscriptions, entitlement gating, and learner billing portal.',
   },
   {
+    key: 'ffRevenueShare',
+    label: 'Creator revenue share & affiliates',
+    description:
+      'Creator earnings ledger, affiliate referral links, and Stripe Connect payouts for course sales.',
+  },
+  {
     key: 'ffCoCurricularTranscript',
     label: 'Co-curricular transcript (CLR)',
     description:

--- a/clients/web/src/components/settings/platform-settings-panel.tsx
+++ b/clients/web/src/components/settings/platform-settings-panel.tsx
@@ -64,6 +64,7 @@ function emptyForm(): PlatformSettingsPayload {
     ffCeuTracking: false,
     ffConsortiumSharing: false,
     ffStripeBilling: false,
+    ffRevenueShare: false,
     ffLearningPaths: false,
     ffCompletionCredentials: false,
     translationMemoryEnabled: false,

--- a/clients/web/src/components/settings/platform-settings-types.ts
+++ b/clients/web/src/components/settings/platform-settings-types.ts
@@ -42,6 +42,7 @@ export type PlatformSettingsPayload = {
   ffCeuTracking: boolean
   ffConsortiumSharing: boolean
   ffStripeBilling: boolean
+  ffRevenueShare: boolean
   ffLearningPaths: boolean
   ffCompletionCredentials: boolean
   translationMemoryEnabled: boolean

--- a/clients/web/src/context/platform-features-context.tsx
+++ b/clients/web/src/context/platform-features-context.tsx
@@ -70,6 +70,7 @@ export type PlatformFeatures = {
   ffCeuTracking: boolean
   ffConsortiumSharing: boolean
   ffStripeBilling: boolean
+  ffRevenueShare: boolean
   ffLearningPaths: boolean
   ffCompletionCredentials: boolean
   ffCourseReviews: boolean
@@ -137,6 +138,7 @@ const defaultFeatures: PlatformFeatures = {
   ffCeuTracking: false,
   ffConsortiumSharing: false,
   ffStripeBilling: false,
+  ffRevenueShare: false,
   ffLearningPaths: false,
   ffCompletionCredentials: false,
   ffCourseReviews: false,
@@ -209,6 +211,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
     ffCeuTracking: false,
   ffConsortiumSharing: false,
   ffStripeBilling: false,
+  ffRevenueShare: false,
   ffLearningPaths: false,
   ffCompletionCredentials: false,
   ffCourseReviews: false,
@@ -282,6 +285,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffCeuTracking: data.ffCeuTracking === true,
           ffConsortiumSharing: data.ffConsortiumSharing === true,
           ffStripeBilling: data.ffStripeBilling === true,
+          ffRevenueShare: data.ffRevenueShare === true,
           ffLearningPaths: data.ffLearningPaths === true,
           ffCompletionCredentials: data.ffCompletionCredentials === true,
           ffCourseReviews: data.ffCourseReviews === true,
@@ -322,6 +326,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffCeuTracking: next.ffCeuTracking === true,
           ffConsortiumSharing: next.ffConsortiumSharing === true,
           ffStripeBilling: next.ffStripeBilling === true,
+          ffRevenueShare: next.ffRevenueShare === true,
           ffLearningPaths: next.ffLearningPaths === true,
           ffCompletionCredentials: next.ffCompletionCredentials === true,
           ffCourseReviews: next.ffCourseReviews === true,

--- a/clients/web/src/lazy-pages.ts
+++ b/clients/web/src/lazy-pages.ts
@@ -121,6 +121,7 @@ export const PortfolioArtifactContentPage = lazy(() => import('./pages/lms/portf
 export const PublicPortfolioPage = lazy(() => import('./pages/portfolio/public-portfolio-page'))
 export const PublicPortfolioContentPage = lazy(() => import('./pages/portfolio/public-portfolio-content-page'))
 export const BillingSettingsPage = lazy(() => import('./pages/lms/billing-settings'))
+export const CreatorEarningsPage = lazy(() => import('./pages/lms/creator-earnings-page'))
 export const CheckoutSuccessPage = lazy(() => import('./pages/checkout/success'))
 export const CheckoutCancelPage = lazy(() => import('./pages/checkout/cancel'))
 export const CliAuthPage = lazy(() => import('./pages/cli-auth'))

--- a/clients/web/src/lib/billing-api.ts
+++ b/clients/web/src/lib/billing-api.ts
@@ -16,6 +16,7 @@ export type CheckoutPayload = {
   courseId?: string
   plan?: 'monthly' | 'annual'
   promoCode?: string
+  affiliateCode?: string
   successUrl: string
   cancelUrl: string
 }

--- a/clients/web/src/lib/platform-features.ts
+++ b/clients/web/src/lib/platform-features.ts
@@ -57,6 +57,7 @@ export type PlatformFeaturesSnapshot = {
   ffCeuTracking?: boolean
   ffConsortiumSharing?: boolean
   ffStripeBilling?: boolean
+  ffRevenueShare?: boolean
   ffLearningPaths?: boolean
   ffCompletionCredentials?: boolean
   ffCourseReviews?: boolean
@@ -123,6 +124,7 @@ const defaults: PlatformFeaturesSnapshot = {
   ffCeuTracking: false,
   ffConsortiumSharing: false,
   ffStripeBilling: false,
+  ffRevenueShare: false,
   ffLearningPaths: false,
   ffCompletionCredentials: false,
   ffCourseReviews: false,

--- a/clients/web/src/lib/revenue-share-api.ts
+++ b/clients/web/src/lib/revenue-share-api.ts
@@ -1,0 +1,121 @@
+import { authorizedFetch } from './api'
+import { readApiErrorMessage } from './errors'
+import { formatMoney } from './billing-api'
+
+export type EarningsSummary = {
+  pendingCents: number
+  paidCents: number
+  currency: string
+  connectConfigured: boolean
+}
+
+export type LedgerEntry = {
+  id: string
+  entryType: string
+  amountCents: number
+  currency: string
+  status: string
+  courseId?: string
+  affiliateCode?: string
+  createdAt: string
+}
+
+export type AffiliateCode = {
+  id: string
+  code: string
+  courseId?: string | null
+  url: string
+  clickCount: number
+  conversions: number
+  createdAt: string
+}
+
+export async function fetchCreatorEarnings(): Promise<EarningsSummary> {
+  const res = await authorizedFetch('/api/v1/creator/earnings')
+  if (res.status === 404) {
+    return { pendingCents: 0, paidCents: 0, currency: 'usd', connectConfigured: false }
+  }
+  if (!res.ok) {
+    throw new Error('Could not load earnings.')
+  }
+  return (await res.json()) as EarningsSummary
+}
+
+export async function fetchCreatorLedger(limit = 20): Promise<LedgerEntry[]> {
+  const res = await authorizedFetch(`/api/v1/creator/earnings/ledger?limit=${limit}`)
+  if (res.status === 404) {
+    return []
+  }
+  if (!res.ok) {
+    throw new Error('Could not load earnings ledger.')
+  }
+  const data = (await res.json()) as { entries?: LedgerEntry[] }
+  return data.entries ?? []
+}
+
+export async function createAffiliateCode(courseId?: string): Promise<AffiliateCode> {
+  const res = await authorizedFetch('/api/v1/creator/affiliate-codes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(courseId ? { courseId } : {}),
+  })
+  if (!res.ok) {
+    const raw = (await res.json().catch(() => ({}))) as Record<string, unknown>
+    throw new Error(readApiErrorMessage(raw) || 'Could not create affiliate code.')
+  }
+  return (await res.json()) as AffiliateCode
+}
+
+export async function fetchAffiliateCodes(): Promise<AffiliateCode[]> {
+  const res = await authorizedFetch('/api/v1/creator/affiliate-codes')
+  if (res.status === 404) {
+    return []
+  }
+  if (!res.ok) {
+    throw new Error('Could not load affiliate codes.')
+  }
+  const data = (await res.json()) as { codes?: AffiliateCode[] }
+  return data.codes ?? []
+}
+
+export async function startConnectOnboarding(): Promise<string> {
+  const res = await authorizedFetch('/api/v1/creator/connect/onboarding', { method: 'POST' })
+  if (!res.ok) {
+    const raw = (await res.json().catch(() => ({}))) as Record<string, unknown>
+    throw new Error(readApiErrorMessage(raw) || 'Could not start Connect onboarding.')
+  }
+  const data = (await res.json()) as { onboardingUrl?: string }
+  if (!data.onboardingUrl) {
+    throw new Error('Unexpected response from server.')
+  }
+  return data.onboardingUrl
+}
+
+export { formatMoney }
+
+export const AFFILIATE_REF_COOKIE = 'lextures_ref'
+export const AFFILIATE_REF_MAX_AGE_DAYS = 30
+
+export function setAffiliateRefCookie(code: string): void {
+  const maxAge = AFFILIATE_REF_MAX_AGE_DAYS * 24 * 60 * 60
+  document.cookie = `${AFFILIATE_REF_COOKIE}=${encodeURIComponent(code)}; path=/; max-age=${maxAge}; SameSite=Lax`
+}
+
+export function getAffiliateRefCookie(): string | null {
+  const prefix = `${AFFILIATE_REF_COOKIE}=`
+  for (const part of document.cookie.split(';')) {
+    const trimmed = part.trim()
+    if (trimmed.startsWith(prefix)) {
+      return decodeURIComponent(trimmed.slice(prefix.length))
+    }
+  }
+  return null
+}
+
+export async function trackAffiliateClick(code: string): Promise<void> {
+  try {
+    await fetch(`/api/v1/affiliate/track-click?code=${encodeURIComponent(code)}`, { method: 'POST' })
+  } catch {
+    // best-effort
+  }
+}

--- a/clients/web/src/pages/explore-course-page.tsx
+++ b/clients/web/src/pages/explore-course-page.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useId, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
 import { ArrowLeft, Star } from 'lucide-react'
 import { CourseReviewsSection } from '../components/reviews/course-reviews-section'
 import { fetchPublicCourseReviews, type ReviewsListResponse } from '../lib/course-reviews-api'
+import {
+  setAffiliateRefCookie,
+  trackAffiliateClick,
+} from '../lib/revenue-share-api'
 import {
   fetchPublicCatalogCourse,
   formatPrice,
@@ -27,6 +31,7 @@ function useCourseJsonLd(jsonLd: Record<string, unknown> | null) {
 
 export default function ExploreCoursePage() {
   const { slug } = useParams<{ slug: string }>()
+  const [searchParams] = useSearchParams()
   const [detail, setDetail] = useState<PublicCatalogCourseDetail | null>(null)
   const [reviews, setReviews] = useState<ReviewsListResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -63,6 +68,13 @@ export default function ExploreCoursePage() {
   }, [slug])
 
   useCourseJsonLd(detail?.jsonLd ?? null)
+
+  useEffect(() => {
+    const ref = searchParams.get('ref')?.trim()
+    if (!ref) return
+    setAffiliateRefCookie(ref)
+    void trackAffiliateClick(ref)
+  }, [searchParams])
 
   useEffect(() => {
     if (detail) document.title = `${detail.course.title} — Lextures`

--- a/clients/web/src/pages/lms/creator-earnings-page.tsx
+++ b/clients/web/src/pages/lms/creator-earnings-page.tsx
@@ -1,0 +1,238 @@
+import { useCallback, useEffect, useId, useState } from 'react'
+import { DollarSign, Link2, Wallet } from 'lucide-react'
+import { usePlatformFeatures } from '../../context/platform-features-context'
+import {
+  createAffiliateCode,
+  fetchAffiliateCodes,
+  fetchCreatorEarnings,
+  fetchCreatorLedger,
+  formatMoney,
+  startConnectOnboarding,
+  type AffiliateCode,
+  type EarningsSummary,
+  type LedgerEntry,
+} from '../../lib/revenue-share-api'
+
+export default function CreatorEarningsPage() {
+  const { ffRevenueShare, loading: featuresLoading } = usePlatformFeatures()
+  const [summary, setSummary] = useState<EarningsSummary | null>(null)
+  const [ledger, setLedger] = useState<LedgerEntry[]>([])
+  const [codes, setCodes] = useState<AffiliateCode[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const pendingId = useId()
+  const paidId = useId()
+  const tableCaptionId = useId()
+
+  const load = useCallback(async () => {
+    setError(null)
+    try {
+      const [s, l, c] = await Promise.all([
+        fetchCreatorEarnings(),
+        fetchCreatorLedger(),
+        fetchAffiliateCodes(),
+      ])
+      setSummary(s)
+      setLedger(l)
+      setCodes(c)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Could not load earnings.')
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!featuresLoading && ffRevenueShare) void load()
+  }, [featuresLoading, ffRevenueShare, load])
+
+  async function handleConnect() {
+    setBusy(true)
+    setError(null)
+    try {
+      const url = await startConnectOnboarding()
+      window.location.href = url
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Connect onboarding failed.')
+      setBusy(false)
+    }
+  }
+
+  async function handleNewCode() {
+    setBusy(true)
+    setError(null)
+    try {
+      await createAffiliateCode()
+      await load()
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Could not create referral link.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (featuresLoading) {
+    return <p className="p-6 text-sm text-slate-600">Loading…</p>
+  }
+
+  if (!ffRevenueShare) {
+    return (
+      <div className="p-6">
+        <p className="text-sm text-slate-600">Creator earnings are not enabled on this platform.</p>
+      </div>
+    )
+  }
+
+  const currency = summary?.currency ?? 'usd'
+  const hasEarnings = (summary?.pendingCents ?? 0) > 0 || (summary?.paidCents ?? 0) > 0 || ledger.length > 0
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 p-6">
+      <header>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-neutral-100">Creator earnings</h1>
+        <p className="mt-1 text-sm text-slate-600 dark:text-neutral-400">
+          Track sales revenue, affiliate commissions, and payouts.
+        </p>
+      </header>
+
+      {error ? (
+        <div role="alert" className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {error}
+        </div>
+      ) : null}
+
+      {!summary?.connectConfigured ? (
+        <section
+          aria-label="Stripe Connect onboarding"
+          className="rounded-xl border border-amber-200 bg-amber-50 p-5 dark:border-amber-900 dark:bg-amber-950"
+        >
+          <p className="text-sm text-amber-900 dark:text-amber-100">
+            Connect your bank account via Stripe to receive payouts.
+          </p>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void handleConnect()}
+            className="mt-3 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+          >
+            Set up payouts
+          </button>
+        </section>
+      ) : null}
+
+      <section aria-labelledby="earnings-summary-heading" className="grid gap-4 sm:grid-cols-2">
+        <h2 id="earnings-summary-heading" className="sr-only">
+          Earnings summary
+        </h2>
+        <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+          <div className="flex items-center gap-2 text-sm text-slate-500">
+            <Wallet className="h-4 w-4" aria-hidden="true" />
+            Pending balance
+          </div>
+          <data value={summary?.pendingCents ?? 0} className="mt-2 block text-3xl font-bold" id={pendingId}>
+            {formatMoney(summary?.pendingCents ?? 0, currency)}
+          </data>
+        </div>
+        <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+          <div className="flex items-center gap-2 text-sm text-slate-500">
+            <DollarSign className="h-4 w-4" aria-hidden="true" />
+            Paid out
+          </div>
+          <data value={summary?.paidCents ?? 0} className="mt-2 block text-3xl font-bold" id={paidId}>
+            {formatMoney(summary?.paidCents ?? 0, currency)}
+          </data>
+        </div>
+      </section>
+
+      {!hasEarnings ? (
+        <p className="text-sm text-slate-600 dark:text-neutral-400">
+          No earnings yet — publish a course and start selling!
+        </p>
+      ) : (
+        <section aria-labelledby="ledger-heading">
+          <h2 id="ledger-heading" className="text-lg font-semibold">
+            Recent activity
+          </h2>
+          <div className="mt-3 overflow-x-auto rounded-xl border border-slate-200 dark:border-neutral-800">
+            <table className="min-w-full text-sm" aria-describedby={tableCaptionId}>
+              <caption id={tableCaptionId} className="sr-only">
+                Earnings ledger with date, type, and amount
+              </caption>
+              <thead className="bg-slate-50 text-start dark:bg-neutral-900">
+                <tr>
+                  <th scope="col" className="px-4 py-2 font-medium">
+                    Date
+                  </th>
+                  <th scope="col" className="px-4 py-2 font-medium">
+                    Type
+                  </th>
+                  <th scope="col" className="px-4 py-2 font-medium">
+                    Amount
+                  </th>
+                  <th scope="col" className="px-4 py-2 font-medium">
+                    Status
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {ledger.map((row) => (
+                  <tr key={row.id} className="border-t border-slate-100 dark:border-neutral-800">
+                    <td className="px-4 py-2">{new Date(row.createdAt).toLocaleDateString()}</td>
+                    <td className="px-4 py-2 capitalize">{row.entryType}</td>
+                    <td className="px-4 py-2">
+                      <data value={row.amountCents}>{formatMoney(row.amountCents, row.currency)}</data>
+                    </td>
+                    <td className="px-4 py-2 capitalize">{row.status}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      <section aria-labelledby="affiliate-heading">
+        <div className="flex items-center justify-between gap-4">
+          <h2 id="affiliate-heading" className="text-lg font-semibold">
+            Referral links
+          </h2>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void handleNewCode()}
+            className="inline-flex items-center gap-1 rounded-lg border border-slate-300 px-3 py-1.5 text-sm font-medium hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          >
+            <Link2 className="h-4 w-4" aria-hidden="true" />
+            New link
+          </button>
+        </div>
+        {codes.length === 0 ? (
+          <p className="mt-2 text-sm text-slate-600 dark:text-neutral-400">
+            Generate a referral link to earn commission when others purchase through your link.
+          </p>
+        ) : (
+          <ul className="mt-3 space-y-3">
+            {codes.map((code) => (
+              <li
+                key={code.id}
+                className="rounded-xl border border-slate-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <code className="text-xs text-slate-600 dark:text-neutral-400">{code.url}</code>
+                  <button
+                    type="button"
+                    className="text-sm font-medium text-indigo-600 hover:underline"
+                    onClick={() => void navigator.clipboard.writeText(code.url)}
+                  >
+                    Copy
+                  </button>
+                </div>
+                <p className="mt-2 text-xs text-slate-500">
+                  {code.clickCount} clicks · {code.conversions} conversions
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/docs/completed/15-self-learner-specific/15.8-affiliate-revenue-share.md
+++ b/docs/completed/15-self-learner-specific/15.8-affiliate-revenue-share.md
@@ -10,7 +10,7 @@
 | **Section** | Self-Learner-Specific |
 | **Severity** | MAJOR |
 | **Markets** | SL |
-| **Status (today)** | MISSING |
+| **Status (today)** | COMPLETE |
 | **Estimated effort** | M (2–4w) |
 | **Owner (proposed)** | Backend platform team |
 | **Depends on** | 15.3 Stripe billing, 15.14 creator portal |

--- a/e2e/tests/revenue-share.spec.ts
+++ b/e2e/tests/revenue-share.spec.ts
@@ -24,7 +24,7 @@ test.describe('Revenue share — API auth', () => {
 test.describe('Revenue share — authenticated API', () => {
   test('teacher can load earnings summary when feature enabled', async ({ seededCourse }) => {
     const res = await fetch(`${apiBase}/api/v1/creator/earnings`, {
-      headers: { Authorization: `Bearer ${seededCourse.teacherToken}` },
+      headers: { Authorization: `Bearer ${seededCourse.instructorToken}` },
     })
     if (res.status === 404) {
       test.skip(true, 'ff_revenue_share not enabled in this environment')
@@ -39,7 +39,7 @@ test.describe('Revenue share — authenticated API', () => {
 test.describe('Revenue share — UI', () => {
   test('creator earnings page loads when feature enabled', async ({ page, seededCourse }) => {
     const featRes = await fetch(`${apiBase}/api/v1/platform/features`, {
-      headers: { Authorization: `Bearer ${seededCourse.teacherToken}` },
+      headers: { Authorization: `Bearer ${seededCourse.instructorToken}` },
     })
     if (!featRes.ok) {
       test.skip(true, 'platform features unavailable')
@@ -49,7 +49,7 @@ test.describe('Revenue share — UI', () => {
       test.skip(true, 'ff_revenue_share not enabled in this environment')
     }
 
-    await injectToken(page, seededCourse.teacherToken)
+    await injectToken(page, seededCourse.instructorToken)
     await page.goto('/me/creator/earnings')
     await expect(page.getByRole('heading', { name: /creator earnings/i })).toBeVisible({
       timeout: 10_000,

--- a/e2e/tests/revenue-share.spec.ts
+++ b/e2e/tests/revenue-share.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Creator revenue share & affiliate tracking (plan 15.8).
+ */
+import { test, expect, injectToken } from '../fixtures/test.js'
+
+const apiBase = process.env.E2E_API_URL ?? 'http://localhost:8080'
+
+test.describe('Revenue share — API auth', () => {
+  test('GET /api/v1/creator/earnings returns 401 without auth', async () => {
+    const res = await fetch(`${apiBase}/api/v1/creator/earnings`)
+    expect(res.status).toBe(401)
+  })
+
+  test('POST /api/v1/creator/affiliate-codes returns 401 without auth', async () => {
+    const res = await fetch(`${apiBase}/api/v1/creator/affiliate-codes`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    })
+    expect(res.status).toBe(401)
+  })
+})
+
+test.describe('Revenue share — authenticated API', () => {
+  test('teacher can load earnings summary when feature enabled', async ({ seededCourse }) => {
+    const res = await fetch(`${apiBase}/api/v1/creator/earnings`, {
+      headers: { Authorization: `Bearer ${seededCourse.teacherToken}` },
+    })
+    if (res.status === 404) {
+      test.skip(true, 'ff_revenue_share not enabled in this environment')
+    }
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { pendingCents: number; currency: string }
+    expect(typeof body.pendingCents).toBe('number')
+    expect(typeof body.currency).toBe('string')
+  })
+})
+
+test.describe('Revenue share — UI', () => {
+  test('creator earnings page loads when feature enabled', async ({ page, seededCourse }) => {
+    const featRes = await fetch(`${apiBase}/api/v1/platform/features`, {
+      headers: { Authorization: `Bearer ${seededCourse.teacherToken}` },
+    })
+    if (!featRes.ok) {
+      test.skip(true, 'platform features unavailable')
+    }
+    const feats = (await featRes.json()) as { ffRevenueShare?: boolean }
+    if (!feats.ffRevenueShare) {
+      test.skip(true, 'ff_revenue_share not enabled in this environment')
+    }
+
+    await injectToken(page, seededCourse.teacherToken)
+    await page.goto('/me/creator/earnings')
+    await expect(page.getByRole('heading', { name: /creator earnings/i })).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+})

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -367,6 +367,9 @@ type Config struct {
 	// FFStripeBilling enables Stripe checkout, subscriptions, and entitlement gating (plan 15.3).
 	// Managed in Settings → Global platform (not process env).
 	FFStripeBilling bool
+	// FFRevenueShare enables creator revenue share, affiliate tracking, and Stripe Connect payouts (plan 15.8).
+	// Managed in Settings → Global platform (not process env).
+	FFRevenueShare bool
 
 	// StripeSecretKey is the Stripe API secret key (sk_live_… or sk_test_…).
 	StripeSecretKey string

--- a/server/internal/httpserver/billing_http.go
+++ b/server/internal/httpserver/billing_http.go
@@ -116,11 +116,12 @@ func (d Deps) handleBillingCheckout() http.HandlerFunc {
 			return
 		}
 		var body struct {
-			CourseID   *string `json:"courseId"`
-			Plan       string  `json:"plan"`
-			PromoCode  string  `json:"promoCode"`
-			SuccessURL string  `json:"successUrl"`
-			CancelURL  string  `json:"cancelUrl"`
+			CourseID      *string `json:"courseId"`
+			Plan          string  `json:"plan"`
+			PromoCode     string  `json:"promoCode"`
+			AffiliateCode string  `json:"affiliateCode"`
+			SuccessURL    string  `json:"successUrl"`
+			CancelURL     string  `json:"cancelUrl"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
@@ -152,13 +153,14 @@ func (d Deps) handleBillingCheckout() http.HandlerFunc {
 			return
 		}
 		result, err := svcBilling.CreateCheckoutSession(r.Context(), d.Pool, cfg, svcBilling.CheckoutRequest{
-			UserID:     userID,
-			Email:      email,
-			CourseID:   courseID,
-			Plan:       body.Plan,
-			PromoCode:  body.PromoCode,
-			SuccessURL: successURL,
-			CancelURL:  cancelURL,
+			UserID:        userID,
+			Email:         email,
+			CourseID:      courseID,
+			Plan:          body.Plan,
+			PromoCode:     body.PromoCode,
+			AffiliateCode: body.AffiliateCode,
+			SuccessURL:    successURL,
+			CancelURL:     cancelURL,
 		})
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Could not start checkout.")
@@ -312,7 +314,9 @@ func (d Deps) handleStripeWebhook() http.HandlerFunc {
 		}
 		cfg := svcBilling.ConfigFrom(d.effectiveConfig())
 		sig := r.Header.Get("Stripe-Signature")
-		result, err := svcBilling.HandleWebhook(r.Context(), d.Pool, cfg, body, sig)
+		result, err := svcBilling.HandleWebhook(r.Context(), d.Pool, cfg, body, sig, svcBilling.WebhookOptions{
+			RevenueShareEnabled: d.effectiveConfig().FFRevenueShare,
+		})
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid webhook.")
 			return

--- a/server/internal/httpserver/platform_features.go
+++ b/server/internal/httpserver/platform_features.go
@@ -73,6 +73,7 @@ type platformFeaturesJSON struct {
 	FFSelfPacedMode             bool `json:"ffSelfPacedMode"`
 	FFPublicCatalog             bool `json:"ffPublicCatalog"`
 	FFStripeBilling             bool `json:"ffStripeBilling"`
+	FFRevenueShare              bool `json:"ffRevenueShare"`
 	FFLearningPaths             bool `json:"ffLearningPaths"`
 	FFCompletionCredentials     bool `json:"ffCompletionCredentials"`
 	FFCourseReviews             bool `json:"ffCourseReviews"`
@@ -155,6 +156,7 @@ func platformFeaturesFromConfig(cfg config.Config) platformFeaturesJSON {
 		FFSelfPacedMode:             cfg.FFSelfPacedMode,
 		FFPublicCatalog:             cfg.FFPublicCatalog,
 		FFStripeBilling:             cfg.FFStripeBilling,
+		FFRevenueShare:              cfg.FFRevenueShare,
 		FFLearningPaths:             cfg.FFLearningPaths,
 		FFCompletionCredentials:     cfg.FFCompletionCredentials,
 		FFCourseReviews:             cfg.FFCourseReviews,

--- a/server/internal/httpserver/revenue_share_http.go
+++ b/server/internal/httpserver/revenue_share_http.go
@@ -1,0 +1,359 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/lextures/lextures/server/internal/apierr"
+	repoBilling "github.com/lextures/lextures/server/internal/repos/billing"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+	svcBilling "github.com/lextures/lextures/server/internal/service/billing"
+)
+
+func (d Deps) revenueShareFeatureOff(w http.ResponseWriter) bool {
+	if !d.effectiveConfig().FFRevenueShare {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Revenue share is not enabled.")
+		return true
+	}
+	if !d.effectiveConfig().FFStripeBilling {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Billing is not enabled.")
+		return true
+	}
+	return false
+}
+
+func (d Deps) registerRevenueShareRoutes(r chi.Router) {
+	r.Get("/api/v1/creator/earnings", d.handleCreatorEarningsSummary())
+	r.Get("/api/v1/creator/earnings/ledger", d.handleCreatorEarningsLedger())
+	r.Post("/api/v1/creator/affiliate-codes", d.handleCreateAffiliateCode())
+	r.Get("/api/v1/creator/affiliate-codes", d.handleListAffiliateCodes())
+	r.Post("/api/v1/creator/connect/onboarding", d.handleConnectOnboarding())
+	r.Get("/api/v1/creator/connect/status", d.handleConnectStatus())
+	r.Post("/api/v1/affiliate/track-click", d.handleAffiliateTrackClick())
+	r.Get("/api/v1/admin/revenue/summary", d.handleAdminRevenueSummary())
+	r.Post("/api/v1/admin/revenue/trigger-payout", d.handleAdminTriggerPayout())
+}
+
+func ledgerToJSON(e repoBilling.LedgerEntry) map[string]any {
+	out := map[string]any{
+		"id":          e.ID.String(),
+		"entryType":   e.EntryType,
+		"amountCents": e.AmountCents,
+		"currency":    e.Currency,
+		"status":      e.Status,
+		"createdAt":   e.CreatedAt.UTC().Format(time.RFC3339),
+	}
+	if e.CourseID != nil {
+		out["courseId"] = e.CourseID.String()
+	}
+	if e.AffiliateCode != nil {
+		out["affiliateCode"] = *e.AffiliateCode
+	}
+	return out
+}
+
+func (d Deps) handleCreatorEarningsSummary() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.revenueShareFeatureOff(w) {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+			return
+		}
+		summary, err := repoBilling.EarningsSummaryForUser(r.Context(), d.Pool, userID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not load earnings.")
+			return
+		}
+		connectID, _ := repoBilling.StripeConnectID(r.Context(), d.Pool, userID)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"pendingCents":      summary.PendingCents,
+			"paidCents":         summary.PaidCents,
+			"currency":          summary.Currency,
+			"connectConfigured": connectID != "",
+		})
+	}
+}
+
+func (d Deps) handleCreatorEarningsLedger() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.revenueShareFeatureOff(w) {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+			return
+		}
+		limit := 20
+		if v := strings.TrimSpace(r.URL.Query().Get("limit")); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				limit = n
+			}
+		}
+		var before *time.Time
+		if v := strings.TrimSpace(r.URL.Query().Get("before")); v != "" {
+			if t, err := time.Parse(time.RFC3339, v); err == nil {
+				before = &t
+			}
+		}
+		rows, err := repoBilling.ListLedgerForUser(r.Context(), d.Pool, userID, limit, before)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not load ledger.")
+			return
+		}
+		items := make([]map[string]any, 0, len(rows))
+		for _, row := range rows {
+			items = append(items, ledgerToJSON(row))
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{"entries": items})
+	}
+}
+
+func (d Deps) handleCreateAffiliateCode() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.revenueShareFeatureOff(w) {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+			return
+		}
+		var body struct {
+			CourseID *string `json:"courseId"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		var courseID *uuid.UUID
+		if body.CourseID != nil && strings.TrimSpace(*body.CourseID) != "" {
+			id, err := uuid.Parse(strings.TrimSpace(*body.CourseID))
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid courseId.")
+				return
+			}
+			courseID = &id
+		}
+		ac, err := repoBilling.CreateAffiliateCode(r.Context(), d.Pool, userID, courseID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not create affiliate code.")
+			return
+		}
+		origin := strings.TrimRight(d.effectiveConfig().PublicWebOrigin, "/")
+		url := origin + "/explore"
+		if courseID != nil {
+			url += "/course/" + courseID.String()
+		}
+		url += "?ref=" + ac.Code
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":        ac.ID.String(),
+			"code":      ac.Code,
+			"courseId":  nullableUUID(ac.CourseID),
+			"url":       url,
+			"createdAt": ac.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+}
+
+func (d Deps) handleListAffiliateCodes() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.revenueShareFeatureOff(w) {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+			return
+		}
+		codes, conversions, err := repoBilling.ListAffiliateCodesForUser(r.Context(), d.Pool, userID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not load affiliate codes.")
+			return
+		}
+		origin := strings.TrimRight(d.effectiveConfig().PublicWebOrigin, "/")
+		items := make([]map[string]any, 0, len(codes))
+		for _, ac := range codes {
+			url := origin + "/explore?ref=" + ac.Code
+			items = append(items, map[string]any{
+				"id":           ac.ID.String(),
+				"code":         ac.Code,
+				"courseId":     nullableUUID(ac.CourseID),
+				"url":          url,
+				"clickCount":   ac.ClickCount,
+				"conversions":  conversions[ac.Code],
+				"createdAt":    ac.CreatedAt.UTC().Format(time.RFC3339),
+			})
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{"codes": items})
+	}
+}
+
+func (d Deps) handleConnectOnboarding() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.revenueShareFeatureOff(w) {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+			return
+		}
+		email, err := svcBilling.LookupUserEmail(r.Context(), d.Pool, userID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "User not found.")
+			return
+		}
+		cfg := svcBilling.ConnectConfig{
+			SecretKey:       d.effectiveConfig().StripeSecretKey,
+			PublicWebOrigin: d.effectiveConfig().PublicWebOrigin,
+		}
+		url, err := svcBilling.CreateConnectOnboardingLink(r.Context(), d.Pool, cfg, userID, email)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Could not start Connect onboarding.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]string{"onboardingUrl": url})
+	}
+}
+
+func (d Deps) handleConnectStatus() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.revenueShareFeatureOff(w) {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+			return
+		}
+		connectID, err := repoBilling.StripeConnectID(r.Context(), d.Pool, userID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not load Connect status.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"connectConfigured": connectID != "",
+			"connectAccountId":  connectID,
+		})
+	}
+}
+
+func (d Deps) handleAffiliateTrackClick() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.revenueShareFeatureOff(w) {
+			return
+		}
+		code := strings.TrimSpace(r.URL.Query().Get("code"))
+		if code == "" || d.Pool == nil {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		_ = repoBilling.IncrementAffiliateClickCount(r.Context(), d.Pool, code)
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (d Deps) handleAdminRevenueSummary() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.revenueShareFeatureOff(w) {
+			return
+		}
+		isAdmin, err := rbac.UserHasPermission(r.Context(), d.Pool, userID, permGlobalRBACManage)
+		if err != nil || !isAdmin {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission for this action.")
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+			return
+		}
+		summary, err := repoBilling.PlatformRevenueOverview(r.Context(), d.Pool)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not load revenue summary.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"totalSalesCents":     summary.TotalSalesCents,
+			"totalCreatorCents":   summary.TotalCreatorCents,
+			"totalAffiliateCents": summary.TotalAffiliateCents,
+			"pendingPayoutCents":  summary.PendingPayoutCents,
+		})
+	}
+}
+
+func (d Deps) handleAdminTriggerPayout() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.revenueShareFeatureOff(w) {
+			return
+		}
+		isAdmin, err := rbac.UserHasPermission(r.Context(), d.Pool, userID, permGlobalRBACManage)
+		if err != nil || !isAdmin {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission for this action.")
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+			return
+		}
+		cfg := svcBilling.ConnectConfig{
+			SecretKey: d.effectiveConfig().StripeSecretKey,
+		}
+		result, err := svcBilling.RunMonthlyPayouts(r.Context(), d.Pool, cfg)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Payout batch failed.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"processed": result.Processed,
+			"failed":    result.Failed,
+			"errors":    result.Errors,
+		})
+	}
+}
+
+func nullableUUID(id *uuid.UUID) any {
+	if id == nil {
+		return nil
+	}
+	return id.String()
+}

--- a/server/internal/httpserver/revenue_share_nodb_test.go
+++ b/server/internal/httpserver/revenue_share_nodb_test.go
@@ -1,0 +1,60 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/config"
+)
+
+func TestRevenueShare_Unauthenticated(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	cfg := config.Config{FFRevenueShare: true, FFStripeBilling: true}
+	d := Deps{Pool: nil, JWTSigner: signer, Config: cfg}
+	h := NewHandler(d)
+
+	paths := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/creator/earnings"},
+		{http.MethodGet, "/api/v1/creator/earnings/ledger"},
+		{http.MethodPost, "/api/v1/creator/affiliate-codes"},
+		{http.MethodGet, "/api/v1/creator/affiliate-codes"},
+	}
+	for _, tc := range paths {
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s: want 401 got %d", tc.method, tc.path, w.Code)
+		}
+	}
+}
+
+func TestRevenueShare_FeatureOff(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	cfg := config.Config{FFRevenueShare: false, FFStripeBilling: true}
+	d := Deps{Pool: nil, JWTSigner: signer, Config: cfg}
+	h := NewHandler(d)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/creator/earnings", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("feature off without auth want 401 got %d", w.Code)
+	}
+}
+
+func TestAffiliateTrackClick_FeatureOff(t *testing.T) {
+	d := Deps{Config: config.Config{FFRevenueShare: false}}
+	h := NewHandler(d)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/affiliate/track-click?code=abc", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status=%d want 404", w.Code)
+	}
+}

--- a/server/internal/httpserver/server.go
+++ b/server/internal/httpserver/server.go
@@ -145,6 +145,7 @@ func NewHandler(d Deps) http.Handler {
 	d.registerResearchConsentRoutes(r)
 	d.registerConsortiumRoutes(r)
 	d.registerBillingRoutes(r)
+	d.registerRevenueShareRoutes(r)
 	d.registerLearningPathRoutes(r)
 	d.registerAccessibilityRoutes(r)
 	d.registerBroadcastRoutes(r)

--- a/server/internal/httpserver/settings_platform.go
+++ b/server/internal/httpserver/settings_platform.go
@@ -129,6 +129,7 @@ type platformSettingsJSON struct {
 	FFSelfPacedMode                 bool `json:"ffSelfPacedMode"`
 	FFPublicCatalog                 bool `json:"ffPublicCatalog"`
 	FFStripeBilling                 bool `json:"ffStripeBilling"`
+	FFRevenueShare                  bool `json:"ffRevenueShare"`
 	FFLearningPaths                 bool `json:"ffLearningPaths"`
 	FFCompletionCredentials         bool `json:"ffCompletionCredentials"`
 	FFCourseReviews                 bool `json:"ffCourseReviews"`
@@ -310,6 +311,7 @@ func (d Deps) handleGetPlatformSettings() http.HandlerFunc {
 			FFSelfPacedMode:                 merged.FFSelfPacedMode,
 			FFPublicCatalog:                 merged.FFPublicCatalog,
 			FFStripeBilling:                 merged.FFStripeBilling,
+			FFRevenueShare:                  merged.FFRevenueShare,
 			FFLearningPaths:                 merged.FFLearningPaths,
 			FFCompletionCredentials:         merged.FFCompletionCredentials,
 			FFCourseReviews:                 merged.FFCourseReviews,
@@ -466,6 +468,7 @@ type putPlatformBody struct {
 	FFSelfPacedMode                 *bool `json:"ffSelfPacedMode"`
 	FFPublicCatalog                 *bool `json:"ffPublicCatalog"`
 	FFStripeBilling                 *bool `json:"ffStripeBilling"`
+	FFRevenueShare                  *bool `json:"ffRevenueShare"`
 	FFLearningPaths                 *bool `json:"ffLearningPaths"`
 	FFCompletionCredentials         *bool `json:"ffCompletionCredentials"`
 	FFCourseReviews                 *bool `json:"ffCourseReviews"`
@@ -768,6 +771,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 		setBool("ffselfpacedmode", body.FFSelfPacedMode, func(v bool) { wr.FFSelfPacedMode = &v })
 		setBool("ffpubliccatalog", body.FFPublicCatalog, func(v bool) { wr.FFPublicCatalog = &v })
 		setBool("ffstripebilling", body.FFStripeBilling, func(v bool) { wr.FFStripeBilling = &v })
+		setBool("ffrevenueshare", body.FFRevenueShare, func(v bool) { wr.FFRevenueShare = &v })
 		setBool("fflearningpaths", body.FFLearningPaths, func(v bool) { wr.FFLearningPaths = &v })
 		setBool("ffcompletioncredentials", body.FFCompletionCredentials, func(v bool) { wr.FFCompletionCredentials = &v })
 		setBool("ffcoursereviews", body.FFCourseReviews, func(v bool) { wr.FFCourseReviews = &v })
@@ -903,6 +907,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 			FFSelfPacedMode:                 merged.FFSelfPacedMode,
 			FFPublicCatalog:                 merged.FFPublicCatalog,
 			FFStripeBilling:                 merged.FFStripeBilling,
+			FFRevenueShare:                  merged.FFRevenueShare,
 			FFLearningPaths:                 merged.FFLearningPaths,
 			FFCompletionCredentials:         merged.FFCompletionCredentials,
 			FFCourseReviews:                 merged.FFCourseReviews,

--- a/server/internal/repos/billing/revenue_share.go
+++ b/server/internal/repos/billing/revenue_share.go
@@ -1,0 +1,484 @@
+// Package billing persists creator earnings and affiliate codes (plan 15.8).
+package billing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	EntrySale      = "sale"
+	EntryAffiliate = "affiliate"
+	EntryRefund    = "refund"
+	EntryPayout    = "payout"
+
+	EarningsPending = "pending"
+	EarningsPaid    = "paid"
+	EarningsHeld    = "held"
+
+	defaultPlatformFeePct  = 0.30
+	defaultAffiliateFeePct = 0.10
+)
+
+// RevenueConfig holds per-creator fee overrides.
+type RevenueConfig struct {
+	UserID          uuid.UUID
+	PlatformFeePct  float64
+	AffiliateFeePct float64
+}
+
+// LedgerEntry is a row in billing.earnings_ledger.
+type LedgerEntry struct {
+	ID               uuid.UUID
+	PayeeID          uuid.UUID
+	EntryType        string
+	AmountCents      int
+	Currency         string
+	StripeEventID    *string
+	StripeTransferID *string
+	CourseID         *uuid.UUID
+	AffiliateCode    *string
+	Status           string
+	CreatedAt        time.Time
+}
+
+// AffiliateCode is a referral code owned by a user.
+type AffiliateCode struct {
+	ID         uuid.UUID
+	UserID     uuid.UUID
+	Code       string
+	CourseID   *uuid.UUID
+	ClickCount int
+	CreatedAt  time.Time
+}
+
+// EarningsSummary aggregates pending and paid balances.
+type EarningsSummary struct {
+	PendingCents int
+	PaidCents    int
+	Currency     string
+}
+
+// GetRevenueConfig returns fee percentages for a creator, using defaults when unset.
+func GetRevenueConfig(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) (RevenueConfig, error) {
+	cfg := RevenueConfig{
+		UserID:          userID,
+		PlatformFeePct:  defaultPlatformFeePct,
+		AffiliateFeePct: defaultAffiliateFeePct,
+	}
+	err := pool.QueryRow(ctx, `
+SELECT platform_fee_pct, affiliate_fee_pct
+FROM billing.creator_revenue_configs WHERE user_id = $1
+`, userID).Scan(&cfg.PlatformFeePct, &cfg.AffiliateFeePct)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return cfg, nil
+	}
+	return cfg, err
+}
+
+// UpsertRevenueConfig stores admin overrides for a creator.
+func UpsertRevenueConfig(ctx context.Context, pool *pgxpool.Pool, cfg RevenueConfig) error {
+	_, err := pool.Exec(ctx, `
+INSERT INTO billing.creator_revenue_configs (user_id, platform_fee_pct, affiliate_fee_pct, updated_at)
+VALUES ($1, $2, $3, NOW())
+ON CONFLICT (user_id) DO UPDATE SET
+    platform_fee_pct = EXCLUDED.platform_fee_pct,
+    affiliate_fee_pct = EXCLUDED.affiliate_fee_pct,
+    updated_at = NOW()
+`, cfg.UserID, cfg.PlatformFeePct, cfg.AffiliateFeePct)
+	return err
+}
+
+// CourseCreatorID returns the user who created the course.
+func CourseCreatorID(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (uuid.UUID, error) {
+	var id uuid.UUID
+	err := pool.QueryRow(ctx, `
+SELECT created_by_user_id FROM course.courses WHERE id = $1
+`, courseID).Scan(&id)
+	return id, err
+}
+
+// CreateLedgerEntryInput is the payload for idempotent ledger writes.
+type CreateLedgerEntryInput struct {
+	PayeeID          uuid.UUID
+	EntryType        string
+	AmountCents      int
+	Currency         string
+	StripeEventID    string
+	StripeTransferID *string
+	CourseID         *uuid.UUID
+	AffiliateCode    *string
+	Status           string
+}
+
+// CreateLedgerEntryIdempotent inserts or returns existing row for stripe_event_id.
+func CreateLedgerEntryIdempotent(ctx context.Context, pool *pgxpool.Pool, in CreateLedgerEntryInput) (*LedgerEntry, bool, error) {
+	if in.StripeEventID == "" {
+		return nil, false, errors.New("stripe_event_id required")
+	}
+	status := in.Status
+	if status == "" {
+		status = EarningsPending
+	}
+	currency := in.Currency
+	if currency == "" {
+		currency = "usd"
+	}
+	e, err := scanLedgerEntry(ctx, pool, `
+INSERT INTO billing.earnings_ledger (
+    payee_id, entry_type, amount_cents, currency, stripe_event_id,
+    stripe_transfer_id, course_id, affiliate_code, status
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+ON CONFLICT (stripe_event_id) DO NOTHING
+RETURNING id, payee_id, entry_type, amount_cents, currency, stripe_event_id,
+          stripe_transfer_id, course_id, affiliate_code, status, created_at
+`, in.PayeeID, in.EntryType, in.AmountCents, currency, in.StripeEventID,
+		in.StripeTransferID, in.CourseID, in.AffiliateCode, status)
+	if err == nil {
+		return e, true, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, false, err
+	}
+	e, err = scanLedgerEntry(ctx, pool, `
+SELECT id, payee_id, entry_type, amount_cents, currency, stripe_event_id,
+       stripe_transfer_id, course_id, affiliate_code, status, created_at
+FROM billing.earnings_ledger WHERE stripe_event_id = $1
+`, in.StripeEventID)
+	if err != nil {
+		return nil, false, err
+	}
+	return e, false, nil
+}
+
+func scanLedgerEntry(ctx context.Context, pool *pgxpool.Pool, query string, args ...any) (*LedgerEntry, error) {
+	var e LedgerEntry
+	var courseID *uuid.UUID
+	var affiliateCode *string
+	var stripeEventID *string
+	var stripeTransferID *string
+	err := pool.QueryRow(ctx, query, args...).Scan(
+		&e.ID, &e.PayeeID, &e.EntryType, &e.AmountCents, &e.Currency, &stripeEventID,
+		&stripeTransferID, &courseID, &affiliateCode, &e.Status, &e.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	e.StripeEventID = stripeEventID
+	e.StripeTransferID = stripeTransferID
+	e.CourseID = courseID
+	e.AffiliateCode = affiliateCode
+	return &e, nil
+}
+
+// EarningsSummaryForUser aggregates ledger balances.
+func EarningsSummaryForUser(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) (EarningsSummary, error) {
+	var s EarningsSummary
+	s.Currency = "usd"
+	err := pool.QueryRow(ctx, `
+SELECT
+    COALESCE(SUM(CASE WHEN status = 'pending' AND entry_type != 'payout' THEN amount_cents ELSE 0 END), 0),
+    COALESCE(SUM(CASE WHEN status = 'paid' AND entry_type = 'payout' THEN -amount_cents ELSE 0 END), 0)
+FROM billing.earnings_ledger
+WHERE payee_id = $1
+`, userID).Scan(&s.PendingCents, &s.PaidCents)
+	return s, err
+}
+
+// ListLedgerForUser returns paginated ledger entries for a payee.
+func ListLedgerForUser(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, limit int, before *time.Time) ([]LedgerEntry, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	args := []any{userID, limit}
+	query := `
+SELECT id, payee_id, entry_type, amount_cents, currency, stripe_event_id,
+       stripe_transfer_id, course_id, affiliate_code, status, created_at
+FROM billing.earnings_ledger
+WHERE payee_id = $1
+`
+	if before != nil {
+		query += ` AND created_at < $3`
+		args = append(args, *before)
+	}
+	query += ` ORDER BY created_at DESC LIMIT $2`
+
+	rows, err := pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []LedgerEntry
+	for rows.Next() {
+		var e LedgerEntry
+		var courseID *uuid.UUID
+		var affiliateCode *string
+		var stripeEventID *string
+		var stripeTransferID *string
+		if err := rows.Scan(
+			&e.ID, &e.PayeeID, &e.EntryType, &e.AmountCents, &e.Currency, &stripeEventID,
+			&stripeTransferID, &courseID, &affiliateCode, &e.Status, &e.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		e.StripeEventID = stripeEventID
+		e.StripeTransferID = stripeTransferID
+		e.CourseID = courseID
+		e.AffiliateCode = affiliateCode
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// CreateAffiliateCode inserts a new referral code.
+func CreateAffiliateCode(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, courseID *uuid.UUID) (*AffiliateCode, error) {
+	code := uuid.New().String()[:8]
+	for i := 0; i < 5; i++ {
+		ac, err := insertAffiliateCode(ctx, pool, userID, code, courseID)
+		if err == nil {
+			return ac, nil
+		}
+		if !isUniqueViolation(err) {
+			return nil, err
+		}
+		code = uuid.New().String()[:8]
+	}
+	return nil, fmt.Errorf("could not generate unique affiliate code")
+}
+
+func insertAffiliateCode(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, code string, courseID *uuid.UUID) (*AffiliateCode, error) {
+	var ac AffiliateCode
+	var cid *uuid.UUID
+	err := pool.QueryRow(ctx, `
+INSERT INTO billing.affiliate_codes (user_id, code, course_id)
+VALUES ($1, $2, $3)
+RETURNING id, user_id, code, course_id, click_count, created_at
+`, userID, code, courseID).Scan(&ac.ID, &ac.UserID, &ac.Code, &cid, &ac.ClickCount, &ac.CreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	ac.CourseID = cid
+	return &ac, nil
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+// ListAffiliateCodesForUser returns codes owned by a user with conversion counts.
+func ListAffiliateCodesForUser(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) ([]AffiliateCode, map[string]int, error) {
+	rows, err := pool.Query(ctx, `
+SELECT id, user_id, code, course_id, click_count, created_at
+FROM billing.affiliate_codes
+WHERE user_id = $1
+ORDER BY created_at DESC
+`, userID)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+	var codes []AffiliateCode
+	codeStrs := []string{}
+	for rows.Next() {
+		var ac AffiliateCode
+		var cid *uuid.UUID
+		if err := rows.Scan(&ac.ID, &ac.UserID, &ac.Code, &cid, &ac.ClickCount, &ac.CreatedAt); err != nil {
+			return nil, nil, err
+		}
+		ac.CourseID = cid
+		codes = append(codes, ac)
+		codeStrs = append(codeStrs, ac.Code)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, err
+	}
+	conversions := map[string]int{}
+	if len(codeStrs) == 0 {
+		return codes, conversions, nil
+	}
+	convRows, err := pool.Query(ctx, `
+SELECT affiliate_code, COUNT(*)::int
+FROM billing.earnings_ledger
+WHERE entry_type = 'affiliate' AND affiliate_code = ANY($1)
+GROUP BY affiliate_code
+`, codeStrs)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer convRows.Close()
+	for convRows.Next() {
+		var code string
+		var count int
+		if err := convRows.Scan(&code, &count); err != nil {
+			return nil, nil, err
+		}
+		conversions[code] = count
+	}
+	return codes, conversions, convRows.Err()
+}
+
+// LookupAffiliateCode resolves a referral code to its owner.
+func LookupAffiliateCode(ctx context.Context, pool *pgxpool.Pool, code string) (*AffiliateCode, error) {
+	var ac AffiliateCode
+	var cid *uuid.UUID
+	err := pool.QueryRow(ctx, `
+SELECT id, user_id, code, course_id, click_count, created_at
+FROM billing.affiliate_codes WHERE code = $1
+`, code).Scan(&ac.ID, &ac.UserID, &ac.Code, &cid, &ac.ClickCount, &ac.CreatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	ac.CourseID = cid
+	return &ac, nil
+}
+
+// IncrementAffiliateClickCount records a referral link click.
+func IncrementAffiliateClickCount(ctx context.Context, pool *pgxpool.Pool, code string) error {
+	_, err := pool.Exec(ctx, `
+UPDATE billing.affiliate_codes SET click_count = click_count + 1 WHERE code = $1
+`, code)
+	return err
+}
+
+// StripeConnectID returns the stored Connect account id.
+func StripeConnectID(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) (string, error) {
+	var id *string
+	err := pool.QueryRow(ctx, `
+SELECT stripe_connect_id FROM "user".users WHERE id = $1
+`, userID).Scan(&id)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if id == nil {
+		return "", nil
+	}
+	return *id, nil
+}
+
+// SetStripeConnectID stores the Connect account id.
+func SetStripeConnectID(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, connectID string) error {
+	_, err := pool.Exec(ctx, `
+UPDATE "user".users SET stripe_connect_id = $2 WHERE id = $1
+`, userID, connectID)
+	return err
+}
+
+// PendingPayoutsByUser sums pending earnings per payee with Connect accounts.
+type PendingPayout struct {
+	UserID       uuid.UUID
+	AmountCents  int
+	Currency     string
+	ConnectID    string
+	LedgerIDs    []uuid.UUID
+}
+
+// ListPendingPayouts returns users with pending earnings above minCents.
+func ListPendingPayouts(ctx context.Context, pool *pgxpool.Pool, minCents int) ([]PendingPayout, error) {
+	rows, err := pool.Query(ctx, `
+SELECT u.id, u.stripe_connect_id,
+       COALESCE(SUM(e.amount_cents), 0)::int,
+       COALESCE(MAX(e.currency), 'usd'),
+       ARRAY_AGG(e.id ORDER BY e.created_at)
+FROM "user".users u
+JOIN billing.earnings_ledger e ON e.payee_id = u.id
+WHERE e.status = 'pending'
+  AND e.entry_type IN ('sale', 'affiliate', 'refund')
+  AND u.stripe_connect_id IS NOT NULL
+GROUP BY u.id, u.stripe_connect_id
+HAVING COALESCE(SUM(e.amount_cents), 0) >= $1
+`, minCents)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PendingPayout
+	for rows.Next() {
+		var p PendingPayout
+		var connectID *string
+		if err := rows.Scan(&p.UserID, &connectID, &p.AmountCents, &p.Currency, &p.LedgerIDs); err != nil {
+			return nil, err
+		}
+		if connectID == nil || *connectID == "" || p.AmountCents <= 0 {
+			continue
+		}
+		p.ConnectID = *connectID
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// MarkLedgerPaid marks pending entries as paid and records a payout entry.
+func MarkLedgerPaid(ctx context.Context, pool *pgxpool.Pool, payeeID uuid.UUID, ledgerIDs []uuid.UUID, transferID string, amountCents int, currency string) error {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	tag, err := tx.Exec(ctx, `
+UPDATE billing.earnings_ledger SET status = 'paid'
+WHERE id = ANY($1) AND payee_id = $2 AND status = 'pending'
+`, ledgerIDs, payeeID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("no pending entries to mark paid")
+	}
+
+	payoutEventID := fmt.Sprintf("payout_%s", transferID)
+	_, err = tx.Exec(ctx, `
+INSERT INTO billing.earnings_ledger (
+    payee_id, entry_type, amount_cents, currency, stripe_event_id, stripe_transfer_id, status
+) VALUES ($1, 'payout', $2, $3, $4, $5, 'paid')
+ON CONFLICT (stripe_event_id) DO NOTHING
+`, payeeID, -amountCents, currency, payoutEventID, transferID)
+	if err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+// PlatformRevenueSummary aggregates platform-side revenue metrics.
+type PlatformRevenueSummary struct {
+	TotalSalesCents     int
+	TotalAffiliateCents int
+	TotalCreatorCents   int
+	PendingPayoutCents  int
+}
+
+// PlatformRevenueOverview returns admin revenue metrics.
+func PlatformRevenueOverview(ctx context.Context, pool *pgxpool.Pool) (PlatformRevenueSummary, error) {
+	var s PlatformRevenueSummary
+	err := pool.QueryRow(ctx, `
+SELECT
+    COALESCE(SUM(CASE WHEN entry_type = 'sale' THEN amount_cents ELSE 0 END), 0),
+    COALESCE(SUM(CASE WHEN entry_type = 'affiliate' THEN amount_cents ELSE 0 END), 0),
+    COALESCE(SUM(CASE WHEN entry_type IN ('sale', 'affiliate') AND status = 'pending' THEN amount_cents ELSE 0 END), 0)
+FROM billing.earnings_ledger
+`).Scan(&s.TotalCreatorCents, &s.TotalAffiliateCents, &s.PendingPayoutCents)
+	if err != nil {
+		return s, err
+	}
+	// Total sales = creator + affiliate + platform fee approximated from sale entries
+	err = pool.QueryRow(ctx, `
+SELECT COALESCE(SUM(amount_paid_cents), 0)
+FROM billing.user_entitlements
+WHERE status = 'active' AND entitlement_type = 'course_purchase'
+`).Scan(&s.TotalSalesCents)
+	return s, err
+}

--- a/server/internal/repos/billing/revenue_share.go
+++ b/server/internal/repos/billing/revenue_share.go
@@ -427,7 +427,7 @@ func MarkLedgerPaid(ctx context.Context, pool *pgxpool.Pool, payeeID uuid.UUID, 
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback(ctx)
+	defer tx.Rollback(ctx) //nolint:errcheck
 
 	tag, err := tx.Exec(ctx, `
 UPDATE billing.earnings_ledger SET status = 'paid'

--- a/server/internal/repos/platformconfig/features.go
+++ b/server/internal/repos/platformconfig/features.go
@@ -82,6 +82,7 @@ func applyPlatformBools(out *config.Config, db *Row, def Defaults) {
 	out.FFSelfPacedMode = mergeBool(db.FFSelfPacedMode, false)
 	out.FFPublicCatalog = mergeBool(db.FFPublicCatalog, false)
 	out.FFStripeBilling = mergeBool(db.FFStripeBilling, false)
+	out.FFRevenueShare = mergeBool(db.FFRevenueShare, false)
 	out.FFLearningPaths = mergeBool(db.FFLearningPaths, false)
 	out.FFCompletionCredentials = mergeBool(db.FFCompletionCredentials, false)
 	out.FFCourseReviews = mergeBool(db.FFCourseReviews, false)

--- a/server/internal/repos/platformconfig/patch.go
+++ b/server/internal/repos/platformconfig/patch.go
@@ -150,6 +150,7 @@ func patch(ctx context.Context, pool *pgxpool.Pool, w *Write) error {
 	addBool("ff_self_paced_mode", w.FFSelfPacedMode)
 	addBool("ff_public_catalog", w.FFPublicCatalog)
 	addBool("ff_stripe_billing", w.FFStripeBilling)
+	addBool("ff_revenue_share", w.FFRevenueShare)
 	addBool("ff_learning_paths", w.FFLearningPaths)
 	addBool("ff_completion_credentials", w.FFCompletionCredentials)
 	addBool("ff_course_reviews", w.FFCourseReviews)

--- a/server/internal/repos/platformconfig/platformconfig.go
+++ b/server/internal/repos/platformconfig/platformconfig.go
@@ -116,6 +116,7 @@ type Row struct {
 	FFSelfPacedMode                 *bool
 	FFPublicCatalog                 *bool
 	FFStripeBilling                 *bool
+	FFRevenueShare                  *bool
 	FFLearningPaths                 *bool
 	FFCompletionCredentials         *bool
 	FFCourseReviews                 *bool
@@ -249,6 +250,7 @@ type Write struct {
 	FFSelfPacedMode                 *bool
 	FFPublicCatalog                 *bool
 	FFStripeBilling                 *bool
+	FFRevenueShare                  *bool
 	FFLearningPaths                 *bool
 	FFCompletionCredentials         *bool
 	FFCourseReviews                 *bool
@@ -382,6 +384,7 @@ SELECT
 	ff_learning_paths,
 	ff_completion_credentials,
 	ff_course_reviews,
+	ff_revenue_share,
 	lrs_anonymize_actors,
 	ferpa_workflow_enabled,
 	dpa_portal_enabled,
@@ -506,6 +509,7 @@ WHERE id = 1
 		&r.FFLearningPaths,
 		&r.FFCompletionCredentials,
 		&r.FFCourseReviews,
+		&r.FFRevenueShare,
 		&r.LRSAnonymizeActors,
 		&r.FERPAWorkflowEnabled,
 		&r.DPAPortalEnabled,
@@ -679,6 +683,7 @@ INSERT INTO settings.platform_app_settings (
 	ff_learning_paths,
 	ff_completion_credentials,
 	ff_course_reviews,
+	ff_revenue_share,
 	mfa_enabled,
 	mfa_enforcement,
 	smtp_host,
@@ -809,6 +814,7 @@ ON CONFLICT (id) DO UPDATE SET
 	ff_learning_paths = COALESCE(EXCLUDED.ff_learning_paths, settings.platform_app_settings.ff_learning_paths),
 	ff_completion_credentials = COALESCE(EXCLUDED.ff_completion_credentials, settings.platform_app_settings.ff_completion_credentials),
 	ff_course_reviews = COALESCE(EXCLUDED.ff_course_reviews, settings.platform_app_settings.ff_course_reviews),
+	ff_revenue_share = COALESCE(EXCLUDED.ff_revenue_share, settings.platform_app_settings.ff_revenue_share),
 	lrs_anonymize_actors = COALESCE(EXCLUDED.lrs_anonymize_actors, settings.platform_app_settings.lrs_anonymize_actors),
 	ferpa_workflow_enabled = COALESCE(EXCLUDED.ferpa_workflow_enabled, settings.platform_app_settings.ferpa_workflow_enabled),
 	dpa_portal_enabled = COALESCE(EXCLUDED.dpa_portal_enabled, settings.platform_app_settings.dpa_portal_enabled),
@@ -931,6 +937,7 @@ ON CONFLICT (id) DO UPDATE SET
 		w.FFLearningPaths,
 		w.FFCompletionCredentials,
 		w.FFCourseReviews,
+		w.FFRevenueShare,
 		w.MFAEnabled,
 		w.MFAEnforcement,
 		w.SMTPHost,

--- a/server/internal/service/billing/metrics.go
+++ b/server/internal/service/billing/metrics.go
@@ -6,8 +6,13 @@ import (
 )
 
 var (
-	paymentsTotal       atomic.Uint64
-	subscriptionMRRCent atomic.Int64
+	paymentsTotal          atomic.Uint64
+	subscriptionMRRCent      atomic.Int64
+	creatorPayoutsTotal    atomic.Uint64
+	creatorPayoutFailures  atomic.Uint64
+	platformRevenueCents   atomic.Int64
+	creatorEarningsCents   atomic.Int64
+	affiliateEarningsCents atomic.Int64
 )
 
 func init() {
@@ -17,6 +22,15 @@ func init() {
 	expvar.Publish("subscription_mrr_cents", expvar.Func(func() any {
 		return subscriptionMRRCent.Load()
 	}))
+	expvar.Publish("creator_payouts_total", expvar.Func(func() any {
+		return creatorPayoutsTotal.Load()
+	}))
+	expvar.Publish("creator_payout_failures", expvar.Func(func() any {
+		return creatorPayoutFailures.Load()
+	}))
+	expvar.Publish("platform_revenue_cents_total", expvar.Func(func() any {
+		return platformRevenueCents.Load()
+	}))
 }
 
 // RecordPayment increments payment counter and optional MRR gauge (plan 15.3).
@@ -25,4 +39,25 @@ func RecordPayment(amountCents int, entitlementType string) {
 	if entitlementType == "subscription_monthly" && amountCents > 0 {
 		subscriptionMRRCent.Add(int64(amountCents))
 	}
+}
+
+// RecordCreatorEarnings tracks creator share (plan 15.8).
+func RecordCreatorEarnings(amountCents int) {
+	creatorEarningsCents.Add(int64(amountCents))
+}
+
+// RecordAffiliateEarnings tracks affiliate commission (plan 15.8).
+func RecordAffiliateEarnings(amountCents int) {
+	affiliateEarningsCents.Add(int64(amountCents))
+}
+
+// RecordPayoutSuccess increments successful payout counter (plan 15.8).
+func RecordPayoutSuccess(amountCents int) {
+	creatorPayoutsTotal.Add(1)
+	platformRevenueCents.Add(int64(amountCents))
+}
+
+// RecordPayoutFailure increments failed payout counter (plan 15.8).
+func RecordPayoutFailure() {
+	creatorPayoutFailures.Add(1)
 }

--- a/server/internal/service/billing/revenue_share.go
+++ b/server/internal/service/billing/revenue_share.go
@@ -1,0 +1,308 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stripe/stripe-go/v81"
+	"github.com/stripe/stripe-go/v81/account"
+	"github.com/stripe/stripe-go/v81/accountlink"
+	"github.com/stripe/stripe-go/v81/transfer"
+
+	repoBilling "github.com/lextures/lextures/server/internal/repos/billing"
+)
+
+const minPayoutCents = 2500 // $25 minimum payout threshold
+
+// SaleEarningsInput is passed when a course purchase is confirmed.
+type SaleEarningsInput struct {
+	BuyerUserID   uuid.UUID
+	CourseID      uuid.UUID
+	AmountCents   int
+	Currency      string
+	StripeEventID string
+	AffiliateCode string
+}
+
+// ComputeCreatorShare returns creator earnings in cents after platform fee.
+func ComputeCreatorShare(amountCents int, platformFeePct float64) int {
+	if amountCents <= 0 {
+		return 0
+	}
+	share := float64(amountCents) * (1 - platformFeePct)
+	return int(math.Round(share))
+}
+
+// ComputeAffiliateCommission returns affiliate commission in cents.
+func ComputeAffiliateCommission(amountCents int, affiliateFeePct float64) int {
+	if amountCents <= 0 {
+		return 0
+	}
+	commission := float64(amountCents) * affiliateFeePct
+	return int(math.Round(commission))
+}
+
+// IsSelfReferral reports whether affiliate commission should be blocked.
+func IsSelfReferral(buyerID, affiliateOwnerID, courseCreatorID uuid.UUID) bool {
+	if buyerID == affiliateOwnerID {
+		return true
+	}
+	if buyerID == courseCreatorID && affiliateOwnerID == courseCreatorID {
+		return true
+	}
+	return false
+}
+
+// RecordSaleEarnings creates creator and optional affiliate ledger entries.
+func RecordSaleEarnings(ctx context.Context, pool *pgxpool.Pool, in SaleEarningsInput) error {
+	if pool == nil || in.CourseID == uuid.Nil || in.StripeEventID == "" {
+		return nil
+	}
+	creatorID, err := repoBilling.CourseCreatorID(ctx, pool, in.CourseID)
+	if err != nil {
+		return err
+	}
+	if creatorID == uuid.Nil {
+		return nil
+	}
+	cfg, err := repoBilling.GetRevenueConfig(ctx, pool, creatorID)
+	if err != nil {
+		return err
+	}
+	creatorCents := ComputeCreatorShare(in.AmountCents, cfg.PlatformFeePct)
+	if creatorCents > 0 {
+		_, _, err = repoBilling.CreateLedgerEntryIdempotent(ctx, pool, repoBilling.CreateLedgerEntryInput{
+			PayeeID:       creatorID,
+			EntryType:     repoBilling.EntrySale,
+			AmountCents:   creatorCents,
+			Currency:      in.Currency,
+			StripeEventID: in.StripeEventID + ":sale",
+			CourseID:      &in.CourseID,
+		})
+		if err != nil {
+			return err
+		}
+		RecordCreatorEarnings(creatorCents)
+	}
+
+	code := strings.TrimSpace(in.AffiliateCode)
+	if code == "" {
+		return nil
+	}
+	ac, err := repoBilling.LookupAffiliateCode(ctx, pool, code)
+	if err != nil || ac == nil {
+		return err
+	}
+	if ac.CourseID != nil && *ac.CourseID != in.CourseID {
+		return nil
+	}
+	if IsSelfReferral(in.BuyerUserID, ac.UserID, creatorID) {
+		return nil
+	}
+	affCfg, err := repoBilling.GetRevenueConfig(ctx, pool, ac.UserID)
+	if err != nil {
+		return err
+	}
+	affCents := ComputeAffiliateCommission(in.AmountCents, affCfg.AffiliateFeePct)
+	if affCents <= 0 {
+		return nil
+	}
+	affCode := code
+	_, _, err = repoBilling.CreateLedgerEntryIdempotent(ctx, pool, repoBilling.CreateLedgerEntryInput{
+		PayeeID:       ac.UserID,
+		EntryType:     repoBilling.EntryAffiliate,
+		AmountCents:   affCents,
+		Currency:      in.Currency,
+		StripeEventID: in.StripeEventID + ":affiliate",
+		CourseID:      &in.CourseID,
+		AffiliateCode: &affCode,
+	})
+	if err != nil {
+		return err
+	}
+	RecordAffiliateEarnings(affCents)
+	return nil
+}
+
+// RefundEarningsInput offsets prior creator/affiliate earnings on refund.
+type RefundEarningsInput struct {
+	CourseID      uuid.UUID
+	AmountCents   int
+	Currency      string
+	StripeEventID string
+	AffiliateCode string
+	OriginalEvent string
+}
+
+// RecordRefundEarnings creates negative ledger entries for a refund.
+func RecordRefundEarnings(ctx context.Context, pool *pgxpool.Pool, in RefundEarningsInput) error {
+	if pool == nil || in.CourseID == uuid.Nil || in.StripeEventID == "" {
+		return nil
+	}
+	creatorID, err := repoBilling.CourseCreatorID(ctx, pool, in.CourseID)
+	if err != nil {
+		return err
+	}
+	if creatorID == uuid.Nil {
+		return nil
+	}
+	cfg, err := repoBilling.GetRevenueConfig(ctx, pool, creatorID)
+	if err != nil {
+		return err
+	}
+	creatorCents := -ComputeCreatorShare(in.AmountCents, cfg.PlatformFeePct)
+	if creatorCents != 0 {
+		_, _, err = repoBilling.CreateLedgerEntryIdempotent(ctx, pool, repoBilling.CreateLedgerEntryInput{
+			PayeeID:       creatorID,
+			EntryType:     repoBilling.EntryRefund,
+			AmountCents:   creatorCents,
+			Currency:      in.Currency,
+			StripeEventID: in.StripeEventID + ":refund:sale",
+			CourseID:      &in.CourseID,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	code := strings.TrimSpace(in.AffiliateCode)
+	if code == "" {
+		return nil
+	}
+	ac, err := repoBilling.LookupAffiliateCode(ctx, pool, code)
+	if err != nil || ac == nil {
+		return err
+	}
+	affCfg, err := repoBilling.GetRevenueConfig(ctx, pool, ac.UserID)
+	if err != nil {
+		return err
+	}
+	affCents := -ComputeAffiliateCommission(in.AmountCents, affCfg.AffiliateFeePct)
+	if affCents == 0 {
+		return nil
+	}
+	affCode := code
+	_, _, err = repoBilling.CreateLedgerEntryIdempotent(ctx, pool, repoBilling.CreateLedgerEntryInput{
+		PayeeID:       ac.UserID,
+		EntryType:     repoBilling.EntryRefund,
+		AmountCents:   affCents,
+		Currency:      in.Currency,
+		StripeEventID: in.StripeEventID + ":refund:affiliate",
+		CourseID:      &in.CourseID,
+		AffiliateCode: &affCode,
+	})
+	return err
+}
+
+// ConnectConfig holds Stripe Connect settings.
+type ConnectConfig struct {
+	SecretKey       string
+	PublicWebOrigin string
+}
+
+func (c ConnectConfig) IsConfigured() bool {
+	return strings.TrimSpace(c.SecretKey) != ""
+}
+
+// EnsureConnectAccount creates or returns a Stripe Connect Express account.
+func EnsureConnectAccount(ctx context.Context, pool *pgxpool.Pool, cfg ConnectConfig, userID uuid.UUID, email string) (string, error) {
+	existing, err := repoBilling.StripeConnectID(ctx, pool, userID)
+	if err != nil {
+		return "", err
+	}
+	if existing != "" {
+		return existing, nil
+	}
+	if !cfg.IsConfigured() {
+		return "", errors.New("stripe not configured")
+	}
+	stripe.Key = cfg.SecretKey
+	acct, err := account.New(&stripe.AccountParams{
+		Type:  stripe.String(string(stripe.AccountTypeExpress)),
+		Email: stripe.String(email),
+		Metadata: map[string]string{
+			"user_id": userID.String(),
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if err := repoBilling.SetStripeConnectID(ctx, pool, userID, acct.ID); err != nil {
+		return "", err
+	}
+	return acct.ID, nil
+}
+
+// CreateConnectOnboardingLink returns a Stripe-hosted onboarding URL.
+func CreateConnectOnboardingLink(ctx context.Context, pool *pgxpool.Pool, cfg ConnectConfig, userID uuid.UUID, email string) (string, error) {
+	acctID, err := EnsureConnectAccount(ctx, pool, cfg, userID, email)
+	if err != nil {
+		return "", err
+	}
+	stripe.Key = cfg.SecretKey
+	origin := strings.TrimRight(cfg.PublicWebOrigin, "/")
+	link, err := accountlink.New(&stripe.AccountLinkParams{
+		Account:    stripe.String(acctID),
+		RefreshURL: stripe.String(origin + "/me/creator/earnings?connect=refresh"),
+		ReturnURL:  stripe.String(origin + "/me/creator/earnings?connect=done"),
+		Type:       stripe.String("account_onboarding"),
+	})
+	if err != nil {
+		return "", err
+	}
+	return link.URL, nil
+}
+
+// PayoutResult summarizes a payout batch run.
+type PayoutResult struct {
+	Processed int
+	Failed    int
+	Errors    []string
+}
+
+// RunMonthlyPayouts transfers pending earnings to connected accounts.
+func RunMonthlyPayouts(ctx context.Context, pool *pgxpool.Pool, cfg ConnectConfig) (*PayoutResult, error) {
+	if !cfg.IsConfigured() {
+		return nil, errors.New("stripe not configured")
+	}
+	pending, err := repoBilling.ListPendingPayouts(ctx, pool, minPayoutCents)
+	if err != nil {
+		return nil, err
+	}
+	result := &PayoutResult{}
+	stripe.Key = cfg.SecretKey
+	for _, p := range pending {
+		idempotencyKey := fmt.Sprintf("payout_%s_%d", p.UserID.String(), p.AmountCents)
+		tr, err := transfer.New(&stripe.TransferParams{
+			Amount:      stripe.Int64(int64(p.AmountCents)),
+			Currency:    stripe.String(p.Currency),
+			Destination: stripe.String(p.ConnectID),
+			Metadata: map[string]string{
+				"user_id": p.UserID.String(),
+			},
+			Params: stripe.Params{
+				IdempotencyKey: stripe.String(idempotencyKey),
+			},
+		})
+		if err != nil {
+			result.Failed++
+			result.Errors = append(result.Errors, err.Error())
+			RecordPayoutFailure()
+			continue
+		}
+		if err := repoBilling.MarkLedgerPaid(ctx, pool, p.UserID, p.LedgerIDs, tr.ID, p.AmountCents, p.Currency); err != nil {
+			result.Failed++
+			result.Errors = append(result.Errors, err.Error())
+			RecordPayoutFailure()
+			continue
+		}
+		result.Processed++
+		RecordPayoutSuccess(p.AmountCents)
+	}
+	return result, nil
+}

--- a/server/internal/service/billing/revenue_share_test.go
+++ b/server/internal/service/billing/revenue_share_test.go
@@ -1,0 +1,49 @@
+package billing
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestComputeCreatorShare(t *testing.T) {
+	tests := []struct {
+		amount    int
+		feePct    float64
+		wantCents int
+	}{
+		{4900, 0.30, 3430},
+		{1000, 0.30, 700},
+		{0, 0.30, 0},
+		{100, 0.0, 100},
+	}
+	for _, tc := range tests {
+		got := ComputeCreatorShare(tc.amount, tc.feePct)
+		if got != tc.wantCents {
+			t.Errorf("ComputeCreatorShare(%d, %v) = %d, want %d", tc.amount, tc.feePct, got, tc.wantCents)
+		}
+	}
+}
+
+func TestComputeAffiliateCommission(t *testing.T) {
+	got := ComputeAffiliateCommission(4900, 0.10)
+	if got != 490 {
+		t.Fatalf("want 490 got %d", got)
+	}
+}
+
+func TestIsSelfReferral(t *testing.T) {
+	buyer := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	affiliate := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	creator := uuid.MustParse("00000000-0000-0000-0000-000000000003")
+
+	if !IsSelfReferral(buyer, buyer, creator) {
+		t.Fatal("buyer == affiliate should be self-referral")
+	}
+	if !IsSelfReferral(creator, creator, creator) {
+		t.Fatal("creator buying via own link should be self-referral")
+	}
+	if IsSelfReferral(buyer, affiliate, creator) {
+		t.Fatal("unrelated buyer should not be self-referral")
+	}
+}

--- a/server/internal/service/billing/stripe.go
+++ b/server/internal/service/billing/stripe.go
@@ -24,13 +24,14 @@ import (
 
 // CheckoutRequest is the learner checkout payload.
 type CheckoutRequest struct {
-	UserID     uuid.UUID
-	Email      string
-	CourseID   *uuid.UUID
-	Plan       string // monthly | annual
-	PromoCode  string
-	SuccessURL string
-	CancelURL  string
+	UserID        uuid.UUID
+	Email         string
+	CourseID      *uuid.UUID
+	Plan          string // monthly | annual
+	PromoCode     string
+	AffiliateCode string
+	SuccessURL    string
+	CancelURL     string
 }
 
 // CheckoutResult is a Stripe Checkout redirect.
@@ -105,6 +106,12 @@ func CreateCheckoutSession(ctx context.Context, pool *pgxpool.Pool, cfg StripeCo
 		}
 		params.Metadata["course_id"] = req.CourseID.String()
 		params.Metadata["entitlement_type"] = repoBilling.TypeCoursePurchase
+		if code := strings.TrimSpace(req.AffiliateCode); code != "" {
+			params.Metadata["affiliate_code"] = code
+		}
+		params.PaymentIntentData = &stripe.CheckoutSessionPaymentIntentDataParams{
+			Metadata: params.Metadata,
+		}
 		params.LineItems = []*stripe.CheckoutSessionLineItemParams{
 			{
 				PriceData: &stripe.CheckoutSessionLineItemPriceDataParams{
@@ -169,8 +176,13 @@ type WebhookResult struct {
 	Created   bool
 }
 
+// WebhookOptions configures optional post-payment side effects.
+type WebhookOptions struct {
+	RevenueShareEnabled bool
+}
+
 // HandleWebhook verifies and processes a Stripe webhook payload.
-func HandleWebhook(ctx context.Context, pool *pgxpool.Pool, cfg StripeConfig, body []byte, sigHeader string) (*WebhookResult, error) {
+func HandleWebhook(ctx context.Context, pool *pgxpool.Pool, cfg StripeConfig, body []byte, sigHeader string, opts WebhookOptions) (*WebhookResult, error) {
 	if cfg.WebhookSecret == "" {
 		return nil, errors.New("stripe webhook secret not configured")
 	}
@@ -180,19 +192,21 @@ func HandleWebhook(ctx context.Context, pool *pgxpool.Pool, cfg StripeConfig, bo
 	}
 	switch event.Type {
 	case "checkout.session.completed":
-		return handleCheckoutCompleted(ctx, pool, event)
+		return handleCheckoutCompleted(ctx, pool, event, opts)
 	case "invoice.payment_succeeded":
 		return handleInvoicePaymentSucceeded(ctx, pool, event)
 	case "invoice.payment_failed":
 		return handleInvoicePaymentFailed(ctx, pool, event)
 	case "customer.subscription.deleted":
 		return handleSubscriptionDeleted(ctx, pool, event)
+	case "charge.refunded":
+		return handleChargeRefunded(ctx, pool, event, opts)
 	default:
 		return &WebhookResult{EventType: string(event.Type)}, nil
 	}
 }
 
-func handleCheckoutCompleted(ctx context.Context, pool *pgxpool.Pool, event stripe.Event) (*WebhookResult, error) {
+func handleCheckoutCompleted(ctx context.Context, pool *pgxpool.Pool, event stripe.Event, opts WebhookOptions) (*WebhookResult, error) {
 	var sess stripe.CheckoutSession
 	if err := json.Unmarshal(event.Data.Raw, &sess); err != nil {
 		return nil, err
@@ -238,6 +252,18 @@ func handleCheckoutCompleted(ctx context.Context, pool *pgxpool.Pool, event stri
 	}
 	if created {
 		RecordPayment(amount, entType)
+		if opts.RevenueShareEnabled && courseID != nil && entType == repoBilling.TypeCoursePurchase {
+			if err := RecordSaleEarnings(ctx, pool, SaleEarningsInput{
+				BuyerUserID:   userID,
+				CourseID:      *courseID,
+				AmountCents:   amount,
+				Currency:      currency,
+				StripeEventID: event.ID,
+				AffiliateCode: strings.TrimSpace(sess.Metadata["affiliate_code"]),
+			}); err != nil {
+				return nil, err
+			}
+		}
 	}
 	return &WebhookResult{EventType: string(event.Type), Created: created}, nil
 }
@@ -311,6 +337,39 @@ func handleSubscriptionDeleted(ctx context.Context, pool *pgxpool.Pool, event st
 	}
 	_, err = repoBilling.ExpireActiveSubscriptions(ctx, pool, userID)
 	if err != nil {
+		return nil, err
+	}
+	return &WebhookResult{EventType: string(event.Type)}, nil
+}
+
+func handleChargeRefunded(ctx context.Context, pool *pgxpool.Pool, event stripe.Event, opts WebhookOptions) (*WebhookResult, error) {
+	if !opts.RevenueShareEnabled {
+		return &WebhookResult{EventType: string(event.Type)}, nil
+	}
+	var ch stripe.Charge
+	if err := json.Unmarshal(event.Data.Raw, &ch); err != nil {
+		return nil, err
+	}
+	rawCourse := strings.TrimSpace(ch.Metadata["course_id"])
+	if rawCourse == "" {
+		return &WebhookResult{EventType: string(event.Type)}, nil
+	}
+	courseID, err := uuid.Parse(rawCourse)
+	if err != nil {
+		return &WebhookResult{EventType: string(event.Type)}, nil
+	}
+	refundAmount := int(ch.AmountRefunded)
+	if refundAmount <= 0 {
+		refundAmount = int(ch.Amount)
+	}
+	currency := string(ch.Currency)
+	if err := RecordRefundEarnings(ctx, pool, RefundEarningsInput{
+		CourseID:      courseID,
+		AmountCents:   refundAmount,
+		Currency:      currency,
+		StripeEventID: event.ID,
+		AffiliateCode: strings.TrimSpace(ch.Metadata["affiliate_code"]),
+	}); err != nil {
 		return nil, err
 	}
 	return &WebhookResult{EventType: string(event.Type)}, nil

--- a/server/migrations/285_revenue_share.sql
+++ b/server/migrations/285_revenue_share.sql
@@ -1,0 +1,67 @@
+-- Plan 15.8 — Affiliate / referral / instructor revenue share.
+
+ALTER TABLE "user".users
+    ADD COLUMN IF NOT EXISTS stripe_connect_id TEXT UNIQUE;
+
+COMMENT ON COLUMN "user".users.stripe_connect_id IS
+    'Stripe Connect Express account id for creator payouts (plan 15.8).';
+
+CREATE TABLE IF NOT EXISTS billing.creator_revenue_configs (
+    user_id           UUID PRIMARY KEY REFERENCES "user".users (id) ON DELETE CASCADE,
+    platform_fee_pct  NUMERIC(5, 4) NOT NULL DEFAULT 0.30,
+    affiliate_fee_pct NUMERIC(5, 4) NOT NULL DEFAULT 0.10,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (platform_fee_pct >= 0 AND platform_fee_pct < 1),
+    CHECK (affiliate_fee_pct >= 0 AND affiliate_fee_pct < 1)
+);
+
+COMMENT ON TABLE billing.creator_revenue_configs IS
+    'Per-creator revenue share overrides (plan 15.8).';
+
+CREATE TABLE IF NOT EXISTS billing.affiliate_codes (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id     UUID NOT NULL REFERENCES "user".users (id) ON DELETE CASCADE,
+    code        TEXT NOT NULL UNIQUE,
+    course_id   UUID REFERENCES course.courses (id) ON DELETE SET NULL,
+    click_count INT NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE billing.affiliate_codes IS
+    'User referral codes for affiliate commission tracking (plan 15.8).';
+
+CREATE INDEX IF NOT EXISTS idx_billing_affiliate_codes_user
+    ON billing.affiliate_codes (user_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS billing.earnings_ledger (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    payee_id        UUID NOT NULL REFERENCES "user".users (id) ON DELETE CASCADE,
+    entry_type      TEXT NOT NULL,
+    amount_cents    INT NOT NULL,
+    currency        TEXT NOT NULL DEFAULT 'usd',
+    stripe_event_id TEXT UNIQUE,
+    stripe_transfer_id TEXT,
+    course_id       UUID REFERENCES course.courses (id) ON DELETE SET NULL,
+    affiliate_code  TEXT,
+    status          TEXT NOT NULL DEFAULT 'pending',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (entry_type IN ('sale', 'affiliate', 'refund', 'payout')),
+    CHECK (status IN ('pending', 'paid', 'held'))
+);
+
+COMMENT ON TABLE billing.earnings_ledger IS
+    'Creator and affiliate earnings ledger (plan 15.8).';
+
+CREATE INDEX IF NOT EXISTS idx_billing_earnings_payee
+    ON billing.earnings_ledger (payee_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_billing_earnings_pending
+    ON billing.earnings_ledger (payee_id, status)
+    WHERE status = 'pending';
+
+ALTER TABLE settings.platform_app_settings
+    ADD COLUMN IF NOT EXISTS ff_revenue_share BOOLEAN;
+
+COMMENT ON COLUMN settings.platform_app_settings.ff_revenue_share IS
+    'Enables creator revenue share, affiliate tracking, and Stripe Connect payouts (plan 15.8).';


### PR DESCRIPTION
## Summary
- Adds creator earnings ledger, configurable platform/affiliate fee percentages, and Stripe Connect Express onboarding and monthly payout batch (plan 15.8).
- Implements affiliate referral codes with 30-day cookie attribution, click tracking, self-referral blocking, and refund reversals wired into Stripe webhooks.
- Ships creator earnings dashboard (`/me/creator/earnings`), platform flag `ff_revenue_share`, and Playwright coverage.

## Test plan
- [x] `go test ./internal/service/billing/... ./internal/httpserver/... -short -run 'RevenueShare|ComputeCreator|Billing_'`
- [x] `npm run typecheck` in `clients/web/`
- [ ] Enable `ff_stripe_billing` + `ff_revenue_share` in Settings → Global platform
- [ ] Purchase a paid course via `?ref=` link; verify creator sale + affiliate ledger entries
- [ ] Confirm self-referral does not create affiliate commission
- [ ] Run `e2e/tests/revenue-share.spec.ts` against a stack with flags enabled


Made with [Cursor](https://cursor.com)