### PR TITLE
Complete plan 2.15: differentiated assignments e2e tests

### DIFF
--- a/docs/completed/02-assessment-and-authoring/2.15-differentiated-assignments.md
+++ b/docs/completed/02-assessment-and-authoring/2.15-differentiated-assignments.md
@@ -10,7 +10,7 @@
 | **Section** | Assessment & Authoring |
 | **Severity** | MAJOR (K12) / MAJOR (HE) |
 | **Markets** | K12 / HE / SL |
-| **Status (today)** | PARTIAL (quiz time/attempt overrides only) |
+| **Status (today)** | COMPLETE |
 | **Estimated effort** | M (2–4w) |
 | **Owner (proposed)** | Assessment team |
 | **Depends on** | 5.4 (sections), 6.6 (group spaces), 2.11 (accommodations), 13.6 (grade-level scoping) |
@@ -127,11 +127,8 @@ None.
 
 ## 15. Rollout Plan
 
-- Feature flag `assign_to_overrides` (default off).
-- Sequence: schema + backfill (everyone targets) → resolver → instructor editor → student filtering → migrate quiz overrides → flip flag.
-- Dogfood in a multi-section course and a differentiated K-12 class.
-- GA criteria: effective-date consistency suite green; visibility security tests green.
-- Rollback: disable flag (items revert to single default date; backfilled `everyone` targets harmless).
+- Shipped without a separate `assign_to_overrides` feature flag — assign-to targeting is always on once migration 304 is applied.
+- `enrollment_quiz_overrides` (extra attempts / time multiplier) remains a linked table for accommodation quiz params; date/visibility targeting uses `course.assignment_overrides`.
 
 ## 16. Test Plan
 

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -789,6 +789,25 @@ export async function apiGetCourseEnrollments(
   return raw.enrollments
 }
 
+export async function apiTransferEnrollmentToSection(
+  token: string,
+  enrollmentId: string,
+  sectionId: string,
+): Promise<void> {
+  const res = await fetch(`${apiBase}/api/v1/enrollments/${encodeURIComponent(enrollmentId)}/section`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ sectionId }),
+  })
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Transfer enrollment to section failed (${res.status}): ${body}`)
+  }
+}
+
 export interface ApiOutcomesReportOutcome {
   outcomeId: string
   title: string

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -1488,3 +1488,124 @@ export async function apiPatchAssignmentSubmissionTypes(
     throw new Error(`Patch assignment submission types failed (${res.status}): ${body}`)
   }
 }
+
+export type AssignToTargetType = 'everyone' | 'section' | 'group' | 'student'
+
+export type AssignToTargetWrite = {
+  targetType: AssignToTargetType
+  targetId?: string | null
+  dueAt?: string | null
+  availableFrom?: string | null
+  availableUntil?: string | null
+}
+
+export async function apiCreateCourseSection(
+  token: string,
+  courseCode: string,
+  sectionCode: string,
+  name?: string,
+): Promise<{ id: string; sectionCode: string }> {
+  const res = await fetch(
+    `${apiBase}/api/v1/courses/${encodeURIComponent(courseCode)}/sections`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ sectionCode, ...(name ? { name } : {}) }),
+    },
+  )
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Create section failed (${res.status}): ${body}`)
+  }
+  return res.json() as Promise<{ id: string; sectionCode: string }>
+}
+
+export async function apiGetAssignToTargets(
+  token: string,
+  courseCode: string,
+  itemId: string,
+): Promise<{ targets: unknown[]; orphaned: boolean }> {
+  const res = await fetch(
+    `${apiBase}/api/v1/courses/${encodeURIComponent(courseCode)}/items/${encodeURIComponent(itemId)}/overrides`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Get assign-to targets failed (${res.status}): ${body}`)
+  }
+  return res.json() as Promise<{ targets: unknown[]; orphaned: boolean }>
+}
+
+export async function apiPutAssignToTargets(
+  token: string,
+  courseCode: string,
+  itemId: string,
+  targets: AssignToTargetWrite[],
+): Promise<{ targets: unknown[]; orphaned: boolean }> {
+  const res = await fetch(
+    `${apiBase}/api/v1/courses/${encodeURIComponent(courseCode)}/items/${encodeURIComponent(itemId)}/overrides`,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ targets }),
+    },
+  )
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Put assign-to targets failed (${res.status}): ${body}`)
+  }
+  return res.json() as Promise<{ targets: unknown[]; orphaned: boolean }>
+}
+
+export async function apiBulkExtendAssignToDueDate(
+  token: string,
+  courseCode: string,
+  itemId: string,
+  enrollmentIds: string[],
+  dueAt: string,
+): Promise<void> {
+  const res = await fetch(
+    `${apiBase}/api/v1/courses/${encodeURIComponent(courseCode)}/items/${encodeURIComponent(itemId)}/overrides/bulk-extend`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ enrollmentIds, dueAt }),
+    },
+  )
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Bulk extend due date failed (${res.status}): ${body}`)
+  }
+}
+
+export type ApiStructureItem = {
+  id: string
+  kind: string
+  title: string
+  dueAt?: string | null
+}
+
+export async function apiGetCourseStructure(
+  token: string,
+  courseCode: string,
+): Promise<ApiStructureItem[]> {
+  const res = await fetch(
+    `${apiBase}/api/v1/courses/${encodeURIComponent(courseCode)}/structure`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Get course structure failed (${res.status}): ${body}`)
+  }
+  const raw = (await res.json()) as { items?: ApiStructureItem[] }
+  return raw.items ?? []
+}

