### PR TITLE
Add adoption-blocker plans and harden dev Docker against OOM

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,8 +26,9 @@ services:
     environment:
       JWT_SECRET: dev-only-change-me-in-production
       RABBITMQ_URL: amqp://studydrift:studydrift@rabbitmq:5672/
-      # Limit parallel package builds so cold compiles fit in ~2GB Docker Desktop / VM limits.
-      GOFLAGS: -p=1
+      # Limit parallel package builds and compiler memory for internal/httpserver in ~2GB Docker VMs.
+      GOFLAGS: -p=1 -gcflags=all=-l
+      GOMAXPROCS: "1"
     volumes:
       - ./server:/app
       - ./data/course-files:/var/course-files

--- a/docs/plan/01-adaptive-learning-core/1.11-conditional-release-module-requirements.md
+++ b/docs/plan/01-adaptive-learning-core/1.11-conditional-release-module-requirements.md
@@ -1,0 +1,166 @@
+# 1.11 — Conditional Release & Module Requirements (Rule-Based Gating)
+
+> Implementation plan. Source: gap scan 2026-06-19. The `competencygating` service is a stub ([service.go](../../../server/internal/service/competencygating/service.go)); there is no native instructor-facing module-requirement / prerequisite gating. Concept-graph prerequisites ([1.2](../../completed/01-adaptive-learning-core/1.2-skill-concept-graph.md)) and AI adaptive paths ([1.4](../../completed/01-adaptive-learning-core/1.4-adaptive-paths-across-modules.md)) exist but are different mechanisms.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | 1.11 |
+| **Section** | Adaptive Learning Core |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING (stub only) |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Learning platform team |
+| **Depends on** | course module structure, 2.9 (attempt policies), gradebook, 1.4 (adaptive paths — adjacent, not a dependency) |
+| **Unblocks** | Mastery-based progression, self-paced course sequencing, competency-based education (CBE) programs |
+
+---
+
+## 1. Problem Statement
+
+Instructors cannot gate content with simple rules. There is no "complete Module 1 before Module 2 unlocks", no "score ≥ 80% on the check quiz to proceed", and no "mark as done" completion requirement — the Canvas "Modules with requirements & prerequisites" pattern. The platform has AI adaptive paths ([1.4](../../completed/01-adaptive-learning-core/1.4-adaptive-paths-across-modules.md)) and concept prerequisites ([1.2](../../completed/01-adaptive-learning-core/1.2-skill-concept-graph.md)), but instructors who want deterministic, rule-based sequencing have nothing. This is essential for self-paced self-learner courses, mastery/competency-based K-12 and HE programs, and any course where ordering enforces pedagogy. The `competencygating` service exists only as a placeholder stub, confirming the intent was never implemented.
+
+## 2. Goals
+
+- Let instructors define per-item **completion requirements** within a module: view, mark-as-done, submit, or score-at-least.
+- Let instructors require all/any/sequential completion of a module's items before the module is "complete".
+- Let instructors set **module prerequisites** (Module B locked until Module A complete) and date-based unlocks.
+- Enforce gating server-side and reflect lock state, progress, and "what unlocks this" in the student UI.
+- Provide an instructor progress view of who has met which requirements.
+
+## 3. Non-Goals
+
+- AI/adaptive sequencing (that is [1.4](../../completed/01-adaptive-learning-core/1.4-adaptive-paths-across-modules.md)).
+- Concept/skill-graph prerequisites (that is [1.2](../../completed/01-adaptive-learning-core/1.2-skill-concept-graph.md)); this is instructor-authored module rules.
+- Cross-course prerequisites (course-registration prereqs already exist in the catalog).
+- Partial-credit "mastery" inference beyond explicit score thresholds.
+
+## 4. Personas & User Stories
+
+- **As a self-learner**, I want each lesson to unlock only after I pass the previous quiz so I can't skip ahead unprepared.
+- **As a K-12 teacher (mastery)**, I want students to redo a check until ≥ 80% before the next unit opens.
+- **As an HE instructor (CBE)**, I want competencies demonstrated in order before the capstone unlocks.
+- **As a student**, I want to see what's locked, why, and exactly what I must do to unlock it.
+- **As an instructor**, I want a dashboard of who's stuck on which requirement.
+
+## 5. Functional Requirements
+
+- **FR-1.** The system MUST let instructors set per-item completion requirements: `must_view`, `must_mark_done`, `must_submit`, `must_score_at_least(threshold)`, `must_contribute` (discussion).
+- **FR-2.** The system MUST let a module require `all_items` | `one_item` | `sequential_order` completion.
+- **FR-3.** The system MUST let a module declare prerequisite module(s) and/or an unlock date; the module stays locked until satisfied.
+- **FR-4.** The system MUST enforce gating server-side: a locked item/module's content is not served and submissions are rejected, regardless of direct URL access.
+- **FR-5.** The system MUST recompute and persist per-student progress as requirements are met, in near-real-time, and emit a completion event.
+- **FR-6.** The system MUST display lock state with a clear reason and the unlocking requirement to students.
+- **FR-7.** The system MUST provide an instructor progress report (students × requirements) and allow manual override/unlock for an individual.
+- **FR-8.** The system SHOULD respect assignment availability/differentiation ([2.15](../02-assessment-and-authoring/2.15-differentiated-assignments.md)) when evaluating dates.
+- **FR-9.** The system MAY allow "requirements as recommendations" (soft gating that warns but does not block).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — gating evaluation per student per module p95 < 150ms; progress recompute incremental (event-driven, not full scan).
+- **Security** — locked content never served; server enforces on every content/submission route; instructor override is authz-checked and audited.
+- **Privacy & Compliance** — progress is an education record; manual overrides audited.
+- **Accessibility** — lock states conveyed by text + icon (not color alone); SR announces "locked — complete X to unlock".
+- **Scalability** — progress stored per (student, item); incremental updates on events; supports large self-paced cohorts.
+- **Reliability** — gating deterministic and idempotent; replaying a completion event does not double-count; no race that unlocks prematurely.
+- **Observability** — metrics: items_gated, students_blocked, avg_time_to_unlock, manual_overrides.
+- **Maintainability** — replace the `competencygating` stub with a real, well-tested rules engine module.
+- **Internationalization** — requirement/lock copy keyed; dates in student tz.
+- **Backward compatibility** — additive; modules without requirements behave as today (always open).
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* Module B requires Module A complete, *When* a student has not completed A, *Then* B is locked and its items are not served (including via direct URL).
+- **AC-2.** *Given* an item requires `must_score_at_least(80)`, *When* a student scores 75 then 85, *Then* the requirement flips to met after the 85 attempt and dependent content unlocks.
+- **AC-3.** *Given* `sequential_order`, *When* a student tries item 3 before item 2, *Then* item 3 is locked with the reason shown.
+- **AC-4.** *Given* an instructor manually unlocks a module for one student, *When* that student returns, *Then* it is open for them only, and the override is audited.
+- **AC-5.** *Given* an unlock date in the future, *When* the date passes, *Then* the module unlocks without instructor action.
+- **AC-6.** *Given* a completion event is delivered twice, *When* progress recomputes, *Then* state is unchanged (idempotent).
+
+## 8. Data Model
+
+- `module_requirements` (id, module_id, completion_mode [`all`|`one`|`sequential`], unlock_at NULL, created_at).
+- `module_prerequisites` (id, module_id, prerequisite_module_id) — UNIQUE; cycle-checked.
+- `item_completion_rules` (id, item_id, rule_type, threshold NULL).
+- `student_item_progress` (id, enrollment_id, item_id, status [`incomplete`|`complete`], met_at, evidence_json).
+- `student_module_progress` (id, enrollment_id, module_id, status, unlocked_at).
+- `module_unlock_overrides` (id, enrollment_id, module_id, granted_by, granted_at).
+- Indexes on (module_id), (enrollment_id, item_id), (enrollment_id, module_id). Migration: `server/migrations/3NN_conditional_release.sql`. Cycle detection mirrors concept-graph prerequisite checks.
+- Backfill: none (no requirements => open).
+
+## 9. API Surface
+
+- `PUT /api/v1/modules/:mid/requirements` (instructor) — set completion mode, prerequisites, unlock date.
+- `PUT /api/v1/items/:iid/completion-rule` (instructor) — set item rule.
+- `GET /api/v1/courses/:cid/modules/progress` (student) — lock/progress state with reasons.
+- `GET /api/v1/courses/:cid/requirements/report` (instructor) — students × requirements.
+- `POST /api/v1/modules/:mid/unlock-override` (instructor) — unlock for a student.
+- Content/submission routes MUST check gating; locked → 403 with reason. OpenAPI documented.
+
+## 10. UI / UX
+
+- Instructor module editor: per-item requirement dropdowns; module completion mode; "Prerequisites" + "Lock until" controls.
+- Student module list: lock badges, "Complete X to unlock" hints, progress checkmarks per item.
+- Instructor requirements report with stuck-student drill-down + per-student override.
+- **States:** open, locked (with reason), in-progress, complete; empty (no requirements).
+- **Mobile:** lock states and progress visible on small screens.
+- **Accessibility:** non-color lock indicators; SR reasons; focus order.
+- **i18n/tz:** copy keyed; dates localized.
+
+## 11. AI / ML Considerations
+
+None (deterministic rules). Complements, but is independent of, AI adaptive paths ([1.4](../../completed/01-adaptive-learning-core/1.4-adaptive-paths-across-modules.md)).
+
+## 12. Integration Points
+
+- Internal: replace [competencygating stub](../../../server/internal/service/competencygating/service.go); module structure (`coursestructure`, `coursemodulecontent`), gradebook (score thresholds), discussions (contribute), [learnerprogress repo](../../../server/internal/repos/learnerprogress/repo.go), learning events ([9.6](../../completed/09-analytics-reporting/9.6-caliper-xapi-emission.md)).
+- Events: consume submission/score/view events; emit `module.unlocked`, `requirement.met`.
+- Differentiation ([2.15](../02-assessment-and-authoring/2.15-differentiated-assignments.md)) for date evaluation.
+
+## 13. Dependencies & Sequencing
+
+- Must ship after: module structure + gradebook (present); ideally after 2.15 for date consistency.
+- Shared infra: event stream / job queue for incremental progress.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Locked content served via direct URL | M | H | Enforce on every content/submission route; security tests |
+| Students stuck/frustrated by gating | M | M | Clear reasons, instructor override, optional soft gating |
+| Progress recompute races unlock early | M | H | Idempotent event handling; transactional state |
+| Prerequisite cycles | L | M | Cycle detection (reuse concept-graph approach) |
+
+## 15. Rollout Plan
+
+- Feature flag `conditional_release` (default off).
+- Sequence: schema → rules engine (replace stub) → enforcement on content/submission routes → student progress UI → instructor report/override → flip flag.
+- Dogfood in a self-paced course and a mastery K-12 unit.
+- GA criteria: enforcement security tests green; idempotency verified; report accurate.
+- Rollback: disable flag (all modules open; progress retained).
+
+## 16. Test Plan
+
+- **Unit** — rule evaluation per type; completion modes; prerequisite cycle detection; idempotent recompute.
+- **Integration** — score-threshold unlock; sequential order; date unlock; override scope.
+- **E2E** — student blocked then unlocks by meeting requirement; instructor override.
+- **Security** — direct-URL access to locked content blocked; submission to locked item rejected.
+- **Accessibility** — axe + SR on lock states.
+- **Performance** — progress recompute under event load.
+
+## 17. Documentation & Training
+
+- Help center: "Set module requirements and prerequisites"; student "Why is this locked?".
+- Note distinguishing rule-based gating from adaptive paths.
+
+## 18. Open Questions
+
+1. Offer soft (warn-only) gating in v1, or hard gating only?
+2. Should `must_score_at_least` use highest attempt, latest, or the gradebook's kept score per [2.9](../../completed/02-assessment-and-authoring/2.9-multiple-attempts-policies.md)?
+
+## 19. References
+
+- Existing files: [competencygating stub](../../../server/internal/service/competencygating/service.go), [learnerprogress repo](../../../server/internal/repos/learnerprogress/repo.go), [concepts/prerequisites.go](../../../server/internal/repos/concepts/prerequisites.go), `server/internal/models/coursestructure/types.go`.
+- Related plans: [1.2 Concept Graph](../../completed/01-adaptive-learning-core/1.2-skill-concept-graph.md), [1.4 Adaptive Paths](../../completed/01-adaptive-learning-core/1.4-adaptive-paths-across-modules.md), [2.9 Attempt Policies](../../completed/02-assessment-and-authoring/2.9-multiple-attempts-policies.md), [2.15 Differentiated Assignments](../02-assessment-and-authoring/2.15-differentiated-assignments.md).

