### PR TITLE
feat: SpeedGrader comment threads with Canvas sync and import fixes

### DIFF
--- a/.cursor/skills/implement/SKILL.md
+++ b/.cursor/skills/implement/SKILL.md
@@ -10,6 +10,8 @@ You are an staff software engineer. You are highly skilled at implementation.
 
 # Steps
 
+Follow all of the instructions
+
 1. Before doing anything, the user must request for either a markdown file to be implemented or they must tell you what is to be implemented. We are going to call this `THING_TO_IMPLEMENT`
 2. Implement `THING_TO_IMPLEMENT`
 3. Move it to docs/completed once it's done. 
@@ -17,5 +19,5 @@ You are an staff software engineer. You are highly skilled at implementation.
 5. Make sure it's linted
 6. Ensure there are e2e tests to prove that it works (where applicable)
 7. Make sure the lints, tests, and the e2e tests work locally before committing.
-8. Create a PR
+8. Commit and create a PR
 9. Run /fix-ci and make sure the ci passes

--- a/clients/web/src/components/annotation/__tests__/submission-navigator.test.tsx
+++ b/clients/web/src/components/annotation/__tests__/submission-navigator.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import type { ModuleAssignmentSubmissionApi } from '../../../lib/courses-api'
+import { SubmissionNavigator } from '../submission-navigator'
+
+function submission(
+  id: string,
+  label: string,
+  isGraded?: boolean,
+): ModuleAssignmentSubmissionApi {
+  return {
+    id,
+    submittedByDisplayName: label,
+    attachmentFileId: null,
+    submittedAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    isGraded,
+  }
+}
+
+describe('SubmissionNavigator student filter', () => {
+  it('navigates filtered students with arrow keys and selects with Enter', async () => {
+    const user = userEvent.setup()
+    const onIndexChange = vi.fn()
+    const submissions = [
+      submission('a', 'Alice'),
+      submission('b', 'Bob'),
+      submission('c', 'Carol'),
+    ]
+
+    render(
+      <SubmissionNavigator
+        submissions={submissions}
+        index={0}
+        onIndexChange={onIndexChange}
+        gradedFilter="all"
+        onGradedFilterChange={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Alice/i }))
+    const filter = screen.getByRole('searchbox', { name: /filter students/i })
+    await user.type(filter, 'b')
+
+    expect(screen.getByRole('menuitemradio', { name: /Bob/i })).toBeInTheDocument()
+    expect(screen.queryByRole('menuitemradio', { name: /Alice/i })).not.toBeInTheDocument()
+
+    await user.keyboard('{ArrowDown}')
+    await user.keyboard('{Enter}')
+
+    expect(onIndexChange).toHaveBeenCalledWith(1)
+  })
+
+  it('highlights the current student when the picker opens', async () => {
+    const user = userEvent.setup()
+    const onIndexChange = vi.fn()
+    const submissions = [
+      submission('a', 'Alice'),
+      submission('b', 'Bob'),
+      submission('c', 'Carol'),
+    ]
+
+    render(
+      <SubmissionNavigator
+        submissions={submissions}
+        index={1}
+        onIndexChange={onIndexChange}
+        gradedFilter="all"
+        onGradedFilterChange={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Bob/i }))
+    const filter = screen.getByRole('searchbox', { name: /filter students/i })
+    await waitFor(() => expect(filter).toHaveFocus())
+
+    await user.keyboard('{Enter}')
+
+    expect(onIndexChange).toHaveBeenCalledWith(1)
+  })
+})

--- a/clients/web/src/components/annotation/submission-comment-thread.tsx
+++ b/clients/web/src/components/annotation/submission-comment-thread.tsx
@@ -1,0 +1,113 @@
+import { EnrollmentAvatar } from '../enrollment/enrollment-avatar'
+import { formatAbsolute, formatRelativeCompact } from '../../lib/format-datetime'
+import type { GradeCommentApi } from '../../lib/courses-api'
+
+export type CommentRosterPerson = {
+  userId: string
+  displayName: string | null
+  avatarUrl?: string | null
+}
+
+function authorLabel(c: GradeCommentApi, roster?: Map<string, CommentRosterPerson>): string {
+  const fromComment = c.displayName?.trim()
+  if (fromComment) return fromComment
+  const uid = c.userId?.trim().toLowerCase()
+  if (uid && roster?.has(uid)) {
+    const p = roster.get(uid)!
+    return p.displayName?.trim() || '—'
+  }
+  return '—'
+}
+
+function resolveAvatar(
+  c: GradeCommentApi,
+  roster?: Map<string, CommentRosterPerson>,
+): string | null | undefined {
+  if (c.avatarUrl?.trim()) return c.avatarUrl
+  const uid = c.userId?.trim().toLowerCase()
+  if (uid && roster?.has(uid)) return roster.get(uid)?.avatarUrl
+  return null
+}
+
+function resolveUserId(c: GradeCommentApi): string {
+  const uid = c.userId?.trim()
+  if (uid) return uid
+  return `comment-${(c.id ?? c.displayName ?? c.body).toLowerCase()}`
+}
+
+type SubmissionCommentThreadProps = {
+  comments: GradeCommentApi[]
+  roster?: Map<string, CommentRosterPerson>
+  emptyLabel?: string
+}
+
+export function SubmissionCommentThread({
+  comments,
+  roster,
+  emptyLabel = 'No feedback yet. Add a comment when you save the grade.',
+}: SubmissionCommentThreadProps) {
+  if (comments.length === 0) {
+    return (
+      <p className="rounded-xl border border-dashed border-slate-200 bg-slate-50/80 px-4 py-6 text-center text-sm text-slate-500 dark:border-neutral-700 dark:bg-neutral-900/30 dark:text-neutral-400">
+        {emptyLabel}
+      </p>
+    )
+  }
+
+  return (
+    <div
+      className="space-y-1 rounded-xl border border-slate-200 bg-white p-3 dark:border-neutral-600 dark:bg-neutral-950/40"
+      role="log"
+      aria-label="Grade feedback conversation"
+    >
+      {comments.map((c, index) => {
+        const name = authorLabel(c, roster)
+        const userId = resolveUserId(c)
+        const avatarUrl = resolveAvatar(c, roster)
+        const createdAt = c.createdAt?.trim() ?? ''
+        const showTimestamp = Boolean(createdAt)
+        const isCompact = index > 0
+
+        return (
+          <article
+            key={c.id ?? `${userId}-${index}`}
+            className={`group/commentrow flex gap-2.5 rounded-lg px-1 py-1.5 hover:bg-slate-50/90 dark:hover:bg-neutral-900/50 ${
+              isCompact ? 'mt-0.5' : ''
+            }`}
+          >
+            <EnrollmentAvatar
+              userId={userId}
+              name={name}
+              avatarUrl={avatarUrl}
+              size="sm"
+            />
+            <div className="min-w-0 flex-1 pt-0.5">
+              <div className="flex items-baseline gap-x-1.5 leading-none">
+                <span className="truncate text-[13px] font-semibold text-slate-900 dark:text-neutral-100">
+                  {name}
+                </span>
+                {showTimestamp ? (
+                  <time
+                    className="shrink-0 text-[10px] font-medium text-neutral-500 dark:text-neutral-400"
+                    dateTime={createdAt}
+                    title={formatAbsolute(createdAt)}
+                  >
+                    {formatRelativeCompact(createdAt)}
+                  </time>
+                ) : null}
+                {c.source === 'rubric' ? (
+                  <span className="rounded bg-violet-100/90 px-1 py-px text-[9px] font-medium text-violet-800 dark:bg-violet-950/50 dark:text-violet-200">
+                    Rubric
+                  </span>
+                ) : null}
+              </div>
+              <p className="mt-1 whitespace-pre-wrap break-words text-[0.8125rem] leading-relaxed text-slate-700 dark:text-neutral-200">
+                {c.body}
+              </p>
+            </div>
+          </article>
+        )
+      })}
+    </div>
+  )
+}

--- a/clients/web/src/components/annotation/submission-grading-panel.tsx
+++ b/clients/web/src/components/annotation/submission-grading-panel.tsx
@@ -6,14 +6,20 @@ import { postGraderAgentRegradeRequest } from '../../lib/courses-api'
 import {
   fetchAssignmentStudentGrade,
   fetchCourseCanvasLink,
+  fetchCourseEnrollmentsList,
   fetchModuleAssignment,
   fetchSubmissionGrade,
   putAssignmentStudentGrade,
   putSubmissionGrade,
   type CourseCanvasLinkApi,
+  type GradeCommentApi,
   type RubricDefinition,
   type SubmissionGradeApi,
 } from '../../lib/courses-api'
+import {
+  SubmissionCommentThread,
+  type CommentRosterPerson,
+} from './submission-comment-thread'
 import { queueCanvasGradeSync, type CanvasGradePushPayload } from '../canvas/canvas-grade-sync'
 import { RubricGradePicker } from '../grading/rubric-grade-picker'
 import { formatPointsCell, rubricScoresComplete, rubricTotal } from '../../lib/rubric-utils'