--- a/e2e/tests/differentiated-assignments.spec.ts
+++ b/e2e/tests/differentiated-assignments.spec.ts
@@ -222,6 +222,7 @@ test.describe('Differentiated assignments (2.15)', () => {
       `/courses/${seededCourse.courseCode}/modules/assignment/${assignment.id}`,
     )
     await coursePage.getByRole('button', { name: /^Edit$/i }).click()
+    await coursePage.getByRole('tab', { name: /^Settings$/i }).click()
     const assignToSummary = coursePage.locator('summary').filter({ hasText: /^Assign to$/ })
     await expect(assignToSummary).toBeVisible({ timeout: 12000 })
     await assignToSummary.click()

--- a/e2e/tests/differentiated-assignments.spec.ts
+++ b/e2e/tests/differentiated-assignments.spec.ts
@@ -15,6 +15,7 @@ import {
   apiBulkExtendAssignToDueDate,
   apiGetCourseStructure,
   apiGetCourseEnrollments,
+  apiTransferEnrollmentToSection,
 } from '../fixtures/api.js'
 
 const PASSWORD = 'E2eTestPass1!'
@@ -77,22 +78,8 @@ async function setupDifferentiatedCourse() {
   const sectionA = await apiCreateCourseSection(instructorToken, course.courseCode, 'SEC-A', 'Section A')
   const sectionB = await apiCreateCourseSection(instructorToken, course.courseCode, 'SEC-B', 'Section B')
 
-  await apiEnroll(instructorToken, course.courseCode, studentAEmail, 'student', {
-    memberToken: studentAToken,
-    sectionId: sectionA.id,
-  })
-  await apiEnroll(instructorToken, course.courseCode, studentBEmail, 'student', {
-    memberToken: studentBToken,
-    sectionId: sectionB.id,
-  })
-
-  const mod = await apiCreateModule(instructorToken, course.courseCode, 'Unit 1')
-  const assignment = await apiCreateAssignment(
-    instructorToken,
-    course.courseCode,
-    mod.id,
-    'Differentiated Essay',
-  )
+  await apiEnroll(instructorToken, course.courseCode, studentAEmail, 'student', studentAToken)
+  await apiEnroll(instructorToken, course.courseCode, studentBEmail, 'student', studentBToken)
 
   const [userIdA, userIdB] = await Promise.all([
     apiMeUserId(studentAToken),
@@ -101,6 +88,19 @@ async function setupDifferentiatedCourse() {
   const enrollments = await apiGetCourseEnrollments(instructorToken, course.courseCode)
   const enrollmentA = enrollments.find((e) => e.role === 'student' && e.userId === userIdA)
   const enrollmentB = enrollments.find((e) => e.role === 'student' && e.userId === userIdB)
+  if (!enrollmentA?.id || !enrollmentB?.id) {
+    throw new Error('Expected student enrollments for section transfer setup')
+  }
+  await apiTransferEnrollmentToSection(instructorToken, enrollmentA.id, sectionA.id)
+  await apiTransferEnrollmentToSection(instructorToken, enrollmentB.id, sectionB.id)
+
+  const mod = await apiCreateModule(instructorToken, course.courseCode, 'Unit 1')
+  const assignment = await apiCreateAssignment(
+    instructorToken,
+    course.courseCode,
+    mod.id,
+    'Differentiated Essay',
+  )
 
   return {
     instructorToken,
@@ -222,10 +222,9 @@ test.describe('Differentiated assignments (2.15)', () => {
       `/courses/${seededCourse.courseCode}/modules/assignment/${assignment.id}`,
     )
     await coursePage.getByRole('button', { name: /^Edit$/i }).click()
-    await expect(coursePage.getByRole('button', { name: /^Assign to$/i })).toBeVisible({
-      timeout: 12000,
-    })
-    await coursePage.getByRole('button', { name: /^Assign to$/i }).click()
+    const assignToSummary = coursePage.locator('summary').filter({ hasText: /^Assign to$/ })
+    await expect(assignToSummary).toBeVisible({ timeout: 12000 })
+    await assignToSummary.click()
     await expect(coursePage.getByRole('button', { name: /Save assign-to targets/i })).toBeVisible()
     await expect(coursePage.getByRole('button', { name: /Add audience/i })).toBeVisible()
   })

--- a/e2e/tests/differentiated-assignments.spec.ts
+++ b/e2e/tests/differentiated-assignments.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * Differentiated assignments — assign-to targeting & multiple due dates (plan 2.15)
+ */
+import { test, expect, uniqueEmail } from '../fixtures/test.js'
+import {
+  apiSignup,
+  apiCreateCourse,
+  apiCreateModule,
+  apiCreateAssignment,
+  apiEnroll,
+  apiPatchCourseFeatures,
+  apiCreateCourseSection,
+  apiPutAssignToTargets,
+  apiGetAssignToTargets,
+  apiBulkExtendAssignToDueDate,
+  apiGetCourseStructure,
+  apiGetCourseEnrollments,
+} from '../fixtures/api.js'
+
+const PASSWORD = 'E2eTestPass1!'
+
+const apiBase = process.env.E2E_API_URL ?? 'http://localhost:8080'
+
+async function apiMeUserId(token: string): Promise<string> {
+  const res = await fetch(`${apiBase}/api/v1/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) throw new Error(`GET /api/v1/me failed (${res.status})`)
+  const data = (await res.json()) as { id?: string }
+  if (!data.id) throw new Error('GET /api/v1/me missing id')
+  return data.id
+}
+
+function dueIso(year: number, month: number, day: number): string {
+  return new Date(Date.UTC(year, month - 1, day, 23, 59, 0)).toISOString()
+}
+
+function sameCalendarDay(a: string | null | undefined, b: string): boolean {
+  if (!a) return false
+  const da = new Date(a)
+  const db = new Date(b)
+  return (
+    da.getUTCFullYear() === db.getUTCFullYear() &&
+    da.getUTCMonth() === db.getUTCMonth() &&
+    da.getUTCDate() === db.getUTCDate()
+  )
+}
+
+async function setupDifferentiatedCourse() {
+  const instructorEmail = uniqueEmail('assign-inst')
+  const { access_token: instructorToken } = await apiSignup({
+    email: instructorEmail,
+    password: PASSWORD,
+    displayName: 'Assign-To Instructor',
+  })
+
+  const studentAEmail = uniqueEmail('assign-stu-a')
+  const { access_token: studentAToken } = await apiSignup({
+    email: studentAEmail,
+    password: PASSWORD,
+    displayName: 'Section A Student',
+    accountType: 'parent',
+  })
+
+  const studentBEmail = uniqueEmail('assign-stu-b')
+  const { access_token: studentBToken } = await apiSignup({
+    email: studentBEmail,
+    password: PASSWORD,
+    displayName: 'Section B Student',
+    accountType: 'parent',
+  })
+
+  const course = await apiCreateCourse(instructorToken, { title: 'Assign-To E2E Course' })
+  await apiEnroll(instructorToken, course.courseCode, instructorEmail, 'teacher')
+  await apiPatchCourseFeatures(instructorToken, course.courseCode, { sectionsEnabled: true })
+
+  const sectionA = await apiCreateCourseSection(instructorToken, course.courseCode, 'SEC-A', 'Section A')
+  const sectionB = await apiCreateCourseSection(instructorToken, course.courseCode, 'SEC-B', 'Section B')
+
+  await apiEnroll(instructorToken, course.courseCode, studentAEmail, 'student', {
+    memberToken: studentAToken,
+    sectionId: sectionA.id,
+  })
+  await apiEnroll(instructorToken, course.courseCode, studentBEmail, 'student', {
+    memberToken: studentBToken,
+    sectionId: sectionB.id,
+  })
+
+  const mod = await apiCreateModule(instructorToken, course.courseCode, 'Unit 1')
+  const assignment = await apiCreateAssignment(
+    instructorToken,
+    course.courseCode,
+    mod.id,
+    'Differentiated Essay',
+  )
+
+  const [userIdA, userIdB] = await Promise.all([
+    apiMeUserId(studentAToken),
+    apiMeUserId(studentBToken),
+  ])
+  const enrollments = await apiGetCourseEnrollments(instructorToken, course.courseCode)
+  const enrollmentA = enrollments.find((e) => e.role === 'student' && e.userId === userIdA)
+  const enrollmentB = enrollments.find((e) => e.role === 'student' && e.userId === userIdB)
+
+  return {
+    instructorToken,
+    studentAToken,
+    studentBToken,
+    courseCode: course.courseCode,
+    sectionA,
+    sectionB,
+    assignment,
+    enrollmentA,
+    enrollmentB,
+  }
+}
+
+test.describe('Differentiated assignments (2.15)', () => {
+  test('section-specific due dates resolve per student (AC-1)', async () => {
+    const ctx = await setupDifferentiatedCourse()
+    const dueA = dueIso(2026, 6, 13) // Friday
+    const dueB = dueIso(2026, 6, 16) // Monday
+
+    await apiPutAssignToTargets(ctx.instructorToken, ctx.courseCode, ctx.assignment.id, [
+      { targetType: 'section', targetId: ctx.sectionA.id, dueAt: dueA },
+      { targetType: 'section', targetId: ctx.sectionB.id, dueAt: dueB },
+    ])
+
+    const structA = await apiGetCourseStructure(ctx.studentAToken, ctx.courseCode)
+    const itemA = structA.find((i) => i.id === ctx.assignment.id)
+    expect(itemA).toBeTruthy()
+    expect(sameCalendarDay(itemA?.dueAt, dueA)).toBe(true)
+
+    const structB = await apiGetCourseStructure(ctx.studentBToken, ctx.courseCode)
+    const itemB = structB.find((i) => i.id === ctx.assignment.id)
+    expect(itemB).toBeTruthy()
+    expect(sameCalendarDay(itemB?.dueAt, dueB)).toBe(true)
+  })
+
+  test('non-targeted student does not see section-only assignment (AC-2)', async () => {
+    const ctx = await setupDifferentiatedCourse()
+
+    await apiPutAssignToTargets(ctx.instructorToken, ctx.courseCode, ctx.assignment.id, [
+      { targetType: 'section', targetId: ctx.sectionA.id, dueAt: dueIso(2026, 6, 13) },
+    ])
+
+    const structA = await apiGetCourseStructure(ctx.studentAToken, ctx.courseCode)
+    expect(structA.some((i) => i.id === ctx.assignment.id)).toBe(true)
+
+    const structB = await apiGetCourseStructure(ctx.studentBToken, ctx.courseCode)
+    expect(structB.some((i) => i.id === ctx.assignment.id)).toBe(false)
+  })
+
+  test('student override wins over section target (AC-4)', async () => {
+    const ctx = await setupDifferentiatedCourse()
+    expect(ctx.enrollmentA?.id).toBeTruthy()
+
+    const sectionDue = dueIso(2026, 6, 13)
+    const studentDue = dueIso(2026, 6, 20)
+
+    await apiPutAssignToTargets(ctx.instructorToken, ctx.courseCode, ctx.assignment.id, [
+      { targetType: 'section', targetId: ctx.sectionA.id, dueAt: sectionDue },
+      {
+        targetType: 'student',
+        targetId: ctx.enrollmentA!.id,
+        dueAt: studentDue,
+      },
+    ])
+
+    const structA = await apiGetCourseStructure(ctx.studentAToken, ctx.courseCode)
+    const itemA = structA.find((i) => i.id === ctx.assignment.id)
+    expect(itemA).toBeTruthy()
+    expect(sameCalendarDay(itemA?.dueAt, studentDue)).toBe(true)
+    expect(sameCalendarDay(itemA?.dueAt, sectionDue)).toBe(false)
+  })
+
+  test('orphaned targets are flagged when no student matches (AC-5)', async () => {
+    const ctx = await setupDifferentiatedCourse()
+    const emptySection = await apiCreateCourseSection(
+      ctx.instructorToken,
+      ctx.courseCode,
+      'EMPTY',
+      'Empty Section',
+    )
+
+    await apiPutAssignToTargets(ctx.instructorToken, ctx.courseCode, ctx.assignment.id, [
+      { targetType: 'section', targetId: emptySection.id, dueAt: dueIso(2026, 6, 13) },
+    ])
+
+    const res = await apiGetAssignToTargets(ctx.instructorToken, ctx.courseCode, ctx.assignment.id)
+    expect(res.orphaned).toBe(true)
+  })
+
+  test('bulk extend sets student-level due date override', async () => {
+    const ctx = await setupDifferentiatedCourse()
+    expect(ctx.enrollmentB?.id).toBeTruthy()
+
+    const extendedDue = dueIso(2026, 7, 1)
+    await apiBulkExtendAssignToDueDate(
+      ctx.instructorToken,
+      ctx.courseCode,
+      ctx.assignment.id,
+      [ctx.enrollmentB!.id],
+      extendedDue,
+    )
+
+    const structB = await apiGetCourseStructure(ctx.studentBToken, ctx.courseCode)
+    const itemB = structB.find((i) => i.id === ctx.assignment.id)
+    expect(itemB).toBeTruthy()
+    expect(sameCalendarDay(itemB?.dueAt, extendedDue)).toBe(true)
+  })
+
+  test('assign-to editor is visible on assignment settings', async ({ coursePage, seededCourse }) => {
+    const assignment = await apiCreateAssignment(
+      seededCourse.instructorToken,
+      seededCourse.courseCode,
+      seededCourse.moduleId,
+      'Assign-To UI Check',
+    )
+
+    await coursePage.goto(
+      `/courses/${seededCourse.courseCode}/modules/assignment/${assignment.id}`,
+    )
+    await coursePage.getByRole('button', { name: /^Edit$/i }).click()
+    await expect(coursePage.getByRole('button', { name: /^Assign to$/i })).toBeVisible({
+      timeout: 12000,
+    })
+    await coursePage.getByRole('button', { name: /^Assign to$/i }).click()
+    await expect(coursePage.getByRole('button', { name: /Save assign-to targets/i })).toBeVisible()
+    await expect(coursePage.getByRole('button', { name: /Add audience/i })).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- Move plan 2.15 to `docs/completed` (core feature shipped in #323).
- Add Playwright e2e coverage for assign-to targeting: section-specific due dates, visibility filtering, student-override precedence, orphaned-target detection, bulk extend, and the assignment settings UI.
- Add e2e API helpers for sections, assign-to overrides, and student structure listing.

## Test plan
- [x] `go test ./internal/repos/assignmentoverrides/... -short`
- [ ] `bash e2e/scripts/e2e-local.sh tests/differentiated-assignments.spec.ts` (CI)
- [ ] Full e2e suite in CI


Made with [Cursor](https://cursor.com)