--- a/docs/plan/02-assessment-and-authoring/2.14-scorm-xapi-cmi5.md
+++ b/docs/plan/02-assessment-and-authoring/2.14-scorm-xapi-cmi5.md
@@ -1,0 +1,174 @@
+# 2.14 — SCORM / xAPI / cmi5 Content Package Ingestion
+
+> Implementation plan. Source: gap scan 2026-06-19 (referenced as a "related plan" by [2.12](../../completed/02-assessment-and-authoring/2.12-lti-1.3.md) and [2.13](../../completed/02-assessment-and-authoring/2.13-qti-common-cartridge-import.md) but never written or implemented).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | 2.14 |
+| **Section** | Assessment & Authoring |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | L (1–2mo) |
+| **Owner (proposed)** | Content & Interop team |
+| **Depends on** | 8.1 (object storage), 9.6 (Caliper/xAPI emission — shares an LRS), 2.12 (LTI 1.3 — cmi5/SCORM are sometimes launched via LTI) |
+| **Unblocks** | Publisher courseware adoption; corporate/CE content reuse; 8.9 (OER library completeness); 14.17 (CEU seat-time from external content) |
+
+---
+
+## 1. Problem Statement
+
+Lextures imports QTI and Common Cartridge ([2.13](../../completed/02-assessment-and-authoring/2.13-qti-common-cartridge-import.md)) and renders H5P ([8.12](../../completed/08-content-media-files/8.12-interactive-h5p-content.md)), but cannot ingest or launch **SCORM 1.2 / SCORM 2004**, **xAPI (Tin Can)**, or **cmi5** packages. SCORM remains the dominant packaging format for publisher courseware, compliance/CE training, and a large share of corporate and OER content. Districts, universities, and continuing-education providers routinely have libraries of SCORM/cmi5 content they expect to upload and run with progress and score tracking. Without this, Lextures is disqualified from RFPs that list "SCORM-conformant LMS" as a hard requirement and forces customers to rebuild existing content from scratch.
+
+## 2. Goals
+
+- Upload a SCORM 1.2, SCORM 2004 (2nd–4th ed.), or cmi5 package (`.zip`) and add it to a course module as a launchable activity.
+- Run the package in a sandboxed player that implements the SCORM RTE (API/API_1484_11) and cmi5/xAPI runtime, persisting `cmi.core.lesson_status`/`cmi.completion_status`, `cmi.core.score`/`cmi.score.scaled`, `cmi.core.session_time`/`total_time`, and bookmarks/suspend_data.
+- Push the package's completion and score into the existing gradebook as a graded item (where the activity is gradable).
+- Emit xAPI statements to the platform LRS (reuse [9.6](../../completed/09-analytics-reporting/9.6-caliper-xapi-emission.md)) so SCORM/cmi5 runs appear in analytics and seat-time reporting ([14.17](../../completed/14-higher-ed-specific/14.17-ceu-tracking.md)).
+- Pass ADL SCORM conformance test suite (1.2 + 2004 4th ed. RTE) and cmi5 CATAPULT tests.
+
+## 3. Non-Goals
+
+- Authoring SCORM/cmi5 content inside Lextures (we ingest and play, not author).
+- Exporting Lextures courses *as* SCORM packages (separate future plan).
+- Re-implementing AICC HACP (legacy; out of scope unless a customer requires it).
+- LRS hosting for third parties (we run an internal LRS only).
+
+## 4. Personas & User Stories
+
+- **As an instructor/designer**, I want to upload a publisher's SCORM package and add it to a module so that students can launch it and I get their scores back automatically.
+- **As a student**, I want to resume a SCORM lesson where I left off (suspend/bookmark) and have my completion count toward my grade.
+- **As an admin**, I want SCORM packages scanned for malware ([8.6](../../completed/08-content-media-files/8.6-antivirus-malware-scanning.md)) and sandboxed so untrusted HTML/JS cannot exfiltrate session tokens or access other learners' data.
+- **As a CE provider (HE)**, I want cmi5/xAPI seat-time recorded so CEU certificates ([14.17](../../completed/14-higher-ed-specific/14.17-ceu-tracking.md)) reflect time-in-content.
+- **As a self-learner**, I want third-party SCORM courses I've purchased to run on my account with progress saved.
+
+## 5. Functional Requirements
+
+- **FR-1.** The system MUST accept a `.zip` upload, detect package type by manifest (`imsmanifest.xml` → SCORM/CC; `cmi5.xml` → cmi5), and reject unrecognized/invalid packages with a clear error.
+- **FR-2.** The system MUST parse `imsmanifest.xml` (organizations, resources, sequencing) for SCORM 1.2 and 2004, and `cmi5.xml` (course/AU structure, `moveOn`, `masteryScore`, `launchMethod`) for cmi5.
+- **FR-3.** The system MUST store extracted package files in object storage ([8.1](../../completed/08-content-media-files/8.1-object-storage-backend.md)) and serve them from a sandboxed origin (no platform cookies/tokens exposed to package JS).
+- **FR-4.** The system MUST implement the SCORM 1.2 RTE (`window.API`) and SCORM 2004 RTE (`window.API_1484_11`) data model and persist runtime CMI data per learner per attempt.
+- **FR-5.** The system MUST implement the cmi5 runtime: fetch token, launch with `endpoint`/`fetch`/`registration`/`actor`, accept `initialized`/`completed`/`passed`/`failed`/`terminated` statements, and enforce `moveOn`.
+- **FR-6.** The system MUST persist and restore `suspend_data` and bookmark/location so learners resume mid-package.
+- **FR-7.** The system MUST map package outcomes to a gradebook item: SCORM score (`cmi.core.score.raw` scaled to max, or `cmi.score.scaled`) and completion → grade and submission status, respecting existing grade posting policies ([3.8](../../completed/03-submissions-grading-integrity/3.8-grade-posting-policies.md)).
+- **FR-8.** The system MUST emit xAPI statements to the internal LRS for launch/progress/completion (reuse [9.6](../../completed/09-analytics-reporting/9.6-caliper-xapi-emission.md)).
+- **FR-9.** The system SHOULD support package versioning/replacement without losing prior attempt data.
+- **FR-10.** The system MAY support multi-SCO packages with manifest-driven navigation (table of contents).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — package extraction handled by the background job queue (async); player asset serving p95 < 200ms via CDN; RTE commit (LMSCommit/SetValue batch) p95 < 150ms.
+- **Security** — packages contain untrusted HTML/JS. MUST run in a sandboxed iframe on a separate, cookieless origin; CSP restricts network egress; RTE bridge uses `postMessage` with strict origin checks; no platform JWT reachable from package context. Scan with ClamAV ([8.6](../../completed/08-content-media-files/8.6-antivirus-malware-scanning.md)) before extraction; cap zip entry count/size (zip-bomb defense, reuse [zipimport](../../../server/internal/service/zipimport/) guards).
+- **Privacy & Compliance** — runtime data is an education record (FERPA). xAPI actor uses a per-package pseudonymous account, not raw email, where possible. COPPA: no third-party network calls from K-12 packages without admin allowlist.
+- **Accessibility** — player chrome (launch, resume, exit, progress) WCAG 2.1 AA; package content accessibility is the publisher's responsibility but MUST not be blocked by our wrapper (keyboard focus passes into iframe).
+- **Scalability** — extraction is queue-backed; storage quota counts against course/org quotas ([8.5](../../completed/08-content-media-files/8.5-per-course-user-storage-quotas.md)).
+- **Reliability** — RTE commits are idempotent and durable; loss of a commit must not corrupt prior CMI state; resume always reflects last durable commit.
+- **Observability** — metrics: packages_ingested, ingest_failures_by_reason, rte_commits, launch_failures, avg_session_time; logs include package_id, sco_id, attempt_id (PII-redacted).
+- **Maintainability** — RTE data-model mapping table lives in one module; conformance fixtures checked into the repo.
+- **Internationalization** — player chrome strings externalized; package locale untouched.
+- **Backward compatibility** — additive: new module item type; existing module items unaffected.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a valid SCORM 1.2 package, *When* an instructor uploads it and adds it to a module, *Then* it appears as a launchable item and a student can open it.
+- **AC-2.** *Given* a student completes a SCORM SCO that sets `lesson_status=passed` and `score.raw=85`, *When* they exit, *Then* the gradebook shows 85 (scaled to the item's max points) and submission status "graded/complete".
+- **AC-3.** *Given* a student exits a SCORM package mid-way with `suspend_data` set, *When* they relaunch, *Then* they resume at the saved location with state intact.
+- **AC-4.** *Given* a cmi5 AU sends a `passed` statement meeting `masteryScore`, *When* `moveOn=Passed`, *Then* the AU is marked satisfied and gradebook reflects pass.
+- **AC-5.** *Given* a malicious package attempting `fetch('/api/v1/me')` with credentials, *When* it runs, *Then* the request is blocked by CSP/origin isolation and no platform data is returned.
+- **AC-6.** *Given* the ADL SCORM 2004 4th ed. RTE conformance suite, *When* run against the player, *Then* all required tests pass.
+
+## 8. Data Model
+
+- `scorm_packages` (id, course_id, org_id, owner_id, type [`scorm12`|`scorm2004`|`cmi5`], version, manifest_json, storage_prefix, status, created_at).
+- `scorm_scos` (id, package_id, identifier, title, launch_href, sequencing_json, mastery_score) — one row per SCO/AU.
+- `scorm_registrations` (id, sco_id, enrollment_id, attempt_no, completion_status, success_status, score_scaled, score_raw, score_max, total_time_seconds, suspend_data, location, updated_at) — per-learner runtime state.
+- `scorm_rte_events` (id, registration_id, verb, payload_json, occurred_at) — audit/replay (optional, partitioned).
+- Module item link: extend the existing module content item type enum to add `scorm`.
+- Indexes: `scorm_scos(package_id)`, `scorm_registrations(sco_id, enrollment_id)` UNIQUE on (sco_id, enrollment_id, attempt_no).
+- Migration: `server/migrations/3NN_scorm_packages.sql` (next free number).
+- Backfill: none (new feature).
+
+## 9. API Surface
+
+- `POST /api/v1/courses/:cid/scorm-packages` (instructor) — multipart upload → enqueues extraction; returns package id + status.
+- `GET /api/v1/scorm-packages/:pid` (course member) — metadata + SCO tree + status.
+- `POST /api/v1/scorm/:scoId/launch` (student) — returns a short-lived signed launch URL + (cmi5) fetch token.
+- `POST /api/v1/scorm/rte/:registrationId/commit` (student, sandboxed-origin CORS) — batched SetValue/Commit for SCORM RTE.
+- `POST /api/v1/scorm/cmi5/statements` (student) — xAPI statement forwarder → internal LRS.
+- WebSocket: optional progress push to instructor gradebook.
+- Rate limits: RTE commit limited per registration; launch token TTL ≤ 10 min.
+- OpenAPI: document all routes; mark sandboxed-origin routes explicitly.
+
+## 10. UI / UX
+
+- **Instructor:** "Add SCORM/cmi5 package" in the module item picker; upload modal with progress, type detection, and post-extract SCO preview.
+- **Student:** full-bleed sandboxed player with resume banner, exit/save, and progress indicator.
+- **States:** empty (no packages), uploading, extracting (queued), ready, failed (with reason), unsupported-package.
+- **Mobile:** player responsive; resume works across devices (server-side state).
+- **Accessibility:** player controls keyboard-navigable; focus moves into the package iframe on launch; "Exit" always reachable.
+- **i18n:** all wrapper copy keyed.
+
+## 11. AI / ML Considerations
+
+Not AI-touching. (Optional future: auto-generate alt descriptions or captions for media inside packages — out of scope here.)
+
+## 12. Integration Points
+
+- External standards: ADL SCORM 1.2 & 2004 (4th ed.), IEEE 1484.11.x, IMS cmi5/xAPI.
+- Internal modules: [zipimport](../../../server/internal/service/zipimport/), [filestorage](../../../server/internal/service/filestorage/), [clamav](../../../server/internal/service/clamav/), [xapi](../../../server/internal/service/xapi/), [caliper](../../../server/internal/service/caliper/), grading/gradebook handlers in `server/internal/httpserver/`.
+- Webhooks: emit `scorm.package.ingested` and `scorm.attempt.completed` ([16.3](../../completed/16-integrations-extensibility/16.3-outbound-webhooks.md)).
+
+## 13. Dependencies & Sequencing
+
+- Must ship after: object storage (8.1), antivirus (8.6), xAPI emission (9.6).
+- Must ship before: nothing blocking; complements 8.9 OER and 14.17 CEU.
+- Shared infra: object storage, background job queue, internal LRS, sandboxed asset origin (CDN subdomain).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Malicious package JS exfiltrates data | M | H | Cookieless sandbox origin, strict CSP, postMessage origin checks, AV scan |
+| SCORM conformance edge cases | H | M | Run ADL/CATAPULT suites in CI; fixture-driven RTE tests |
+| Large packages exhaust storage | M | M | Enforce quotas + zip-bomb caps; async extraction |
+| Publisher packages call external trackers (COPPA) | M | H | Admin egress allowlist; block by default for K-12 orgs |
+
+## 15. Rollout Plan
+
+- Feature flag `scorm_ingestion` (default off).
+- Sequence: schema → extraction worker → sandboxed player + RTE → gradebook mapping → xAPI emission → flip flag.
+- Dogfood with one publisher SCORM package and one cmi5 CATAPULT package.
+- GA criteria: ADL 2004 4th ed. RTE suite green; cmi5 CATAPULT green; gradebook write verified.
+- Rollback: disable flag (existing attempts preserved; items hidden).
+
+## 16. Test Plan
+
+- **Unit** — manifest/cmi5.xml parsing, CMI data-model get/set mapping, score scaling.
+- **Integration** — upload→extract→launch→commit→gradebook write; resume/suspend round-trip.
+- **E2E** — Playwright: instructor adds package, student completes, grade appears.
+- **Security** — sandbox escape attempts, credentialed fetch blocked, zip-bomb, malformed manifest.
+- **Conformance** — ADL SCORM 1.2 & 2004 RTE suites; cmi5 CATAPULT.
+- **Accessibility** — axe on player chrome; keyboard launch/exit.
+- **Performance/load** — concurrent RTE commits; large-package extraction timing.
+
+## 17. Documentation & Training
+
+- Help center: "Add SCORM/cmi5 content"; "Why did my SCORM grade not appear?" troubleshooting.
+- Admin docs: egress allowlist, storage quota impact.
+- API reference updates for new routes.
+- Runbook: extraction worker failures, conformance-suite CI.
+
+## 18. Open Questions
+
+1. Do we need AICC HACP for any committed customer, or SCORM/cmi5 only?
+2. Internal LRS reuse vs. dedicated SCORM runtime store — single table or separate service?
+3. Should multi-SCO sequencing (SCORM 2004 simple sequencing) be full or "navigation only" in v1?
+
+## 19. References
+
+- Existing files: [server/internal/service/zipimport/](../../../server/internal/service/zipimport/), [server/internal/service/xapi/](../../../server/internal/service/xapi/), [server/internal/service/caliper/](../../../server/internal/service/caliper/), `server/internal/httpserver/h5p.go`.
+- External standards: ADL SCORM 1.2/2004, IEEE 1484.11, IMS cmi5 + xAPI 1.0.3, ADL CATAPULT.
+- Related plans: [2.12 LTI 1.3](../../completed/02-assessment-and-authoring/2.12-lti-1.3.md), [2.13 QTI/Common Cartridge](../../completed/02-assessment-and-authoring/2.13-qti-common-cartridge-import.md), [8.12 H5P](../../completed/08-content-media-files/8.12-interactive-h5p-content.md), [9.6 Caliper/xAPI](../../completed/09-analytics-reporting/9.6-caliper-xapi-emission.md).

--- a/docs/plan/02-assessment-and-authoring/2.15-differentiated-assignments.md
+++ b/docs/plan/02-assessment-and-authoring/2.15-differentiated-assignments.md
@@ -1,0 +1,157 @@
+# 2.15 — Differentiated Assignments (Assign-To Targeting & Multiple Due Dates)
+
+> Implementation plan. Source: gap scan 2026-06-19. Only per-enrollment **quiz** overrides exist (extra attempts / time multiplier for accommodations, [migration 084](../../../server/migrations/084_enrollment_quiz_overrides.sql)). No general "assign to" targeting or per-section/group/student due-date and availability differentiation exists.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | 2.15 |
+| **Section** | Assessment & Authoring |
+| **Severity** | MAJOR (K12) / MAJOR (HE) |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | PARTIAL (quiz time/attempt overrides only) |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Assessment team |
+| **Depends on** | 5.4 (sections), 6.6 (group spaces), 2.11 (accommodations), 13.6 (grade-level scoping) |
+| **Unblocks** | Differentiated instruction (K-12), multi-section course management (HE), tiered/leveled assignments |
+
+---
+
+## 1. Problem Statement
+
+An assignment or quiz can only be assigned to the whole course with a single due date and availability window. Instructors cannot "assign to" specific sections, groups, or individual students, nor give different due dates / availability per audience. This is a core Canvas capability ("Assign To") that K-12 teachers rely on for differentiated instruction (leveled work, IEP/504 timing, make-up groups) and that HE instructors need for multi-section courses and individual extensions. The absence forces instructors to duplicate assignments or manage exceptions manually, and blocks make-up/extension workflows beyond the narrow quiz-time override that exists today.
+
+## 2. Goals
+
+- Let instructors target an assignment/quiz to one or more audiences: everyone, specific sections, specific groups, or specific students.
+- Allow per-target due date, available-from, and available-until overrides; an item can have multiple concurrent assignment targets.
+- Hide an item entirely from students not in any assigned target.
+- Surface the *student's own* effective dates everywhere (calendar, to-do, gradebook) and the full override matrix to instructors.
+- Generalize the existing quiz-only overrides into one differentiation model.
+
+## 3. Non-Goals
+
+- Differentiating assignment *content* per audience (different files/questions) — that is tiered/branching content, a separate plan; here only audience + dates + visibility differ.
+- Adaptive/AI-driven targeting ([1.4](../../completed/01-adaptive-learning-core/1.4-adaptive-paths-across-modules.md) covers adaptive paths).
+- Per-target distinct point values.
+
+## 4. Personas & User Stories
+
+- **As a teacher (K-12)**, I want to assign the "advanced" version to my honors group and a different due date to my support group so I can differentiate.
+- **As a teacher**, I want to grant one student a later due date without editing the assignment for everyone.
+- **As an instructor (HE)**, I want one assignment shared across three sections with section-specific due dates.
+- **As a student**, I want my calendar and to-do list to show *my* due date, not someone else's.
+- **As an accommodations coordinator**, I want extended-time/availability overrides to flow from the accommodations engine ([2.11](../../completed/02-assessment-and-authoring/2.11-accommodations.md)) into the same model.
+
+## 5. Functional Requirements
+
+- **FR-1.** The system MUST let an instructor add one or more "assign-to" targets per assignment/quiz: `everyone`, `section`, `group`, or `student` (multiple allowed).
+- **FR-2.** Each target MUST support optional `due_at`, `available_from`, `available_until` overriding the item defaults.
+- **FR-3.** The system MUST hide an item from students who are not in any target (no visibility, no to-do, no calendar entry).
+- **FR-4.** The system MUST compute a single **effective** due/availability per student (most-specific target wins: student > group > section > everyone) and use it consistently across availability gating, late detection, calendar ([course calendar]), to-do, and notifications.
+- **FR-5.** The system MUST validate against orphaned items (an item assigned to nobody) and warn the instructor.
+- **FR-6.** The system MUST fold the existing per-enrollment quiz overrides ([084](../../../server/migrations/084_enrollment_quiz_overrides.sql)) and accommodation time extensions ([2.11](../../completed/02-assessment-and-authoring/2.11-accommodations.md)) into (or interoperate cleanly with) this model so there is one source of effective dates/limits.
+- **FR-7.** The system SHOULD show instructors an override matrix (audience → dates) and flag conflicts/overlaps.
+- **FR-8.** The system SHOULD support bulk "extend due date for selected students".
+
+## 6. Non-Functional Requirements
+
+- **Performance** — effective-date resolution is indexed and O(targets); student dashboards p95 < 400ms with overrides applied.
+- **Security** — students MUST NOT see items they aren't assigned, nor other audiences' dates; instructors/graders scoped to their sections.
+- **Privacy & Compliance** — individual targeting (e.g., for accommodations) MUST NOT reveal *why* a student has a different date; minors' targeting not exposed to peers.
+- **Accessibility** — assign-to editor and date pickers WCAG 2.1 AA.
+- **Scalability** — supports many sections/groups; resolution does not N+1 across students.
+- **Reliability** — effective-date computation deterministic; consistent between availability gating and gradebook late flags.
+- **Observability** — metrics: items_with_overrides, orphaned_item_warnings; logs include item_id, target_type.
+- **Maintainability** — one effective-date resolver reused everywhere; remove duplicated date logic.
+- **Internationalization** — dates rendered in each student's timezone ([11.4](../../completed/11-i18n-l10n/11.4-time-zones.md)).
+- **Backward compatibility** — existing single-date assignments become an implicit `everyone` target; quiz overrides migrated.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* an assignment targeted to Section A (due Fri) and Section B (due Mon), *When* a Section A student views it, *Then* they see due Friday; a Section B student sees Monday.
+- **AC-2.** *Given* an item targeted only to Group 1, *When* a non-group student loads the course, *Then* the item is absent from their list, to-do, and calendar.
+- **AC-3.** *Given* a student-specific override (later due date), *When* the gradebook evaluates lateness, *Then* it uses that student's effective due date.
+- **AC-4.** *Given* overlapping targets (in a section *and* an individual override), *When* effective date is computed, *Then* the most-specific (student) override wins.
+- **AC-5.** *Given* an item with no targets, *When* the instructor tries to publish, *Then* they receive an orphaned-item warning.
+- **AC-6.** *Given* an accommodation extended-time grant, *When* the student takes the quiz, *Then* the effective time limit reflects it via the unified model.
+
+## 8. Data Model
+
+- `assignment_overrides` (id, item_id, item_type [`assignment`|`quiz`], target_type [`everyone`|`section`|`group`|`student`], target_id NULL, due_at NULL, available_from NULL, available_until NULL, created_by, created_at).
+- Optional generalization of `enrollment_quiz_overrides` (extra_attempts, time_multiplier) into `assignment_overrides` or a linked `quiz_override_params` row keyed by override id.
+- Effective-date resolution view/function `effective_item_dates(item_id, student_id)`.
+- Indexes: (item_id, target_type, target_id); (target_type, target_id).
+- Migration: `server/migrations/3NN_assignment_overrides.sql`; backfill existing items as `everyone` targets and migrate quiz overrides.
+
+## 9. API Surface
+
+- `GET/PUT /api/v1/assignments/:aid/overrides` and `/api/v1/quizzes/:qid/overrides` (instructor) — list/replace targets.
+- `POST /api/v1/assignments/:aid/overrides/bulk-extend` (instructor) — extend due date for selected students.
+- Student-facing item/listing endpoints MUST filter by assignment and return effective dates.
+- OpenAPI documented; authz section-scoped.
+
+## 10. UI / UX
+
+- "Assign To" editor on assignment/quiz settings: chips for everyone/sections/groups/students; per-card due/available date pickers; "+ Add" for another audience.
+- Instructor override matrix view; orphaned-item warning banner.
+- Bulk "extend due date" from the gradebook selection.
+- Student side: only effective dates shown; no hint of other audiences.
+- **States:** single-target (default everyone), multi-target, conflict warning, orphaned warning.
+- **Mobile:** assign-to editor responsive.
+- **Accessibility:** date pickers labeled; chip removal keyboard-accessible.
+- **i18n/tz:** dates in student tz; copy keyed.
+
+## 11. AI / ML Considerations
+
+None.
+
+## 12. Integration Points
+
+- Internal: sections ([5.4](../../completed/05-multi-tenancy-org-roles/5.4-sections.md)), groups ([6.6](../../completed/06-communication-collaboration/6.6-group-spaces.md)), accommodations ([2.11](../../completed/02-assessment-and-authoring/2.11-accommodations.md)), course calendar pages, to-do/notifications, gradebook late logic.
+- Canvas import already parses `unlock_at`/section overrides — map imported overrides into this model.
+
+## 13. Dependencies & Sequencing
+
+- Must ship after: 5.4 sections, 6.6 groups.
+- Should ship before/with: anything depending on a single effective-date resolver (calendar, to-do consistency).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Inconsistent effective dates across surfaces | H | H | One shared resolver; integration tests across calendar/to-do/gradebook |
+| Visibility leak of targeted items | M | H | Server-side filtering + tests |
+| Migration of existing quiz overrides breaks accommodations | M | H | Backfill carefully; keep accommodation grants authoritative; regression tests |
+
+## 15. Rollout Plan
+
+- Feature flag `assign_to_overrides` (default off).
+- Sequence: schema + backfill (everyone targets) → resolver → instructor editor → student filtering → migrate quiz overrides → flip flag.
+- Dogfood in a multi-section course and a differentiated K-12 class.
+- GA criteria: effective-date consistency suite green; visibility security tests green.
+- Rollback: disable flag (items revert to single default date; backfilled `everyone` targets harmless).
+
+## 16. Test Plan
+
+- **Unit** — most-specific-wins resolution; orphan detection; tz handling.
+- **Integration** — dates consistent across availability/gradebook/calendar/to-do; quiz override migration.
+- **E2E** — section/group/student targeting visibility + due dates; bulk extend.
+- **Security** — non-targeted students cannot see item or others' dates.
+- **Accessibility** — axe + keyboard on assign-to editor.
+
+## 17. Documentation & Training
+
+- Help center: "Assign to sections, groups, or students" and "Give a student more time".
+- Note on how accommodations and assign-to interact.
+
+## 18. Open Questions
+
+1. Fully merge `enrollment_quiz_overrides` into the new model, or keep quiz-specific params linked?
+2. Should group targeting auto-update when group membership changes mid-assignment?
+
+## 19. References
+
+- Existing files: [migration 084](../../../server/migrations/084_enrollment_quiz_overrides.sql), `server/internal/repos/coursesections/repo.go`, `server/internal/httpserver/course_sections.go`, course calendar pages in `clients/web/src/pages/lms/`.
+- Related plans: [5.4 Sections](../../completed/05-multi-tenancy-org-roles/5.4-sections.md), [6.6 Group Spaces](../../completed/06-communication-collaboration/6.6-group-spaces.md), [2.11 Accommodations](../../completed/02-assessment-and-authoring/2.11-accommodations.md).

--- a/docs/plan/03-submissions-grading-integrity/3.15-peer-review-assessment.md
+++ b/docs/plan/03-submissions-grading-integrity/3.15-peer-review-assessment.md
@@ -1,0 +1,169 @@
+# 3.15 — Peer Review & Peer Assessment
+
+> Implementation plan. Source: gap scan 2026-06-19. Explicitly deferred as a "separate feature" in [3.3](../../completed/03-submissions-grading-integrity/3.3-anonymous-blind-grading.md) §3, [3.4](../../completed/03-submissions-grading-integrity/3.4-moderated-grading.md) §3, and [3.13](../../completed/03-submissions-grading-integrity/3.13-resubmission-workflow.md) §3. No implementation exists.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | 3.15 |
+| **Section** | Submissions, Grading & Academic Integrity |
+| **Severity** | BLOCKER (HE) / MAJOR (K12, SL) |
+| **Markets** | HE / K12 / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | L (1–2mo) |
+| **Owner (proposed)** | Assessment team |
+| **Depends on** | 3.1 (inline annotation), 3.3 (anonymous/blind grading), 6.6 (group spaces — team peer eval), rubrics |
+| **Unblocks** | Writing-intensive courses, large-lecture peer grading, capstone/studio crits, MOOC-scale self-learner grading |
+
+---
+
+## 1. Problem Statement
+
+Lextures has no peer review / peer assessment workflow. Students cannot evaluate each other's submissions against a rubric, and instructors cannot run calibrated peer grading. This is a disqualifying gap for higher-education writing programs, large-enrollment courses that rely on peer grading to scale feedback, design/studio critiques, and any pedagogy built on peer learning. Self-learner cohort courses and MOOCs similarly depend on peer grading because instructor time does not scale. Three existing plans explicitly punt this to "a separate feature" — this plan is that feature.
+
+## 2. Goals
+
+- Let instructors configure a peer-review stage on an assignment: number of reviews per student, anonymity level, rubric, due dates, and whether peer scores contribute to the grade.
+- Automatically (and manually) allocate reviewers to submissions, excluding self and (optionally) same-group members.
+- Provide reviewers an annotation + rubric interface ([3.1](../../completed/03-submissions-grading-integrity/3.1-inline-document-annotation.md)) to assess assigned peers.
+- Aggregate peer scores (mean/median/trimmed) and optionally blend with instructor grade; flag low-agreement or non-completing reviewers.
+- Support **team peer evaluation** (CATME-style member contribution rating) for group assignments ([6.6](../../completed/06-communication-collaboration/6.6-group-spaces.md)).
+
+## 3. Non-Goals
+
+- Cross-institution peer review (single org/course scope).
+- AI-generated peer feedback (covered by AI plans in §19; peer review here is human).
+- Calibrated peer review with instructor "gold" pre-scoring as a hard requirement (MAY in a later phase).
+- Replacing instructor grading — peer scores augment, not replace, unless explicitly configured.
+
+## 4. Personas & User Stories
+
+- **As an instructor (HE)**, I want each student to anonymously review 3 peers against my rubric so that students get fast, multiple-perspective feedback at scale.
+- **As an instructor (K-12)**, I want a "two stars and a wish" structured peer review with names visible so I can teach constructive feedback.
+- **As a student**, I want to see the peer feedback I received and (optionally) rate its helpfulness.
+- **As a group member**, I want to rate teammates' contributions confidentially so free-riding is surfaced to the instructor.
+- **As a self-learner in a cohort**, I want my project peer-graded so I get a grade even without an instructor.
+
+## 5. Functional Requirements
+
+- **FR-1.** The system MUST let an instructor enable peer review on an assignment with: reviews-per-reviewer (N), anonymity (`double_blind` | `reviewer_anon` | `named`), rubric selection, review window (open/close), and grade contribution mode (`none` | `score_only` | `weighted_blend`).
+- **FR-2.** The system MUST allocate N submissions to each reviewer after the submission deadline, excluding self and same-group, balancing review load; instructors MAY reassign manually.
+- **FR-3.** The system MUST present reviewers an annotation + rubric form scoped to assigned submissions only, enforcing the configured anonymity on both sides.
+- **FR-4.** The system MUST aggregate received peer scores per submission (mean/median/trimmed-mean configurable) and surface them to the instructor before grade posting.
+- **FR-5.** The system MUST track reviewer completion and flag incomplete reviewers; instructors MAY assign a participation grade for reviewing.
+- **FR-6.** The system MUST support team peer evaluation: each group member rates co-members on a contribution scale; results are visible to instructor only and MAY adjust the shared group grade per a configured multiplier.
+- **FR-7.** The system SHOULD compute reviewer reliability (deviation from peer median / instructor score) to flag outliers.
+- **FR-8.** The system SHOULD let students rate received reviews for helpfulness (back-evaluation).
+- **FR-9.** The system MUST respect existing grade posting policies ([3.8](../../completed/03-submissions-grading-integrity/3.8-grade-posting-policies.md)) and the grade-change audit trail ([3.10](../../completed/03-submissions-grading-integrity/3.10-grade-change-audit-trail.md)).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — allocation for a 500-student course completes < 5s (batch job); reviewer page p95 < 400ms.
+- **Security** — anonymity enforced server-side: identity fields stripped from API responses per anonymity mode; a reviewer can only access submissions allocated to them; no enumeration of unassigned submissions.
+- **Privacy & Compliance** — peer feedback is part of the education record (FERPA); double-blind preserves anonymity even in exports; minors' identities (K-12) never leaked across the anonymity boundary.
+- **Accessibility** — review/rubric forms WCAG 2.1 AA; annotation tools keyboard-operable (inherits [3.1](../../completed/03-submissions-grading-integrity/3.1-inline-document-annotation.md)/[12.x](../../completed/12-accessibility/)).
+- **Scalability** — allocation algorithm O(n·N); supports large-lecture and MOOC cohorts.
+- **Reliability** — allocation idempotent; re-running after a late submission adds reviews without duplicating.
+- **Observability** — metrics: reviews_assigned, reviews_completed_rate, median_agreement, outlier_reviewers.
+- **Maintainability** — allocation + aggregation isolated in a `peerreview` service module.
+- **Internationalization** — all rubric/instruction/feedback UI strings keyed; feedback text language-agnostic.
+- **Backward compatibility** — additive to assignments; peer review off by default.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a peer-review assignment set to 3 reviews/double-blind, *When* the submission window closes, *Then* each submitting student is allocated exactly 3 distinct peer submissions (never their own) and identities are hidden on both sides.
+- **AC-2.** *Given* a reviewer completes a rubric review, *When* they submit it, *Then* the score is recorded and counts toward the reviewee's aggregated peer score.
+- **AC-3.** *Given* `weighted_blend` at 30%, *When* the instructor posts grades, *Then* each student's grade = 0.7·instructor + 0.3·peer-aggregate, and the audit trail records the computation.
+- **AC-4.** *Given* a group assignment with team peer evaluation, *When* all members rate, *Then* the instructor sees per-member contribution scores and any free-rider flags, invisible to students.
+- **AC-5.** *Given* a reviewer never completes their reviews, *When* the review window closes, *Then* they are flagged and (if configured) their participation grade reflects 0 completed reviews.
+- **AC-6.** *Given* double-blind mode, *When* any peer-review API response or export is generated, *Then* no reviewer or reviewee identity fields are present.
+
+## 8. Data Model
+
+- `peer_review_configs` (id, assignment_id, reviews_per_reviewer, anonymity, rubric_id, opens_at, closes_at, grade_mode, blend_weight, aggregation [`mean`|`median`|`trimmed`], created_at).
+- `peer_review_allocations` (id, config_id, reviewer_enrollment_id, target_submission_id, status [`assigned`|`in_progress`|`submitted`|`expired`], assigned_at) — UNIQUE(config_id, reviewer_enrollment_id, target_submission_id).
+- `peer_reviews` (id, allocation_id, rubric_assessment_id, score, comments, submitted_at) — links to existing rubric assessment store.
+- `peer_review_helpfulness` (id, peer_review_id, rater_enrollment_id, rating).
+- `team_peer_evaluations` (id, group_id, rater_enrollment_id, ratee_enrollment_id, contribution_score, comment, submitted_at).
+- Indexes on (config_id), (reviewer_enrollment_id), (target_submission_id). Migration: `server/migrations/3NN_peer_review.sql`.
+- Backfill: none.
+
+## 9. API Surface
+
+- `PUT /api/v1/assignments/:aid/peer-review` (instructor) — create/update config.
+- `POST /api/v1/assignments/:aid/peer-review/allocate` (instructor) — run/re-run allocation.
+- `GET /api/v1/peer-review/assigned` (student) — submissions allocated to me (anonymized).
+- `POST /api/v1/peer-review/allocations/:id` (student) — submit a review (rubric + annotations).
+- `GET /api/v1/assignments/:aid/peer-review/received` (student) — feedback I received (anonymized per mode).
+- `POST /api/v1/groups/:gid/team-eval` (student) — submit team peer evaluation.
+- `GET /api/v1/assignments/:aid/peer-review/summary` (instructor) — aggregates, agreement, outliers, completion.
+- Rate limits standard; OpenAPI documented; anonymity enforced in serializers.
+
+## 10. UI / UX
+
+- **Instructor:** peer-review setup panel on the assignment; allocation dashboard (completion %, outliers); summary with per-student peer vs. instructor scores.
+- **Student:** "Peer reviews to complete" list with progress; review workspace (submission + annotations + rubric); "Feedback you received" view; team-eval form.
+- **States:** before window (not yet open), open (with countdown), submitted, closed; empty (no allocations), error.
+- **Mobile:** review workspace responsive; rubric usable on small screens.
+- **Accessibility:** rubric radio groups labeled; annotation keyboard support; focus management on submit.
+- **i18n:** all copy keyed.
+
+## 11. AI / ML Considerations
+
+Not required for v1 (human peer review). Optional later: AI helpfulness scoring of peer comments and AI calibration hints — defer to §19 AI plans; keep this plan model-free.
+
+## 12. Integration Points
+
+- Internal modules: rubric/assessment store, [3.1 annotation](../../completed/03-submissions-grading-integrity/3.1-inline-document-annotation.md), [3.3 anonymity](../../completed/03-submissions-grading-integrity/3.3-anonymous-blind-grading.md), [6.6 groups](../../completed/06-communication-collaboration/6.6-group-spaces.md), grading handlers in `server/internal/httpserver/`.
+- Notifications: "reviews assigned", "review window closing", "feedback received" ([6.2](../../completed/06-communication-collaboration/6.2-email-notifications.md)/[6.3](../../completed/06-communication-collaboration/6.3-push-notifications.md)).
+- Webhooks: `peer_review.completed`.
+
+## 13. Dependencies & Sequencing
+
+- Must ship after: rubrics, 3.1, 3.3, 6.6.
+- Shared infra: notifications, background job (allocation), object storage (annotated artifacts).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Anonymity leak via API/export | M | H | Server-side serializer stripping; security tests per mode |
+| Uneven/low review completion | H | M | Reminders, participation grade, late-submission re-allocation |
+| Gaming team evaluations (collusion) | M | M | Confidential to instructor; outlier flagging; instructor override |
+| Allocation imbalance with late submitters | M | M | Idempotent re-allocation; instructor manual reassign |
+
+## 15. Rollout Plan
+
+- Feature flag `peer_review` (default off).
+- Sequence: schema → config UI → allocation job → reviewer workspace → aggregation/blend → team eval → flip flag.
+- Dogfood in one writing course + one group-project course.
+- GA criteria: anonymity security tests green; blend math audited; allocation correctness verified.
+- Rollback: disable flag; peer data retained, hidden.
+
+## 16. Test Plan
+
+- **Unit** — allocation (no self, no same-group, balanced N), aggregation (mean/median/trimmed), blend math.
+- **Integration** — full cycle incl. late submission re-allocation; anonymity in responses/exports.
+- **E2E** — Playwright: instructor configures, students review, instructor posts blended grades.
+- **Security** — access only to allocated submissions; anonymity by mode; no enumeration.
+- **Accessibility** — axe + keyboard on review workspace.
+- **Performance** — allocation at 500 and 5,000 students.
+
+## 17. Documentation & Training
+
+- Help center: instructor setup; student "how to peer review"; team evaluation guide.
+- Pedagogy note: anonymity modes and when to use each.
+- API reference updates.
+
+## 18. Open Questions
+
+1. Default aggregation: median vs. trimmed mean?
+2. Should calibration (instructor gold submissions) be in v1 or phase 2?
+3. Team-eval multiplier caps to prevent extreme grade swings?
+
+## 19. References
+
+- Existing files: `server/internal/httpserver/` grading handlers, [server/internal/service/moderatedgrading/](../../../server/internal/service/moderatedgrading/), rubric/assessment repos in `server/internal/repos/`.
+- External: CATME team-evaluation methodology; AAC&U VALUE rubrics.
+- Related plans: [3.3](../../completed/03-submissions-grading-integrity/3.3-anonymous-blind-grading.md), [3.4](../../completed/03-submissions-grading-integrity/3.4-moderated-grading.md), [3.13](../../completed/03-submissions-grading-integrity/3.13-resubmission-workflow.md), [6.6](../../completed/06-communication-collaboration/6.6-group-spaces.md).

--- a/docs/plan/03-submissions-grading-integrity/3.16-what-if-grades.md
+++ b/docs/plan/03-submissions-grading-integrity/3.16-what-if-grades.md
@@ -1,0 +1,150 @@
+# 3.16 — What-If Grades (Student Grade Projection)
+
+> Implementation plan. Source: gap scan 2026-06-19. No "what-if"/grade-projection capability exists in code, migrations, or docs.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | 3.16 |
+| **Section** | Submissions, Grading & Academic Integrity |
+| **Severity** | MAJOR |
+| **Markets** | HE / K12 / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Grading team |
+| **Depends on** | 3.6 (grade categories), 3.8 (grade posting policies), 3.9 (drop/replace lowest), 9.1 (progress dashboard) |
+| **Unblocks** | Student self-regulation, reduced "what do I need on the final?" support load |
+
+---
+
+## 1. Problem Statement
+
+Students can see their current grade but cannot model hypothetical scores ("if I get 90% on the final, what's my course grade?"). This "what-if grades" feature is a baseline expectation set by Canvas and is one of the most-used student gradebook features. Without it, students cannot self-regulate, advisors cannot counsel on recovery scenarios, and support channels field repetitive "what do I need to pass?" questions. It matters across all three markets and is low-cost relative to its visible student value.
+
+## 2. Goals
+
+- Let a student enter hypothetical scores for ungraded (or any) items and instantly see their projected course grade.
+- Compute projections using the *exact* grading rules already in the gradebook: weighted categories, drop/replace-lowest, excused items, posting policies.
+- Show a "target score needed" helper: given a goal grade, what score is required on remaining items.
+- Keep what-if entries private to the student and non-persistent (or per-student scratch only) — never affecting real grades.
+
+## 3. Non-Goals
+
+- Instructor-side scenario modeling (separate; instructors use the gradebook directly).
+- Persisting what-if values across devices in v1 (local/session scope acceptable; MAY persist later).
+- Projecting GPA across courses (that's advising/[14.14](../../completed/14-higher-ed-specific/14.14-advising-degree-planner.md)).
+
+## 4. Personas & User Stories
+
+- **As a student**, I want to type a hypothetical final-exam score and see my projected letter grade so I know how hard to study.
+- **As a student**, I want to ask "what do I need on the final to get a B?" and get the number.
+- **As a parent (K-12)**, I want to model my child's outcomes in the parent portal ([13.1](../../completed/13-k12-specific/13.1-parent-portal.md)) read-only.
+- **As a self-learner**, I want to see whether I can still earn the certificate threshold.
+
+## 5. Functional Requirements
+
+- **FR-1.** The system MUST let a student enter or override a score for any gradebook item in a what-if scratch state, scoped to that student only.
+- **FR-2.** The system MUST recompute the projected total using the same engine as the real gradebook: category weights ([3.6](../../completed/03-submissions-grading-integrity/3.6-grade-categories-beyond-points.md)), drop/replace-lowest ([3.9](../../completed/03-submissions-grading-integrity/3.9-drop-lowest-replace-lowest.md)), excused/exempt ([3.12](../../completed/03-submissions-grading-integrity/3.12-excused-exempt-state.md)).
+- **FR-3.** The system MUST clearly label projected values as hypothetical and visually distinguish them from real grades.
+- **FR-4.** The system MUST never write what-if values to the authoritative gradebook or any instructor-visible store.
+- **FR-5.** The system MUST provide a "reset to actual" action restoring real grades.
+- **FR-6.** The system SHOULD provide a "score needed for target grade" calculator across remaining ungraded items (assuming equal effort or a chosen distribution).
+- **FR-7.** The system SHOULD reflect unposted/hidden items per posting policy ([3.8](../../completed/03-submissions-grading-integrity/3.8-grade-posting-policies.md)) — what-if cannot reveal a hidden real score.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — projection recompute < 100ms client-side (or p95 < 200ms if server-computed); no full page reload per edit.
+- **Security** — what-if is read-only against real data; server endpoints (if any) reject writes to grade tables; a student can only model their own grades.
+- **Privacy & Compliance** — no new education-record writes; FERPA-neutral. Parent access mirrors existing portal scoping.
+- **Accessibility** — editable cells keyboard-operable; projected vs. real distinguished by more than color (icon/label); screen-reader announces "hypothetical".
+- **Scalability** — ideally pure client computation reusing a shared grade-calc module; no DB load.
+- **Reliability** — deterministic; matches real gradebook to the cent/letter.
+- **Observability** — lightweight usage metric (whatif_sessions) only.
+- **Maintainability** — extract the grade-calculation logic into a single shared module (server + client parity) to prevent drift.
+- **Internationalization** — number/locale formatting via existing locale utilities ([11.3](../../completed/11-i18n-l10n/11.3-locale-aware-dates-numbers.md)).
+- **Backward compatibility** — purely additive UI.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a course with weighted categories and one ungraded final, *When* a student enters 90% on the final, *Then* the projected course grade updates instantly using the correct weights.
+- **AC-2.** *Given* a drop-lowest policy, *When* the student's what-if scores change which item is dropped, *Then* the projection reflects the new dropped item.
+- **AC-3.** *Given* the student sets a target grade of "B", *When* they open the target calculator, *Then* the system shows the score needed on remaining items (or "not achievable").
+- **AC-4.** *Given* what-if edits, *When* the instructor opens the gradebook, *Then* no what-if values are visible and real grades are unchanged.
+- **AC-5.** *Given* a hidden/unposted item, *When* a student uses what-if, *Then* the real hidden score is never revealed.
+- **AC-6.** *Given* "reset to actual", *When* clicked, *Then* all projections revert to real grades.
+
+## 8. Data Model
+
+- No authoritative schema changes required. What-if state is client/session-only.
+- *Optional (phase 2):* `student_whatif_scratch` (student_id, course_id, item_id, hypothetical_score, updated_at) for cross-device persistence — clearly isolated from grade tables.
+- The key engineering artifact is a **shared grade-calculation module** (already implied by the existing gradebook) exposed for client reuse.
+
+## 9. API Surface
+
+- Primary path: client-side computation against the already-fetched gradebook payload (no new endpoint).
+- Optional: `POST /api/v1/courses/:cid/grades/project` (student) — server computes projection from a posted set of hypothetical scores; returns projected totals (no writes). Useful for parity testing and complex policies.
+- OpenAPI documents the optional endpoint; rate-limited.
+
+## 10. UI / UX
+
+- In the student grade view: each item's score becomes inline-editable in "what-if" mode; projected total + letter shown prominently with a "Hypothetical" badge.
+- "What score do I need?" panel with target-grade selector.
+- "Reset to actual" button; banner explaining what-if is private.
+- **States:** no grades yet, all graded (what-if still allowed for replay), error.
+- **Mobile:** editable rows usable on touch.
+- **Accessibility:** clear non-color indication of hypothetical; SR labels; focus retained on edit.
+- **i18n:** all copy + number formats localized.
+
+## 11. AI / ML Considerations
+
+None.
+
+## 12. Integration Points
+
+- Internal: student gradebook view in `clients/web/src/`, grade-calc logic mirrored from [gradingdisplay](../../../server/internal/gradingdisplay/)/[gradingdrops](../../../server/internal/gradingdrops/) and grading handlers; progress dashboard ([9.1](../../completed/09-analytics-reporting/9.1-per-student-progress-dashboard.md)).
+- Parent portal ([13.1](../../completed/13-k12-specific/13.1-parent-portal.md)) read-only reuse.
+
+## 13. Dependencies & Sequencing
+
+- Must ship after: 3.6, 3.8, 3.9, 3.12 (grading rules must exist to project correctly).
+- Shared infra: shared grade-calculation module.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Projection diverges from real gradebook | M | H | Single shared calc module + parity tests against server |
+| Hidden score leakage via what-if | L | H | Compute only over posted items; never fetch hidden reals |
+| Students mistake projection for real grade | M | M | Strong labeling/badging + reset action |
+
+## 15. Rollout Plan
+
+- Feature flag `whatif_grades` (default off → on after parity verified).
+- Sequence: extract shared calc module → student UI → (optional) projection endpoint → flip flag.
+- Dogfood in a course with weighted categories + drop-lowest.
+- GA criteria: projection matches server gradebook in parity suite; a11y pass.
+- Rollback: disable flag.
+
+## 16. Test Plan
+
+- **Unit** — calc parity: weighted categories, drop/replace-lowest, excused, points-based, letter mapping.
+- **Integration** — optional endpoint vs. real gradebook equality across fixtures.
+- **E2E** — student edits hypothetical, sees correct projection; reset works; instructor sees nothing.
+- **Security** — student cannot project others' grades; no write to grade tables; hidden items safe.
+- **Accessibility** — axe + keyboard + SR labels.
+
+## 17. Documentation & Training
+
+- Help center: "Use What-If Grades"; "What do I need on the final?".
+- Note for instructors that what-if is student-private.
+
+## 18. Open Questions
+
+1. Pure client compute vs. server projection endpoint for v1 — which is the source of truth for complex policies?
+2. Persist what-if across sessions/devices, or session-only?
+
+## 19. References
+
+- Existing files: [server/internal/gradingdisplay/](../../../server/internal/gradingdisplay/), [server/internal/gradingdrops/](../../../server/internal/gradingdrops/), student grade pages in `clients/web/src/`.
+- Related plans: [3.6](../../completed/03-submissions-grading-integrity/3.6-grade-categories-beyond-points.md), [3.8](../../completed/03-submissions-grading-integrity/3.8-grade-posting-policies.md), [3.9](../../completed/03-submissions-grading-integrity/3.9-drop-lowest-replace-lowest.md), [9.1](../../completed/09-analytics-reporting/9.1-per-student-progress-dashboard.md).

--- a/docs/plan/03-submissions-grading-integrity/3.17-grade-curving-scaling.md
+++ b/docs/plan/03-submissions-grading-integrity/3.17-grade-curving-scaling.md
@@ -1,0 +1,156 @@
+# 3.17 — Grade Curving & Scaling
+
+> Implementation plan. Source: gap scan 2026-06-19. No grade-curve/scaling tooling exists (the only "curve" in code is a video drop-off curve in `engagement.go`).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | 3.17 |
+| **Section** | Submissions, Grading & Academic Integrity |
+| **Severity** | MAJOR (HE) / MINOR (K12, SL) |
+| **Markets** | HE / K12 / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Grading team |
+| **Depends on** | 3.8 (grade posting policies), 3.10 (grade-change audit trail), 9.4 (item analysis) |
+| **Unblocks** | STEM/large-lecture HE grading workflows where curving is standard policy |
+
+---
+
+## 1. Problem Statement
+
+Instructors cannot curve or scale grades. There is no way to add a flat bonus, scale to a target mean, fit to a distribution, or set a custom score floor for an assessment — all standard faculty operations in higher education (especially large STEM courses) and used by some K-12 teachers. Today an instructor must export, recompute in a spreadsheet, and re-import — error-prone and untraceable. Faculty evaluating Lextures against Canvas/Blackboard treat curving as table stakes.
+
+## 2. Goals
+
+- Provide instructor-initiated curving on a per-assignment (and optionally per-final-grade) basis: flat bonus, linear scale to target mean/max, square-root curve, set minimum, and custom mapping.
+- Preview the effect (before/after distribution, who changes) before applying.
+- Apply non-destructively: store an adjustment layer so the original raw score is preserved and reversible.
+- Record every curve in the grade-change audit trail ([3.10](../../completed/03-submissions-grading-integrity/3.10-grade-change-audit-trail.md)) and respect posting policies ([3.8](../../completed/03-submissions-grading-integrity/3.8-grade-posting-policies.md)).
+
+## 3. Non-Goals
+
+- Automatic/AI-driven curving recommendations (could reference item analysis but not auto-apply).
+- Curving across multiple courses/sections simultaneously in v1 (per-assessment scope; section selection MAY be included).
+- Norm-referenced final letter assignment policies beyond simple distribution fitting.
+
+## 4. Personas & User Stories
+
+- **As an instructor (HE STEM)**, I want to scale a hard midterm so the class mean is 75 so that the exam difficulty doesn't unfairly tank grades.
+- **As an instructor**, I want to add 5 points to everyone after a flawed question, with an audit record.
+- **As an instructor**, I want to preview exactly who moves above/below a threshold before committing.
+- **As a student**, I want my displayed grade to reflect the curve and (per policy) optionally see that a curve was applied.
+
+## 5. Functional Requirements
+
+- **FR-1.** The system MUST offer curve methods per assessment: `flat_bonus` (add N points/percent), `linear_scale` (to target mean or target max), `sqrt_curve`, `set_minimum` (floor), and `custom_mapping` (raw→adjusted table).
+- **FR-2.** The system MUST show a preview: resulting distribution, mean/median, and a list of students whose grade changes (and by how much) before apply.
+- **FR-3.** The system MUST apply curves as a stored, reversible adjustment that preserves the original raw score; an instructor MUST be able to undo/replace a curve.
+- **FR-4.** The system MUST cap adjusted scores at the assessment max unless an explicit "allow above max / extra credit" toggle is set.
+- **FR-5.** The system MUST write a grade-change audit entry ([3.10](../../completed/03-submissions-grading-integrity/3.10-grade-change-audit-trail.md)) for each affected student with method + parameters + before/after.
+- **FR-6.** The system MUST respect posting policies ([3.8](../../completed/03-submissions-grading-integrity/3.8-grade-posting-policies.md)) — curving an unposted assessment does not reveal scores.
+- **FR-7.** The system MUST exclude excused/exempt ([3.12](../../completed/03-submissions-grading-integrity/3.12-excused-exempt-state.md)) submissions from curve math and not assign them a curved score.
+- **FR-8.** The system SHOULD support curving the computed final course grade with the same methods.
+- **FR-9.** The system MAY surface item-analysis ([9.4](../../completed/09-analytics-reporting/9.4-item-analysis.md)) context next to the curve tool.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — preview + apply for 1,000 students < 2s; computation server-side, transactional.
+- **Security** — instructor/grader scope only; section-scoped graders can only curve their sections; all writes authz-checked.
+- **Privacy & Compliance** — adjustment + raw retained as education record; curve metadata auditable for grade appeals.
+- **Accessibility** — curve dialog + distribution preview WCAG 2.1 AA; preview table screen-reader navigable.
+- **Scalability** — batch update; large-course safe.
+- **Reliability** — apply is atomic (all-or-nothing); undo restores raw exactly; idempotent re-apply.
+- **Observability** — metrics: curves_applied, curves_reverted, avg_shift; audit completeness check.
+- **Maintainability** — curve functions isolated and unit-tested; shared with what-if engine where sensible.
+- **Internationalization** — number/locale formatting localized.
+- **Backward compatibility** — additive; ungraded/uncurved assessments unaffected.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a midterm with mean 62, *When* the instructor selects `linear_scale` to target mean 75 and previews, *Then* the preview shows the new mean ≈75 and the per-student deltas.
+- **AC-2.** *Given* the instructor applies the curve, *When* a student views the grade, *Then* it reflects the curved value and the raw score remains stored.
+- **AC-3.** *Given* a curve is applied then undone, *When* undo completes, *Then* every student's grade equals the original raw score and the audit log records both actions.
+- **AC-4.** *Given* `set_minimum=50`, *When* applied, *Then* all non-excused scores below 50 become 50 and no score above 50 changes.
+- **AC-5.** *Given* an excused submission, *When* a curve is applied, *Then* it is excluded from the mean and receives no curved score.
+- **AC-6.** *Given* "allow above max" is off, *When* a flat bonus would exceed max, *Then* the adjusted score is capped at max.
+
+## 8. Data Model
+
+- `grade_curves` (id, assessment_id | course_id, scope [`assessment`|`final`], section_id NULL, method, params_json, allow_above_max, applied_by, applied_at, reverted_at NULL).
+- `grade_curve_adjustments` (id, curve_id, submission_id, raw_score, adjusted_score) — preserves raw; one row per affected submission.
+- Reuse existing audit trail tables for change records.
+- Indexes on (assessment_id), (curve_id). Migration: `server/migrations/3NN_grade_curving.sql`.
+- Backfill: none.
+
+## 9. API Surface
+
+- `POST /api/v1/assessments/:aid/curve/preview` (instructor) — method + params → distribution + per-student deltas (no write).
+- `POST /api/v1/assessments/:aid/curve` (instructor) — apply; transactional; returns curve id.
+- `DELETE /api/v1/curves/:id` (instructor) — revert to raw.
+- `POST /api/v1/courses/:cid/final-grade/curve` (instructor) — curve final grade (phase 2).
+- Rate-limited; OpenAPI documented; authz section-scoped.
+
+## 10. UI / UX
+
+- Gradebook column menu → "Curve grades" dialog: method selector, params, "allow above max" toggle, live preview (histogram + affected-students table), Apply/Cancel.
+- Applied-curve indicator on the column with "Undo curve".
+- **States:** no submissions yet, all excused, error, already-curved (offers replace/undo).
+- **Mobile:** dialog scrolls; preview table responsive.
+- **Accessibility:** histogram has text/table equivalent; dialog focus trap; SR-announced deltas.
+- **i18n:** copy + numbers localized.
+
+## 11. AI / ML Considerations
+
+None for v1.
+
+## 12. Integration Points
+
+- Internal: grading handlers + repos in `server/internal/httpserver/` / `server/internal/repos/`, [gradingdisplay](../../../server/internal/gradingdisplay/), [3.10 audit](../../completed/03-submissions-grading-integrity/3.10-grade-change-audit-trail.md), [9.4 item analysis](../../completed/09-analytics-reporting/9.4-item-analysis.md).
+- Webhooks: `grade.curve.applied`.
+
+## 13. Dependencies & Sequencing
+
+- Must ship after: 3.8, 3.10, 3.12.
+- Shared infra: audit trail; shared curve/grade-calc functions (overlap with 3.16).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Irreversible grade corruption | L | H | Store raw separately; transactional apply; tested undo |
+| Section-scoped grader curves others' students | M | H | Authz section scoping + tests |
+| Confusing/opaque curve math | M | M | Mandatory preview + audit transparency |
+
+## 15. Rollout Plan
+
+- Feature flag `grade_curving` (default off).
+- Sequence: schema (raw preservation) → preview endpoint → apply/undo → UI → final-grade curve (phase 2) → flip flag.
+- Dogfood in a large STEM course.
+- GA criteria: undo restores raw exactly in tests; audit complete; authz verified.
+- Rollback: disable flag; existing curves remain reversible.
+
+## 16. Test Plan
+
+- **Unit** — each curve function (flat, linear-to-mean/max, sqrt, min, custom); cap behavior; excused exclusion.
+- **Integration** — apply→view→undo round-trip; audit entries; posting-policy interaction.
+- **E2E** — instructor curves a midterm, students see updated grades, undo works.
+- **Security** — section scoping; only graders; no write outside scope.
+- **Accessibility** — axe + keyboard on dialog; histogram text equivalent.
+- **Performance** — 1,000-student apply/undo timing.
+
+## 17. Documentation & Training
+
+- Help center: "Curve grades" with method explanations and examples.
+- Grade-appeal note: how curves appear in the audit trail.
+
+## 18. Open Questions
+
+1. Include final-grade curving in v1 or defer to phase 2?
+2. Should students always be told a curve was applied, or per instructor/org policy?
+
+## 19. References
+
+- Existing files: [server/internal/gradingdisplay/](../../../server/internal/gradingdisplay/), grading handlers/repos in `server/internal/`, audit trail from [3.10](../../completed/03-submissions-grading-integrity/3.10-grade-change-audit-trail.md).
+- Related plans: [3.8](../../completed/03-submissions-grading-integrity/3.8-grade-posting-policies.md), [3.16 What-If Grades](3.16-what-if-grades.md), [9.4 Item Analysis](../../completed/09-analytics-reporting/9.4-item-analysis.md).

--- a/docs/plan/15-self-learner-specific/15.13-tax-compliance.md
+++ b/docs/plan/15-self-learner-specific/15.13-tax-compliance.md
@@ -1,0 +1,169 @@
+# 15.13 — Tax Compliance (Sales Tax / VAT / GST via Stripe Tax)
+
+> Implementation plan. Source: gap scan 2026-06-19. Tax was explicitly deferred to "phase 2" and listed as a Non-Goal / Open Question in [15.3](../../completed/15-self-learner-specific/15.3-billing-stripe.md) and [16.8](../16-integrations-extensibility/16.8-payment-provider-abstraction.md). No tax calculation, collection, or reporting exists in the billing code.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | 15.13 |
+| **Section** | Self-Learner Specific |
+| **Severity** | BLOCKER (global/multi-jurisdiction sales) / MAJOR (US-only) |
+| **Markets** | SL (primary); HE continuing-ed self-pay (secondary) |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Billing/Commerce team |
+| **Depends on** | 15.3 (Stripe billing), 16.8 (payment provider abstraction), 20.1 (terms/receipts) |
+| **Unblocks** | Legal sale of paid courses in the EU/UK (VAT), economic-nexus US states, and other GST jurisdictions |
+
+---
+
+## 1. Problem Statement
+
+Lextures sells paid courses, bundles, and subscriptions ([15.3](../../completed/15-self-learner-specific/15.3-billing-stripe.md), [15.4](../../completed/15-self-learner-specific/15.4-course-bundles-learning-paths.md)) but collects no sales tax, VAT, or GST and produces no tax-compliant invoices. Selling digital education to consumers in the EU/UK legally requires VAT collection and remittance from the first sale; many US states require sales tax once economic nexus is met; Canada/Australia and others require GST. Operating without this exposes the business to back-tax liability and penalties and blocks legitimate international expansion. Both prior billing plans named this explicitly as deferred — this plan closes it.
+
+## 2. Goals
+
+- Calculate the correct tax at checkout for one-time purchases, bundles, and subscriptions based on customer location and product tax category, using **Stripe Tax**.
+- Collect tax as a separate, itemized line and store it with the transaction.
+- Capture and validate the data required for compliance (customer country/region, VAT/GST ID for B2B reverse-charge, IP/billing-address evidence).
+- Produce tax-compliant invoices/receipts and the reports needed for filing/remittance.
+- Make tax behavior configurable per org/creator (registered jurisdictions, tax categories, inclusive vs. exclusive pricing).
+
+## 3. Non-Goals
+
+- Building a bespoke tax engine (we integrate Stripe Tax; alternative providers handled via [16.8](../16-integrations-extensibility/16.8-payment-provider-abstraction.md)).
+- Automatic filing/remittance to tax authorities (we provide the data; filing may use Stripe Tax filing or be manual/3rd-party).
+- Income/corporate tax, 1099/payout tax for affiliates ([15.8](../../completed/15-self-learner-specific/15.8-affiliate-revenue-share.md)) — separate.
+- Non-Stripe payment rails in v1 (deferred to 16.8).
+
+## 4. Personas & User Stories
+
+- **As a self-learner in Germany**, I want VAT shown and charged correctly at checkout and a valid VAT invoice so my purchase is compliant.
+- **As a business buyer with a VAT ID**, I want to enter it and have reverse-charge applied (no VAT charged) so I'm billed correctly.
+- **As a creator/org admin**, I want to set the jurisdictions I'm registered in and the tax category for my courses so the right rate applies.
+- **As a finance admin**, I want a tax report by jurisdiction and period so I can file returns.
+- **As a self-learner in a US state with no tax**, I want no tax added.
+
+## 5. Functional Requirements
+
+- **FR-1.** The system MUST integrate Stripe Tax so checkout ([15.3](../../completed/15-self-learner-specific/15.3-billing-stripe.md)) computes tax from customer location + product tax category for one-time, bundle, and subscription charges.
+- **FR-2.** The system MUST collect and persist the customer's tax location (billing address; country required) and store tax amount, rate, jurisdiction, and tax type per transaction.
+- **FR-3.** The system MUST support B2B VAT/GST ID entry with validation (Stripe Tax ID validation) and apply reverse-charge where applicable.
+- **FR-4.** The system MUST display tax as a separate, itemized line before payment and on the final receipt; support inclusive (tax-included) and exclusive pricing per org config.
+- **FR-5.** The system MUST generate tax-compliant invoices/receipts including seller details, customer details, tax breakdown, and (where required) the customer's VAT ID.
+- **FR-6.** The system MUST let an org/creator configure registered jurisdictions, default product tax category, and price-display mode.
+- **FR-7.** The system MUST produce a tax report by jurisdiction and period (collected amounts, transaction counts) for filing/remittance.
+- **FR-8.** The system MUST handle refunds ([15.3](../../completed/15-self-learner-specific/15.3-billing-stripe.md)) with correct tax reversal and corrected/credit invoices.
+- **FR-9.** The system SHOULD warn an org approaching economic nexus thresholds (informational; Stripe Tax monitoring).
+- **FR-10.** The system MUST keep tax records for the retention period required by law (configurable, default ≥ 7 years).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — tax calc at checkout p95 < 500ms (Stripe Tax call); cached per session where allowed.
+- **Security** — VAT IDs and addresses are PII; encrypt at rest ([10.13](../../completed/10-compliance-privacy-security/10.13-encryption-at-rest.md)); restrict tax reports to finance/admin roles.
+- **Privacy & Compliance** — GDPR/CCPA for stored billing PII; tax records retained per fiscal law even against deletion requests (legal-hold exception documented in [10.3](../../completed/10-compliance-privacy-security/10.3-gdpr-uk-gdpr.md) workflow).
+- **Accessibility** — checkout tax fields + VAT ID entry WCAG 2.1 AA; errors announced.
+- **Scalability** — tax calc scales with checkout volume; reports computed from stored transaction tax fields (no recompute).
+- **Reliability** — tax amount captured atomically with the charge; webhook reconciliation ensures stored tax matches Stripe; idempotent on retries.
+- **Observability** — metrics: tax_collected_by_jurisdiction, tax_calc_failures, reverse_charge_count; alert on calc failures.
+- **Maintainability** — tax logic behind the payment abstraction ([16.8](../16-integrations-extensibility/16.8-payment-provider-abstraction.md)) so providers are swappable.
+- **Internationalization** — currency/locale formatting; jurisdiction names localized; multi-currency aware ([15.3](../../completed/15-self-learner-specific/15.3-billing-stripe.md)).
+- **Backward compatibility** — existing entitlements unaffected; tax applies to new transactions once enabled.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a buyer in the UK, *When* they check out a paid course, *Then* 20% VAT is shown as a line item, charged, and recorded with jurisdiction = GB.
+- **AC-2.** *Given* a buyer in a US state with no sales tax on digital goods, *When* they check out, *Then* no tax is added.
+- **AC-3.** *Given* a B2B buyer enters a valid EU VAT ID, *When* reverse-charge applies, *Then* no VAT is charged and the invoice notes reverse-charge.
+- **AC-4.** *Given* a completed taxed purchase, *When* the buyer downloads the receipt, *Then* it is a tax-compliant invoice with seller/customer details and tax breakdown.
+- **AC-5.** *Given* a refund, *When* processed, *Then* the tax portion is reversed and a corrected/credit invoice is issued.
+- **AC-6.** *Given* a finance admin opens the tax report for a period/jurisdiction, *When* generated, *Then* totals match the sum of stored transaction tax for that scope.
+
+## 8. Data Model
+
+- Extend the billing transaction/entitlement records with: `tax_amount_cents`, `tax_rate`, `tax_jurisdiction`, `tax_type` (`vat`|`gst`|`sales_tax`|`none`), `tax_inclusive` (bool), `customer_country`, `customer_region`, `customer_tax_id`, `reverse_charge` (bool), `stripe_tax_calculation_id`, `invoice_id`.
+- `org_tax_settings` (org_id, registered_jurisdictions_json, default_tax_category, price_display [`inclusive`|`exclusive`], filing_mode, record_retention_years).
+- `tax_invoices` (id, transaction_id, number, pdf_storage_key, issued_at, credited_by NULL).
+- Indexes on (tax_jurisdiction, created_at) for reporting. Migration: `server/migrations/3NN_tax_compliance.sql`.
+- Backfill: existing transactions get `tax_type='none'` historical (no retroactive tax).
+
+## 9. API Surface
+
+- `POST /api/v1/checkout/quote` (buyer) — returns price + computed tax line before payment (Stripe Tax calculation).
+- `POST /api/v1/checkout/tax-id` (buyer) — submit + validate VAT/GST ID; returns reverse-charge applicability.
+- Stripe webhook handlers extended to persist tax from the completed `checkout.session`/`invoice`.
+- `GET /api/v1/orgs/:oid/tax/settings` + `PUT` (admin) — configure jurisdictions/categories/display.
+- `GET /api/v1/orgs/:oid/tax/report?period=&jurisdiction=` (finance/admin) — collected tax report (CSV/JSON).
+- `GET /api/v1/invoices/:id` (buyer/admin) — tax-compliant invoice PDF.
+- Rate-limited; OpenAPI documented; report routes admin-scoped.
+
+## 10. UI / UX
+
+- Checkout: address/country capture, optional "I'm a business — add VAT ID", itemized tax line, inclusive/exclusive display per org.
+- Receipt/invoice download (PDF) post-purchase and in purchase history.
+- Org settings: tax configuration panel (jurisdictions, category, display mode, retention).
+- Finance: tax report screen with period/jurisdiction filters + export.
+- **States:** tax not yet computed (address needed), computing, computed, exempt/reverse-charge, calc error (fail-safe message).
+- **Mobile:** checkout fields responsive.
+- **Accessibility:** labeled fields, announced errors, accessible invoice PDF.
+- **i18n:** currency/locale + jurisdiction names localized.
+
+## 11. AI / ML Considerations
+
+None.
+
+## 12. Integration Points
+
+- External: Stripe Tax (calculation, tax-ID validation, optional filing); Stripe Invoicing.
+- Internal: [billing service](../../../server/internal/service/billing/) (`stripe.go`, `entitlements.go`, `metrics.go`), payment abstraction ([16.8](../16-integrations-extensibility/16.8-payment-provider-abstraction.md)), encryption ([10.13](../../completed/10-compliance-privacy-security/10.13-encryption-at-rest.md)), GDPR retention exception ([10.3](../../completed/10-compliance-privacy-security/10.3-gdpr-uk-gdpr.md)), report PDF ([reportpdf](../../../server/internal/service/reportpdf/)).
+- Webhooks: `invoice.created`, `tax.collected` (outbound, [16.3](../../completed/16-integrations-extensibility/16.3-outbound-webhooks.md)).
+
+## 13. Dependencies & Sequencing
+
+- Must ship after: 15.3 billing; ideally with/after 16.8 abstraction so tax sits behind the provider interface.
+- Shared infra: PDF generation, encryption, object storage (invoice PDFs).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Wrong rate/jurisdiction → liability | M | H | Use Stripe Tax as source of truth; store its calculation id; reconcile via webhook |
+| Tax calc failure blocks checkout | M | H | Fail-safe: clear error + retry; never silently zero-tax in registered jurisdictions |
+| PII (VAT ID/address) exposure | M | H | Encrypt at rest; role-gated reports; audit access |
+| Deletion request vs. tax retention | M | M | Documented legal-hold exception in GDPR workflow |
+
+## 15. Rollout Plan
+
+- Feature flag `tax_collection` (default off; enable per-org as they register jurisdictions).
+- Sequence: schema → org tax settings → Stripe Tax checkout calc + persistence → invoices → refund tax reversal → reports → flip per-org.
+- Pilot with one EU-registered and one US-nexus org.
+- GA criteria: rate correctness across sample jurisdictions; report totals reconcile to Stripe; invoice format reviewed by counsel/accounting.
+- Rollback: disable flag (revert to no-tax checkout); retain captured tax records.
+
+## 16. Test Plan
+
+- **Unit** — tax field persistence; inclusive/exclusive math; reverse-charge logic; refund tax reversal.
+- **Integration** — Stripe Tax calc (test mode) across jurisdictions; webhook reconciliation; VAT ID validation.
+- **E2E** — UK VAT purchase, no-tax US purchase, B2B reverse-charge, refund-with-tax, invoice download.
+- **Security** — report access control; PII encryption; idempotent webhook handling.
+- **Accessibility** — axe + keyboard on checkout/settings; accessible invoice PDF.
+- **Compliance review** — invoice fields validated against EU VAT invoice requirements.
+
+## 17. Documentation & Training
+
+- Help center: "How tax is calculated"; "Add your VAT ID".
+- Admin docs: registering jurisdictions, choosing tax categories, running tax reports.
+- Finance runbook: period-end reporting + remittance handoff.
+
+## 18. Open Questions
+
+1. Use Stripe Tax automated filing, or provide data for external filing in v1?
+2. Default price display: tax-inclusive (EU norm) or exclusive (US norm) per buyer geography?
+3. Who owns nexus monitoring/alerts — platform or per-org admin?
+
+## 19. References
+
+- Existing files: [server/internal/service/billing/stripe.go](../../../server/internal/service/billing/stripe.go), [entitlements.go](../../../server/internal/service/billing/entitlements.go), [metrics.go](../../../server/internal/service/billing/metrics.go).
+- External: Stripe Tax API; EU VAT (Directive 2006/112/EC, MOSS/OSS); US state economic-nexus rules; Canada GST/HST; AU GST.
+- Related plans: [15.3 Billing (Stripe)](../../completed/15-self-learner-specific/15.3-billing-stripe.md), [16.8 Payment Provider Abstraction](../16-integrations-extensibility/16.8-payment-provider-abstraction.md), [20.1 Privacy/Terms & Receipts](../../completed/20-docs-trust/20.1-privacy-policy-terms.md).

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -17,9 +17,9 @@ One plan per feature gap identified in `[docs/MISSING_FEATURES.md](../MISSING_FE
 
 ## Sections
 
-- [01 — Adaptive Learning Core](../completed/01-adaptive-learning-core/) (completed plans)
-- [02 — Assessment & Authoring](../completed/02-assessment-and-authoring/) (completed plans)
-- [03 — Submissions, Grading & Academic Integrity](../completed/03-submissions-grading-integrity/) (completed plans)
+- [01 — Adaptive Learning Core](01-adaptive-learning-core/) (open plans) · [completed](../completed/01-adaptive-learning-core/)
+- [02 — Assessment & Authoring](02-assessment-and-authoring/) (open plans) · [completed](../completed/02-assessment-and-authoring/)
+- [03 — Submissions, Grading & Academic Integrity](03-submissions-grading-integrity/) (open plans) · [completed](../completed/03-submissions-grading-integrity/)
 - [04 — Identity, SSO & Provisioning](../completed/04-identity-sso-provisioning/) (completed plans)
 - [05 — Multi-tenancy, Org Hierarchy & Roles](../completed/05-multi-tenancy-org-roles/) (completed plans)
 - [06 — Communication & Collaboration](../completed/06-communication-collaboration/) (completed plans)
@@ -31,7 +31,7 @@ One plan per feature gap identified in `[docs/MISSING_FEATURES.md](../MISSING_FE
 - [12 — Accessibility (WCAG 2.1 AA)](../completed/12-accessibility/) (completed plans)
 - [13 — K-12 Specific](13-k12-specific/)
 - [14 — Higher-Education Specific](14-higher-ed-specific/)
-- [15 — Self-Learner Specific](15-self-learner-specific/)
+- [15 — Self-Learner Specific](15-self-learner-specific/) · [completed](../completed/15-self-learner-specific/)
 - [16 — Integrations & Extensibility](16-integrations-extensibility/)
 - [17 — Platform, Performance & Operability](17-platform-performance-operability/)
 - [18 — Admin Experience](18-admin-experience/)
@@ -39,3 +39,19 @@ One plan per feature gap identified in `[docs/MISSING_FEATURES.md](../MISSING_FE
 - [20 — Documentation & Trust Surfaces](20-docs-trust/)
 - [21 — Mobile, Offline & Cross-Platform](21-mobile-offline-cross-platform/)
 - [LH — Lighthouse remediation](lighthouse/) (audits from `docs/lighthouse/` reports)
+
+## Newly identified gaps — adoption-blocker scan (2026-06-19)
+
+Gaps found by scanning `docs/completed`, `docs/plan`, and the codebase (handlers, repos, migrations) for features absent from **both** the completed set and existing plans, scoped to what blocks adoption by Higher-Ed, K-12, and Self-Learners. Each was verified to have **no** implementation in `server/internal/httpserver`, `server/internal/repos`, or `server/migrations`.
+
+| ID | Plan | Severity | Markets | Why it blocks adoption |
+|---|---|---|---|---|
+| 3.15 | [Peer review & peer assessment](03-submissions-grading-integrity/3.15-peer-review-assessment.md) | BLOCKER (HE) / MAJOR | HE · K12 · SL | Explicitly deferred 3× (3.3/3.4/3.13); required by writing programs, large-lecture peer grading, MOOC cohorts |
+| 2.14 | [SCORM / xAPI / cmi5 ingestion](02-assessment-and-authoring/2.14-scorm-xapi-cmi5.md) | MAJOR | HE · K12 · SL | Dangling reference (2.12/2.13 link a `2.14` that was never written); publisher/CE/OER courseware is SCORM-packaged |
+| 2.15 | [Differentiated assignments (assign-to / multiple due dates)](02-assessment-and-authoring/2.15-differentiated-assignments.md) | MAJOR | K12 · HE | Only quiz time/attempt overrides exist; no per-section/group/student targeting — core differentiation & multi-section workflow |
+| 1.11 | [Conditional release & module requirements](01-adaptive-learning-core/1.11-conditional-release-module-requirements.md) | MAJOR | K12 · HE · SL | `competencygating` is a stub; no rule-based gating for mastery/self-paced/CBE sequencing |
+| 3.16 | [What-if grades (student projection)](03-submissions-grading-integrity/3.16-what-if-grades.md) | MAJOR | HE · K12 · SL | Baseline student gradebook expectation (Canvas parity); absent entirely |
+| 3.17 | [Grade curving & scaling](03-submissions-grading-integrity/3.17-grade-curving-scaling.md) | MAJOR (HE) | HE · K12 · SL | Faculty cannot curve/scale grades; forces error-prone spreadsheet round-trips |
+| 15.13 | [Tax compliance (Stripe Tax / VAT / GST)](15-self-learner-specific/15.13-tax-compliance.md) | BLOCKER (global) | SL · HE (CE) | Deferred to "phase 2" in 15.3/16.8; legally required to sell paid courses in EU/UK and US-nexus states |
+
+**Reviewed and judged already-covered / out-of-scope:** IEP/504 *document* management (correctly delegated to special-ed software; enforcement settings exist in [12.10](../completed/12-accessibility/12.10-accommodations-engine.md)), native calendar (built), waitlists ([5.4](../completed/05-multi-tenancy-org-roles/5.4-sections.md)/[14.2](../completed/14-higher-ed-specific/14.2-course-catalog-registration.md)), coupons/subscriptions/refunds ([15.3](../completed/15-self-learner-specific/15.3-billing-stripe.md)), group assignments ([6.6](../completed/06-communication-collaboration/6.6-group-spaces.md)).

--- a/server/.air.toml
+++ b/server/.air.toml
@@ -5,7 +5,7 @@ tmp_dir = "tmp"
 
 [build]
   bin = "./tmp/main"
-  cmd = "go build -p 1 -o ./tmp/main ./cmd/server"
+  cmd = "go build -o ./tmp/main ./cmd/server"
   delay = 200
   exclude_dir = ["tmp", "vendor"]
   exclude_unchanged = true

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -5,12 +5,20 @@ FROM golang:1.25-bookworm
 WORKDIR /app
 
 ENV CGO_ENABLED=0
+ENV GOFLAGS="-p=1 -gcflags=all=-l"
+ENV GOMAXPROCS=1
 # Pinned: @latest can require a newer Go than the app image; bump when upgrading the base `golang` image.
 RUN go install github.com/air-verse/air@v1.61.0
 
-# Warm module cache; full tree comes from the host via bind mount when the container runs.
 COPY go.mod go.sum* ./
 RUN go mod download
+
+# Cold compiles of internal/httpserver OOM in ~2GB Docker Desktop VMs (compile: signal: killed).
+# Build once at image build time and seed the Go cache; entrypoint copies the binary when tmp/main is missing.
+COPY . .
+RUN mkdir -p /opt/go-build-cache-seed \
+    && GOCACHE=/opt/go-build-cache-seed \
+       go build -o /opt/lextures-server-dev-main ./cmd/server
 
 COPY docker-entrypoint.dev.sh /usr/local/bin/docker-entrypoint.dev.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.dev.sh

--- a/server/docker-entrypoint.dev.sh
+++ b/server/docker-entrypoint.dev.sh
@@ -2,13 +2,31 @@
 set -e
 
 # Cold builds of internal/httpserver can OOM in memory-constrained Docker VMs (compile: signal: killed).
+# -p=1 limits parallel packages; -gcflags=all=-l lowers peak compiler memory for huge packages.
 # GOFLAGS is also set in docker-compose.dev.yml; default here for direct `docker run` / missing env.
-export GOFLAGS="${GOFLAGS:--p=1}"
+export GOFLAGS="${GOFLAGS:--p=1 -gcflags=all=-l}"
+export GOMAXPROCS="${GOMAXPROCS:-1}"
+
+CACHE_DIR=/root/.cache/go-build
+SEED_DIR=/opt/go-build-cache-seed
+if [ -d "$SEED_DIR" ] && [ -z "$(ls -A "$CACHE_DIR" 2>/dev/null)" ]; then
+  echo "==> Seeding Go build cache from image..."
+  mkdir -p "$CACHE_DIR"
+  cp -a "$SEED_DIR/." "$CACHE_DIR/"
+fi
+
+mkdir -p ./tmp
+
+if [ ! -f ./tmp/main ] && [ -f /opt/lextures-server-dev-main ]; then
+  echo "==> Using pre-built server binary from image (avoids cold-compile OOM)..."
+  cp /opt/lextures-server-dev-main ./tmp/main
+fi
 
 if [ ! -f ./tmp/main ]; then
   echo "==> Initial server build (no binary yet)..."
   if ! go build -o ./tmp/main ./cmd/server; then
-    echo "==> Initial build failed; Air will retry on file changes."
+    echo "==> Initial build failed (often OOM in Docker). Try: docker compose ... build --no-cache server"
+    echo "==> Or raise Docker Desktop memory; Air will retry on file changes."
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Adds seven implementation plans for adoption-blocking feature gaps identified in a 2026-06-19 scan of completed docs, open plans, and the codebase
- Updates `docs/plan/README.md` with open/completed section links and a severity/market summary table
- Hardens the dev Docker server workflow against cold-compile OOM in ~2GB VMs (pre-build at image time, Go cache seeding, binary fallback, tighter `GOFLAGS`/`GOMAXPROCS`)

## New plans

| ID | Feature | Severity |
|---|---|---|
| 3.15 | Peer review & peer assessment | BLOCKER (HE) / MAJOR |
| 2.14 | SCORM / xAPI / cmi5 ingestion | MAJOR |
| 2.15 | Differentiated assignments | MAJOR |
| 1.11 | Conditional release & module requirements | MAJOR |
| 3.16 | What-if grades (student projection) | MAJOR |
| 3.17 | Grade curving & scaling | MAJOR |
| 15.13 | Tax compliance (Stripe Tax / VAT / GST) | BLOCKER (global) |

## Dev Docker changes

- `server/Dockerfile.dev`: pre-build server binary and seed Go build cache at image build time
- `server/docker-entrypoint.dev.sh`: seed cache from image, copy pre-built binary when `tmp/main` is missing, improved OOM guidance
- `docker-compose.dev.yml`: add `-gcflags=all=-l` and `GOMAXPROCS=1`
- `server/.air.toml`: rely on `GOFLAGS` env for parallelism limits instead of hardcoded `-p 1`

## Test plan

- [ ] Review new plan documents for completeness against `_TEMPLATE.md`
- [ ] Rebuild dev server image: `docker compose -f docker-compose.dev.yml build --no-cache server`
- [ ] Start dev stack and confirm server starts without cold-compile OOM
- [ ] Verify Air hot-reload still works after initial startup