### PR TITLE
feat(16.5): iCal/CalDAV calendar feeds

### DIFF
--- a/clients/web/src/components/settings/calendar-subscriptions-panel.tsx
+++ b/clients/web/src/components/settings/calendar-subscriptions-panel.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Calendar, Copy, RefreshCw } from 'lucide-react'
+import { authorizedFetch } from '../../lib/api'
+import { readApiErrorMessage } from '../../lib/errors'
+import { formatDateTime } from '../../lib/format'
+import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
+import { usePlatformFeatures } from '../../context/platform-features-context'
+
+type CourseFeed = {
+  courseId: string
+  courseCode: string
+  title: string
+  feedUrl: string
+}
+
+type CalendarTokenInfo = {
+  hasToken?: boolean
+  personalFeedUrl?: string
+  expiresAt?: string
+  courseFeeds?: CourseFeed[]
+  token?: string
+  feedUrl?: string
+}
+
+function withToken(url: string, token: string): string {
+  return url.replace('<token>', encodeURIComponent(token))
+}
+
+export function CalendarSubscriptionsPanel() {
+  const { ffCalendarFeeds, loading: featuresLoading } = usePlatformFeatures()
+  const [loading, setLoading] = useState(true)
+  const [token, setToken] = useState<string | null>(null)
+  const [expiresAt, setExpiresAt] = useState<string | null>(null)
+  const [personalUrl, setPersonalUrl] = useState<string | null>(null)
+  const [courseFeeds, setCourseFeeds] = useState<CourseFeed[]>([])
+  const [hasActiveToken, setHasActiveToken] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await authorizedFetch('/api/v1/me/calendar-token')
+      const raw: unknown = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(readApiErrorMessage(raw))
+      const data = raw as CalendarTokenInfo
+      if (data.hasToken === false) {
+        setHasActiveToken(false)
+        setToken(null)
+        setPersonalUrl(null)
+        setExpiresAt(null)
+        setCourseFeeds([])
+        return
+      }
+      setHasActiveToken(true)
+      setExpiresAt(data.expiresAt ?? null)
+      setCourseFeeds(data.courseFeeds ?? [])
+      setPersonalUrl(data.personalFeedUrl ?? null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load calendar subscriptions.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!featuresLoading && ffCalendarFeeds) void load()
+  }, [featuresLoading, ffCalendarFeeds, load])
+
+  async function regenerate() {
+    if (
+      !globalThis.confirm(
+        'Regenerate your calendar URL? The old link will stop working immediately.',
+      )
+    ) {
+      return
+    }
+    setError(null)
+    try {
+      const res = await authorizedFetch('/api/v1/me/calendar-token', { method: 'POST' })
+      const raw: unknown = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(readApiErrorMessage(raw))
+      const data = raw as CalendarTokenInfo
+      if (!data.token) throw new Error('Token was missing from the response.')
+      setToken(data.token)
+      setHasActiveToken(true)
+      setExpiresAt(data.expiresAt ?? null)
+      setPersonalUrl(data.feedUrl ?? null)
+      toastSaveOk('Calendar subscription URL generated.')
+      await load()
+    } catch (e) {
+      toastMutationError(e instanceof Error ? e.message : 'Could not regenerate calendar URL.')
+    }
+  }
+
+  async function copyText(label: string, text: string) {
+    try {
+      await navigator.clipboard.writeText(text)
+      toastSaveOk(`${label} copied.`)
+    } catch {
+      toastMutationError('Could not copy to clipboard.')
+    }
+  }
+
+  if (featuresLoading || !ffCalendarFeeds) return null
+
+  const resolvedPersonal =
+    token && personalUrl ? withToken(personalUrl, token) : personalUrl?.replace('?token=<token>', '') ?? null
+
+  return (
+    <section className="mt-8 rounded-xl border border-slate-200 bg-white p-5 dark:border-neutral-700 dark:bg-neutral-900">
+      <div className="flex items-start gap-3">
+        <Calendar className="mt-0.5 h-5 w-5 shrink-0 text-slate-500 dark:text-neutral-400" aria-hidden />
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Calendar subscriptions</h3>
+          <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+            Subscribe to assignment and quiz deadlines in Google Calendar, Apple Calendar, or Outlook using a private
+            feed URL.
+          </p>
+
+          {loading ? (
+            <p className="mt-4 text-sm text-slate-500 dark:text-neutral-400">Loading…</p>
+          ) : error ? (
+            <p className="mt-4 text-sm text-red-600 dark:text-red-400">{error}</p>
+          ) : (
+            <div className="mt-4 space-y-4">
+              <div>
+                <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+                  Personal feed (all courses)
+                </p>
+                {resolvedPersonal ? (
+                  <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <input
+                      readOnly
+                      value={resolvedPersonal}
+                      className="min-w-0 flex-1 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 font-mono text-xs text-slate-800 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+                      aria-label="Personal calendar feed URL"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => void copyText('Feed URL', resolvedPersonal)}
+                      className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                    >
+                      <Copy className="h-4 w-4" aria-hidden />
+                      Copy
+                    </button>
+                  </div>
+                ) : hasActiveToken ? (
+                  <p className="mt-2 text-sm text-slate-600 dark:text-neutral-300">
+                    You have an active subscription URL. Regenerate to view and copy the link.
+                  </p>
+                ) : (
+                  <p className="mt-2 text-sm text-slate-600 dark:text-neutral-300">
+                    Generate a URL to subscribe in your calendar app.
+                  </p>
+                )}
+                {expiresAt ? (
+                  <p className="mt-1 text-xs text-slate-500 dark:text-neutral-400">
+                    Expires {formatDateTime(expiresAt)}
+                  </p>
+                ) : null}
+              </div>
+
+              {token && courseFeeds.length > 0 ? (
+                <div>
+                  <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+                    Per-course feeds
+                  </p>
+                  <ul className="mt-2 divide-y divide-slate-100 dark:divide-neutral-800">
+                    {courseFeeds.map((c) => {
+                      const url = withToken(c.feedUrl, token)
+                      return (
+                        <li key={c.courseId} className="flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between">
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-medium text-slate-900 dark:text-neutral-100">{c.title}</p>
+                            <p className="truncate font-mono text-xs text-slate-500 dark:text-neutral-400">{url}</p>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => void copyText(`${c.title} feed`, url)}
+                            className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                          >
+                            <Copy className="h-4 w-4" aria-hidden />
+                            Copy
+                          </button>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                </div>
+              ) : null}
+
+              <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
+                Anyone with your feed URL can see assignment titles and due dates. Do not share it publicly.
+              </div>
+
+              <details className="rounded-lg border border-slate-200 p-3 dark:border-neutral-700">
+                <summary className="cursor-pointer text-sm font-medium text-slate-800 dark:text-neutral-200">
+                  How to subscribe
+                </summary>
+                <ol className="mt-3 list-decimal space-y-2 pl-5 text-sm text-slate-600 dark:text-neutral-300">
+                  <li>
+                    <strong>Google Calendar:</strong> Settings → Add calendar → From URL → paste your feed URL.
+                  </li>
+                  <li>
+                    <strong>Apple Calendar:</strong> File → New Calendar Subscription → paste your feed URL.
+                  </li>
+                  <li>
+                    <strong>Outlook:</strong> Add calendar → Subscribe from web → paste your feed URL.
+                  </li>
+                </ol>
+              </details>
+
+              <button
+                type="button"
+                onClick={() => void regenerate()}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-white"
+              >
+                <RefreshCw className="h-4 w-4" aria-hidden />
+                {token ? 'Regenerate URL' : 'Generate URL'}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/clients/web/src/components/settings/platform-feature-definitions.ts
+++ b/clients/web/src/components/settings/platform-feature-definitions.ts
@@ -276,6 +276,12 @@ const PLATFORM_FEATURE_DEFINITIONS_UNSORTED: PlatformFeatureDefinition[] = [
       'Personal and institutional API tokens with scoped access for integrations, automation, and MCP agents (plan 16.2).',
   },
   {
+    key: 'ffCalendarFeeds',
+    label: 'Calendar feeds',
+    description:
+      'iCal and CalDAV calendar feed subscriptions for assignment and quiz deadlines (plan 16.5).',
+  },
+  {
     key: 'mfaEnabled',
     label: 'Two-factor authentication',
     description: 'Offer TOTP authenticator apps and passkeys as optional login factors.',

--- a/clients/web/src/components/settings/platform-settings-panel.tsx
+++ b/clients/web/src/components/settings/platform-settings-panel.tsx
@@ -72,6 +72,7 @@ function emptyForm(): PlatformSettingsPayload {
     ffOnboardingFlow: false,
     ffAiStudyBuddy: false,
     ffApiTokens: false,
+    ffCalendarFeeds: false,
     translationMemoryEnabled: false,
     storageQuotasEnabled: false,
     avScanningEnabled: false,

--- a/clients/web/src/components/settings/platform-settings-types.ts
+++ b/clients/web/src/components/settings/platform-settings-types.ts
@@ -50,6 +50,7 @@ export type PlatformSettingsPayload = {
   ffOnboardingFlow: boolean
   ffAiStudyBuddy: boolean
   ffApiTokens: boolean
+  ffCalendarFeeds: boolean
   translationMemoryEnabled: boolean
   storageQuotasEnabled: boolean
   avScanningEnabled: boolean

--- a/clients/web/src/context/platform-features-context.tsx
+++ b/clients/web/src/context/platform-features-context.tsx
@@ -80,6 +80,7 @@ export type PlatformFeatures = {
   ffOnboardingFlow: boolean
   ffStudyReminders: boolean
   ffAiStudyBuddy: boolean
+  ffCalendarFeeds: boolean
   aiStudyBuddyEnabled: boolean
   gdprModuleEnabled: boolean
   aiDisclosureEnabled: boolean
@@ -155,6 +156,7 @@ const defaultFeatures: PlatformFeatures = {
   ffOnboardingFlow: false,
   ffStudyReminders: false,
   ffAiStudyBuddy: false,
+  ffCalendarFeeds: false,
   aiStudyBuddyEnabled: false,
   gdprModuleEnabled: false,
   aiDisclosureEnabled: false,
@@ -235,6 +237,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
   ffOnboardingFlow: false,
   ffStudyReminders: false,
   ffAiStudyBuddy: false,
+  ffCalendarFeeds: false,
   aiStudyBuddyEnabled: false,
   gdprModuleEnabled: false,
   aiDisclosureEnabled: false,
@@ -316,6 +319,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffOnboardingFlow: data.ffOnboardingFlow === true,
           ffStudyReminders: data.ffStudyReminders === true,
           ffAiStudyBuddy: data.ffAiStudyBuddy === true,
+          ffCalendarFeeds: data.ffCalendarFeeds === true,
           aiStudyBuddyEnabled: data.aiStudyBuddyEnabled === true,
           gdprModuleEnabled: data.gdprModuleEnabled === true,
           aiDisclosureEnabled: data.aiDisclosureEnabled === true,
@@ -363,6 +367,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffOnboardingFlow: next.ffOnboardingFlow === true,
           ffStudyReminders: next.ffStudyReminders === true,
           ffAiStudyBuddy: next.ffAiStudyBuddy === true,
+          ffCalendarFeeds: next.ffCalendarFeeds === true,
           aiStudyBuddyEnabled: next.aiStudyBuddyEnabled === true,
           gdprModuleEnabled: next.gdprModuleEnabled === true,
           aiDisclosureEnabled: next.aiDisclosureEnabled === true,

--- a/clients/web/src/lib/platform-features.ts
+++ b/clients/web/src/lib/platform-features.ts
@@ -67,6 +67,7 @@ export type PlatformFeaturesSnapshot = {
   ffOnboardingFlow?: boolean
   ffStudyReminders?: boolean
   ffAiStudyBuddy?: boolean
+  ffCalendarFeeds?: boolean
   aiStudyBuddyEnabled?: boolean
   gdprModuleEnabled?: boolean
   aiDisclosureEnabled?: boolean
@@ -141,6 +142,7 @@ const defaults: PlatformFeaturesSnapshot = {
   ffOnboardingFlow: false,
   ffStudyReminders: false,
   ffAiStudyBuddy: false,
+  ffCalendarFeeds: false,
   aiStudyBuddyEnabled: false,
   gdprModuleEnabled: false,
   aiDisclosureEnabled: false,

--- a/clients/web/src/pages/lms/settings.tsx
+++ b/clients/web/src/pages/lms/settings.tsx
@@ -36,6 +36,7 @@ import {
 import { OidcConnectedAccountsPanel } from '../../components/oidc-connected-accounts-panel'
 import { MfaFactorsPanel } from '../../components/settings/mfa-factors-panel'
 import { IntegrationsAccessKeysPanel } from '../../components/settings/integrations-access-keys-panel'
+import { CalendarSubscriptionsPanel } from '../../components/settings/calendar-subscriptions-panel'
 import { AdminServiceTokensPanel } from '../../components/settings/admin-service-tokens-panel'
 import { IntegrationsMcpPanel } from '../../components/settings/integrations-mcp-panel'
 import { NotificationPreferencesPanel } from '../../components/settings/notification-preferences-panel'
@@ -1737,6 +1738,7 @@ export default function Settings() {
               Create access keys for API tools and configure MCP so AI agents can work with your Lextures data.
             </p>
             <IntegrationsAccessKeysPanel />
+            <CalendarSubscriptionsPanel />
             <AdminServiceTokensPanel />
             <IntegrationsMcpPanel />
           </div>

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -390,6 +390,9 @@ type Config struct {
 	// FFAPITokens enables personal and institutional API access keys (plan 16.2).
 	// Managed in Settings → Global platform (not process env).
 	FFAPITokens bool
+	// FFCalendarFeeds enables iCal/CalDAV calendar feed subscriptions (plan 16.5).
+	// Managed in Settings → Global platform (not process env).
+	FFCalendarFeeds bool
 
 	// FFStripeBilling enables Stripe checkout, subscriptions, and entitlement gating (plan 15.3).
 	// Managed in Settings → Global platform (not process env).

--- a/server/internal/httpserver/calendar_http.go
+++ b/server/internal/httpserver/calendar_http.go
@@ -1,0 +1,416 @@
+package httpserver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/lextures/lextures/server/internal/apierr"
+	courserepo "github.com/lextures/lextures/server/internal/repos/course"
+	calendartokens "github.com/lextures/lextures/server/internal/repos/calendartokens"
+	"github.com/lextures/lextures/server/internal/repos/enrollment"
+	userrepo "github.com/lextures/lextures/server/internal/repos/user"
+	calendarsvc "github.com/lextures/lextures/server/internal/service/calendar"
+)
+
+func (d Deps) calendarFeedsEnabled() bool {
+	return d.effectiveConfig().FFCalendarFeeds
+}
+
+func (d Deps) requireCalendarFeedsEnabled(w http.ResponseWriter) bool {
+	if !d.calendarFeedsEnabled() {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Calendar feeds are not enabled on this server.")
+		return false
+	}
+	return true
+}
+
+func (d Deps) registerCalendarFeedRoutes(r chi.Router) {
+	r.Get("/api/v1/me/calendar.ics", d.handleMeCalendarICS())
+	r.Get("/.well-known/caldav", d.handleCalDAVWellKnown())
+	r.HandleFunc("/caldav/users/{user_id}/", d.handleCalDAVCollection())
+}
+
+func (d Deps) registerCalendarFeedMeRoutes(r chi.Router) {
+	r.Post("/api/v1/me/calendar-token", d.handlePostMeCalendarToken())
+	r.Get("/api/v1/me/calendar-token", d.handleGetMeCalendarToken())
+}
+
+// handleMeCalendarICS is GET /api/v1/me/calendar.ics?token= — personal iCal feed for all enrolled courses.
+func (d Deps) handleMeCalendarICS() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		if !d.requireCalendarFeedsEnabled(w) {
+			return
+		}
+		userID, ok := d.calendarTokenUserID(w, r)
+		if !ok {
+			return
+		}
+		d.serveUserCalendarFeed(w, r, userID, nil)
+	}
+}
+
+// handleCourseCalendarICS is GET /api/v1/courses/{course_code}/calendar.ics?token=
+func (d Deps) handleCourseCalendarICS() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		courseCode := chi.URLParam(r, "course_code")
+		if courseCode == "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Missing course code.")
+			return
+		}
+
+		if d.calendarFeedsEnabled() && strings.TrimSpace(r.URL.Query().Get("token")) != "" {
+			userID, ok := d.calendarTokenUserID(w, r)
+			if !ok {
+				return
+			}
+			ctx := r.Context()
+			crow, err := courserepo.GetPublicByCourseCode(ctx, d.Pool, courseCode)
+			if err != nil || crow == nil {
+				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+				return
+			}
+			if !d.userCanAccessCourseCalendar(ctx, userID, courseCode, crow.ID) {
+				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+				return
+			}
+			cid, err := uuid.Parse(crow.ID)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Invalid course id.")
+				return
+			}
+			d.serveUserCalendarFeed(w, r, userID, &cid)
+			return
+		}
+
+		// Legacy session-authenticated term-only feed (pre-16.5).
+		d.handleCourseICSLegacy(w, r, courseCode)
+	}
+}
+
+func (d Deps) userCanAccessCourseCalendar(ctx context.Context, userID uuid.UUID, courseCode string, courseID string) bool {
+	hasAccess, err := enrollment.UserHasAccess(ctx, d.Pool, courseCode, userID)
+	if err != nil {
+		return false
+	}
+	if hasAccess {
+		return true
+	}
+	isStaff, err := enrollment.UserIsCourseStaff(ctx, d.Pool, courseCode, userID)
+	return err == nil && isStaff
+}
+
+func (d Deps) serveUserCalendarFeed(w http.ResponseWriter, r *http.Request, userID uuid.UUID, courseID *uuid.UUID) {
+	ctx := r.Context()
+	now := time.Now()
+	rangeStart, rangeEnd := parseCalendarRange(r)
+
+	var cacheKey string
+	var courseIDs []uuid.UUID
+
+	if courseID != nil {
+		cacheKey = fmt.Sprintf("course:%s:%s", courseID.String(), userID.String())
+		courseIDs = []uuid.UUID{*courseID}
+	} else {
+		cacheKey = "user:" + userID.String()
+		courses, err := courserepo.ListForEnrolledUser(ctx, d.Pool, userID, nil)
+		if err != nil {
+			d.serveCalendarWithCacheFallback(w, cacheKey, "Failed to load courses.")
+			return
+		}
+		courseIDs = make([]uuid.UUID, 0, len(courses))
+		for _, c := range courses {
+			id, err := uuid.Parse(c.ID)
+			if err != nil {
+				continue
+			}
+			courseIDs = append(courseIDs, id)
+		}
+	}
+
+	if body, ok := calendarsvc.DefaultFeedCache.Get(cacheKey, now); ok {
+		w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
+		w.Header().Set("X-Cache", "hit")
+		_, _ = w.Write(body)
+		return
+	}
+
+	events, err := calendarsvc.LoadEventsForCourses(ctx, d.Pool, courseIDs, rangeStart, rangeEnd)
+	if err != nil {
+		d.serveCalendarWithCacheFallback(w, cacheKey, "Failed to generate calendar feed.")
+		return
+	}
+
+	tz := d.userTimezone(ctx, userID)
+	body := calendarsvc.BuildICalendar(events, d.effectiveConfig().PublicWebOrigin, tz, now)
+	calendarsvc.DefaultFeedCache.Set(cacheKey, body, now)
+
+	w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
+	w.Header().Set("X-Cache", "miss")
+	_, _ = w.Write(body)
+}
+
+func (d Deps) serveCalendarWithCacheFallback(w http.ResponseWriter, cacheKey, errMsg string) {
+	if body, ok := calendarsvc.DefaultFeedCache.GetStale(cacheKey); ok {
+		w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
+		w.Header().Set("X-Cache", "stale")
+		_, _ = w.Write(body)
+		return
+	}
+	apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, errMsg)
+	w.Header().Set("Retry-After", "60")
+}
+
+func (d Deps) userTimezone(ctx context.Context, userID uuid.UUID) string {
+	u, err := userrepo.FindByID(ctx, d.Pool, userID)
+	if err != nil || u == nil || u.Timezone == nil || strings.TrimSpace(*u.Timezone) == "" {
+		return "UTC"
+	}
+	return strings.TrimSpace(*u.Timezone)
+}
+
+func (d Deps) calendarTokenUserID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	token := strings.TrimSpace(r.URL.Query().Get("token"))
+	if token == "" {
+		apierr.WriteJSON(w, http.StatusUnauthorized, apierr.CodeUnauthorized, "Missing calendar token.")
+		return uuid.Nil, false
+	}
+	userID, err := calendartokens.ResolveQueryParam(r.Context(), d.Pool, token, time.Now())
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusUnauthorized, apierr.CodeUnauthorized, "Invalid or expired calendar token.")
+		return uuid.Nil, false
+	}
+	return userID, true
+}
+
+func parseCalendarRange(r *http.Request) (start, end *time.Time) {
+	if s := strings.TrimSpace(r.URL.Query().Get("start")); s != "" {
+		if t, err := time.Parse("2006-01-02", s); err == nil {
+			start = &t
+		}
+	}
+	if s := strings.TrimSpace(r.URL.Query().Get("end")); s != "" {
+		if t, err := time.Parse("2006-01-02", s); err == nil {
+			endOfDay := t.Add(24*time.Hour - time.Nanosecond)
+			end = &endOfDay
+		}
+	}
+	return start, end
+}
+
+type calendarTokenStatusJSON struct {
+	HasToken  bool       `json:"hasToken"`
+	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
+	FeedURL   string     `json:"feedUrl,omitempty"`
+}
+
+type calendarTokenCreatedJSON struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expiresAt"`
+	FeedURL   string    `json:"feedUrl"`
+}
+
+type calendarCourseFeedJSON struct {
+	CourseID   string `json:"courseId"`
+	CourseCode string `json:"courseCode"`
+	Title      string `json:"title"`
+	FeedURL    string `json:"feedUrl"`
+}
+
+type calendarTokenInfoJSON struct {
+	HasToken        bool                     `json:"hasToken"`
+	PersonalFeedURL string                   `json:"personalFeedUrl"`
+	ExpiresAt       time.Time                `json:"expiresAt"`
+	CourseFeeds     []calendarCourseFeedJSON `json:"courseFeeds"`
+}
+
+func (d Deps) handleGetMeCalendarToken() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if !d.requireCalendarFeedsEnabled(w) {
+			return
+		}
+		ctx := r.Context()
+		now := time.Now()
+		row, err := calendartokens.GetActiveForUser(ctx, d.Pool, userID, now)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load calendar token.")
+			return
+		}
+		if row == nil {
+			writeJSON(w, http.StatusOK, calendarTokenStatusJSON{HasToken: false})
+			return
+		}
+		base := calendarFeedBaseURL(r, d.effectiveConfig().PublicWebOrigin)
+		writeJSON(w, http.StatusOK, calendarTokenInfoJSON{
+			HasToken:        true,
+			PersonalFeedURL: base + "/api/v1/me/calendar.ics?token=<token>",
+			ExpiresAt:       row.ExpiresAt,
+			CourseFeeds:     d.listCourseFeedURLs(ctx, userID, base),
+		})
+	}
+}
+
+func (d Deps) handlePostMeCalendarToken() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if !d.requireCalendarFeedsEnabled(w) {
+			return
+		}
+		ctx := r.Context()
+		now := time.Now()
+		row, secret, err := calendartokens.RotateForUser(ctx, d.Pool, userID, now)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to generate calendar token.")
+			return
+		}
+		calendarsvc.DefaultFeedCache.InvalidateUser(userID.String())
+		base := calendarFeedBaseURL(r, d.effectiveConfig().PublicWebOrigin)
+		writeJSON(w, http.StatusOK, calendarTokenCreatedJSON{
+			Token:     secret,
+			ExpiresAt: row.ExpiresAt,
+			FeedURL:   base + "/api/v1/me/calendar.ics?token=" + secret,
+		})
+	}
+}
+
+func (d Deps) listCourseFeedURLs(ctx context.Context, userID uuid.UUID, base string) []calendarCourseFeedJSON {
+	courses, err := courserepo.ListForEnrolledUser(ctx, d.Pool, userID, nil)
+	if err != nil {
+		return nil
+	}
+	out := make([]calendarCourseFeedJSON, 0, len(courses))
+	for _, c := range courses {
+		out = append(out, calendarCourseFeedJSON{
+			CourseID:   c.ID,
+			CourseCode: c.CourseCode,
+			Title:      c.Title,
+			FeedURL:    fmt.Sprintf("%s/api/v1/courses/%s/calendar.ics?token=<token>", base, c.CourseCode),
+		})
+	}
+	return out
+}
+
+func calendarFeedBaseURL(r *http.Request, configuredOrigin string) string {
+	if o := strings.TrimRight(strings.TrimSpace(configuredOrigin), "/"); o != "" {
+		return o
+	}
+	scheme := "https"
+	if r.TLS == nil {
+		scheme = "http"
+	}
+	return scheme + "://" + r.Host
+}
+
+// handleCalDAVWellKnown redirects to the per-user CalDAV collection (RFC 4791 discovery).
+func (d Deps) handleCalDAVWellKnown() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.calendarFeedsEnabled() {
+			http.NotFound(w, r)
+			return
+		}
+		token := strings.TrimSpace(r.URL.Query().Get("token"))
+		if token == "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Missing token query parameter.")
+			return
+		}
+		userID, err := calendartokens.ResolveQueryParam(r.Context(), d.Pool, token, time.Now())
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusUnauthorized, apierr.CodeUnauthorized, "Invalid or expired calendar token.")
+			return
+		}
+		base := calendarFeedBaseURL(r, d.effectiveConfig().PublicWebOrigin)
+		target := fmt.Sprintf("%s/caldav/users/%s/?token=%s", base, userID.String(), token)
+		http.Redirect(w, r, target, http.StatusPermanentRedirect)
+	}
+}
+
+func (d Deps) handleCalDAVCollection() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.calendarFeedsEnabled() {
+			http.NotFound(w, r)
+			return
+		}
+		userIDParam := chi.URLParam(r, "user_id")
+		pathUserID, err := uuid.Parse(userIDParam)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid user id.")
+			return
+		}
+		tokenUserID, ok := d.calendarTokenUserID(w, r)
+		if !ok {
+			return
+		}
+		if tokenUserID != pathUserID {
+			apierr.WriteJSON(w, http.StatusUnauthorized, apierr.CodeUnauthorized, "Token does not match user.")
+			return
+		}
+
+		switch r.Method {
+		case http.MethodOptions:
+			w.Header().Set("Allow", "OPTIONS, PROPFIND, GET")
+			w.Header().Set("DAV", "1, calendar-access")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		case "PROPFIND":
+			base := calendarFeedBaseURL(r, d.effectiveConfig().PublicWebOrigin)
+			feedHref := fmt.Sprintf("%s/api/v1/me/calendar.ics?token=%s", base, strings.TrimSpace(r.URL.Query().Get("token")))
+			body := caldavPropfindResponse(feedHref)
+			w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+			w.WriteHeader(http.StatusMultiStatus)
+			_, _ = w.Write([]byte(body))
+			return
+		case http.MethodGet:
+			d.handleMeCalendarICS()(w, r)
+			return
+		default:
+			w.Header().Set("Allow", "OPTIONS, PROPFIND, GET")
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+func caldavPropfindResponse(calendarHref string) string {
+	return `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:response>
+    <D:href>` + xmlEscape(calendarHref) + `</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>
+        <D:displayname>Lextures Calendar</D:displayname>
+        <C:calendar-description>Lextures assignment and quiz deadlines</C:calendar-description>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`
+}
+
+func xmlEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, `"`, "&quot;")
+	return s
+}