@@ -70,6 +76,10 @@ export function SubmissionGradingPanel({
   const [saveError, setSaveError] = useState<string | null>(null)
   const [savedFlash, setSavedFlash] = useState(false)
   const [comment, setComment] = useState('')
+  const [threadComments, setThreadComments] = useState<GradeCommentApi[]>([])
+  const [rosterByUserId, setRosterByUserId] = useState<Map<string, CommentRosterPerson>>(
+    () => new Map(),
+  )
   const [pointsInput, setPointsInput] = useState('')
   const [rubricScores, setRubricScores] = useState<Record<string, number>>({})
   const [posted, setPosted] = useState(false)
@@ -106,6 +116,30 @@ export function SubmissionGradingPanel({
   }, [courseCode])
 
   useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const roster = await fetchCourseEnrollmentsList(courseCode)
+        if (cancelled) return
+        const map = new Map<string, CommentRosterPerson>()
+        for (const person of roster) {
+          map.set(person.userId.toLowerCase(), {
+            userId: person.userId,
+            displayName: person.displayName,
+            avatarUrl: person.avatarUrl,
+          })
+        }
+        setRosterByUserId(map)
+      } catch {
+        if (!cancelled) setRosterByUserId(new Map())
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [courseCode])
+
+  useEffect(() => {
     canvasSyncAbortRef.current?.()
     canvasSyncAbortRef.current = null
     setCanvasSyncPending(false)
@@ -134,8 +168,11 @@ export function SubmissionGradingPanel({
   }, [courseCode, itemId, rubricProp])
 
   const applyGrade = useCallback(
-    (grade: SubmissionGradeApi) => {
-      setComment(grade.instructorComment ?? '')
+    (grade: SubmissionGradeApi, options?: { preserveDraft?: boolean }) => {
+      setThreadComments(grade.comments ?? [])
+      if (!options?.preserveDraft) {
+        setComment('')
+      }
       setPosted(Boolean(grade.posted))
       setGradedByAi(Boolean(grade.gradedByAi))
       setGradeMode(initialGradeMode(grade, hasRubric))
@@ -159,6 +196,7 @@ export function SubmissionGradingPanel({
   useEffect(() => {
     if (!submissionId && !studentUserId) {
       setComment('')
+      setThreadComments([])
       setPointsInput('')
       setRubricScores({})
       setPosted(false)
@@ -179,6 +217,7 @@ export function SubmissionGradingPanel({
       } catch (e) {
         if (!cancelled) {
           setComment('')
+          setThreadComments([])
           setPointsInput('')
           setRubricScores({})
           setPosted(false)
@@ -254,10 +293,11 @@ export function SubmissionGradingPanel({
   }, [gradeMode, hasRubric, pointsInput, rubric, rubricScores])
 
   const canvasGradePayload = useMemo((): CanvasGradePushPayload | undefined => {
-    if (hasRubric && gradeMode === 'rubric' && rubric && rubricScoresComplete(rubric, rubricScores)) {
+    const instructorComment = comment.trim() || null
+    if (hasRubric && rubric && rubricScoresComplete(rubric, rubricScores)) {
       return {
         rubricScores,
-        instructorComment: comment.trim() || null,
+        instructorComment,
       }
     }
     const trimmed = pointsInput.trim()
@@ -266,12 +306,18 @@ export function SubmissionGradingPanel({
       if (Number.isFinite(n) && n >= 0) {
         return {
           pointsEarned: n,
-          instructorComment: comment.trim() || null,
+          instructorComment,
         }
       }
     }
+    if (hasGrade && instructorComment) {
+      if (Object.keys(rubricScores).length > 0) {
+        return { rubricScores, instructorComment }
+      }
+      return { instructorComment }
+    }
     return undefined
-  }, [comment, gradeMode, hasRubric, pointsInput, rubric, rubricScores])
+  }, [comment, hasGrade, hasRubric, pointsInput, rubric, rubricScores])
 
   const handleSave = useCallback(async () => {
     if (!submissionId && !studentUserId) return
@@ -284,15 +330,70 @@ export function SubmissionGradingPanel({
             putSubmissionGrade(courseCode, itemId, submissionId, body)
         : (body: Parameters<typeof putAssignmentStudentGrade>[3]) =>
             putAssignmentStudentGrade(courseCode, itemId, studentUserId!, body)
+      const trimmedComment = comment.trim()
+      const commentOnlySave =
+        hasGrade &&
+        trimmedComment !== '' &&
+        pointsInput.trim() === '' &&
+        (!hasRubric || !rubric || Object.keys(rubricScores).length === 0)
+      if (commentOnlySave) {
+        const saved = await saveGrade({ instructorComment: trimmedComment })
+        applyGrade(saved)
+        const savedMsg = 'Comment saved' + (posted ? '' : ' (held until posted)')
+        setFlashMsg(savedMsg)
+        setSavedFlash(true)
+        setPosted(true)
+        pendingScoreFocusRef.current = null
+        scoreInputRef.current?.blur()
+        if (focusTargetRef.current === focusTarget) {
+          onGradeSaved?.()
+        }
+        let startedCanvasSync = false
+        if (submissionId && canvasLink && canvasGradePayload) {
+          canvasSyncAbortRef.current?.()
+          const syncHandle = queueCanvasGradeSync({
+            courseCode,
+            itemId,
+            submissionId,
+            canvasLink,
+            gradePayload: canvasGradePayload,
+            onComplete: () => {
+              if (focusTargetRef.current !== focusTarget) return
+              setCanvasSyncPending(false)
+              setFlashMsg('Comment saved and synced to Canvas.')
+              setSavedFlash(true)
+              onGradeSaved?.()
+              window.setTimeout(() => setSavedFlash(false), 2500)
+            },
+            onError: (message) => {
+              if (focusTargetRef.current !== focusTarget) return
+              setCanvasSyncPending(false)
+              setFlashMsg(message)
+              setSavedFlash(true)
+              window.setTimeout(() => setSavedFlash(false), 4000)
+            },
+          })
+          if (syncHandle) {
+            canvasSyncAbortRef.current = syncHandle.abort
+            setCanvasSyncPending(true)
+            startedCanvasSync = true
+          }
+        }
+        if (!startedCanvasSync) {
+          window.setTimeout(() => setSavedFlash(false), 2500)
+        }
+        return
+      }
       if (hasRubric && gradeMode === 'rubric' && rubric) {
         if (!rubricScoresComplete(rubric, rubricScores)) {
           setSaveError('Select a rating for every rubric criterion.')
           return
         }
-        await saveGrade({
+        const saved = await saveGrade({
           rubricScores,
-          instructorComment: comment.trim() || null,
+          instructorComment: trimmedComment || null,
         })
+        applyGrade(saved)
       } else {
         const trimmed = pointsInput.trim()
         if (trimmed === '') {
@@ -308,10 +409,11 @@ export function SubmissionGradingPanel({
           setSaveError(`Score cannot exceed ${maxPoints} points.`)
           return
         }
-        await saveGrade({
+        const saved = await saveGrade({
           pointsEarned: n,
-          instructorComment: comment.trim() || null,
+          instructorComment: trimmedComment || null,
         })
+        applyGrade(saved)
       }
       const savedMsg = 'Grade saved' + (posted ? '' : ' (held until posted)')
       setFlashMsg(savedMsg)
@@ -335,8 +437,14 @@ export function SubmissionGradingPanel({
           onComplete: (grade) => {
             if (focusTargetRef.current !== focusTarget) return
             setCanvasSyncPending(false)
-            applyGrade(grade)
-            setFlashMsg('Grade saved and synced to Canvas.')
+            if (grade.comments?.length) {
+              applyGrade(grade)
+            }
+            setFlashMsg(
+              trimmedComment
+                ? 'Grade and comment saved and synced to Canvas.'
+                : 'Grade saved and synced to Canvas.',
+            )
             setSavedFlash(true)
             onGradeSaved?.()
             window.setTimeout(() => setSavedFlash(false), 2500)
@@ -368,6 +476,7 @@ export function SubmissionGradingPanel({
     canvasGradePayload,
     canvasLink,
     comment,
+    hasGrade,
     courseCode,
     gradeMode,
     hasRubric,
@@ -401,6 +510,7 @@ export function SubmissionGradingPanel({
       setPointsInput('')
       setRubricScores({})
       setComment('')
+      setThreadComments([])
       setPosted(false)
       setHasGrade(false)
       setFlashMsg('Grade cleared.')
@@ -586,19 +696,40 @@ export function SubmissionGradingPanel({
           </label>
         )}
 
-        <label className="block text-sm text-slate-700 dark:text-neutral-200">
-          <span className="mb-1.5 block text-xs font-medium text-slate-500 dark:text-neutral-400">
-            Feedback comment
-          </span>
-          <textarea
-            className="min-h-28 w-full rounded-lg border border-slate-300 bg-white px-3 py-2.5 text-sm leading-relaxed dark:border-neutral-600 dark:bg-neutral-950"
-            value={comment}
-            onChange={(e) => setComment(e.target.value)}
-            disabled={formDisabled}
-            placeholder="Share feedback the student will see with their grade…"
-            rows={5}
-          />
-        </label>
+        <div className="space-y-3 text-sm text-slate-700 dark:text-neutral-200">
+          <div>
+            <span className="mb-1.5 block text-xs font-medium text-slate-500 dark:text-neutral-400">
+              Feedback conversation
+            </span>
+            <SubmissionCommentThread
+              comments={threadComments}
+              roster={rosterByUserId}
+              emptyLabel={
+                mode === 'student'
+                  ? 'No feedback has been posted yet.'
+                  : 'No feedback yet. Add a comment below when you save the grade.'
+              }
+            />
+          </div>
+          {mode === 'staff' ? (
+            <label className="block">
+              <span className="mb-1.5 block text-xs font-medium text-slate-500 dark:text-neutral-400">
+                Add comment
+              </span>
+              <textarea
+                className="min-h-24 w-full rounded-lg border border-slate-300 bg-white px-3 py-2.5 text-sm leading-relaxed dark:border-neutral-600 dark:bg-neutral-950"
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                disabled={formDisabled}
+                placeholder="Write feedback to add to the conversation…"
+                rows={4}
+              />
+              <p className="mt-1.5 text-xs text-slate-500 dark:text-neutral-400">
+                Your comment is added to the thread when you save the grade.
+              </p>
+            </label>
+          ) : null}
+        </div>
       </div>
 
       <div className="shrink-0 space-y-2 border-t border-slate-200 bg-slate-50 p-4 dark:border-neutral-600 dark:bg-neutral-900/80">

--- a/clients/web/src/components/annotation/submission-navigator.tsx
+++ b/clients/web/src/components/annotation/submission-navigator.tsx
@@ -45,8 +45,11 @@ function SubmissionStudentPicker({
 }: SubmissionStudentPickerProps) {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
+  const [highlightedIndex, setHighlightedIndex] = useState(0)
   const rootRef = useRef<HTMLDivElement>(null)
   const filterRef = useRef<HTMLInputElement>(null)
+  const listItemRefs = useRef<Map<number, HTMLButtonElement>>(new Map())
+  const openedRef = useRef(false)
   const buttonId = useId()
   const menuId = useId()
   const filterId = useId()
@@ -66,14 +69,35 @@ function SubmissionStudentPicker({
 
   useEffect(() => {
     if (!open) {
+      openedRef.current = false
       setQuery('')
+      setHighlightedIndex(0)
       return
     }
+    if (openedRef.current) return
+    openedRef.current = true
+    const currentEntryIndex = visibleEntries.findIndex((entry) => entry.i === index)
+    setHighlightedIndex(currentEntryIndex >= 0 ? currentEntryIndex : 0)
     const frame = window.requestAnimationFrame(() => {
       filterRef.current?.focus()
     })
     return () => window.cancelAnimationFrame(frame)
-  }, [open])
+  }, [index, open, visibleEntries])
+
+  useEffect(() => {
+    if (!open) return
+    setHighlightedIndex(0)
+  }, [query])
+
+  useEffect(() => {
+    if (!open || visibleEntries.length === 0) return
+    const clamped = Math.min(highlightedIndex, visibleEntries.length - 1)
+    if (clamped !== highlightedIndex) {
+      setHighlightedIndex(clamped)
+      return
+    }
+    listItemRefs.current.get(clamped)?.scrollIntoView({ block: 'nearest' })
+  }, [highlightedIndex, open, visibleEntries.length])
 
   useEffect(() => {
     if (!open) return
@@ -138,6 +162,27 @@ function SubmissionStudentPicker({
                 if (e.key === 'Escape') {
                   e.stopPropagation()
                   setOpen(false)
+                  return
+                }
+                if (visibleEntries.length === 0) return
+
+                if (e.key === 'ArrowDown') {
+                  e.preventDefault()
+                  setHighlightedIndex((prev) => Math.min(prev + 1, visibleEntries.length - 1))
+                  return
+                }
+                if (e.key === 'ArrowUp') {
+                  e.preventDefault()
+                  setHighlightedIndex((prev) => Math.max(prev - 1, 0))
+                  return
+                }
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  const entry = visibleEntries[highlightedIndex]
+                  if (entry) {
+                    onIndexChange(entry.i)
+                    setOpen(false)
+                  }
                 }
               }}
               className="w-full rounded-lg border border-slate-300 bg-white px-2.5 py-1.5 text-xs text-slate-900 outline-none ring-indigo-500/0 placeholder:text-slate-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-400"
@@ -150,22 +195,30 @@ function SubmissionStudentPicker({
             ) : visibleEntries.length === 0 ? (
               <p className="px-3 py-2 text-xs text-slate-500 dark:text-neutral-400">No matching students.</p>
             ) : (
-              visibleEntries.map(({ submission, i, label }) => {
+              visibleEntries.map(({ submission, i, label }, visibleIndex) => {
                 const active = i === index
+                const highlighted = visibleIndex === highlightedIndex
                 return (
                   <button
                     key={submissionNavigatorKey(submission, i)}
+                    ref={(el) => {
+                      if (el) listItemRefs.current.set(visibleIndex, el)
+                      else listItemRefs.current.delete(visibleIndex)
+                    }}
                     type="button"
                     role="menuitemradio"
                     aria-checked={active}
+                    onMouseEnter={() => setHighlightedIndex(visibleIndex)}
                     onClick={() => {
                       onIndexChange(i)
                       setOpen(false)
                     }}
                     className={`flex w-full items-center gap-2 px-3 py-2 text-start text-xs transition ${
-                      active
+                      highlighted
                         ? 'bg-indigo-50 font-semibold text-indigo-900 dark:bg-indigo-950/50 dark:text-indigo-100'
-                        : 'text-slate-700 hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800'
+                        : active
+                          ? 'font-semibold text-indigo-800 dark:text-indigo-200'
+                          : 'text-slate-700 hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800'
                     }`}
                   >
                     <span className="w-5 shrink-0 tabular-nums text-slate-400 dark:text-neutral-500">

--- a/clients/web/src/components/layout/side-nav-admin-links.tsx
+++ b/clients/web/src/components/layout/side-nav-admin-links.tsx
@@ -69,6 +69,21 @@ export function SideNavAdminLinks() {
     location.pathname === path || location.pathname.startsWith(`${path}/`)
 
   const showCcrAdmin = canManageAccommodations && ffCoCurricularTranscript
+  const showIntegrations = ffSisIntegration || ffContentFilterIntegration
+  const showStudentRecords =
+    ffDemographics ||
+    ffIncompleteGradeWorkflow ||
+    ffGradeSubmission ||
+    (ffCoCurricularTranscript && canManageAccommodations)
+  const showSchoolOperations =
+    ffClassroomSignals ||
+    ffAcademicCalendar ||
+    (ffBroadcasts && !!orgId) ||
+    ffConferenceScheduling ||
+    ffCourseEvaluations ||
+    (ffLibrary && !!orgId) ||
+    ffLearningPaths
+
   if (!canManageRbac && !showCcrAdmin) return null
 
   return (
@@ -130,171 +145,196 @@ export function SideNavAdminLinks() {
             </SideNavLink>
           ) : null}
 
-          <SideNavSectionLabel>Integrations</SideNavSectionLabel>
-          {ffSisIntegration ? (
-            <SideNavLink
-              to={orgPath('/admin/sis', orgId)}
-              className={() => (active('/admin/sis') ? sideNavActiveClass : '')}
-              icon={<School className="h-5 w-5" />}
-            >
-              SIS integration
-            </SideNavLink>
-          ) : null}
-          {ffContentFilterIntegration ? (
-            <SideNavLink
-              to={orgPath('/admin/content-filter', orgId)}
-              className={() => (active('/admin/content-filter') ? sideNavActiveClass : '')}
-              icon={<Filter className="h-5 w-5" />}
-            >
-              Content filter
-            </SideNavLink>
+          {showIntegrations ? (
+            <>
+              <SideNavSectionLabel>Integrations</SideNavSectionLabel>
+              {ffSisIntegration ? (
+                <SideNavLink
+                  to={orgPath('/admin/sis', orgId)}
+                  className={() => (active('/admin/sis') ? sideNavActiveClass : '')}
+                  icon={<School className="h-5 w-5" />}
+                >
+                  SIS integration
+                </SideNavLink>
+              ) : null}
+              {ffContentFilterIntegration ? (
+                <SideNavLink
+                  to={orgPath('/admin/content-filter', orgId)}
+                  className={() => (active('/admin/content-filter') ? sideNavActiveClass : '')}
+                  icon={<Filter className="h-5 w-5" />}
+                >
+                  Content filter
+                </SideNavLink>
+              ) : null}
+            </>
           ) : null}
 
-          <SideNavSectionLabel>Student records</SideNavSectionLabel>
-          {ffDemographics ? (
+          {showStudentRecords ? (
             <>
-              <SideNavLink
-                to="/admin/demographics/student"
-                className={() => (active('/admin/demographics/student') ? sideNavActiveClass : '')}
-                icon={<Users className="h-5 w-5" />}
-              >
-                Student demographics
-              </SideNavLink>
-              <SideNavLink
-                to="/admin/demographics/title1"
-                className={() => (active('/admin/demographics/title1') ? sideNavActiveClass : '')}
-                icon={<BarChart2 className="h-5 w-5" />}
-              >
-                Title I report
-              </SideNavLink>
+              <SideNavSectionLabel>Student records</SideNavSectionLabel>
+              {ffDemographics ? (
+                <>
+                  <SideNavLink
+                    to="/admin/demographics/student"
+                    className={() =>
+                      active('/admin/demographics/student') ? sideNavActiveClass : ''
+                    }
+                    icon={<Users className="h-5 w-5" />}
+                  >
+                    Student demographics
+                  </SideNavLink>
+                  <SideNavLink
+                    to="/admin/demographics/title1"
+                    className={() =>
+                      active('/admin/demographics/title1') ? sideNavActiveClass : ''
+                    }
+                    icon={<BarChart2 className="h-5 w-5" />}
+                  >
+                    Title I report
+                  </SideNavLink>
+                </>
+              ) : null}
+              {ffIncompleteGradeWorkflow ? (
+                <SideNavLink
+                  to="/admin/incompletes"
+                  className={() => (active('/admin/incompletes') ? sideNavActiveClass : '')}
+                  icon={<FileSpreadsheet className="h-5 w-5" />}
+                >
+                  Incomplete grades
+                </SideNavLink>
+              ) : null}
+              {ffGradeSubmission ? (
+                <SideNavLink
+                  to="/admin/final-grades/status"
+                  className={() => (active('/admin/final-grades') ? sideNavActiveClass : '')}
+                  icon={<ClipboardList className="h-5 w-5" />}
+                >
+                  Final grade status
+                </SideNavLink>
+              ) : null}
+              {ffCoCurricularTranscript && canManageAccommodations ? (
+                <SideNavLink
+                  to="/admin/ccr/achievements"
+                  className={() => (active('/admin/ccr') ? sideNavActiveClass : '')}
+                  icon={<Award className="h-5 w-5" />}
+                >
+                  CCR achievements
+                </SideNavLink>
+              ) : null}
             </>
           ) : null}
-          {ffIncompleteGradeWorkflow ? (
-            <SideNavLink
-              to="/admin/incompletes"
-              className={() => (active('/admin/incompletes') ? sideNavActiveClass : '')}
-              icon={<FileSpreadsheet className="h-5 w-5" />}
-            >
-              Incomplete grades
-            </SideNavLink>
-          ) : null}
-          {ffGradeSubmission ? (
-            <SideNavLink
-              to="/admin/final-grades/status"
-              className={() => (active('/admin/final-grades') ? sideNavActiveClass : '')}
-              icon={<ClipboardList className="h-5 w-5" />}
-            >
-              Final grade status
-            </SideNavLink>
-          ) : null}
-          {ffCoCurricularTranscript && canManageAccommodations ? (
-            <SideNavLink
-              to="/admin/ccr/achievements"
-              className={() => (active('/admin/ccr') ? sideNavActiveClass : '')}
-              icon={<Award className="h-5 w-5" />}
-            >
-              CCR achievements
-            </SideNavLink>
-          ) : null}
-          <SideNavSectionLabel>School operations</SideNavSectionLabel>
-          {ffClassroomSignals ? (
+
+          {showSchoolOperations ? (
             <>
-              <SideNavLink
-                to="/admin/attendance/dashboard"
-                className={() => (active('/admin/attendance/dashboard') ? sideNavActiveClass : '')}
-                icon={<ClipboardList className="h-5 w-5" />}
-              >
-                Attendance dashboard
-              </SideNavLink>
-              <SideNavLink
-                to="/admin/attendance/export"
-                className={() => (active('/admin/attendance/export') ? sideNavActiveClass : '')}
-                icon={<FileSpreadsheet className="h-5 w-5" />}
-              >
-                Attendance export
-              </SideNavLink>
-              <SideNavLink
-                to={orgPath('/admin/behavior/dashboard', orgId)}
-                className={() => (active('/admin/behavior/dashboard') ? sideNavActiveClass : '')}
-                icon={<Activity className="h-5 w-5" />}
-              >
-                Behavior dashboard
-              </SideNavLink>
+              <SideNavSectionLabel>School operations</SideNavSectionLabel>
+              {ffClassroomSignals ? (
+                <>
+                  <SideNavLink
+                    to="/admin/attendance/dashboard"
+                    className={() =>
+                      active('/admin/attendance/dashboard') ? sideNavActiveClass : ''
+                    }
+                    icon={<ClipboardList className="h-5 w-5" />}
+                  >
+                    Attendance dashboard
+                  </SideNavLink>
+                  <SideNavLink
+                    to="/admin/attendance/export"
+                    className={() => (active('/admin/attendance/export') ? sideNavActiveClass : '')}
+                    icon={<FileSpreadsheet className="h-5 w-5" />}
+                  >
+                    Attendance export
+                  </SideNavLink>
+                  <SideNavLink
+                    to={orgPath('/admin/behavior/dashboard', orgId)}
+                    className={() =>
+                      active('/admin/behavior/dashboard') ? sideNavActiveClass : ''
+                    }
+                    icon={<Activity className="h-5 w-5" />}
+                  >
+                    Behavior dashboard
+                  </SideNavLink>
+                </>
+              ) : null}
+              {ffAcademicCalendar ? (
+                <SideNavLink
+                  to={orgPath('/admin/academic-calendar', orgId)}
+                  className={() => (active('/admin/academic-calendar') ? sideNavActiveClass : '')}
+                  icon={<CalendarRange className="h-5 w-5" />}
+                >
+                  Academic calendar
+                </SideNavLink>
+              ) : null}
+              {ffBroadcasts && orgId ? (
+                <SideNavLink
+                  to={broadcastsPath}
+                  className={() => (active('/admin/broadcasts') ? sideNavActiveClass : '')}
+                  icon={<Megaphone className="h-5 w-5" />}
+                >
+                  Broadcasts
+                </SideNavLink>
+              ) : null}
+              {ffConferenceScheduling ? (
+                <>
+                  <SideNavLink
+                    to="/admin/conferences/schedule"
+                    className={() =>
+                      active('/admin/conferences/schedule') ? sideNavActiveClass : ''
+                    }
+                    icon={<CalendarRange className="h-5 w-5" />}
+                  >
+                    Conference schedule
+                  </SideNavLink>
+                  <SideNavLink
+                    to="/conferences/availability"
+                    className={() =>
+                      location.pathname === '/conferences/availability' ? sideNavActiveClass : ''
+                    }
+                    icon={<CalendarRange className="h-5 w-5" />}
+                  >
+                    Conference availability
+                  </SideNavLink>
+                </>
+              ) : null}
+              {ffCourseEvaluations ? (
+                <>
+                  <SideNavLink
+                    to="/admin/evaluations/templates"
+                    className={() =>
+                      active('/admin/evaluations/templates') ? sideNavActiveClass : ''
+                    }
+                    icon={<ClipboardList className="h-5 w-5" />}
+                  >
+                    Evaluation templates
+                  </SideNavLink>
+                  <SideNavLink
+                    to="/admin/evaluations/report"
+                    className={() => (active('/admin/evaluations/report') ? sideNavActiveClass : '')}
+                    icon={<BarChart2 className="h-5 w-5" />}
+                  >
+                    Evaluation report
+                  </SideNavLink>
+                </>
+              ) : null}
+              {ffLibrary && orgId ? (
+                <SideNavLink
+                  to={libraryPath}
+                  className={() => (active('/library') ? sideNavActiveClass : '')}
+                  icon={<Library className="h-5 w-5" />}
+                >
+                  Library catalog
+                </SideNavLink>
+              ) : null}
+              {ffLearningPaths ? (
+                <SideNavLink
+                  to="/creator/learning-paths"
+                  className={() => (active('/creator/learning-paths') ? sideNavActiveClass : '')}
+                  icon={<Route className="h-5 w-5" />}
+                >
+                  Learning path builder
+                </SideNavLink>
+              ) : null}
             </>
-          ) : null}
-          {ffAcademicCalendar ? (
-            <SideNavLink
-              to={orgPath('/admin/academic-calendar', orgId)}
-              className={() => (active('/admin/academic-calendar') ? sideNavActiveClass : '')}
-              icon={<CalendarRange className="h-5 w-5" />}
-            >
-              Academic calendar
-            </SideNavLink>
-          ) : null}
-          {ffBroadcasts && orgId ? (
-            <SideNavLink
-              to={broadcastsPath}
-              className={() => (active('/admin/broadcasts') ? sideNavActiveClass : '')}
-              icon={<Megaphone className="h-5 w-5" />}
-            >
-              Broadcasts
-            </SideNavLink>
-          ) : null}
-          {ffConferenceScheduling ? (
-            <>
-              <SideNavLink
-                to="/admin/conferences/schedule"
-                className={() => (active('/admin/conferences/schedule') ? sideNavActiveClass : '')}
-                icon={<CalendarRange className="h-5 w-5" />}
-              >
-                Conference schedule
-              </SideNavLink>
-              <SideNavLink
-                to="/conferences/availability"
-                className={() =>
-                  location.pathname === '/conferences/availability' ? sideNavActiveClass : ''
-                }
-                icon={<CalendarRange className="h-5 w-5" />}
-              >
-                Conference availability
-              </SideNavLink>
-            </>
-          ) : null}
-          {ffCourseEvaluations ? (
-            <>
-              <SideNavLink
-                to="/admin/evaluations/templates"
-                className={() => (active('/admin/evaluations/templates') ? sideNavActiveClass : '')}
-                icon={<ClipboardList className="h-5 w-5" />}
-              >
-                Evaluation templates
-              </SideNavLink>
-              <SideNavLink
-                to="/admin/evaluations/report"
-                className={() => (active('/admin/evaluations/report') ? sideNavActiveClass : '')}
-                icon={<BarChart2 className="h-5 w-5" />}
-              >
-                Evaluation report
-              </SideNavLink>
-            </>
-          ) : null}
-          {ffLibrary && orgId ? (
-            <SideNavLink
-              to={libraryPath}
-              className={() => (active('/library') ? sideNavActiveClass : '')}
-              icon={<Library className="h-5 w-5" />}
-            >
-              Library catalog
-            </SideNavLink>
-          ) : null}
-          {ffLearningPaths ? (
-            <SideNavLink
-              to="/creator/learning-paths"
-              className={() => (active('/creator/learning-paths') ? sideNavActiveClass : '')}
-              icon={<Route className="h-5 w-5" />}
-            >
-              Learning path builder
-            </SideNavLink>
           ) : null}
         </>
       ) : null}

--- a/clients/web/src/lib/__tests__/build-search-items.test.ts
+++ b/clients/web/src/lib/__tests__/build-search-items.test.ts
@@ -140,6 +140,11 @@ describe('buildSearchItems', () => {
     expect(create?.path).toBe('/courses/create')
   })
 
+  it('omits Create course action without PERM_COURSE_CREATE', () => {
+    const items = buildSearchItems([], [], allowsNone)
+    expect(items.some((i) => i.id === 'action:/courses/create')).toBe(false)
+  })
+
   it('adds per-course page shortcuts and enrollment actions', () => {
     const allowsRosterX = (p: string) => p === courseEnrollmentsReadPermission('X')
     const items = buildSearchItems([{ courseCode: 'X', title: 'Y' }], [], allowsRosterX)

--- a/clients/web/src/lib/__tests__/rbac-api.test.ts
+++ b/clients/web/src/lib/__tests__/rbac-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isValidPermissionString } from '../rbac-api'
+import { canCreateCourses, isValidPermissionString, PERM_COURSE_CREATE } from '../rbac-api'
 
 describe('isValidPermissionString', () => {
   it('accepts exactly four colon-separated non-empty parts', () => {
@@ -19,5 +19,21 @@ describe('isValidPermissionString', () => {
 
   it('trims whitespace before validating', () => {
     expect(isValidPermissionString('  a:b:c:d  ')).toBe(true)
+  })
+})
+
+describe('canCreateCourses', () => {
+  it('is false while permissions are loading', () => {
+    const allows = (p: string) => p === PERM_COURSE_CREATE
+    expect(canCreateCourses(allows, true)).toBe(false)
+  })
+
+  it('is true when PERM_COURSE_CREATE is granted', () => {
+    const allows = (p: string) => p === PERM_COURSE_CREATE
+    expect(canCreateCourses(allows, false)).toBe(true)
+  })
+
+  it('is false without PERM_COURSE_CREATE', () => {
+    expect(canCreateCourses(() => false, false)).toBe(false)
   })
 })

--- a/clients/web/src/lib/courses-api.ts
+++ b/clients/web/src/lib/courses-api.ts
@@ -4246,6 +4246,7 @@ export type CourseEnrollmentRosterRow = {
   id: string
   userId: string
   displayName: string | null
+  avatarUrl?: string | null
   role: string
   sectionId?: string | null
   sectionCode?: string | null
@@ -4271,6 +4272,12 @@ export async function fetchCourseEnrollmentsList(
     const role = typeof o.role === 'string' ? o.role : ''
     if (!id || !userId) continue
     const displayName = typeof o.displayName === 'string' ? o.displayName : null
+    const avatarUrl =
+      typeof o.avatarUrl === 'string'
+        ? o.avatarUrl
+        : typeof o.avatar_url === 'string'
+          ? o.avatar_url
+          : null
     const sectionId =
       typeof o.sectionId === 'string' ? o.sectionId : typeof o.section_id === 'string' ? o.section_id : null
     const sectionCode =
@@ -4285,7 +4292,7 @@ export async function fetchCourseEnrollmentsList(
         : typeof o.section_name === 'string'
           ? o.section_name
           : null
-    out.push({ id, userId, displayName, role, sectionId, sectionCode, sectionName })
+    out.push({ id, userId, displayName, avatarUrl, role, sectionId, sectionCode, sectionName })
   }
   return out
 }
@@ -5433,6 +5440,16 @@ export async function fetchModuleAssignmentSubmissions(
 }
 
 /** Grade for one submission (`GET/PUT .../submissions/:id/grade`). */
+export type GradeCommentApi = {
+  id?: string
+  userId?: string | null
+  displayName?: string | null
+  avatarUrl?: string | null
+  body: string
+  createdAt?: string | null
+  source?: string | null
+}
+
 export type SubmissionGradeApi = {
   submissionId?: string
   studentUserId?: string
@@ -5440,11 +5457,58 @@ export type SubmissionGradeApi = {
   maxPoints?: number | null
   rubricScores?: Record<string, number>
   instructorComment?: string | null
+  comments?: GradeCommentApi[]
   posted?: boolean
   excused?: boolean
   gradedByAi?: boolean
   /** True when the grade was pushed to Canvas successfully. */
   syncedToCanvas?: boolean
+}
+
+function parseGradeComments(raw: unknown): GradeCommentApi[] | undefined {
+  if (!Array.isArray(raw)) return undefined
+  const out: GradeCommentApi[] = []
+  for (const row of raw) {
+    if (!row || typeof row !== 'object') continue
+    const o = row as Record<string, unknown>
+    const body = typeof o.body === 'string' ? o.body.trim() : ''
+    if (!body) continue
+    out.push({
+      id: typeof o.id === 'string' ? o.id : undefined,
+      userId:
+        typeof o.userId === 'string'
+          ? o.userId
+          : typeof o.user_id === 'string'
+            ? o.user_id
+            : null,
+      displayName:
+        typeof o.displayName === 'string'
+          ? o.displayName
+          : typeof o.display_name === 'string'
+            ? o.display_name
+            : null,
+      avatarUrl:
+        typeof o.avatarUrl === 'string'
+          ? o.avatarUrl
+          : typeof o.avatar_url === 'string'
+            ? o.avatar_url
+            : null,
+      body,
+      createdAt:
+        typeof o.createdAt === 'string'
+          ? o.createdAt
+          : typeof o.created_at === 'string'
+            ? o.created_at
+            : null,
+      source: typeof o.source === 'string' ? o.source : null,
+    })
+  }
+  return out.length ? out : undefined
+}
+
+function normalizeSubmissionGradeApi(raw: SubmissionGradeApi): SubmissionGradeApi {
+  const comments = parseGradeComments((raw as { comments?: unknown }).comments)
+  return comments ? { ...raw, comments } : raw
 }
 
 export type GraderAgentConfigApi = {
@@ -5595,7 +5659,7 @@ export async function fetchSubmissionGrade(
   )
   const raw = await parseJson(res)
   if (!res.ok) throw new Error(readApiErrorMessage(raw))
-  return raw as SubmissionGradeApi
+  return normalizeSubmissionGradeApi(raw as SubmissionGradeApi)
 }
 
 export async function putSubmissionGrade(
@@ -5620,7 +5684,7 @@ export async function putSubmissionGrade(
   )
   const raw = await parseJson(res)
   if (!res.ok) throw new Error(readApiErrorMessage(raw))
-  return raw as SubmissionGradeApi
+  return normalizeSubmissionGradeApi(raw as SubmissionGradeApi)
 }
 
 export async function fetchAssignmentStudentGrade(
@@ -5633,7 +5697,7 @@ export async function fetchAssignmentStudentGrade(
   )
   const raw = await parseJson(res)
   if (!res.ok) throw new Error(readApiErrorMessage(raw))
-  return raw as SubmissionGradeApi
+  return normalizeSubmissionGradeApi(raw as SubmissionGradeApi)
 }
 
 export async function putAssignmentStudentGrade(
@@ -5657,7 +5721,7 @@ export async function putAssignmentStudentGrade(
   )
   const raw = await parseJson(res)
   if (!res.ok) throw new Error(readApiErrorMessage(raw))
-  return raw as SubmissionGradeApi
+  return normalizeSubmissionGradeApi(raw as SubmissionGradeApi)
 }
 
 export type CourseCanvasLinkApi = {

--- a/clients/web/src/lib/rbac-api.ts
+++ b/clients/web/src/lib/rbac-api.ts
@@ -16,6 +16,14 @@ export const PERM_COURSE_ROLE_STUDENT = 'course:*:enrollments:role-student' as c
 /** Create new courses (Courses page + POST /api/v1/courses). */
 export const PERM_COURSE_CREATE = 'global:app:course:create' as const
 
+/** True when the signed-in user may create or import courses on the platform. */
+export function canCreateCourses(
+  allows: (permission: string) => boolean,
+  loading = false,
+): boolean {
+  return !loading && allows(PERM_COURSE_CREATE)
+}
+
 /** Manage org hierarchy (schools / departments) within the user's org, or all orgs as platform admin. */
 export const PERM_TENANT_ORG_UNITS_ADMIN = 'tenant:org:units:admin' as const
 

--- a/clients/web/src/pages/lms/__tests__/courses.test.tsx
+++ b/clients/web/src/pages/lms/__tests__/courses.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Courses from '../courses'
+import { PERM_COURSE_CREATE } from '../../../lib/rbac-api'
+
+const usePermissions = vi.fn()
+const authorizedFetch = vi.fn()
+
+vi.mock('../../../context/use-permissions', () => ({
+  usePermissions: () => usePermissions(),
+}))
+
+vi.mock('../../../context/use-inbox-unread', () => ({
+  useCoursesRevision: () => 0,
+}))
+
+vi.mock('../../../lib/api', () => ({
+  authorizedFetch: (...args: unknown[]) => authorizedFetch(...args),
+}))
+
+vi.mock('../../../lib/auth', () => ({
+  getAccessToken: () => 'token',
+}))
+
+vi.mock('../../../lib/jwt-payload', () => ({
+  decodeJwtPayload: () => ({ org_id: '' }),
+}))
+
+describe('Courses page', () => {
+  beforeEach(() => {
+    authorizedFetch.mockImplementation(async (path: unknown) => {
+      if (typeof path === 'string' && path.startsWith('/api/v1/courses')) {
+        return {
+          ok: true,
+          json: async () => ({ courses: [] }),
+        }
+      }
+      return { ok: true, json: async () => ({}) }
+    })
+  })
+
+  it('shows create and import actions for users with course create permission', async () => {
+    usePermissions.mockReturnValue({
+      allows: (p: string) => p === PERM_COURSE_CREATE,
+      loading: false,
+    })
+
+    render(
+      <MemoryRouter>
+        <Courses />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByRole('link', { name: /new course/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^import$/i })).toBeInTheDocument()
+  })
+
+  it('hides create and import actions for users without course create permission', async () => {
+    usePermissions.mockReturnValue({
+      allows: () => false,
+      loading: false,
+    })
+
+    render(
+      <MemoryRouter>
+        <Courses />
+      </MemoryRouter>,
+    )
+
+    await screen.findByText(/no courses yet/i)
+    expect(screen.queryByRole('link', { name: /new course/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /^import$/i })).toBeNull()
+  })
+})

--- a/clients/web/src/pages/lms/courses.tsx
+++ b/clients/web/src/pages/lms/courses.tsx
@@ -40,7 +40,6 @@ import type { CourseCatalogView, KanbanColumnId } from '../../lib/course-catalog
 import { EmptyState } from '../../components/ui/empty-state'
 import { CoursesCatalogSkeleton } from '../../components/ui/lms-content-skeletons'
 import { LmsPage } from './lms-page'
-import { RequirePermission } from '../../components/require-permission'
 import { usePermissions } from '../../context/use-permissions'
 import { useCoursesRevision } from '../../context/use-inbox-unread'
 import { authorizedFetch } from '../../lib/api'
@@ -51,7 +50,7 @@ import { readApiErrorMessage } from '../../lib/errors'
 import { heroImageObjectStyle } from '../../lib/hero-image-position'
 import { formatRelativeCompact } from '../../lib/format-datetime'
 import { CourseCatalogStatusPill } from '../../components/ui/status-vocabulary'
-import { PERM_COURSE_CREATE } from '../../lib/rbac-api'
+import { canCreateCourses } from '../../lib/rbac-api'
 import { CourseHeroImage } from '../../components/course-hero-image'
 import { CourseEnrollmentInvitationActions } from '../../components/enrollment/course-enrollment-invitation-actions'
 
@@ -742,6 +741,7 @@ function SortableCourseTableRow({
 
 export default function Courses() {
   const { allows, loading: permLoading } = usePermissions()
+  const showCourseCreateActions = canCreateCourses(allows, permLoading)
   const coursesRevision = useCoursesRevision()
   const [courses, setCourses] = useState<CoursePublic[] | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -1090,11 +1090,11 @@ export default function Courses() {
       description="Browse and open your enrolled courses. Drag to reorder your catalog."
       actions={
         <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
-          <RequirePermission permission={PERM_COURSE_CREATE} fallback={null}>
+          {showCourseCreateActions ? (
             <CourseCatalogImportMenu onImportCanvas={() => setCanvasImportOpen(true)} />
-          </RequirePermission>
+          ) : null}
           <CourseCatalogViewMenu value={catalogView} onChange={handleCatalogViewChange} />
-          <RequirePermission permission={PERM_COURSE_CREATE} fallback={null}>
+          {showCourseCreateActions ? (
             <Link
               to="/courses/create"
               className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
@@ -1102,7 +1102,7 @@ export default function Courses() {
               <Plus className="h-4 w-4" aria-hidden />
               New course
             </Link>
-          </RequirePermission>
+          ) : null}
         </div>
       }
     >
@@ -1174,7 +1174,7 @@ export default function Courses() {
 
       {courses && courses.length === 0 && !error && (
         <div className="mt-8">
-          {!permLoading && allows(PERM_COURSE_CREATE) ? (
+          {showCourseCreateActions ? (
             <EmptyState
               icon={CreateCourseIcon}
               title="Create your first course"
@@ -1245,10 +1245,12 @@ export default function Courses() {
           </SortableContext>
         </DndContext>
       )}
-      <CanvasImportCoursesModal
-        open={canvasImportOpen}
-        onClose={() => setCanvasImportOpen(false)}
-      />
+      {showCourseCreateActions ? (
+        <CanvasImportCoursesModal
+          open={canvasImportOpen}
+          onClose={() => setCanvasImportOpen(false)}
+        />
+      ) : null}
     </LmsPage>
   )
 }

--- a/clients/web/src/pages/lms/dashboard.tsx
+++ b/clients/web/src/pages/lms/dashboard.tsx
@@ -47,6 +47,7 @@ import { DeadlineDateTime } from '../../components/timezone/deadline-datetime'
 import { useInboxUnreadCount, useCoursesRevision } from '../../context/use-inbox-unread'
 import { useCourseFeedUnread } from '../../context/use-course-feed-unread'
 import { usePermissions } from '../../context/use-permissions'
+import { canCreateCourses } from '../../lib/rbac-api'
 import {
   computeCourseFinalPercent,
   formatFinalPercent,
@@ -279,6 +280,7 @@ export default function Dashboard() {
     }
   }, [navigate])
   const { allows, loading: permLoading } = usePermissions()
+  const showCourseCreateActions = canCreateCourses(allows, permLoading)
   const inboxUnread = useInboxUnreadCount()
   const coursesRevision = useCoursesRevision()
   const { totalFeedUnread } = useCourseFeedUnread()
@@ -655,7 +657,9 @@ export default function Dashboard() {
         <div className="mt-10 rounded-2xl border border-slate-200 bg-slate-50/80 px-6 py-8 text-center dark:border-neutral-700 dark:bg-neutral-900/50">
           <p className="text-sm font-medium text-slate-800 dark:text-neutral-100">No courses yet</p>
           <p className="mt-2 text-xs text-slate-500 dark:text-neutral-400">
-            Join a course from an invite link, or create one if you teach.
+            {showCourseCreateActions
+              ? 'Join a course from an invite link, or create one if you teach.'
+              : 'Join a course from an invite link. When an instructor adds you, courses will appear here.'}
           </p>
           <div className="mt-5 flex flex-wrap justify-center gap-3">
             <Link

--- a/e2e/tests/courses.spec.ts
+++ b/e2e/tests/courses.spec.ts
@@ -43,8 +43,9 @@ test.describe('Courses list', () => {
         res.ok(),
       { timeout: 15_000 },
     )
-    // Students cannot create courses — no link to the create flow.
+    // Students cannot create or import courses — no link to the create flow or import menu.
     await expect(page.locator('a[href="/courses/create"]')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /^import$/i })).toHaveCount(0)
   })
 
   test('course card shows course title', async ({ coursePage: page, seededCourse }) => {

--- a/server/go.mod
+++ b/server/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/conductor-oss/markitdown v0.0.1
 	github.com/coreos/go-oidc/v3 v3.12.0
 	github.com/crewjam/saml v0.4.14
-	github.com/go-chi/chi/v5 v5.2.2
+	github.com/go-chi/chi/v5 v5.2.4
 	github.com/go-webauthn/webauthn v0.17.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -51,8 +51,8 @@ github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+r
 github.com/fxamacker/cbor/v2 v2.9.1/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
-github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
-github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-chi/chi/v5 v5.2.4 h1:WtFKPHwlywe8Srng8j2BhOD9312j9cGUxG1SP4V2cR4=
+github.com/go-chi/chi/v5 v5.2.4/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

--- a/server/internal/httpserver/assignment_submission_grade_http.go
+++ b/server/internal/httpserver/assignment_submission_grade_http.go
@@ -1,6 +1,7 @@
 package httpserver
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/lextures/lextures/server/internal/apierr"
 	"github.com/lextures/lextures/server/internal/models/assignmentrubric"
+	"github.com/lextures/lextures/server/internal/models/gradecomment"
 	"github.com/lextures/lextures/server/internal/repos/coursegrades"
 	"github.com/lextures/lextures/server/internal/repos/coursemoduleassignments"
 	"github.com/lextures/lextures/server/internal/repos/moduleassignmentsubmissions"
@@ -45,6 +47,10 @@ func submissionGradeCellToJSON(
 		if cell.PointsEarned != nil {
 			out["pointsEarned"] = *cell.PointsEarned
 		}
+		comments := gradecomment.ResolveList(cell.InstructorCommentsJSON, cell.InstructorComment)
+		if len(comments) > 0 {
+			out["comments"] = gradecomment.CommentsToJSON(comments)
+		}
 		if cell.InstructorComment != nil {
 			out["instructorComment"] = *cell.InstructorComment
 		}
@@ -68,6 +74,7 @@ func (d Deps) writeSubmissionGrade(
 	studentUserID uuid.UUID,
 	submissionID *uuid.UUID,
 	assignRow *coursemoduleassignments.CourseItemAssignmentRow,
+	viewer uuid.UUID,
 	b submissionGradeWriteBody,
 ) bool {
 	if b.ClearGrade {
@@ -78,7 +85,17 @@ func (d Deps) writeSubmissionGrade(
 		w.WriteHeader(http.StatusNoContent)
 		return true
 	}
+	existingCell, err := coursegrades.GetCell(r.Context(), d.Pool, cid, studentUserID, itemID)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load grade.")
+		return false
+	}
+	existingComments := gradecomment.ResolveList(nil, nil)
+	if existingCell != nil {
+		existingComments = gradecomment.ResolveList(existingCell.InstructorCommentsJSON, existingCell.InstructorComment)
+	}
 	var comment *string
+	var commentsJSON []byte
 	if b.InstructorComment != nil {
 		t := strings.TrimSpace(*b.InstructorComment)
 		if len(t) > maxInstructorCommentLen {
@@ -86,8 +103,26 @@ func (d Deps) writeSubmissionGrade(
 			return false
 		}
 		if t != "" {
-			comment = &t
+			authorName, authorAvatar := d.gradeCommentAuthorProfile(r.Context(), viewer)
+			userID := viewer.String()
+			nextComments, raw, flat, aerr := gradecomment.Append(existingComments, gradecomment.Comment{
+				UserID:      &userID,
+				DisplayName: authorName,
+				AvatarURL:   authorAvatar,
+				Body:        t,
+				Source:      "lextures",
+			})
+			if aerr != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid comment.")
+				return false
+			}
+			existingComments = nextComments
+			commentsJSON = raw
+			comment = flat
 		}
+	} else if existingCell != nil {
+		commentsJSON = existingCell.InstructorCommentsJSON
+		comment = existingCell.InstructorComment
 	}
 	rubricDef, _ := parseAssignmentRubricJSON(assignRow.RubricJSON)
 	var rubricJSON []byte
@@ -114,6 +149,23 @@ func (d Deps) writeSubmissionGrade(
 	} else if b.PointsEarned != nil {
 		points = *b.PointsEarned
 		hasPoints = true
+	} else if existingCell != nil && b.InstructorComment != nil && strings.TrimSpace(*b.InstructorComment) != "" {
+		if len(existingCell.RubricScoresJSON) > 0 {
+			rubricJSON = existingCell.RubricScoresJSON
+			hasPoints = true
+			if rubricDef != nil {
+				if scores, perr := coursegrades.ParseRubricScoresMap(rubricJSON); perr == nil && len(scores) > 0 {
+					uuidScores := parseUUIDScoreMap(scores)
+					if total, verr := assignmentrubric.ValidateRubricScoresForGrade(rubricDef, uuidScores); verr == nil {
+						points = total
+					}
+				}
+			}
+		}
+		if !hasPoints && existingCell.PointsEarned != nil {
+			points = *existingCell.PointsEarned
+			hasPoints = true
+		}
 	}
 	if !hasPoints {
 		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Provide pointsEarned or rubricScores.")
@@ -133,7 +185,7 @@ func (d Deps) writeSubmissionGrade(
 	}
 	if err := coursegrades.UpsertCellWithFlags(
 		r.Context(), d.Pool, cid, studentUserID, itemID,
-		points, rubricJSON, comment, posting, gradedByAI,
+		points, rubricJSON, comment, commentsJSON, posting, gradedByAI,
 	); err != nil {
 		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save grade.")
 		return false
@@ -144,12 +196,52 @@ func (d Deps) writeSubmissionGrade(
 		"posted":        posting == "automatic",
 		"gradedByAi":    gradedByAI,
 	}
+	if len(existingComments) > 0 {
+		out["comments"] = gradecomment.CommentsToJSON(existingComments)
+	}
+	if comment != nil {
+		out["instructorComment"] = *comment
+	}
+	if scores, perr := coursegrades.ParseRubricScoresMap(rubricJSON); perr == nil && len(scores) > 0 {
+		out["rubricScores"] = scores
+	}
 	if submissionID != nil {
 		out["submissionId"] = submissionID.String()
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	_ = json.NewEncoder(w).Encode(out)
 	return true
+}
+
+func (d Deps) gradeCommentAuthorProfile(ctx context.Context, userID uuid.UUID) (string, *string) {
+	if d.Pool == nil {
+		return "Staff", nil
+	}
+	var displayName, email, avatarURL *string
+	err := d.Pool.QueryRow(ctx, `
+SELECT display_name, email, avatar_url
+FROM "user".users
+WHERE id = $1
+`, userID).Scan(&displayName, &email, &avatarURL)
+	if err != nil {
+		return "Staff", nil
+	}
+	name := ""
+	if displayName != nil {
+		name = strings.TrimSpace(*displayName)
+	}
+	if name == "" && email != nil {
+		name = strings.TrimSpace(*email)
+	}
+	if name == "" {
+		name = "Staff"
+	}
+	if avatarURL != nil {
+		if u := strings.TrimSpace(*avatarURL); u != "" {
+			return name, &u
+		}
+	}
+	return name, nil
 }
 
 func (d Deps) handleGetSubmissionGrade() http.HandlerFunc {
@@ -268,7 +360,7 @@ func (d Deps) handlePutSubmissionGrade() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
 			return
 		}
-		_ = d.writeSubmissionGrade(w, r, *cid, itemID, subRow.SubmittedBy, &submissionID, assignRow, b)
+		_ = d.writeSubmissionGrade(w, r, *cid, itemID, subRow.SubmittedBy, &submissionID, assignRow, viewer, b)
 	}
 }
 
@@ -310,7 +402,7 @@ func (d Deps) handlePutAssignmentStudentGrade() http.HandlerFunc {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
 			return
 		}
-		_ = d.writeSubmissionGrade(w, r, *cid, itemID, studentUserID, nil, assignRow, b)
+		_ = d.writeSubmissionGrade(w, r, *cid, itemID, studentUserID, nil, assignRow, viewer, b)
 	}
 }
 

--- a/server/internal/httpserver/canvas_assignment_submissions_import.go
+++ b/server/internal/httpserver/canvas_assignment_submissions_import.go
@@ -19,6 +19,9 @@ import (
 	"github.com/lextures/lextures/server/internal/service/filestorage"
 )
 
+// Matches course.course_files.byte_size CHECK (migration 052).
+const canvasMaxImportedSubmissionFileBytes = 20 << 20
+
 // canvasAssignmentSubmissionImportDeps carries blob + DB context for importing submission bodies/attachments.
 type canvasAssignmentSubmissionImportDeps struct {
 	CourseCode     string
@@ -150,9 +153,12 @@ func canvasDownloadCanvasURL(
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return nil, "", fmt.Errorf("download status %d", resp.StatusCode)
 	}
-	data, err := io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+	data, err := io.ReadAll(io.LimitReader(resp.Body, canvasMaxImportedSubmissionFileBytes+1))
 	if err != nil {
 		return nil, "", err
+	}
+	if len(data) > canvasMaxImportedSubmissionFileBytes {
+		return nil, "", fmt.Errorf("attachment exceeds %d byte limit", canvasMaxImportedSubmissionFileBytes)
 	}
 	ct := strings.TrimSpace(resp.Header.Get("Content-Type"))
 	if ct == "" {
@@ -172,7 +178,7 @@ func canvasStoreImportedSubmissionBlob(
 	filename, mimeType string,
 	data []byte,
 ) (*uuid.UUID, error) {
-	if len(data) == 0 {
+	if len(data) == 0 || len(data) > canvasMaxImportedSubmissionFileBytes {
 		return nil, nil
 	}
 	ext := filepath.Ext(filename)
@@ -293,11 +299,11 @@ func canvasImportOneAssignmentSubmission(
 	var attachmentFileID *uuid.UUID
 
 	if prefetched != nil && len(prefetched.data) > 0 {
-		id, storeErr := canvasStoreImportedSubmissionBlob(ctx, tx, deps, courseID, prefetched.filename, prefetched.mimeType, prefetched.data)
-		if storeErr != nil {
+		if id, storeErr := canvasStoreImportedSubmissionBlob(ctx, tx, deps, courseID, prefetched.filename, prefetched.mimeType, prefetched.data); storeErr != nil {
 			return storeErr
+		} else if id != nil {
+			attachmentFileID = id
 		}
-		attachmentFileID = id
 	} else if att := canvasFirstSubmissionAttachment(sub); att != nil {
 		downloadURL := strAt(att, "url", "")
 		filename := strAt(att, "filename", strAt(att, "display_name", "submission"))
@@ -308,11 +314,11 @@ func canvasImportOneAssignmentSubmission(
 				if mimeType == "" || mimeType == "application/octet-stream" {
 					mimeType = ct
 				}
-				id, storeErr := canvasStoreImportedSubmissionBlob(ctx, tx, deps, courseID, filename, mimeType, data)
-				if storeErr != nil {
+				if id, storeErr := canvasStoreImportedSubmissionBlob(ctx, tx, deps, courseID, filename, mimeType, data); storeErr != nil {
 					return storeErr
+				} else if id != nil {
+					attachmentFileID = id
 				}
-				attachmentFileID = id
 			}
 		}
 	}

--- a/server/internal/httpserver/canvas_enrollment_import.go
+++ b/server/internal/httpserver/canvas_enrollment_import.go
@@ -21,13 +21,68 @@ import (
 	"github.com/lextures/lextures/server/internal/service/authservice"
 )
 
-const canvasAvatarMaxBytes = 512 << 10
+const (
+	canvasAvatarMaxBytes              = 512 << 10
+	canvasImportProvisioningEmailDomain = "canvas-import.invalid"
+)
 
 type canvasEnrollmentImportStats struct {
 	Enrolled        int
 	AccountsCreated int
 	SkippedNoEmail  int
 	AvatarsImported int
+}
+
+func canvasCanvasUserIDFromEnrollment(enrollment, canvasUser map[string]any) int64 {
+	if uid := int64At(canvasUser, "id"); uid > 0 {
+		return uid
+	}
+	return int64At(enrollment, "user_id")
+}
+
+func canvasSanitizeEmailLocal(raw string) string {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '.', r == '_', r == '-', r == '+':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out := strings.Trim(b.String(), ".-_")
+	if len(out) > 48 {
+		out = out[:48]
+	}
+	return out
+}
+
+// canvasResolveProvisioningEmail picks a stable Lextures login for a Canvas roster member.
+// Canvas often omits email on enrollment payloads; login_id, sis_user_id, and canvas user id
+// are used as deterministic fallbacks so accounts and enrollments can still be created.
+func canvasResolveProvisioningEmail(canvasUID int64, canvasUser map[string]any, rosterEmail string) string {
+	if rosterEmail = strings.TrimSpace(rosterEmail); strings.Contains(rosterEmail, "@") {
+		return user.NormalizeEmail(rosterEmail)
+	}
+	if em := normalizedLexturesEmailGuessFromCanvasUserMap(canvasUser); em != "" {
+		return em
+	}
+	if canvasUID <= 0 {
+		return ""
+	}
+	if lid := canvasSanitizeEmailLocal(strAt(canvasUser, "login_id", "")); lid != "" {
+		return fmt.Sprintf("canvas+%s-%d@%s", lid, canvasUID, canvasImportProvisioningEmailDomain)
+	}
+	if sis := canvasSanitizeEmailLocal(strAt(canvasUser, "sis_user_id", "")); sis != "" {
+		return fmt.Sprintf("canvas+sis-%s-%d@%s", sis, canvasUID, canvasImportProvisioningEmailDomain)
+	}
+	return fmt.Sprintf("canvas+%d@%s", canvasUID, canvasImportProvisioningEmailDomain)
 }
 
 func canvasUserDisplayName(u map[string]any, email string) string {
@@ -48,12 +103,119 @@ func canvasUserDisplayName(u map[string]any, email string) string {
 
 func canvasEnrollmentListQuery() url.Values {
 	q := url.Values{}
-	q.Add("state[]", "active")
-	q.Add("state[]", "invited")
-	q.Add("state[]", "creation_pending")
+	// Include concluded/inactive enrollments — common when importing completed Canvas courses.
+	for _, state := range []string{"active", "invited", "creation_pending", "completed", "inactive"} {
+		q.Add("state[]", state)
+	}
 	q.Add("include[]", "user")
 	q.Add("include[]", "avatar_url")
 	return q
+}
+
+func canvasEnrollmentImportableState(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "active", "invited", "creation_pending", "completed", "inactive", "":
+		return true
+	default:
+		return false
+	}
+}
+
+func canvasEnrollmentTypeFromRow(row map[string]any) string {
+	if row == nil {
+		return ""
+	}
+	if typ := strings.TrimSpace(strAt(row, "type", "")); typ != "" {
+		return typ
+	}
+	return strings.TrimSpace(strAt(row, "role", ""))
+}
+
+func canvasEnrollmentRowWithUser(row, canvasUser map[string]any, canvasUID int64) map[string]any {
+	out := make(map[string]any, len(row)+2)
+	for k, v := range row {
+		out[k] = v
+	}
+	if canvasUID > 0 {
+		out["user_id"] = canvasUID
+	}
+	if canvasUser != nil {
+		out["user"] = canvasUser
+	}
+	return out
+}
+
+// canvasEnrollmentRowsFromCourseUsers builds enrollment-shaped rows from the course roster.
+// Some Canvas tokens can list course users but not the full enrollments index.
+func canvasEnrollmentRowsFromCourseUsers(users []map[string]any) []map[string]any {
+	out := make([]map[string]any, 0, len(users))
+	for _, u := range users {
+		canvasUID := int64At(u, "id")
+		if canvasUID <= 0 {
+			continue
+		}
+		enrollments := arrAt(u, "enrollments")
+		if len(enrollments) == 0 {
+			out = append(out, canvasEnrollmentRowWithUser(map[string]any{
+				"type":             "StudentEnrollment",
+				"enrollment_state": "active",
+			}, u, canvasUID))
+			continue
+		}
+		for _, e := range enrollments {
+			state := strAt(e, "enrollment_state", strAt(e, "state", "active"))
+			if !canvasEnrollmentImportableState(state) {
+				continue
+			}
+			row := canvasEnrollmentRowWithUser(e, u, canvasUID)
+			if canvasEnrollmentTypeFromRow(row) == "" {
+				row["type"] = "StudentEnrollment"
+			}
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func canvasFilterImportableEnrollmentRows(rows []map[string]any) []map[string]any {
+	if len(rows) == 0 {
+		return rows
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		state := strAt(row, "enrollment_state", strAt(row, "state", "active"))
+		if !canvasEnrollmentImportableState(state) {
+			continue
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+// canvasFetchEnrollmentRowsForImport loads Canvas enrollments for import, falling back to the
+// course users roster when the enrollments index is empty (concluded courses, limited tokens).
+func canvasFetchEnrollmentRowsForImport(
+	ctx context.Context,
+	client *http.Client,
+	canvasBase, accessToken string,
+	canvasCourseID int64,
+) ([]map[string]any, error) {
+	rows, err := canvasGetArrayPaginated(ctx, client, canvasBase, accessToken,
+		fmt.Sprintf("courses/%d/enrollments", canvasCourseID), canvasEnrollmentListQuery())
+	if err != nil {
+		return nil, err
+	}
+	rows = canvasFilterImportableEnrollmentRows(rows)
+	if len(rows) > 0 {
+		return rows, nil
+	}
+	users, err := canvasGetArrayPaginated(ctx, client, canvasBase, accessToken,
+		fmt.Sprintf("courses/%d/users", canvasCourseID),
+		url.Values{"include[]": []string{"email", "avatar_url", "login_id", "enrollments"}})
+	if err != nil {
+		return nil, err
+	}
+	return canvasEnrollmentRowsFromCourseUsers(users), nil
 }
 
 func canvasRosterEmailsByCanvasUserID(
@@ -64,7 +226,7 @@ func canvasRosterEmailsByCanvasUserID(
 ) (map[int64]string, error) {
 	rows, err := canvasGetArrayPaginated(ctx, client, canvasBase, accessToken,
 		fmt.Sprintf("courses/%d/users", canvasCourseID),
-		url.Values{"include[]": []string{"email", "avatar_url"}})
+		url.Values{"include[]": []string{"email", "avatar_url", "login_id"}})
 	if err != nil {
 		return nil, err
 	}
@@ -204,11 +366,12 @@ func canvasResolveLexturesUserForEnrollment(
 	pool *pgxpool.Pool,
 	tx pgx.Tx,
 	orgID uuid.UUID,
-	email string,
+	canvasUID int64,
+	rosterEmail string,
 	canvasUser map[string]any,
 	stats *canvasEnrollmentImportStats,
 ) (uuid.UUID, error) {
-	em := user.NormalizeEmail(email)
+	em := canvasResolveProvisioningEmail(canvasUID, canvasUser, rosterEmail)
 	if !strings.Contains(em, "@") {
 		if stats != nil {
 			stats.SkippedNoEmail++
@@ -267,18 +430,14 @@ func canvasFillGradeUserMap(
 	}
 	for _, e := range enrollmentRows {
 		u := objAt(e, "user")
-		canvasUID := int64At(u, "id")
+		canvasUID := canvasCanvasUserIDFromEnrollment(e, u)
 		if canvasUID <= 0 {
 			continue
 		}
 		if _, ok := out[canvasUID]; ok {
 			continue
 		}
-		email := rosterEmailByCanvasUID[canvasUID]
-		if email == "" {
-			email = normalizedLexturesEmailGuessFromCanvasUserMap(u)
-		}
-		userID, err := canvasResolveLexturesUserForEnrollment(ctx, pool, tx, orgID, email, u, stats)
+		userID, err := canvasResolveLexturesUserForEnrollment(ctx, pool, tx, orgID, canvasUID, rosterEmailByCanvasUID[canvasUID], u, stats)
 		if err != nil {
 			return err
 		}
@@ -302,8 +461,8 @@ func canvasApplyEnrollment(
 	stats *canvasEnrollmentImportStats,
 ) error {
 	tag, err := tx.Exec(ctx, `
-		INSERT INTO course.course_enrollments (course_id, user_id, role)
-		SELECT $1, $2, $3
+		INSERT INTO course.course_enrollments (course_id, user_id, role, active)
+		SELECT $1, $2, $3, true
 		WHERE NOT EXISTS (
 			SELECT 1 FROM course.course_enrollments
 			WHERE course_id = $1 AND user_id = $2 AND role = 'owner'

--- a/server/internal/httpserver/canvas_enrollment_import_test.go
+++ b/server/internal/httpserver/canvas_enrollment_import_test.go
@@ -46,6 +46,118 @@ func TestCanvasIsDefaultAvatarURL_detectsCanvasPlaceholder(t *testing.T) {
 	}
 }
 
+func TestCanvasCanvasUserIDFromEnrollment_prefersEmbeddedUser(t *testing.T) {
+	enrollment := map[string]any{"user_id": float64(99)}
+	user := map[string]any{"id": float64(42)}
+	if got := canvasCanvasUserIDFromEnrollment(enrollment, user); got != 42 {
+		t.Fatalf("canvasCanvasUserIDFromEnrollment() = %d, want 42", got)
+	}
+}
+
+func TestCanvasCanvasUserIDFromEnrollment_fallsBackToEnrollmentUserID(t *testing.T) {
+	enrollment := map[string]any{"user_id": float64(77)}
+	if got := canvasCanvasUserIDFromEnrollment(enrollment, nil); got != 77 {
+		t.Fatalf("canvasCanvasUserIDFromEnrollment() = %d, want 77", got)
+	}
+}
+
+func TestCanvasResolveProvisioningEmail_usesRosterEmail(t *testing.T) {
+	got := canvasResolveProvisioningEmail(42, map[string]any{"login_id": "jdoe"}, "Jane@School.edu")
+	if got != "jane@school.edu" {
+		t.Fatalf("canvasResolveProvisioningEmail() = %q, want normalized roster email", got)
+	}
+}
+
+func TestCanvasResolveProvisioningEmail_usesLoginIDWhenEmailMissing(t *testing.T) {
+	got := canvasResolveProvisioningEmail(42, map[string]any{"login_id": "jdoe"}, "")
+	want := "canvas+jdoe-42@canvas-import.invalid"
+	if got != want {
+		t.Fatalf("canvasResolveProvisioningEmail() = %q, want %q", got, want)
+	}
+}
+
+func TestCanvasResolveProvisioningEmail_usesCanvasUIDFallback(t *testing.T) {
+	got := canvasResolveProvisioningEmail(12345, nil, "")
+	if got != "canvas+12345@canvas-import.invalid" {
+		t.Fatalf("canvasResolveProvisioningEmail() = %q, want canvas uid fallback", got)
+	}
+}
+
+func TestCanvasSanitizeEmailLocal_stripsUnsafeCharacters(t *testing.T) {
+	if got := canvasSanitizeEmailLocal("Jane O'Neil"); got != "jane-o-neil" {
+		t.Fatalf("canvasSanitizeEmailLocal() = %q, want jane-o-neil", got)
+	}
+}
+
+func TestCanvasEnrollmentListQuery_includesConcludedStates(t *testing.T) {
+	q := canvasEnrollmentListQuery()
+	states := q["state[]"]
+	for _, want := range []string{"active", "invited", "creation_pending", "completed", "inactive"} {
+		found := false
+		for _, s := range states {
+			if s == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("state[] = %v, want to include %q", states, want)
+		}
+	}
+}
+
+func TestCanvasEnrollmentRowsFromCourseUsers_synthesizesStudentWhenNoEnrollments(t *testing.T) {
+	rows := canvasEnrollmentRowsFromCourseUsers([]map[string]any{{
+		"id": float64(42),
+		"name": "Pat Student",
+		"login_id": "pat",
+	}})
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	if got := canvasCanvasUserIDFromEnrollment(rows[0], objAt(rows[0], "user")); got != 42 {
+		t.Fatalf("canvas user id = %d, want 42", got)
+	}
+	if got := canvasEnrollmentTypeFromRow(rows[0]); got != "StudentEnrollment" {
+		t.Fatalf("type = %q, want StudentEnrollment", got)
+	}
+}
+
+func TestCanvasEnrollmentRowsFromCourseUsers_usesNestedEnrollments(t *testing.T) {
+	rows := canvasEnrollmentRowsFromCourseUsers([]map[string]any{{
+		"id": float64(7),
+		"name": "Alex Teacher",
+		"enrollments": []any{
+			map[string]any{
+				"type":             "TeacherEnrollment",
+				"enrollment_state": "completed",
+			},
+		},
+	}})
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	if got := canvasEnrollmentTypeFromRow(rows[0]); got != "TeacherEnrollment" {
+		t.Fatalf("type = %q, want TeacherEnrollment", got)
+	}
+}
+
+func TestCanvasFilterImportableEnrollmentRows_skipsDeleted(t *testing.T) {
+	rows := canvasFilterImportableEnrollmentRows([]map[string]any{
+		{"enrollment_state": "active"},
+		{"enrollment_state": "deleted"},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1 active enrollment", len(rows))
+	}
+}
+
+func TestCanvasEnrollmentTypeFromRow_fallsBackToRole(t *testing.T) {
+	if got := canvasEnrollmentTypeFromRow(map[string]any{"role": "TaEnrollment"}); got != "TaEnrollment" {
+		t.Fatalf("canvasEnrollmentTypeFromRow() = %q, want TaEnrollment", got)
+	}
+}
+
 func TestCanvasEnrollmentListQuery_includesAvatarURL(t *testing.T) {
 	q := canvasEnrollmentListQuery()
 	includes := q["include[]"]

--- a/server/internal/httpserver/canvas_grade_import.go
+++ b/server/internal/httpserver/canvas_grade_import.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"math"
 	"net/http"
 	"net/url"
@@ -247,6 +248,9 @@ func upsertCourseGradeFromCanvas(
 	courseID, studentID, moduleItemID uuid.UUID,
 	pointsEarned float64,
 	excused bool,
+	instructorComment *string,
+	instructorCommentsJSON []byte,
+	rubricJSON []byte,
 ) error {
 	if pointsEarned < 0 {
 		pointsEarned = 0
@@ -254,17 +258,28 @@ func upsertCourseGradeFromCanvas(
 	if pointsEarned > 1e9 {
 		pointsEarned = 1e9
 	}
+	var rubric any
+	if len(rubricJSON) > 0 {
+		rubric = rubricJSON
+	}
+	var comments any
+	if len(instructorCommentsJSON) > 0 {
+		comments = instructorCommentsJSON
+	}
 	_, err := tx.Exec(ctx, `
 INSERT INTO course.course_grades (
-	course_id, student_user_id, module_item_id, points_earned, updated_at, posted_at, excused
-) VALUES ($1, $2, $3, $4, NOW(), NOW(), $5)
+	course_id, student_user_id, module_item_id, points_earned, rubric_scores_json, instructor_comment, instructor_comments_json, updated_at, posted_at, excused
+) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), $8)
 ON CONFLICT (student_user_id, module_item_id) DO UPDATE SET
 	course_id = EXCLUDED.course_id,
 	points_earned = EXCLUDED.points_earned,
+	rubric_scores_json = EXCLUDED.rubric_scores_json,
+	instructor_comment = EXCLUDED.instructor_comment,
+	instructor_comments_json = EXCLUDED.instructor_comments_json,
 	updated_at = NOW(),
-	posted_at = EXCLUDED.posted_at,
+	posted_at = COALESCE(course.course_grades.posted_at, NOW()),
 	excused = EXCLUDED.excused
-`, courseID, studentID, moduleItemID, pointsEarned, excused)
+`, courseID, studentID, moduleItemID, pointsEarned, rubric, instructorComment, comments, excused)
 	return err
 }
 
@@ -317,13 +332,16 @@ func canvasImportAssignmentGrades(
 				continue
 			}
 			if importGrades {
-				exc, score, hasScore := submissionScoreAndExcused(raw)
-				if exc || hasScore {
+				synced, parseErr := canvasGradeFromSubmissionPayload(raw, nil, canvasUserToLocal)
+				if parseErr != nil {
+					return fmt.Errorf("parse grade for assignment canvas id %d: %w", canvasAID, parseErr)
+				}
+				if synced.hasNumericScore || synced.excused || synced.comment != nil || len(synced.rubricJSON) > 0 {
 					pts := 0.0
-					if hasScore {
-						pts = score
+					if synced.hasNumericScore {
+						pts = synced.points
 					}
-					if err := upsertCourseGradeFromCanvas(ctx, tx, courseID, studentID, itemID, pts, exc); err != nil {
+					if err := upsertCourseGradeFromCanvas(ctx, tx, courseID, studentID, itemID, pts, synced.excused, synced.comment, synced.commentsJSON, synced.rubricJSON); err != nil {
 						return fmt.Errorf("save grade for assignment canvas id %d: %w", canvasAID, err)
 					}
 					// #region agent log
@@ -345,7 +363,8 @@ func canvasImportAssignmentGrades(
 				if err := canvasImportOneAssignmentSubmission(
 					ctx, tx, client, accessToken, *submissionDeps, courseID, itemID, studentID, raw, prefetched,
 				); err != nil {
-					return fmt.Errorf("import submission for assignment canvas id %d: %w", canvasAID, err)
+					log.Printf("canvas-import: skip submission for assignment canvas id %d user %s: %v", canvasAID, studentID, err)
+					continue
 				}
 				if canvasAssignmentSubmissionImportable(raw) {
 					submissionRowsUpserted++
@@ -537,7 +556,7 @@ func canvasImportQuizGrades(
 			if hasScore {
 				pts = score
 			}
-			if err := upsertCourseGradeFromCanvas(ctx, tx, courseID, studentID, itemID, pts, exc); err != nil {
+			if err := upsertCourseGradeFromCanvas(ctx, tx, courseID, studentID, itemID, pts, exc, nil, nil, nil); err != nil {
 				return fmt.Errorf("save grade for quiz canvas id %d: %w", canvasQID, err)
 			}
 			// #region agent log

--- a/server/internal/httpserver/canvas_import_ws.go
+++ b/server/internal/httpserver/canvas_import_ws.go
@@ -216,8 +216,7 @@ func (d Deps) runCanvasImport(
 	if needEnrollmentRows {
 		prefetchGroup.Go(func() error {
 			var loadErr error
-			enrollmentRows, loadErr = canvasGetArrayPaginated(prefetchCtx, client, canvasBase, accessToken,
-				fmt.Sprintf("courses/%d/enrollments", canvasCourseID), canvasEnrollmentListQuery())
+			enrollmentRows, loadErr = canvasFetchEnrollmentRowsForImport(prefetchCtx, client, canvasBase, accessToken, canvasCourseID)
 			return loadErr
 		})
 		prefetchGroup.Go(func() error {
@@ -229,7 +228,11 @@ func (d Deps) runCanvasImport(
 	if err := prefetchGroup.Wait(); err != nil {
 		return err
 	}
-	if !progress("Loaded course data from Canvas.") {
+	if needEnrollmentRows {
+		if !progress(fmt.Sprintf("Loaded course data from Canvas (%d enrollment row(s) for import).", len(enrollmentRows))) {
+			return context.Canceled
+		}
+	} else if !progress("Loaded course data from Canvas.") {
 		return context.Canceled
 	}
 
@@ -473,49 +476,60 @@ func (d Deps) runCanvasImport(
 		}
 	}
 
-	needFinalizeTx := include.Enrollments || include.Grades || (include.Assignments && len(canvasAssignToItem) > 0)
-	var tx pgx.Tx
-	if needFinalizeTx {
-		tx, err = d.Pool.Begin(ctx)
-		if err != nil {
-			return errors.New("Failed to start import transaction.")
-		}
-		defer func() { _ = tx.Rollback(ctx) }()
-	}
-
 	if include.Enrollments {
 		if !progress("Applying enrollments from Canvas...") {
 			return context.Canceled
 		}
+		enrollTx, enrollErr := d.Pool.Begin(ctx)
+		if enrollErr != nil {
+			return errors.New("Failed to start import transaction.")
+		}
+		enrollFailed := false
+		defer func() {
+			if enrollFailed {
+				_ = enrollTx.Rollback(ctx)
+			}
+		}()
 		var enrollStats canvasEnrollmentImportStats
 		for _, e := range enrollmentRows {
 			u := objAt(e, "user")
-			canvasUID := int64At(u, "id")
-			email := rosterEmailByCanvasUID[canvasUID]
-			if email == "" {
-				email = normalizedLexturesEmailGuessFromCanvasUserMap(u)
+			canvasUID := canvasCanvasUserIDFromEnrollment(e, u)
+			if canvasUID <= 0 {
+				continue
 			}
-			userID, err := canvasResolveLexturesUserForEnrollment(ctx, d.Pool, tx, orgID, email, u, &enrollStats)
+			userID, err := canvasResolveLexturesUserForEnrollment(ctx, d.Pool, enrollTx, orgID, canvasUID, rosterEmailByCanvasUID[canvasUID], u, &enrollStats)
 			if err != nil {
+				enrollFailed = true
 				return err
 			}
 			if userID == uuid.Nil {
 				continue
 			}
-			if err := canvasImportEnrollmentUserAvatar(ctx, tx, client, accessToken, userID, e, u, &enrollStats); err != nil {
+			if err := canvasImportEnrollmentUserAvatar(ctx, enrollTx, client, accessToken, userID, e, u, &enrollStats); err != nil {
+				enrollFailed = true
 				return err
 			}
-			role := canvasEnrollmentTypeToRole(strAt(e, "type", ""))
+			role := canvasEnrollmentTypeToRole(canvasEnrollmentTypeFromRow(e))
 			if (include.Grades || include.Assignments) && canvasUID > 0 {
 				if canvasUserToLocal == nil {
 					canvasUserToLocal = make(map[int64]uuid.UUID)
 				}
 				canvasUserToLocal[canvasUID] = userID
 			}
-			if err := canvasApplyEnrollment(ctx, tx, courseID, courseCode, userID, role, &enrollStats); err != nil {
+			if err := canvasApplyEnrollment(ctx, enrollTx, courseID, courseCode, userID, role, &enrollStats); err != nil {
+				enrollFailed = true
 				return errors.New("Failed to apply enrollment from Canvas.")
 			}
 		}
+		if !progress("Saving enrollments from Canvas...") {
+			enrollFailed = true
+			return context.Canceled
+		}
+		if err := enrollTx.Commit(ctx); err != nil {
+			enrollFailed = true
+			return errors.New("Something went wrong while saving enrollments.")
+		}
+		d.notifyEnrollmentsForCourse(ctx, courseCode)
 		msg := fmt.Sprintf("Applied %d enrollment(s) from Canvas.", enrollStats.Enrolled)
 		if enrollStats.AccountsCreated > 0 {
 			msg += fmt.Sprintf(" Created %d new Lextures account(s) from Canvas emails.", enrollStats.AccountsCreated)
@@ -529,6 +543,16 @@ func (d Deps) runCanvasImport(
 		if !progress(msg) {
 			return context.Canceled
 		}
+	}
+
+	needGradesTx := include.Grades || (include.Assignments && len(canvasAssignToItem) > 0)
+	var tx pgx.Tx
+	if needGradesTx {
+		tx, err = d.Pool.Begin(ctx)
+		if err != nil {
+			return errors.New("Failed to start import transaction.")
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
 	}
 
 	cfg := d.effectiveConfig()
@@ -582,8 +606,8 @@ func (d Deps) runCanvasImport(
 		}
 	}
 
-	if needFinalizeTx {
-		if !progress("Saving imported content into your course...") {
+	if needGradesTx {
+		if !progress("Saving imported grades and submissions...") {
 			return context.Canceled
 		}
 		if err = tx.Commit(ctx); err != nil {

--- a/server/internal/httpserver/canvas_quiz_submissions_prefetch.go
+++ b/server/internal/httpserver/canvas_quiz_submissions_prefetch.go
@@ -72,6 +72,9 @@ func canvasFetchAssignmentSubmissionsParallel(
 	}
 	assignmentSubsQuery := url.Values{}
 	assignmentSubsQuery.Add("include[]", "submission_history")
+	assignmentSubsQuery.Add("include[]", "submission_comments")
+	assignmentSubsQuery.Add("include[]", "submission_html_comments")
+	assignmentSubsQuery.Add("include[]", "rubric_assessment")
 
 	out := make(map[int64][]map[string]any, len(canvasAssignToItem))
 	var mu sync.Mutex

--- a/server/internal/httpserver/canvas_submission_sync.go
+++ b/server/internal/httpserver/canvas_submission_sync.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lextures/lextures/server/internal/apierr"
 	"github.com/lextures/lextures/server/internal/canvassubmissionsyncqueue"
 	"github.com/lextures/lextures/server/internal/models/assignmentrubric"
+	"github.com/lextures/lextures/server/internal/models/gradecomment"
 	"github.com/lextures/lextures/server/internal/repos/canvasimportjobs"
 	"github.com/lextures/lextures/server/internal/repos/course"
 	"github.com/lextures/lextures/server/internal/repos/coursegrades"
@@ -411,11 +412,9 @@ func resolveLexturesGradeForCanvasPush(
 		if t != "" {
 			out.comment = &t
 		}
-	} else if cell != nil && cell.InstructorComment != nil {
-		t := strings.TrimSpace(*cell.InstructorComment)
-		if t != "" {
-			out.comment = &t
-		}
+	} else if cell != nil {
+		comments := gradecomment.ResolveList(cell.InstructorCommentsJSON, cell.InstructorComment)
+		out.comment = gradecomment.LatestBody(comments)
 	}
 
 	if cell != nil {
@@ -535,6 +534,9 @@ func canvasBuildCanvasGradePushForm(
 			rubricMapped = true
 		}
 		if rubricMapped {
+			if grade.comment != nil {
+				form.Set("comment[text_comment]", *grade.comment)
+			}
 			return form
 		}
 	}
@@ -688,6 +690,7 @@ type canvasSyncedGrade struct {
 	points          float64
 	rubricJSON      []byte
 	comment         *string
+	commentsJSON    []byte
 	excused         bool
 	hasNumericScore bool
 }
@@ -695,6 +698,7 @@ type canvasSyncedGrade struct {
 func canvasGradeFromSubmissionPayload(
 	sub map[string]any,
 	lexturesRubric *assignmentrubric.RubricDefinition,
+	canvasUserToLocal map[int64]uuid.UUID,
 ) (canvasSyncedGrade, error) {
 	var out canvasSyncedGrade
 	if sub == nil {
@@ -731,9 +735,17 @@ func canvasGradeFromSubmissionPayload(
 		}
 	}
 
-	comment := canvasInstructorCommentFromSubmission(sub)
-	if comment != "" {
-		out.comment = &comment
+	comments := canvasSubmissionCommentsFromPayload(sub, canvasUserToLocal)
+	if len(comments) > 0 {
+		raw, err := gradecomment.MarshalList(comments)
+		if err != nil {
+			return out, err
+		}
+		out.commentsJSON = raw
+		flat := gradecomment.Flatten(comments)
+		if flat != "" {
+			out.comment = &flat
+		}
 	}
 	return out, nil
 }
@@ -890,11 +902,67 @@ func canvasRubricCriterionTitles(criteria []map[string]any) map[string]string {
 	return out
 }
 
+func canvasSubmissionCommentAuthorLabel(c map[string]any, studentCanvasUID int64) string {
+	if c == nil {
+		return "Comment"
+	}
+	if name := strings.TrimSpace(strAt(c, "author_name", "")); name != "" {
+		return name
+	}
+	if author := objAt(c, "author"); author != nil {
+		for _, k := range []string{"display_name", "name", "short_name", "sortable_name"} {
+			if n := strings.TrimSpace(strAt(author, k, "")); n != "" {
+				return n
+			}
+		}
+	}
+	authorID := int64At(c, "author_id")
+	if studentCanvasUID > 0 && authorID == studentCanvasUID {
+		return "Student"
+	}
+	if authorID > 0 {
+		return fmt.Sprintf("User %d", authorID)
+	}
+	return "Comment"
+}
+
+func canvasNormalizeCanvasSubmissionCommentText(raw string) string {
+	text := strings.TrimSpace(raw)
+	if text == "" {
+		return ""
+	}
+	if strings.Contains(text, "<") && strings.Contains(text, ">") {
+		if plain := strings.TrimSpace(htmlToPlainText(text)); plain != "" {
+			return plain
+		}
+	}
+	return text
+}
+
+// canvasInstructorCommentFromSubmission builds legacy flat text for tests and callers.
 func canvasInstructorCommentFromSubmission(sub map[string]any) string {
-	studentID := int64At(sub, "user_id")
+	comments := canvasSubmissionCommentsFromPayload(sub, nil)
+	flat := gradecomment.Flatten(comments)
+	if len(flat) > maxInstructorCommentLen {
+		flat = flat[:maxInstructorCommentLen]
+	}
+	return flat
+}
+
+// canvasSubmissionCommentsFromPayload builds structured SpeedGrader comments for import.
+func canvasSubmissionCommentsFromPayload(
+	sub map[string]any,
+	canvasUserToLocal map[int64]uuid.UUID,
+) []gradecomment.Comment {
+	studentCanvasUID := int64At(sub, "user_id")
 	type commentRow struct {
 		created string
+		author  string
 		text    string
+		key     string
+		userID  *string
+		avatar  *string
+		source  string
 	}
 	rows := make([]commentRow, 0)
 	appendCanvasSubmissionComments := func(comments []map[string]any) {
@@ -902,45 +970,81 @@ func canvasInstructorCommentFromSubmission(sub map[string]any) string {
 			if c == nil {
 				continue
 			}
-			text := strings.TrimSpace(strAt(c, "comment", ""))
+			text := canvasNormalizeCanvasSubmissionCommentText(strAt(c, "comment", ""))
 			if text == "" {
 				continue
 			}
-			authorID := int64At(c, "author_id")
-			if studentID > 0 && authorID == studentID {
-				continue
+			author := canvasSubmissionCommentAuthorLabel(c, studentCanvasUID)
+			created := strAt(c, "created_at", "")
+			canvasCommentID := int64At(c, "id")
+			key := fmt.Sprintf("%s|%s|%s|%d", created, author, text, canvasCommentID)
+			var userID *string
+			authorCanvasID := int64At(c, "author_id")
+			if authorCanvasID > 0 && canvasUserToLocal != nil {
+				if localID, ok := canvasUserToLocal[authorCanvasID]; ok {
+					s := localID.String()
+					userID = &s
+				}
+			}
+			var avatar *string
+			if authorObj := objAt(c, "author"); authorObj != nil {
+				if u := strings.TrimSpace(strAt(authorObj, "avatar_url", "")); u != "" {
+					avatar = &u
+				}
 			}
 			rows = append(rows, commentRow{
-				created: strAt(c, "created_at", ""),
+				created: created,
+				author:  author,
 				text:    text,
+				key:     key,
+				userID:  userID,
+				avatar:  avatar,
+				source:  "canvas",
 			})
 		}
 	}
 	appendCanvasSubmissionComments(arrAt(sub, "submission_comments"))
 	appendCanvasSubmissionComments(arrAt(sub, "submission_html_comments"))
+	for _, hist := range arrAt(sub, "submission_history") {
+		appendCanvasSubmissionComments(arrAt(hist, "submission_comments"))
+		appendCanvasSubmissionComments(arrAt(hist, "submission_html_comments"))
+	}
 	for _, text := range canvasRubricCriterionComments(sub) {
-		rows = append(rows, commentRow{text: text})
+		rows = append(rows, commentRow{
+			author: "Rubric",
+			text:   text,
+			key:    "rubric|" + text,
+			source: "rubric",
+		})
 	}
 	if len(rows) == 0 {
-		return ""
+		return nil
 	}
 	sort.SliceStable(rows, func(i, j int) bool {
 		return rows[i].created < rows[j].created
 	})
-	parts := make([]string, 0, len(rows))
+	out := make([]gradecomment.Comment, 0, len(rows))
 	seen := make(map[string]struct{}, len(rows))
 	for _, row := range rows {
-		if _, dup := seen[row.text]; dup {
+		if _, dup := seen[row.key]; dup {
 			continue
 		}
-		seen[row.text] = struct{}{}
-		parts = append(parts, row.text)
+		seen[row.key] = struct{}{}
+		id := row.key
+		if strings.HasPrefix(row.source, "canvas") {
+			id = "canvas-" + row.key
+		}
+		out = append(out, gradecomment.Comment{
+			ID:          id,
+			UserID:      row.userID,
+			DisplayName: row.author,
+			AvatarURL:   row.avatar,
+			Body:        row.text,
+			CreatedAt:   row.created,
+			Source:      row.source,
+		})
 	}
-	joined := strings.Join(parts, "\n\n")
-	if len(joined) > maxInstructorCommentLen {
-		joined = joined[:maxInstructorCommentLen]
-	}
-	return joined
+	return out
 }
 
 func canvasRubricCriterionComments(sub map[string]any) []string {

--- a/server/internal/httpserver/canvas_submission_sync_test.go
+++ b/server/internal/httpserver/canvas_submission_sync_test.go
@@ -24,7 +24,7 @@ func TestCanvasGradeFromSubmissionPayload_pointsOnly(t *testing.T) {
 			},
 		},
 	}
-	got, err := canvasGradeFromSubmissionPayload(sub, nil)
+	got, err := canvasGradeFromSubmissionPayload(sub, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,8 +34,8 @@ func TestCanvasGradeFromSubmissionPayload_pointsOnly(t *testing.T) {
 	if got.points != 8.5 {
 		t.Fatalf("points=%v want 8.5", got.points)
 	}
-	if got.comment == nil || *got.comment != "Nice work." {
-		t.Fatalf("comment=%v", got.comment)
+	if got.comment == nil || *got.comment != "User 1: Nice work.\n\nStudent: Student reply" {
+		t.Fatalf("comment=%q", *got.comment)
 	}
 }
 
@@ -81,7 +81,7 @@ func TestCanvasGradeFromSubmissionPayload_enteredScoreUnposted(t *testing.T) {
 		"entered_score":  9.0,
 		"workflow_state": "graded",
 	}
-	got, err := canvasGradeFromSubmissionPayload(sub, nil)
+	got, err := canvasGradeFromSubmissionPayload(sub, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,15 +163,15 @@ func TestCanvasGradeFromSubmissionPayload_commentOnlyNoScore(t *testing.T) {
 			},
 		},
 	}
-	got, err := canvasGradeFromSubmissionPayload(sub, nil)
+	got, err := canvasGradeFromSubmissionPayload(sub, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got.hasNumericScore {
 		t.Fatal("did not expect numeric score")
 	}
-	if got.comment == nil || *got.comment != "Please revise the intro." {
-		t.Fatalf("comment=%v", got.comment)
+	if got.comment == nil || *got.comment != "User 1: Please revise the intro." {
+		t.Fatalf("comment=%q", *got.comment)
 	}
 }
 
@@ -220,6 +220,8 @@ func TestCanvasBuildCanvasGradePushForm_rubricByTitle(t *testing.T) {
 			},
 		},
 	}
+	comment := "See rubric notes."
+	grade.comment = &comment
 	form := canvasBuildCanvasGradePushForm(grade, rubric, canvasAssign)
 	if form.Get("rubric_assessment[_10][points]") != "4" {
 		t.Fatalf("points=%q", form.Get("rubric_assessment[_10][points]"))
@@ -229,6 +231,9 @@ func TestCanvasBuildCanvasGradePushForm_rubricByTitle(t *testing.T) {
 	}
 	if form.Get("submission[posted_grade]") != "" {
 		t.Fatalf("expected rubric-only form, got posted_grade=%q", form.Get("submission[posted_grade]"))
+	}
+	if form.Get("comment[text_comment]") != comment {
+		t.Fatalf("comment=%q", form.Get("comment[text_comment]"))
 	}
 }
 
@@ -240,18 +245,86 @@ func TestCanvasBuildCanvasGradePushForm_excused(t *testing.T) {
 	}
 }
 
-func TestCanvasInstructorCommentFromSubmission_skipsStudent(t *testing.T) {
+func TestCanvasInstructorCommentFromSubmission_readsHistoryComments(t *testing.T) {
+	sub := map[string]any{
+		"user_id": float64(9),
+		"submission_history": []any{
+			map[string]any{
+				"submission_comments": []any{
+					map[string]any{
+						"author_id":  float64(2),
+						"comment":    "Feedback from an earlier attempt.",
+						"created_at": "2024-01-01T00:00:00Z",
+					},
+				},
+			},
+		},
+	}
+	got := canvasInstructorCommentFromSubmission(sub)
+	if got != "User 2: Feedback from an earlier attempt." {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestCanvasInstructorCommentFromSubmission_includesAllParticipants(t *testing.T) {
 	sub := map[string]any{
 		"user_id": float64(9),
 		"submission_comments": []any{
 			map[string]any{"author_id": float64(9), "comment": "mine", "created_at": "2024-01-01T00:00:00Z"},
-			map[string]any{"author_id": float64(2), "comment": "grader one", "created_at": "2024-01-02T00:00:00Z"},
-			map[string]any{"author_id": float64(3), "comment": "grader two", "created_at": "2024-01-03T00:00:00Z"},
+			map[string]any{"author_id": float64(2), "author_name": "TA Lee", "comment": "grader one", "created_at": "2024-01-02T00:00:00Z"},
+			map[string]any{"author_id": float64(3), "author_name": "Prof Kim", "comment": "grader two", "created_at": "2024-01-03T00:00:00Z"},
 		},
 	}
 	got := canvasInstructorCommentFromSubmission(sub)
-	want := "grader one\n\ngrader two"
+	want := "Student: mine\n\nTA Lee: grader one\n\nProf Kim: grader two"
 	if got != want {
 		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestCanvasSubmissionCommentsFromPayload_structured(t *testing.T) {
+	localUser := uuid.New()
+	sub := map[string]any{
+		"user_id": float64(42),
+		"submission_comments": []any{
+			map[string]any{
+				"id":         float64(10),
+				"author_id":  float64(1),
+				"comment":    "Nice work.",
+				"created_at": "2024-01-02T00:00:00Z",
+				"author": map[string]any{
+					"display_name": "Prof Kim",
+					"avatar_url":   "https://canvas.example/avatar.png",
+				},
+			},
+			map[string]any{
+				"author_id":  float64(42),
+				"comment":    "Student reply",
+				"created_at": "2024-01-03T00:00:00Z",
+			},
+		},
+	}
+	got := canvasSubmissionCommentsFromPayload(sub, map[int64]uuid.UUID{1: localUser})
+	if len(got) != 2 {
+		t.Fatalf("len=%d", len(got))
+	}
+	if got[0].DisplayName != "Prof Kim" || got[0].Body != "Nice work." || got[0].CreatedAt != "2024-01-02T00:00:00Z" {
+		t.Fatalf("first=%+v", got[0])
+	}
+	if got[0].UserID == nil || *got[0].UserID != localUser.String() {
+		t.Fatalf("userId=%v", got[0].UserID)
+	}
+	if got[0].AvatarURL == nil || *got[0].AvatarURL != "https://canvas.example/avatar.png" {
+		t.Fatalf("avatar=%v", got[0].AvatarURL)
+	}
+	if got[1].DisplayName != "Student" || got[1].Body != "Student reply" {
+		t.Fatalf("second=%+v", got[1])
+	}
+}
+
+func TestCanvasNormalizeCanvasSubmissionCommentText_stripsHTML(t *testing.T) {
+	got := canvasNormalizeCanvasSubmissionCommentText("<p>Hello <strong>world</strong></p>")
+	if got != "Hello world" {
+		t.Fatalf("got %q", got)
 	}
 }

--- a/server/internal/httpserver/grading_agent_queue.go
+++ b/server/internal/httpserver/grading_agent_queue.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/lextures/lextures/server/internal/models/gradecomment"
 	gradingagentrepo "github.com/lextures/lextures/server/internal/repos/gradingagent"
 	"github.com/lextures/lextures/server/internal/repos/coursegrades"
 	"github.com/lextures/lextures/server/internal/repos/coursemoduleassignments"
@@ -98,7 +99,12 @@ func (d Deps) HandleGradingAgentQueueMessage(ctx context.Context, msg gradingage
 		posting = "automatic"
 	}
 	gradedByAI := true
-	if err := coursegrades.UpsertCellWithFlags(ctx, d.Pool, msg.CourseID, subRow.SubmittedBy, msg.ItemID, pts, rubricJSON, &comment, posting, gradedByAI); err != nil {
+	_, commentJSON, flatComment, _ := gradecomment.Append(nil, gradecomment.Comment{
+		DisplayName: "Grading agent",
+		Body:        comment,
+		Source:      "lextures",
+	})
+	if err := coursegrades.UpsertCellWithFlags(ctx, d.Pool, msg.CourseID, subRow.SubmittedBy, msg.ItemID, pts, rubricJSON, flatComment, commentJSON, posting, gradedByAI); err != nil {
 		return d.failGradingAgentItem(ctx, msg, "failed to write grade")
 	}
 	_, _ = gradingagentrepo.InsertResult(ctx, d.Pool, gradingagentrepo.InsertResultInput{

--- a/server/internal/migrate/repair.go
+++ b/server/internal/migrate/repair.go
@@ -138,6 +138,72 @@ func repairMigration289RenumberCollision(ctx context.Context, c *pgx.Conn, fsys 
 	return tx.Commit(ctx)
 }
 
+// repairMigration292RenumberCollision fixes dev/demo DBs that applied instructor_comments_json
+// as v292 before main's 292_learner_goals.sql landed and instructor_comments was renumbered to 293.
+func repairMigration292RenumberCollision(ctx context.Context, c *pgx.Conn, fsys fs.FS, dir string) error {
+	if !migrateRepairChecksumsEnabled() {
+		return nil
+	}
+	var v292Desc string
+	err := c.QueryRow(ctx,
+		`SELECT description FROM `+sqlxMigrationsTable+` WHERE version = 292`,
+	).Scan(&v292Desc)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("migrate repair v292 renumber: %w", err)
+	}
+	if v292Desc != "instructor_comments_json" {
+		return nil
+	}
+	var learnerGoalsExists bool
+	err = c.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'user' AND table_name = 'learner_goals')`,
+	).Scan(&learnerGoalsExists)
+	if err != nil {
+		return fmt.Errorf("migrate repair v292 renumber: %w", err)
+	}
+	if learnerGoalsExists {
+		return nil
+	}
+
+	learnerBody, err := fs.ReadFile(fsys, dir+"/292_learner_goals.sql")
+	if err != nil {
+		return fmt.Errorf("migrate repair v292 renumber: read learner_goals: %w", err)
+	}
+	if _, err := c.Exec(ctx, string(learnerBody)); err != nil {
+		return fmt.Errorf("migrate repair v292 renumber: apply learner_goals: %w", err)
+	}
+
+	learnerSum := sqlxChecksum(learnerBody)
+	commentsBody, err := fs.ReadFile(fsys, dir+"/293_instructor_comments_json.sql")
+	if err != nil {
+		return fmt.Errorf("migrate repair v292 renumber: read instructor_comments_json: %w", err)
+	}
+	commentsSum := sqlxChecksum(commentsBody)
+
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx,
+		`UPDATE `+sqlxMigrationsTable+` SET description = $1, checksum = $2 WHERE version = 292`,
+		"learner_goals", learnerSum[:],
+	); err != nil {
+		return fmt.Errorf("migrate repair v292 renumber: update v292: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO `+sqlxMigrationsTable+` (version, description, success, checksum, execution_time) VALUES ($1, $2, true, $3, 0)`,
+		int64(293), "instructor_comments_json", commentsSum[:],
+	); err != nil {
+		return fmt.Errorf("migrate repair v292 renumber: insert v293: %w", err)
+	}
+	return tx.Commit(ctx)
+}
+
 // repairDemoMigrationChecksums updates _sqlx_migrations when a listed version's stored
 // checksum does not match the embedded file. Only runs when MIGRATE_REPAIR_CHECKSUMS
 // is enabled.

--- a/server/internal/migrate/run.go
+++ b/server/internal/migrate/run.go
@@ -57,6 +57,9 @@ func runLocked(ctx context.Context, conn *pgx.Conn, fsys fs.FS, dir string) erro
 	if err := repairMigration289RenumberCollision(ctx, conn, fsys, dir); err != nil {
 		return err
 	}
+	if err := repairMigration292RenumberCollision(ctx, conn, fsys, dir); err != nil {
+		return err
+	}
 	if err := repairDemoMigrationChecksums(ctx, conn, fsys, dir); err != nil {
 		return err
 	}

--- a/server/internal/models/gradecomment/comment.go
+++ b/server/internal/models/gradecomment/comment.go
@@ -1,0 +1,177 @@
+package gradecomment
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Comment is one message in a submission grade feedback thread.
+type Comment struct {
+	ID          string  `json:"id"`
+	UserID      *string `json:"userId,omitempty"`
+	DisplayName string  `json:"displayName"`
+	AvatarURL   *string `json:"avatarUrl,omitempty"`
+	Body        string  `json:"body"`
+	CreatedAt   string  `json:"createdAt"`
+	Source      string  `json:"source,omitempty"`
+}
+
+const maxStoredComments = 200
+
+// ParseList decodes stored JSON into comments. Nil/empty input yields an empty slice.
+func ParseList(raw []byte) ([]Comment, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var out []Comment
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// MarshalList encodes comments for storage.
+func MarshalList(comments []Comment) ([]byte, error) {
+	if len(comments) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(comments)
+}
+
+// Flatten renders comments as legacy instructor_comment text.
+func Flatten(comments []Comment) string {
+	if len(comments) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(comments))
+	for _, c := range comments {
+		body := strings.TrimSpace(c.Body)
+		if body == "" {
+			continue
+		}
+		name := strings.TrimSpace(c.DisplayName)
+		if name != "" && name != "Comment" && name != "Rubric" {
+			parts = append(parts, name+": "+body)
+		} else {
+			parts = append(parts, body)
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// LatestBody returns the most recent non-empty comment body.
+func LatestBody(comments []Comment) *string {
+	for i := len(comments) - 1; i >= 0; i-- {
+		t := strings.TrimSpace(comments[i].Body)
+		if t != "" {
+			return &t
+		}
+	}
+	return nil
+}
+
+// ParseLegacyFlat converts pre-JSON instructor_comment text into comments.
+func ParseLegacyFlat(text string) []Comment {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return nil
+	}
+	chunks := strings.Split(trimmed, "\n\n")
+	out := make([]Comment, 0, len(chunks))
+	for i, chunk := range chunks {
+		chunk = strings.TrimSpace(chunk)
+		if chunk == "" {
+			continue
+		}
+		displayName := "Comment"
+		body := chunk
+		if idx := strings.Index(chunk, ": "); idx > 0 {
+			displayName = strings.TrimSpace(chunk[:idx])
+			body = strings.TrimSpace(chunk[idx+2:])
+		}
+		if body == "" {
+			continue
+		}
+		out = append(out, Comment{
+			ID:          fmt.Sprintf("legacy-%d", i),
+			DisplayName: displayName,
+			Body:        body,
+			Source:      "legacy",
+		})
+	}
+	return out
+}
+
+// ResolveList prefers structured JSON and falls back to legacy flat text.
+func ResolveList(commentsJSON []byte, legacyFlat *string) []Comment {
+	if parsed, err := ParseList(commentsJSON); err == nil && len(parsed) > 0 {
+		return parsed
+	}
+	if legacyFlat != nil {
+		if legacy := ParseLegacyFlat(*legacyFlat); len(legacy) > 0 {
+			return legacy
+		}
+	}
+	return nil
+}
+
+// Append adds a comment and returns updated slice plus marshaled JSON and flat text.
+func Append(existing []Comment, c Comment) ([]Comment, []byte, *string, error) {
+	if strings.TrimSpace(c.Body) == "" {
+		return existing, nil, nil, fmt.Errorf("empty comment body")
+	}
+	if strings.TrimSpace(c.ID) == "" {
+		c.ID = uuid.New().String()
+	}
+	if strings.TrimSpace(c.CreatedAt) == "" {
+		c.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	if strings.TrimSpace(c.DisplayName) == "" {
+		c.DisplayName = "Comment"
+	}
+	next := append(append([]Comment{}, existing...), c)
+	if len(next) > maxStoredComments {
+		next = next[len(next)-maxStoredComments:]
+	}
+	raw, err := MarshalList(next)
+	if err != nil {
+		return existing, nil, nil, err
+	}
+	flat := Flatten(next)
+	var flatPtr *string
+	if flat != "" {
+		flatPtr = &flat
+	}
+	return next, raw, flatPtr, nil
+}
+
+// CommentsToJSON exports comments for API responses.
+func CommentsToJSON(comments []Comment) []map[string]any {
+	if len(comments) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(comments))
+	for _, c := range comments {
+		row := map[string]any{
+			"id":          c.ID,
+			"displayName": c.DisplayName,
+			"body":        c.Body,
+			"createdAt":   c.CreatedAt,
+		}
+		if c.UserID != nil && strings.TrimSpace(*c.UserID) != "" {
+			row["userId"] = *c.UserID
+		}
+		if c.AvatarURL != nil && strings.TrimSpace(*c.AvatarURL) != "" {
+			row["avatarUrl"] = *c.AvatarURL
+		}
+		if strings.TrimSpace(c.Source) != "" {
+			row["source"] = c.Source
+		}
+		out = append(out, row)
+	}
+	return out
+}

--- a/server/internal/models/gradecomment/comment_test.go
+++ b/server/internal/models/gradecomment/comment_test.go
@@ -1,0 +1,33 @@
+package gradecomment
+
+import "testing"
+
+func TestParseLegacyFlat_authorPrefix(t *testing.T) {
+	got := ParseLegacyFlat("User 1: Nice work.\n\nStudent: Student reply")
+	if len(got) != 2 {
+		t.Fatalf("len=%d", len(got))
+	}
+	if got[0].DisplayName != "User 1" || got[0].Body != "Nice work." {
+		t.Fatalf("first=%+v", got[0])
+	}
+	if got[1].DisplayName != "Student" || got[1].Body != "Student reply" {
+		t.Fatalf("second=%+v", got[1])
+	}
+}
+
+func TestAppend_setsCreatedAtAndFlat(t *testing.T) {
+	_, raw, flat, err := Append(nil, Comment{
+		DisplayName: "Prof Kim",
+		Body:        "Strong analysis.",
+		Source:      "lextures",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) == 0 {
+		t.Fatal("expected json")
+	}
+	if flat == nil || *flat != "Prof Kim: Strong analysis." {
+		t.Fatalf("flat=%v", flat)
+	}
+}

--- a/server/internal/repos/coursegrades/cell.go
+++ b/server/internal/repos/coursegrades/cell.go
@@ -13,12 +13,13 @@ import (
 
 // CellRow is one gradebook cell including rubric scores and instructor feedback.
 type CellRow struct {
-	PointsEarned      *float64
-	RubricScoresJSON  []byte
-	InstructorComment *string
-	PostedAt          *time.Time
-	Excused           bool
-	GradedByAI        bool
+	PointsEarned            *float64
+	RubricScoresJSON        []byte
+	InstructorComment       *string
+	InstructorCommentsJSON  []byte
+	PostedAt                *time.Time
+	Excused                 bool
+	GradedByAI              bool
 }
 
 func GetCell(ctx context.Context, pool *pgxpool.Pool, courseID, studentID, itemID uuid.UUID) (*CellRow, error) {
@@ -28,14 +29,15 @@ func GetCell(ctx context.Context, pool *pgxpool.Pool, courseID, studentID, itemI
 	var pts *float64
 	var rubricJSON []byte
 	var comment *string
+	var commentsJSON []byte
 	var posted *time.Time
 	var excused bool
 	var gradedByAI bool
 	err := pool.QueryRow(ctx, `
-SELECT points_earned, rubric_scores_json, instructor_comment, posted_at, excused, graded_by_ai
+SELECT points_earned, rubric_scores_json, instructor_comment, instructor_comments_json, posted_at, excused, graded_by_ai
 FROM course.course_grades
 WHERE course_id = $1 AND student_user_id = $2 AND module_item_id = $3
-`, courseID, studentID, itemID).Scan(&pts, &rubricJSON, &comment, &posted, &excused, &gradedByAI)
+`, courseID, studentID, itemID).Scan(&pts, &rubricJSON, &comment, &commentsJSON, &posted, &excused, &gradedByAI)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
@@ -43,12 +45,13 @@ WHERE course_id = $1 AND student_user_id = $2 AND module_item_id = $3
 		return nil, err
 	}
 	return &CellRow{
-		PointsEarned:      pts,
-		RubricScoresJSON:  rubricJSON,
-		InstructorComment: comment,
-		PostedAt:          posted,
-		Excused:           excused,
-		GradedByAI:        gradedByAI,
+		PointsEarned:           pts,
+		RubricScoresJSON:       rubricJSON,
+		InstructorComment:      comment,
+		InstructorCommentsJSON: commentsJSON,
+		PostedAt:               posted,
+		Excused:                excused,
+		GradedByAI:             gradedByAI,
 	}, nil
 }
 
@@ -62,7 +65,7 @@ func UpsertCell(
 	comment *string,
 	postingPolicy string,
 ) error {
-	return UpsertCellWithFlags(ctx, pool, courseID, studentID, itemID, points, rubricJSON, comment, postingPolicy, false)
+	return UpsertCellWithFlags(ctx, pool, courseID, studentID, itemID, points, rubricJSON, comment, nil, postingPolicy, false)
 }
 
 // UpsertCellWithFlags saves a grade cell including the graded_by_ai audit flag.
@@ -73,6 +76,7 @@ func UpsertCellWithFlags(
 	points float64,
 	rubricJSON []byte,
 	comment *string,
+	commentsJSON []byte,
 	postingPolicy string,
 	gradedByAI bool,
 ) error {
@@ -82,32 +86,34 @@ func UpsertCellWithFlags(
 	if postingPolicy == "automatic" {
 		_, err := pool.Exec(ctx, `
 INSERT INTO course.course_grades (
-	course_id, student_user_id, module_item_id, points_earned, rubric_scores_json, instructor_comment, updated_at, posted_at, graded_by_ai
-) VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW(), $7)
+	course_id, student_user_id, module_item_id, points_earned, rubric_scores_json, instructor_comment, instructor_comments_json, updated_at, posted_at, graded_by_ai
+) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), $8)
 ON CONFLICT (student_user_id, module_item_id) DO UPDATE SET
 	course_id = EXCLUDED.course_id,
 	points_earned = EXCLUDED.points_earned,
 	rubric_scores_json = EXCLUDED.rubric_scores_json,
 	instructor_comment = EXCLUDED.instructor_comment,
+	instructor_comments_json = EXCLUDED.instructor_comments_json,
 	updated_at = NOW(),
 	posted_at = COALESCE(course.course_grades.posted_at, NOW()),
 	graded_by_ai = EXCLUDED.graded_by_ai
-`, courseID, studentID, itemID, points, nullableJSON(rubricJSON), comment, gradedByAI)
+`, courseID, studentID, itemID, points, nullableJSON(rubricJSON), comment, nullableJSON(commentsJSON), gradedByAI)
 		return err
 	}
 	_, err := pool.Exec(ctx, `
 INSERT INTO course.course_grades (
-	course_id, student_user_id, module_item_id, points_earned, rubric_scores_json, instructor_comment, updated_at, posted_at, graded_by_ai
-) VALUES ($1, $2, $3, $4, $5, $6, NOW(), NULL, $7)
+	course_id, student_user_id, module_item_id, points_earned, rubric_scores_json, instructor_comment, instructor_comments_json, updated_at, posted_at, graded_by_ai
+) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NULL, $8)
 ON CONFLICT (student_user_id, module_item_id) DO UPDATE SET
 	course_id = EXCLUDED.course_id,
 	points_earned = EXCLUDED.points_earned,
 	rubric_scores_json = EXCLUDED.rubric_scores_json,
 	instructor_comment = EXCLUDED.instructor_comment,
+	instructor_comments_json = EXCLUDED.instructor_comments_json,
 	updated_at = NOW(),
 	posted_at = course.course_grades.posted_at,
 	graded_by_ai = EXCLUDED.graded_by_ai
-`, courseID, studentID, itemID, points, nullableJSON(rubricJSON), comment, gradedByAI)
+`, courseID, studentID, itemID, points, nullableJSON(rubricJSON), comment, nullableJSON(commentsJSON), gradedByAI)
 	return err
 }
 

--- a/server/migrations/293_instructor_comments_json.sql
+++ b/server/migrations/293_instructor_comments_json.sql
@@ -1,0 +1,6 @@
+-- Structured SpeedGrader comment thread (Canvas import + in-app feedback).
+ALTER TABLE course.course_grades
+    ADD COLUMN IF NOT EXISTS instructor_comments_json JSONB;
+
+COMMENT ON COLUMN course.course_grades.instructor_comments_json IS
+    'Ordered JSON array of grade feedback comments with author, body, and timestamps.';


### PR DESCRIPTION
## Summary

- Add structured instructor comment threads on submission grades, stored as `instructor_comments_json` (migration 293) with a new `gradecomment` model for parse/marshal, legacy flat-text conversion, and append semantics.
- SpeedGrader shows a threaded comment UI (`SubmissionCommentThread`) backed by roster avatars/names; grade save/load APIs return and accept `comments[]` alongside the legacy `instructorComment` field.
- Canvas import, submission sync, grade push, and the grading agent queue preserve comment threads end-to-end instead of collapsing to a single flat string.
- Harden Canvas enrollment import when roster payloads omit email: deterministic provisioning emails from `login_id`, `sis_user_id`, or Canvas user id so accounts and enrollments still provision.
- UI polish: hide empty admin side-nav sections when no feature flags apply; centralize course create/import gating via `canCreateCourses()`.

## Test plan

- [x] `go test ./internal/models/gradecomment/... ./internal/httpserver/ -run 'CanvasEnrollment|CanvasSubmission|Grade' -short`
- [x] `npm run test -- --run submission-navigator.test.tsx courses.test.tsx`
- [ ] Manual: open SpeedGrader, post a comment, confirm thread renders with roster avatar/name
- [ ] Manual: import Canvas submission with existing comments, confirm thread imports intact
- [ ] Manual: push grade back to Canvas and verify comment sync