--- a/server/internal/httpserver/course_ical.go
+++ b/server/internal/httpserver/course_ical.go
@@ -6,71 +6,58 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/lextures/lextures/server/internal/apierr"
 	"github.com/lextures/lextures/server/internal/repos/course"
 	"github.com/lextures/lextures/server/internal/repos/enrollment"
 )
 
-// handleCourseICS is GET /api/v1/courses/{course_code}/calendar.ics — minimal iCalendar with term VEVENT when present.
-func (d Deps) handleCourseICS() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			w.Header().Set("Allow", http.MethodGet)
-			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
-			return
-		}
-		courseCode := chi.URLParam(r, "course_code")
-		if courseCode == "" {
-			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Missing course code.")
-			return
-		}
-		userID, ok := d.meUserID(w, r)
-		if !ok {
-			return
-		}
-		ctx := r.Context()
-		hasAccess, err := enrollment.UserHasAccess(ctx, d.Pool, courseCode, userID)
-		if err != nil {
-			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify course access.")
-			return
-		}
-		if !hasAccess {
-			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
-			return
-		}
-		crow, err := course.GetPublicByCourseCode(ctx, d.Pool, courseCode)
-		if err != nil {
-			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course.")
-			return
-		}
-		if crow == nil {
-			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
-			return
-		}
-		if crow.Term == nil {
-			w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
-			_, _ = w.Write([]byte("BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Lextures//Course//EN\r\nEND:VCALENDAR\r\n"))
-			return
-		}
-		t := crow.Term
-		uid := fmt.Sprintf("term-%s@lextures", t.ID)
-		lines := []string{
-			"BEGIN:VCALENDAR",
-			"VERSION:2.0",
-			"PRODID:-//Lextures//Course//EN",
-			"BEGIN:VEVENT",
-			"UID:" + icalEscapeText(uid),
-			"DTSTAMP:" + time.Now().UTC().Format("20060102T150405Z"),
-			"SUMMARY:" + icalEscapeText(t.Name),
-			"DTSTART;VALUE=DATE:" + strings.ReplaceAll(t.StartDate, "-", ""),
-			"DTEND;VALUE=DATE:" + formatIcalEndExclusive(t.EndDate),
-			"END:VEVENT",
-			"END:VCALENDAR",
-		}
-		w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
-		_, _ = w.Write([]byte(strings.Join(lines, "\r\n") + "\r\n"))
+// handleCourseICSLegacy serves the pre-16.5 session-authenticated term-only iCal feed.
+func (d Deps) handleCourseICSLegacy(w http.ResponseWriter, r *http.Request, courseCode string) {
+	userID, ok := d.meUserID(w, r)
+	if !ok {
+		return
 	}
+	ctx := r.Context()
+	hasAccess, err := enrollment.UserHasAccess(ctx, d.Pool, courseCode, userID)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify course access.")
+		return
+	}
+	if !hasAccess {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+		return
+	}
+	crow, err := course.GetPublicByCourseCode(ctx, d.Pool, courseCode)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course.")
+		return
+	}
+	if crow == nil {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+		return
+	}
+	if crow.Term == nil {
+		w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
+		_, _ = w.Write([]byte("BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Lextures//Course//EN\r\nEND:VCALENDAR\r\n"))
+		return
+	}
+	t := crow.Term
+	uid := fmt.Sprintf("term-%s@lextures", t.ID)
+	lines := []string{
+		"BEGIN:VCALENDAR",
+		"VERSION:2.0",
+		"PRODID:-//Lextures//Course//EN",
+		"BEGIN:VEVENT",
+		"UID:" + icalEscapeText(uid),
+		"DTSTAMP:" + time.Now().UTC().Format("20060102T150405Z"),
+		"SUMMARY:" + icalEscapeText(t.Name),
+		"DTSTART;VALUE=DATE:" + strings.ReplaceAll(t.StartDate, "-", ""),
+		"DTEND;VALUE=DATE:" + formatIcalEndExclusive(t.EndDate),
+		"END:VEVENT",
+		"END:VCALENDAR",
+	}
+	w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
+	_, _ = w.Write([]byte(strings.Join(lines, "\r\n") + "\r\n"))
 }
 
 func icalEscapeText(s string) string {

--- a/server/internal/httpserver/courses_routes.go
+++ b/server/internal/httpserver/courses_routes.go
@@ -15,7 +15,7 @@ func (d Deps) registerCourseRoutes(r chi.Router) {
 	r.Post("/api/v1/courses", d.handleCreateCourse())
 	r.Post("/api/v1/integrations/canvas/courses", d.handleCanvasListCourses())
 	// iCalendar feed must register before the /api/v1/courses/{course_code} subtree.
-	r.Get("/api/v1/courses/{course_code}/calendar.ics", d.handleCourseICS())
+	r.Get("/api/v1/courses/{course_code}/calendar.ics", d.handleCourseCalendarICS())
 	r.Route("/api/v1/courses/{course_code}", func(cr chi.Router) {
 		cr.Get("/", d.handleGetCourse())
 		cr.Put("/", d.handlePutCourse())

--- a/server/internal/httpserver/me.go
+++ b/server/internal/httpserver/me.go
@@ -248,4 +248,5 @@ func (d Deps) registerMeRoutes(r chi.Router) {
 	d.registerCCRRoutes(r)
 	d.registerCredentialsRoutes(r)
 	d.registerIntegrationsRoutes(r)
+	d.registerCalendarFeedMeRoutes(r)
 }

--- a/server/internal/httpserver/platform_features.go
+++ b/server/internal/httpserver/platform_features.go
@@ -85,6 +85,7 @@ type platformFeaturesJSON struct {
 	FFStudyReminders            bool `json:"ffStudyReminders"`
 	FFAIStudyBuddy              bool `json:"ffAiStudyBuddy"`
 	FFAPITokens                 bool `json:"ffApiTokens"`
+	FFCalendarFeeds             bool `json:"ffCalendarFeeds"`
 
 	AiDisclosureEnabled  bool `json:"aiDisclosureEnabled"`
 	OpenRouterConfigured bool `json:"openRouterConfigured"`
@@ -177,6 +178,7 @@ func platformFeaturesFromConfig(cfg config.Config) platformFeaturesJSON {
 		FFStudyReminders:            cfg.FFStudyReminders,
 		FFAIStudyBuddy:              cfg.FFAIStudyBuddy,
 		FFAPITokens:                 cfg.FFAPITokens,
+		FFCalendarFeeds:             cfg.FFCalendarFeeds,
 
 		LRSAnonymizeActors:           cfg.LRSAnonymizeActors,
 		FERPAWorkflowEnabled:         cfg.FERPAWorkflowEnabled,

--- a/server/internal/httpserver/server.go
+++ b/server/internal/httpserver/server.go
@@ -156,6 +156,7 @@ func NewHandler(d Deps) http.Handler {
 	d.registerSBGReportRoutes(r)
 	d.registerSISRoutes(r)
 	d.registerWebhookRoutes(r)
+	d.registerCalendarFeedRoutes(r)
 	d.registerFinalGradeRoutes(r)
 	d.registerCatalogRoutes(r)
 	d.registerLibraryRoutes(r)

--- a/server/internal/httpserver/settings_platform.go
+++ b/server/internal/httpserver/settings_platform.go
@@ -141,6 +141,7 @@ type platformSettingsJSON struct {
 	FFStudyReminders                bool `json:"ffStudyReminders"`
 	FFAIStudyBuddy                  bool `json:"ffAiStudyBuddy"`
 	FFAPITokens                     bool `json:"ffApiTokens"`
+	FFCalendarFeeds                 bool `json:"ffCalendarFeeds"`
 
 	LRSAnonymizeActors           bool    `json:"lrsAnonymizeActors"`
 	FERPAWorkflowEnabled         bool    `json:"ferpaWorkflowEnabled"`
@@ -331,6 +332,7 @@ func (d Deps) handleGetPlatformSettings() http.HandlerFunc {
 			FFStudyReminders:                merged.FFStudyReminders,
 			FFAIStudyBuddy:                  merged.FFAIStudyBuddy,
 			FFAPITokens:                     merged.FFAPITokens,
+		FFCalendarFeeds:                 merged.FFCalendarFeeds,
 			LRSAnonymizeActors:              merged.LRSAnonymizeActors,
 			FERPAWorkflowEnabled:            merged.FERPAWorkflowEnabled,
 			DPAPortalEnabled:                merged.DPAPortalEnabled,
@@ -496,6 +498,7 @@ type putPlatformBody struct {
 	FFStudyReminders                *bool `json:"ffStudyReminders"`
 	FFAIStudyBuddy                  *bool `json:"ffAiStudyBuddy"`
 	FFAPITokens                     *bool `json:"ffApiTokens"`
+	FFCalendarFeeds                 *bool `json:"ffCalendarFeeds"`
 
 	LRSAnonymizeActors           *bool    `json:"lrsAnonymizeActors"`
 	FERPAWorkflowEnabled         *bool    `json:"ferpaWorkflowEnabled"`
@@ -807,6 +810,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 		setBool("ffstudyreminders", body.FFStudyReminders, func(v bool) { wr.FFStudyReminders = &v })
 		setBool("ffaistudybuddy", body.FFAIStudyBuddy, func(v bool) { wr.FFAIStudyBuddy = &v })
 		setBool("ffapitokens", body.FFAPITokens, func(v bool) { wr.FFAPITokens = &v })
+	setBool("ffcalendarfeeds", body.FFCalendarFeeds, func(v bool) { wr.FFCalendarFeeds = &v })
 		setBool("lrsanonymizeactors", body.LRSAnonymizeActors, func(v bool) { wr.LRSAnonymizeActors = &v })
 		setBool("ferpaworkflowenabled", body.FERPAWorkflowEnabled, func(v bool) { wr.FERPAWorkflowEnabled = &v })
 		setBool("dpaportalenabled", body.DPAPortalEnabled, func(v bool) { wr.DPAPortalEnabled = &v })
@@ -951,6 +955,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 			FFStudyReminders:                merged.FFStudyReminders,
 			FFAIStudyBuddy:                  merged.FFAIStudyBuddy,
 			FFAPITokens:                     merged.FFAPITokens,
+		FFCalendarFeeds:                 merged.FFCalendarFeeds,
 			LRSAnonymizeActors:              merged.LRSAnonymizeActors,
 			FERPAWorkflowEnabled:            merged.FERPAWorkflowEnabled,
 			DPAPortalEnabled:                merged.DPAPortalEnabled,

--- a/server/internal/repos/calendartokens/repo.go
+++ b/server/internal/repos/calendartokens/repo.go
@@ -57,7 +57,7 @@ func RotateForUser(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, no
 	if err != nil {
 		return Row{}, "", err
 	}
-	defer tx.Rollback(ctx)
+	defer tx.Rollback(ctx) //nolint:errcheck
 
 	if _, err := tx.Exec(ctx, `DELETE FROM auth.calendar_tokens WHERE user_id = $1`, userID); err != nil {
 		return Row{}, "", err

--- a/server/internal/repos/calendartokens/repo.go
+++ b/server/internal/repos/calendartokens/repo.go
@@ -57,7 +57,7 @@ func RotateForUser(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, no
 	if err != nil {
 		return Row{}, "", err
 	}
-	defer tx.Rollback(ctx) //nolint:errcheck
+	defer tx.Rollback(ctx) //nolint:errcheck //nolint:errcheck
 
 	if _, err := tx.Exec(ctx, `DELETE FROM auth.calendar_tokens WHERE user_id = $1`, userID); err != nil {
 		return Row{}, "", err

--- a/server/internal/repos/calendartokens/repo.go
+++ b/server/internal/repos/calendartokens/repo.go
@@ -1,0 +1,124 @@
+// Package calendartokens stores short-lived capability tokens for calendar feed URLs (plan 16.5).
+package calendartokens
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	tokenPrefixLabel = "lcf_"
+	tokenLifetime    = 30 * 24 * time.Hour
+)
+
+// Row is a stored calendar capability token (secret is never persisted).
+type Row struct {
+	ID        uuid.UUID
+	UserID    uuid.UUID
+	ExpiresAt time.Time
+	CreatedAt time.Time
+}
+
+// GenerateSecret returns a new lcf_ secret and its SHA-256 hex hash.
+func GenerateSecret() (secret, hashHex string, err error) {
+	b := make([]byte, 32)
+	if _, err = rand.Read(b); err != nil {
+		return "", "", err
+	}
+	secret = tokenPrefixLabel + base64.RawURLEncoding.EncodeToString(b)
+	sum := sha256.Sum256([]byte(secret))
+	hashHex = hex.EncodeToString(sum[:])
+	return secret, hashHex, nil
+}
+
+func hashSecret(raw string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(raw)))
+	return hex.EncodeToString(sum[:])
+}
+
+// RotateForUser deletes existing tokens for the user and inserts a fresh one.
+func RotateForUser(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, now time.Time) (Row, string, error) {
+	secret, hashHex, err := GenerateSecret()
+	if err != nil {
+		return Row{}, "", err
+	}
+	expiresAt := now.Add(tokenLifetime)
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return Row{}, "", err
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx, `DELETE FROM auth.calendar_tokens WHERE user_id = $1`, userID); err != nil {
+		return Row{}, "", err
+	}
+
+	var row Row
+	err = tx.QueryRow(ctx, `
+INSERT INTO auth.calendar_tokens (user_id, token_hash, expires_at)
+VALUES ($1, $2, $3)
+RETURNING id, user_id, expires_at, created_at
+`, userID, hashHex, expiresAt).Scan(&row.ID, &row.UserID, &row.ExpiresAt, &row.CreatedAt)
+	if err != nil {
+		return Row{}, "", err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Row{}, "", err
+	}
+	return row, secret, nil
+}
+
+// GetActiveForUser returns the current non-expired token row for a user, if any.
+func GetActiveForUser(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, now time.Time) (*Row, error) {
+	var row Row
+	err := pool.QueryRow(ctx, `
+SELECT id, user_id, expires_at, created_at
+FROM auth.calendar_tokens
+WHERE user_id = $1 AND expires_at > $2
+ORDER BY created_at DESC
+LIMIT 1
+`, userID, now).Scan(&row.ID, &row.UserID, &row.ExpiresAt, &row.CreatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+// ResolveQueryParam validates a ?token= value and returns the owning user id.
+func ResolveQueryParam(ctx context.Context, pool *pgxpool.Pool, rawToken string, now time.Time) (uuid.UUID, error) {
+	raw := strings.TrimSpace(rawToken)
+	if raw == "" || !strings.HasPrefix(raw, tokenPrefixLabel) {
+		return uuid.Nil, errors.New("invalid calendar token")
+	}
+	h := hashSecret(raw)
+	var userID uuid.UUID
+	var expiresAt time.Time
+	err := pool.QueryRow(ctx, `
+SELECT user_id, expires_at
+FROM auth.calendar_tokens
+WHERE token_hash = $1
+`, h).Scan(&userID, &expiresAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, errors.New("invalid calendar token")
+	}
+	if err != nil {
+		return uuid.Nil, err
+	}
+	if !expiresAt.After(now) {
+		return uuid.Nil, errors.New("expired calendar token")
+	}
+	return userID, nil
+}

--- a/server/internal/repos/platformconfig/features.go
+++ b/server/internal/repos/platformconfig/features.go
@@ -94,6 +94,7 @@ func applyPlatformBools(out *config.Config, db *Row, def Defaults) {
 	out.FFStudyReminders = mergeBool(db.FFStudyReminders, false)
 	out.FFAIStudyBuddy = mergeBool(db.FFAIStudyBuddy, false)
 	out.FFAPITokens = mergeBool(db.FFAPITokens, false)
+	out.FFCalendarFeeds = mergeBool(db.FFCalendarFeeds, false)
 	out.SpeechToTextEnabled = mergeBool(db.SpeechToTextEnabled, false)
 	out.AccommodationsEngineEnabled = mergeBool(db.AccommodationsEngineEnabled, false)
 	out.FFAccommodationsEngine = mergeBool(db.FFAccommodationsEngine, false)

--- a/server/internal/repos/platformconfig/patch.go
+++ b/server/internal/repos/platformconfig/patch.go
@@ -162,6 +162,7 @@ func patch(ctx context.Context, pool *pgxpool.Pool, w *Write) error {
 	addBool("ff_study_reminders", w.FFStudyReminders)
 	addBool("ff_ai_study_buddy", w.FFAIStudyBuddy)
 	addBool("ff_api_tokens", w.FFAPITokens)
+	addBool("ff_calendar_feeds", w.FFCalendarFeeds)
 	addBool("lrs_anonymize_actors", w.LRSAnonymizeActors)
 	addBool("ferpa_workflow_enabled", w.FERPAWorkflowEnabled)
 	addBool("dpa_portal_enabled", w.DPAPortalEnabled)

--- a/server/internal/repos/platformconfig/platformconfig.go
+++ b/server/internal/repos/platformconfig/platformconfig.go
@@ -128,6 +128,7 @@ type Row struct {
 	FFStudyReminders                *bool
 	FFAIStudyBuddy                  *bool
 	FFAPITokens                     *bool
+	FFCalendarFeeds                 *bool
 
 	// Previously env-only flags (categories B and C), now platform-managed.
 	LRSAnonymizeActors           *bool
@@ -270,6 +271,7 @@ type Write struct {
 	FFStudyReminders                *bool
 	FFAIStudyBuddy                  *bool
 	FFAPITokens                     *bool
+	FFCalendarFeeds                 *bool
 
 	// Previously env-only flags (categories B and C), now platform-managed.
 	LRSAnonymizeActors           *bool
@@ -408,6 +410,7 @@ SELECT
 	ff_study_reminders,
 	ff_ai_study_buddy,
 	ff_api_tokens,
+	ff_calendar_feeds,
 	ff_revenue_share,
 	lrs_anonymize_actors,
 	ferpa_workflow_enabled,
@@ -541,6 +544,7 @@ WHERE id = 1
 		&r.FFStudyReminders,
 		&r.FFAIStudyBuddy,
 		&r.FFAPITokens,
+		&r.FFCalendarFeeds,
 		&r.FFRevenueShare,
 		&r.LRSAnonymizeActors,
 		&r.FERPAWorkflowEnabled,
@@ -722,6 +726,7 @@ INSERT INTO settings.platform_app_settings (
 	ff_study_reminders,
 	ff_ai_study_buddy,
 	ff_api_tokens,
+	ff_calendar_feeds,
 	ff_revenue_share,
 	mfa_enabled,
 	mfa_enforcement,
@@ -751,7 +756,7 @@ INSERT INTO settings.platform_app_settings (
 	$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18,
 	$19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40,
 	$41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, $66, $67, $68, $69, $70, $71, $72, $73, $74, $75, $76, $77, $78, $79, $80, $81, $82, $83, $84, $85, $86, $87, $88, $89, $90, $91, $92, $93, $94, $95,
-	$96, $97, $98, $99, $100, $101, $102, $103, $104, $105, $106, $107, $108, $109, $110, $111, $112, $113, $114, $115,
+	$96, $97, $98, $99, $100, $101, $102, $103, $104, $105, $106, $107, $108, $109, $110, $111, $112, $113, $114, $115, $116,
 	NOW()
 )
 ON CONFLICT (id) DO UPDATE SET
@@ -860,6 +865,7 @@ ON CONFLICT (id) DO UPDATE SET
 	ff_study_reminders = COALESCE(EXCLUDED.ff_study_reminders, settings.platform_app_settings.ff_study_reminders),
 	ff_ai_study_buddy = COALESCE(EXCLUDED.ff_ai_study_buddy, settings.platform_app_settings.ff_ai_study_buddy),
 	ff_api_tokens = COALESCE(EXCLUDED.ff_api_tokens, settings.platform_app_settings.ff_api_tokens),
+	ff_calendar_feeds = COALESCE(EXCLUDED.ff_calendar_feeds, settings.platform_app_settings.ff_calendar_feeds),
 	ff_revenue_share = COALESCE(EXCLUDED.ff_revenue_share, settings.platform_app_settings.ff_revenue_share),
 	lrs_anonymize_actors = COALESCE(EXCLUDED.lrs_anonymize_actors, settings.platform_app_settings.lrs_anonymize_actors),
 	ferpa_workflow_enabled = COALESCE(EXCLUDED.ferpa_workflow_enabled, settings.platform_app_settings.ferpa_workflow_enabled),
@@ -991,6 +997,7 @@ ON CONFLICT (id) DO UPDATE SET
 		w.FFStudyReminders,
 		w.FFAIStudyBuddy,
 		w.FFAPITokens,
+		w.FFCalendarFeeds,
 		w.FFRevenueShare,
 		w.MFAEnabled,
 		w.MFAEnforcement,

--- a/server/internal/service/calendar/cache.go
+++ b/server/internal/service/calendar/cache.go
@@ -1,0 +1,78 @@
+package calendar
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+const defaultCacheTTL = 15 * time.Minute
+
+type cacheEntry struct {
+	body    []byte
+	expires time.Time
+}
+
+// FeedCache is an in-process TTL cache for generated iCal bodies (plan 16.5; Redis in 17.5).
+type FeedCache struct {
+	mu    sync.RWMutex
+	ttl   time.Duration
+	items map[string]cacheEntry
+}
+
+func NewFeedCache() *FeedCache {
+	return &FeedCache{
+		ttl:   defaultCacheTTL,
+		items: make(map[string]cacheEntry),
+	}
+}
+
+func (c *FeedCache) Get(key string, now time.Time) ([]byte, bool) {
+	c.mu.RLock()
+	e, ok := c.items[key]
+	c.mu.RUnlock()
+	if !ok || now.After(e.expires) {
+		return nil, false
+	}
+	return e.body, true
+}
+
+func (c *FeedCache) GetStale(key string) ([]byte, bool) {
+	c.mu.RLock()
+	e, ok := c.items[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	return e.body, true
+}
+
+func (c *FeedCache) Set(key string, body []byte, now time.Time) {
+	c.mu.Lock()
+	c.items[key] = cacheEntry{body: append([]byte(nil), body...), expires: now.Add(c.ttl)}
+	c.mu.Unlock()
+}
+
+func (c *FeedCache) InvalidateUser(userID string) {
+	c.mu.Lock()
+	for k := range c.items {
+		if k == "user:"+userID || strings.HasSuffix(k, ":"+userID) {
+			delete(c.items, k)
+		}
+	}
+	c.mu.Unlock()
+}
+
+func (c *FeedCache) InvalidateCourse(courseID string) {
+	c.mu.Lock()
+	mid := ":" + courseID + ":"
+	for k := range c.items {
+		if strings.Contains(k, mid) {
+			delete(c.items, k)
+		}
+	}
+	c.mu.Unlock()
+}
+
+// DefaultFeedCache is the process-wide calendar feed cache.
+var DefaultFeedCache = NewFeedCache()

--- a/server/internal/service/calendar/events.go
+++ b/server/internal/service/calendar/events.go
@@ -1,0 +1,167 @@
+package calendar
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Event is one assignment or quiz deadline surfaced in an iCal feed.
+type Event struct {
+	ItemID      uuid.UUID
+	CourseID    uuid.UUID
+	CourseCode  string
+	CourseTitle string
+	Kind        string
+	Title       string
+	Description string
+	Start       time.Time
+	End         time.Time
+	AllDay      bool
+	IsQuizWindow bool
+}
+
+// LoadEventsForCourses returns visible assignment/quiz calendar events for the given courses.
+func LoadEventsForCourses(ctx context.Context, pool *pgxpool.Pool, courseIDs []uuid.UUID, rangeStart, rangeEnd *time.Time) ([]Event, error) {
+	if len(courseIDs) == 0 {
+		return nil, nil
+	}
+	rows, err := pool.Query(ctx, `
+SELECT
+	c.id,
+	c.course_code,
+	c.title,
+	si.id,
+	si.kind,
+	si.title,
+	COALESCE(ma.markdown, mq.markdown, '') AS description,
+	si.due_at,
+	ma.available_from,
+	ma.available_until,
+	mq.available_from,
+	mq.available_until
+FROM course.course_structure_items si
+INNER JOIN course.courses c ON c.id = si.course_id
+LEFT JOIN course.course_structure_items mod ON mod.id = si.parent_id AND mod.kind = 'module'
+LEFT JOIN course.module_assignments ma ON ma.structure_item_id = si.id AND si.kind = 'assignment'
+LEFT JOIN course.module_quizzes mq ON mq.structure_item_id = si.id AND si.kind = 'quiz'
+WHERE si.course_id = ANY($1)
+  AND si.kind IN ('assignment', 'quiz')
+  AND si.published = true
+  AND si.archived = false
+  AND c.archived = false
+  AND (mod.id IS NULL OR (mod.published = true AND mod.archived = false))
+`, courseIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []Event
+	for rows.Next() {
+		var (
+			courseID                      uuid.UUID
+			courseCode, courseTitle       string
+			itemID                        uuid.UUID
+			kind, title, description      string
+			dueAt                         *time.Time
+			assignFrom, assignUntil       *time.Time
+			quizFrom, quizUntil           *time.Time
+		)
+		if err := rows.Scan(
+			&courseID, &courseCode, &courseTitle, &itemID, &kind, &title, &description,
+			&dueAt, &assignFrom, &assignUntil, &quizFrom, &quizUntil,
+		); err != nil {
+			return nil, err
+		}
+
+		if kind == "quiz" && (quizFrom != nil || quizUntil != nil) {
+			start, end, allDay := quizWindowTimes(quizFrom, quizUntil, dueAt)
+			if start.IsZero() {
+				continue
+			}
+			ev := Event{
+				ItemID: itemID, CourseID: courseID, CourseCode: courseCode, CourseTitle: courseTitle,
+				Kind: kind, Title: title, Description: "Quiz window.", Start: start, End: end, AllDay: allDay,
+				IsQuizWindow: true,
+			}
+			if inRange(ev.Start, rangeStart, rangeEnd) {
+				out = append(out, ev)
+			}
+			continue
+		}
+
+		start, end, allDay := assignmentTimes(dueAt, assignFrom, assignUntil)
+		if start.IsZero() {
+			continue
+		}
+		desc := truncateDescription(strings.TrimSpace(description), 500)
+		ev := Event{
+			ItemID: itemID, CourseID: courseID, CourseCode: courseCode, CourseTitle: courseTitle,
+			Kind: kind, Title: title, Description: desc, Start: start, End: end, AllDay: allDay,
+		}
+		if inRange(ev.Start, rangeStart, rangeEnd) {
+			out = append(out, ev)
+		}
+	}
+	return out, rows.Err()
+}
+
+func assignmentTimes(dueAt, availableFrom, availableUntil *time.Time) (start, end time.Time, allDay bool) {
+	if availableFrom != nil && availableUntil != nil {
+		return *availableFrom, *availableUntil, isMidnightUTC(*availableFrom) && isMidnightUTC(*availableUntil)
+	}
+	if dueAt == nil {
+		return time.Time{}, time.Time{}, false
+	}
+	d := dueAt.UTC()
+	if isMidnightUTC(d) {
+		endDay := d.AddDate(0, 0, 1)
+		return d, endDay, true
+	}
+	return d, d.Add(time.Hour), false
+}
+
+func quizWindowTimes(availableFrom, availableUntil, dueAt *time.Time) (start, end time.Time, allDay bool) {
+	if availableFrom != nil {
+		start = *availableFrom
+	}
+	if availableUntil != nil {
+		end = *availableUntil
+	} else if dueAt != nil {
+		end = *dueAt
+	}
+	if start.IsZero() && !end.IsZero() {
+		start = end.Add(-time.Hour)
+	}
+	if !start.IsZero() && end.IsZero() {
+		end = start.Add(time.Hour)
+	}
+	allDay = !start.IsZero() && !end.IsZero() && isMidnightUTC(start) && isMidnightUTC(end)
+	return start, end, allDay
+}
+
+func isMidnightUTC(t time.Time) bool {
+	u := t.UTC()
+	return u.Hour() == 0 && u.Minute() == 0 && u.Second() == 0
+}
+
+func inRange(start time.Time, rangeStart, rangeEnd *time.Time) bool {
+	if rangeStart != nil && start.Before(*rangeStart) {
+		return false
+	}
+	if rangeEnd != nil && start.After(*rangeEnd) {
+		return false
+	}
+	return true
+}
+
+func truncateDescription(s string, max int) string {
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}

--- a/server/internal/service/calendar/ical.go
+++ b/server/internal/service/calendar/ical.go
@@ -1,0 +1,90 @@
+package calendar
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// BuildICalendar serializes events to RFC 5545 text/calendar bytes.
+func BuildICalendar(events []Event, webOrigin, timezone string, now time.Time) []byte {
+	origin := strings.TrimRight(strings.TrimSpace(webOrigin), "/")
+	if timezone == "" {
+		timezone = "UTC"
+	}
+	var b strings.Builder
+	b.WriteString("BEGIN:VCALENDAR\r\n")
+	b.WriteString("VERSION:2.0\r\n")
+	b.WriteString("PRODID:-//Lextures//Calendar Feeds//EN\r\n")
+	b.WriteString("CALSCALE:GREGORIAN\r\n")
+	b.WriteString("METHOD:PUBLISH\r\n")
+	writeVTimezone(&b, timezone)
+
+	for _, ev := range events {
+		writeVEvent(&b, ev, origin, now)
+	}
+	b.WriteString("END:VCALENDAR\r\n")
+	return []byte(b.String())
+}
+
+func writeVTimezone(b *strings.Builder, tz string) {
+	// Minimal VTIMEZONE stub; clients treat DTSTART as floating or UTC when TZID omitted.
+	b.WriteString("BEGIN:VTIMEZONE\r\n")
+	b.WriteString("TZID:" + escapeText(tz) + "\r\n")
+	b.WriteString("X-LIC-LOCATION:" + escapeText(tz) + "\r\n")
+	b.WriteString("END:VTIMEZONE\r\n")
+}
+
+func writeVEvent(b *strings.Builder, ev Event, origin string, now time.Time) {
+	uid := fmt.Sprintf("%s@lextures.io", ev.ItemID.String())
+	summary := ev.Title
+	if ev.CourseTitle != "" {
+		summary = ev.CourseTitle + ": " + ev.Title
+	}
+	url := itemURL(origin, ev.CourseCode, ev.Kind, ev.ItemID)
+
+	b.WriteString("BEGIN:VEVENT\r\n")
+	b.WriteString("UID:" + escapeText(uid) + "\r\n")
+	b.WriteString("DTSTAMP:" + now.UTC().Format("20060102T150405Z") + "\r\n")
+	if ev.AllDay {
+		b.WriteString("DTSTART;VALUE=DATE:" + formatDate(ev.Start) + "\r\n")
+		b.WriteString("DTEND;VALUE=DATE:" + formatDate(ev.End) + "\r\n")
+	} else {
+		b.WriteString("DTSTART:" + ev.Start.UTC().Format("20060102T150405Z") + "\r\n")
+		b.WriteString("DTEND:" + ev.End.UTC().Format("20060102T150405Z") + "\r\n")
+	}
+	b.WriteString("SUMMARY:" + escapeText(summary) + "\r\n")
+	if ev.Description != "" {
+		b.WriteString("DESCRIPTION:" + escapeText(ev.Description) + "\r\n")
+	}
+	if url != "" {
+		b.WriteString("URL:" + escapeText(url) + "\r\n")
+	}
+	b.WriteString("END:VEVENT\r\n")
+}
+
+func itemURL(origin, courseCode, kind string, itemID uuid.UUID) string {
+	if origin == "" || courseCode == "" {
+		return ""
+	}
+	pathKind := "assignments"
+	if kind == "quiz" {
+		pathKind = "quizzes"
+	}
+	return fmt.Sprintf("%s/courses/%s/%s/%s", origin, courseCode, pathKind, itemID.String())
+}
+
+func formatDate(t time.Time) string {
+	return t.UTC().Format("20060102")
+}
+
+func escapeText(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, ";", "\\;")
+	s = strings.ReplaceAll(s, ",", "\\,")
+	s = strings.ReplaceAll(s, "\n", "\\n")
+	s = strings.ReplaceAll(s, "\r", "")
+	return s
+}

--- a/server/internal/service/calendar/ical_test.go
+++ b/server/internal/service/calendar/ical_test.go
@@ -1,0 +1,75 @@
+package calendar_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	calendarsvc "github.com/lextures/lextures/server/internal/service/calendar"
+)
+
+func TestBuildICalendar_VEVENTFields(t *testing.T) {
+	itemID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	due := time.Date(2026, 4, 15, 23, 59, 0, 0, time.UTC)
+	events := []calendarsvc.Event{{
+		ItemID:      itemID,
+		CourseCode:  "BIO101",
+		CourseTitle: "Biology",
+		Kind:        "assignment",
+		Title:       "Lab report",
+		Description: "Submit PDF",
+		Start:       due,
+		End:         due.Add(time.Hour),
+	}}
+	body := string(calendarsvc.BuildICalendar(events, "https://app.lextures.io", "America/New_York", time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)))
+	if !strings.Contains(body, "BEGIN:VCALENDAR") {
+		t.Fatal("missing VCALENDAR")
+	}
+	if !strings.Contains(body, itemID.String()+"@lextures.io") {
+		t.Fatal("missing stable UID")
+	}
+	if !strings.Contains(body, "SUMMARY:Biology: Lab report") {
+		t.Fatal("missing summary")
+	}
+	if !strings.Contains(body, "URL:https://app.lextures.io/courses/BIO101/assignments/"+itemID.String()) {
+		t.Fatal("missing deep link URL")
+	}
+	if !strings.Contains(body, "DESCRIPTION:Submit PDF") {
+		t.Fatal("missing description")
+	}
+}
+
+func TestBuildICalendar_DateRangeAllDay(t *testing.T) {
+	start := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC)
+	events := []calendarsvc.Event{{
+		ItemID:       uuid.New(),
+		CourseCode:   "MATH",
+		Kind:         "quiz",
+		Title:        "Midterm",
+		Description:  "Quiz window.",
+		Start:        start,
+		End:          end,
+		AllDay:       true,
+		IsQuizWindow: true,
+	}}
+	body := string(calendarsvc.BuildICalendar(events, "", "UTC", time.Now()))
+	if !strings.Contains(body, "DTSTART;VALUE=DATE:20260401") {
+		t.Fatal("expected all-day DTSTART")
+	}
+	if !strings.Contains(body, "DTEND;VALUE=DATE:20260408") {
+		t.Fatal("expected all-day DTEND")
+	}
+}
+
+func TestEscapeText(t *testing.T) {
+	events := []calendarsvc.Event{{
+		ItemID: uuid.New(), CourseCode: "X", Kind: "assignment", Title: "A; B, C",
+		Start: time.Now(), End: time.Now().Add(time.Hour),
+	}}
+	body := string(calendarsvc.BuildICalendar(events, "", "UTC", time.Now()))
+	if !strings.Contains(body, "SUMMARY:A\\; B\\, C") {
+		t.Fatalf("expected escaped summary, got: %q", body)
+	}
+}

--- a/server/migrations/301_calendar_tokens.sql
+++ b/server/migrations/301_calendar_tokens.sql
@@ -1,0 +1,21 @@
+-- Plan 16.5 — Calendar feeds (iCal / CalDAV): capability tokens and rollout flag.
+
+CREATE TABLE IF NOT EXISTS auth.calendar_tokens (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id     UUID NOT NULL REFERENCES "user".users (id) ON DELETE CASCADE,
+    token_hash  TEXT NOT NULL UNIQUE,
+    expires_at  TIMESTAMPTZ NOT NULL DEFAULT now() + INTERVAL '30 days',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_calendar_tokens_user
+    ON auth.calendar_tokens (user_id);
+
+COMMENT ON TABLE auth.calendar_tokens IS
+    'Short-lived capability tokens for authenticated iCal/CalDAV calendar feed URLs (plan 16.5).';
+
+ALTER TABLE settings.platform_app_settings
+    ADD COLUMN IF NOT EXISTS ff_calendar_feeds BOOLEAN;
+
+COMMENT ON COLUMN settings.platform_app_settings.ff_calendar_feeds IS
+    'Enables personal and per-course iCal calendar feed subscriptions (plan 16.5).';


### PR DESCRIPTION
## Summary
- Add per-user iCal calendar feeds for assignment and quiz deadlines at authenticated URLs (`lcf_` capability tokens, 30-day expiry).
- Support personal all-courses and per-course feeds, CalDAV discovery (`/.well-known/caldav`), and date-range filtering via `?start=` / `?end=`.
- Add Settings → Integrations **Calendar subscriptions** panel and `ff_calendar_feeds` platform flag (migration 301).

## Test plan
- [ ] Enable **Calendar feeds** in Settings → Global platform
- [ ] Settings → Integrations → Generate calendar URL; copy personal feed URL
- [ ] Fetch feed without session cookie; verify `text/calendar` with VEVENTs for assignments/quizzes
- [ ] Regenerate token; confirm old URL returns 401
- [ ] Subscribe in Google Calendar or Apple Calendar and verify events appear
- [ ] `go test ./internal/service/calendar/ -count=1` passes


Made with [Cursor](https://cursor.com)