### PR TITLE
Add grade curving and scaling (plan 3.17)

### DIFF
--- a/clients/web/src/components/grading/grade-curve-modal.tsx
+++ b/clients/web/src/components/grading/grade-curve-modal.tsx
@@ -103,7 +103,7 @@ export function GradeCurveModal(props: {
       onApplied()
       onClose()
     } catch (e: unknown) {
-      toastMutationError(e, 'Could not apply curve.')
+      toastMutationError(e instanceof Error ? e.message : 'Could not apply curve.')
     } finally {
       setApplying(false)
     }
@@ -119,7 +119,7 @@ export function GradeCurveModal(props: {
       onApplied()
       onClose()
     } catch (e: unknown) {
-      toastMutationError(e, 'Could not revert curve.')
+      toastMutationError(e instanceof Error ? e.message : 'Could not revert curve.')
     } finally {
       setReverting(false)
     }

--- a/clients/web/src/components/grading/grade-curve-modal.tsx
+++ b/clients/web/src/components/grading/grade-curve-modal.tsx
@@ -1,0 +1,394 @@
+import { useCallback, useEffect, useId, useMemo, useState } from 'react'
+import {
+  deleteGradeCurve,
+  postAssignmentCurve,
+  postAssignmentCurvePreview,
+  type GradeCurveMethod,
+  type GradeCurvePreviewResponse,
+} from '../../lib/courses-api'
+import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
+
+type ColRef = { id: string; title: string; kind: string; maxPoints?: number | null }
+
+const METHOD_LABELS: Record<GradeCurveMethod, string> = {
+  flat_bonus: 'Flat bonus',
+  linear_scale: 'Linear scale',
+  sqrt_curve: 'Square-root curve',
+  set_minimum: 'Set minimum',
+  custom_mapping: 'Custom mapping',
+}
+
+export function GradeCurveModal(props: {
+  open: boolean
+  courseCode: string
+  column: ColRef | null
+  activeCurveId?: string | null
+  studentsById: Record<string, { name: string }>
+  onClose: () => void
+  onApplied: () => void
+}) {
+  const { open, courseCode, column, activeCurveId, studentsById, onClose, onApplied } = props
+  const baseId = useId()
+  const [method, setMethod] = useState<GradeCurveMethod>('linear_scale')
+  const [bonus, setBonus] = useState('5')
+  const [targetMean, setTargetMean] = useState('75')
+  const [targetMax, setTargetMax] = useState('')
+  const [minimum, setMinimum] = useState('50')
+  const [scaleTarget, setScaleTarget] = useState<'mean' | 'max'>('mean')
+  const [allowAboveMax, setAllowAboveMax] = useState(false)
+  const [preview, setPreview] = useState<GradeCurvePreviewResponse | null>(null)
+  const [loadingPreview, setLoadingPreview] = useState(false)
+  const [applying, setApplying] = useState(false)
+  const [reverting, setReverting] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const itemKind = column?.kind === 'quiz' ? 'quiz' : 'assignment'
+
+  const params = useMemo(() => {
+    switch (method) {
+      case 'flat_bonus':
+        return { bonus: Number.parseFloat(bonus) || 0 }
+      case 'linear_scale':
+        if (scaleTarget === 'max') {
+          return { targetMax: Number.parseFloat(targetMax) || 0 }
+        }
+        return { targetMean: Number.parseFloat(targetMean) || 0 }
+      case 'set_minimum':
+        return { minimum: Number.parseFloat(minimum) || 0 }
+      default:
+        return {}
+    }
+  }, [method, bonus, targetMean, targetMax, minimum, scaleTarget])
+
+  const requestBody = useMemo(
+    () => ({ method, params, allowAboveMax }),
+    [method, params, allowAboveMax],
+  )
+
+  const runPreview = useCallback(async () => {
+    if (!column) return
+    setLoadingPreview(true)
+    setFormError(null)
+    try {
+      const p = await postAssignmentCurvePreview(courseCode, column.id, requestBody, itemKind)
+      setPreview(p)
+    } catch (e: unknown) {
+      setFormError(e instanceof Error ? e.message : 'Preview failed.')
+      setPreview(null)
+    } finally {
+      setLoadingPreview(false)
+    }
+  }, [column, courseCode, itemKind, requestBody])
+
+  useEffect(() => {
+    if (!open || !column) {
+      setPreview(null)
+      setFormError(null)
+      return
+    }
+    void runPreview()
+  }, [open, column, runPreview])
+
+  const handleApply = useCallback(async () => {
+    if (!column || !preview) return
+    if (preview.preview.eligibleCount === 0) {
+      setFormError('No graded, non-excused submissions to curve.')
+      return
+    }
+    setApplying(true)
+    setFormError(null)
+    try {
+      await postAssignmentCurve(courseCode, column.id, requestBody, itemKind)
+      toastSaveOk('Curve applied.')
+      onApplied()
+      onClose()
+    } catch (e: unknown) {
+      toastMutationError(e, 'Could not apply curve.')
+    } finally {
+      setApplying(false)
+    }
+  }, [column, courseCode, itemKind, onApplied, onClose, preview, requestBody])
+
+  const handleRevert = useCallback(async () => {
+    if (!activeCurveId) return
+    setReverting(true)
+    setFormError(null)
+    try {
+      await deleteGradeCurve(activeCurveId)
+      toastSaveOk('Curve reverted.')
+      onApplied()
+      onClose()
+    } catch (e: unknown) {
+      toastMutationError(e, 'Could not revert curve.')
+    } finally {
+      setReverting(false)
+    }
+  }, [activeCurveId, onApplied, onClose])
+
+  if (!open || !column) return null
+
+  const changedRows = preview?.preview.results.filter((r) => r.changed) ?? []
+
+  return (
+    <div
+      className="fixed inset-0 z-[90] flex items-end justify-center bg-black/40 p-4 sm:items-center"
+      role="presentation"
+    >
+      <button type="button" className="absolute inset-0 cursor-default" aria-label="Close" onClick={onClose} />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${baseId}-title`}
+        className="relative flex max-h-[min(90vh,720px)] w-full max-w-2xl flex-col overflow-hidden rounded-xl bg-white shadow-xl dark:bg-neutral-900"
+      >
+        <div className="flex items-start justify-between gap-3 border-b border-slate-200 px-4 py-3 dark:border-neutral-700">
+          <div>
+            <h2 id={`${baseId}-title`} className="text-lg font-semibold text-slate-900 dark:text-neutral-100">
+              Curve grades — {column.title}
+            </h2>
+            <p className="mt-0.5 text-sm text-slate-600 dark:text-neutral-400">
+              Preview changes before applying. Raw scores are preserved and curves can be undone.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="rounded-md px-2 py-1 text-slate-500 hover:bg-slate-100 dark:hover:bg-neutral-800"
+            onClick={onClose}
+            aria-label="Close dialog"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-4 py-4">
+          {activeCurveId ? (
+            <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
+              A curve is already applied to this column. Applying again replaces it; or undo the current curve first.
+            </div>
+          ) : null}
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="block text-sm">
+              <span className="mb-1 block font-medium text-slate-700 dark:text-neutral-300">Method</span>
+              <select
+                className="w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 text-sm dark:border-neutral-600 dark:bg-neutral-950"
+                value={method}
+                onChange={(e) => setMethod(e.target.value as GradeCurveMethod)}
+              >
+                {(Object.keys(METHOD_LABELS) as GradeCurveMethod[]).map((m) => (
+                  <option key={m} value={m}>
+                    {METHOD_LABELS[m]}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {method === 'flat_bonus' ? (
+              <label className="block text-sm">
+                <span className="mb-1 block font-medium text-slate-700 dark:text-neutral-300">Bonus points</span>
+                <input
+                  type="number"
+                  className="w-full rounded-md border border-slate-300 px-2 py-1.5 text-sm dark:border-neutral-600 dark:bg-neutral-950"
+                  value={bonus}
+                  onChange={(e) => setBonus(e.target.value)}
+                />
+              </label>
+            ) : null}
+
+            {method === 'linear_scale' ? (
+              <>
+                <label className="block text-sm">
+                  <span className="mb-1 block font-medium text-slate-700 dark:text-neutral-300">Scale to</span>
+                  <select
+                    className="w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 text-sm dark:border-neutral-600 dark:bg-neutral-950"
+                    value={scaleTarget}
+                    onChange={(e) => setScaleTarget(e.target.value as 'mean' | 'max')}
+                  >
+                    <option value="mean">Target mean</option>
+                    <option value="max">Target max</option>
+                  </select>
+                </label>
+                <label className="block text-sm">
+                  <span className="mb-1 block font-medium text-slate-700 dark:text-neutral-300">
+                    {scaleTarget === 'mean' ? 'Target mean' : 'Target max score'}
+                  </span>
+                  <input
+                    type="number"
+                    className="w-full rounded-md border border-slate-300 px-2 py-1.5 text-sm dark:border-neutral-600 dark:bg-neutral-950"
+                    value={scaleTarget === 'mean' ? targetMean : targetMax}
+                    onChange={(e) =>
+                      scaleTarget === 'mean' ? setTargetMean(e.target.value) : setTargetMax(e.target.value)
+                    }
+                  />
+                </label>
+              </>
+            ) : null}
+
+            {method === 'set_minimum' ? (
+              <label className="block text-sm">
+                <span className="mb-1 block font-medium text-slate-700 dark:text-neutral-300">Minimum score</span>
+                <input
+                  type="number"
+                  className="w-full rounded-md border border-slate-300 px-2 py-1.5 text-sm dark:border-neutral-600 dark:bg-neutral-950"
+                  value={minimum}
+                  onChange={(e) => setMinimum(e.target.value)}
+                />
+              </label>
+            ) : null}
+
+            <label className="flex items-center gap-2 text-sm sm:col-span-2">
+              <input
+                type="checkbox"
+                checked={allowAboveMax}
+                onChange={(e) => setAllowAboveMax(e.target.checked)}
+              />
+              <span>Allow scores above max (extra credit)</span>
+            </label>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            <button
+              type="button"
+              className="rounded-md border border-slate-300 px-3 py-1.5 text-sm dark:border-neutral-600"
+              onClick={() => void runPreview()}
+              disabled={loadingPreview}
+            >
+              {loadingPreview ? 'Refreshing…' : 'Refresh preview'}
+            </button>
+          </div>
+
+          {formError ? <p className="mt-3 text-sm text-red-600 dark:text-red-400">{formError}</p> : null}
+
+          {preview ? (
+            <div className="mt-4 space-y-4">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <StatCard label="Mean before" value={preview.preview.meanBefore} />
+                <StatCard label="Mean after" value={preview.preview.meanAfter} />
+                <StatCard label="Median before" value={preview.preview.medianBefore} />
+                <StatCard label="Median after" value={preview.preview.medianAfter} />
+              </div>
+
+              <div>
+                <h3 className="mb-2 text-sm font-medium text-slate-800 dark:text-neutral-200">
+                  Distribution (text summary)
+                </h3>
+                <div className="overflow-x-auto rounded-lg border border-slate-200 dark:border-neutral-700">
+                  <table className="min-w-full text-left text-xs">
+                    <caption className="sr-only">Before and after score distribution buckets</caption>
+                    <thead className="bg-slate-50 dark:bg-neutral-800/80">
+                      <tr>
+                        <th scope="col" className="px-2 py-1.5 font-medium">
+                          Range
+                        </th>
+                        <th scope="col" className="px-2 py-1.5 font-medium">
+                          Before
+                        </th>
+                        <th scope="col" className="px-2 py-1.5 font-medium">
+                          After
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {preview.preview.histogramBefore.map((b, i) => (
+                        <tr key={b.label} className="border-t border-slate-100 dark:border-neutral-800">
+                          <td className="px-2 py-1.5">{b.label}</td>
+                          <td className="px-2 py-1.5 tabular-nums">{b.count}</td>
+                          <td className="px-2 py-1.5 tabular-nums">
+                            {preview.preview.histogramAfter[i]?.count ?? 0}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <div>
+                <h3 className="mb-2 text-sm font-medium text-slate-800 dark:text-neutral-200">
+                  Students with changes ({changedRows.length})
+                </h3>
+                {changedRows.length === 0 ? (
+                  <p className="text-sm text-slate-600 dark:text-neutral-400">No scores would change.</p>
+                ) : (
+                  <div className="max-h-48 overflow-y-auto rounded-lg border border-slate-200 dark:border-neutral-700">
+                    <table className="min-w-full text-left text-xs">
+                      <caption className="sr-only">Per-student grade changes from curve preview</caption>
+                      <thead className="sticky top-0 bg-slate-50 dark:bg-neutral-800/95">
+                        <tr>
+                          <th scope="col" className="px-2 py-1.5 font-medium">
+                            Student
+                          </th>
+                          <th scope="col" className="px-2 py-1.5 font-medium">
+                            Before
+                          </th>
+                          <th scope="col" className="px-2 py-1.5 font-medium">
+                            After
+                          </th>
+                          <th scope="col" className="px-2 py-1.5 font-medium">
+                            Δ
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {changedRows.map((row) => (
+                          <tr key={row.studentId} className="border-t border-slate-100 dark:border-neutral-800">
+                            <td className="px-2 py-1.5">{studentsById[row.studentId]?.name ?? row.studentId}</td>
+                            <td className="px-2 py-1.5 tabular-nums">{row.rawScore}</td>
+                            <td className="px-2 py-1.5 tabular-nums">{row.adjustedScore}</td>
+                            <td className="px-2 py-1.5 tabular-nums">
+                              {row.delta > 0 ? `+${row.delta}` : row.delta}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="flex flex-wrap justify-end gap-2 border-t border-slate-200 px-4 py-3 dark:border-neutral-700">
+          {activeCurveId ? (
+            <button
+              type="button"
+              className="rounded-md border border-red-300 px-3 py-1.5 text-sm text-red-700 dark:border-red-800 dark:text-red-300"
+              onClick={() => void handleRevert()}
+              disabled={reverting || applying}
+            >
+              {reverting ? 'Reverting…' : 'Undo curve'}
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="rounded-md border border-slate-300 px-3 py-1.5 text-sm dark:border-neutral-600"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-60"
+            onClick={() => void handleApply()}
+            disabled={applying || reverting || loadingPreview || !preview}
+          >
+            {applying ? 'Applying…' : 'Apply curve'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function StatCard(props: { label: string; value?: number | null }) {
+  const { label, value } = props
+  return (
+    <div className="rounded-lg border border-slate-200 px-3 py-2 dark:border-neutral-700">
+      <div className="text-xs text-slate-500 dark:text-neutral-400">{label}</div>
+      <div className="text-lg font-semibold tabular-nums text-slate-900 dark:text-neutral-100">
+        {value != null ? value.toFixed(2) : '—'}
+      </div>
+    </div>
+  )
+}

--- a/clients/web/src/components/settings/platform-feature-definitions.ts
+++ b/clients/web/src/components/settings/platform-feature-definitions.ts
@@ -281,6 +281,12 @@ const PLATFORM_FEATURE_DEFINITIONS_UNSORTED: PlatformFeatureDefinition[] = [
       'Let students model hypothetical scores and projected course grades on My Grades (plan 3.16).',
   },
   {
+    key: 'ffGradeCurving',
+    label: 'Grade curving',
+    description:
+      'Let instructors curve or scale assignment grades with preview, undo, and audit trail (plan 3.17).',
+  },
+  {
     key: 'ffOnboardingFlow',
     label: 'Self-learner onboarding',
     description:

--- a/clients/web/src/components/settings/platform-settings-panel.tsx
+++ b/clients/web/src/components/settings/platform-settings-panel.tsx
@@ -74,6 +74,7 @@ function emptyForm(): PlatformSettingsPayload {
     ffCompletionCredentials: false,
     ffOnboardingFlow: false,
     ffWhatifGrades: false,
+    ffGradeCurving: false,
     ffAiStudyBuddy: false,
     ffApiTokens: false,
     ffCalendarFeeds: true,

--- a/clients/web/src/components/settings/platform-settings-types.ts
+++ b/clients/web/src/components/settings/platform-settings-types.ts
@@ -52,6 +52,7 @@ export type PlatformSettingsPayload = {
   ffCompletionCredentials: boolean
   ffOnboardingFlow: boolean
   ffWhatifGrades: boolean
+  ffGradeCurving: boolean
   ffAiStudyBuddy: boolean
   ffApiTokens: boolean
   ffCalendarFeeds: boolean

--- a/clients/web/src/context/platform-features-context.tsx
+++ b/clients/web/src/context/platform-features-context.tsx
@@ -58,6 +58,7 @@ export type PlatformFeatures = {
   ffEnrollmentStateMachine: boolean
   ffGradeSubmission: boolean
   ffWhatifGrades: boolean
+  ffGradeCurving: boolean
   ffPlagiarismChecks: boolean
   ffIncompleteGradeWorkflow: boolean
   ffAcademicCalendar: boolean
@@ -138,6 +139,7 @@ const defaultFeatures: PlatformFeatures = {
   ffEnrollmentStateMachine: false,
   ffGradeSubmission: false,
   ffWhatifGrades: false,
+  ffGradeCurving: false,
   ffPlagiarismChecks: false,
   ffIncompleteGradeWorkflow: false,
   ffAcademicCalendar: false,
@@ -223,6 +225,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
     ffEnrollmentStateMachine: false,
     ffGradeSubmission: false,
   ffWhatifGrades: false,
+  ffGradeCurving: false,
     ffPlagiarismChecks: false,
     ffIncompleteGradeWorkflow: false,
     ffAcademicCalendar: false,
@@ -309,6 +312,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffEnrollmentStateMachine: data.ffEnrollmentStateMachine === true,
           ffGradeSubmission: data.ffGradeSubmission === true,
           ffWhatifGrades: data.ffWhatifGrades === true,
+          ffGradeCurving: data.ffGradeCurving === true,
           ffPlagiarismChecks: data.ffPlagiarismChecks === true,
           ffIncompleteGradeWorkflow: data.ffIncompleteGradeWorkflow === true,
           ffAcademicCalendar: data.ffAcademicCalendar === true,
@@ -360,6 +364,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffEnrollmentStateMachine: next.ffEnrollmentStateMachine === true,
           ffGradeSubmission: next.ffGradeSubmission === true,
           ffWhatifGrades: next.ffWhatifGrades === true,
+          ffGradeCurving: next.ffGradeCurving === true,
           ffPlagiarismChecks: next.ffPlagiarismChecks === true,
           ffIncompleteGradeWorkflow: next.ffIncompleteGradeWorkflow === true,
           ffAcademicCalendar: next.ffAcademicCalendar === true,

--- a/clients/web/src/lib/courses-api-schemas.ts
+++ b/clients/web/src/lib/courses-api-schemas.ts
@@ -382,6 +382,16 @@ export const courseGradebookGridResponseSchema = z.object({
   excusedGrades: z
     .record(z.string(), z.record(z.string(), z.boolean()))
     .optional(),
+  activeCurves: z
+    .record(
+      z.string(),
+      z.object({
+        curveId: z.string(),
+        method: z.string(),
+        appliedAt: z.string(),
+      }),
+    )
+    .optional(),
   gradingScheme: z
     .object({
       type: z.string(),

--- a/clients/web/src/lib/courses-api.ts
+++ b/clients/web/src/lib/courses-api.ts
@@ -1739,6 +1739,8 @@ export type CourseGradebookGridResponse = {
   crossListMerged?: boolean
   /** Plan 3.12 */
   excusedGrades?: Record<string, Record<string, boolean>>
+  /** Plan 3.17 — active grade curves by column item id. */
+  activeCurves?: Record<string, { curveId: string; method: string; appliedAt: string }>
 }
 
 export async function fetchCourseGradebookGrid(
@@ -2020,6 +2022,98 @@ export async function retractCourseAssignmentGrades(
     `/api/v1/courses/${encodeURIComponent(courseCode)}/assignments/${encodeURIComponent(itemId)}/post-grades`,
     { method: 'DELETE' },
   )
+  if (res.ok) return
+  const raw = await parseJson(res)
+  throw new Error(readApiErrorMessage(raw))
+}
+
+export type GradeCurveMethod =
+  | 'flat_bonus'
+  | 'linear_scale'
+  | 'sqrt_curve'
+  | 'set_minimum'
+  | 'custom_mapping'
+
+export type GradeCurveParams = {
+  bonus?: number
+  targetMean?: number
+  targetMax?: number
+  minimum?: number
+  mapping?: Record<string, number>
+}
+
+export type GradeCurvePreviewResult = {
+  studentId: string
+  rawScore: number
+  adjustedScore: number
+  delta: number
+  changed: boolean
+}
+
+export type GradeCurvePreviewResponse = {
+  preview: {
+    eligibleCount: number
+    meanBefore?: number | null
+    meanAfter?: number | null
+    medianBefore?: number | null
+    medianAfter?: number | null
+    histogramBefore: { label: string; min: number; max: number; count: number }[]
+    histogramAfter: { label: string; min: number; max: number; count: number }[]
+    results: GradeCurvePreviewResult[]
+  }
+  activeCurveId?: string | null
+  maxPoints: number
+}
+
+function gradeCurveItemPath(courseCode: string, itemId: string, kind: 'assignment' | 'quiz'): string {
+  const segment = kind === 'quiz' ? 'quizzes' : 'assignments'
+  return `/api/v1/courses/${encodeURIComponent(courseCode)}/${segment}/${encodeURIComponent(itemId)}`
+}
+
+export async function postAssignmentCurvePreview(
+  courseCode: string,
+  itemId: string,
+  body: { method: GradeCurveMethod; params: GradeCurveParams; allowAboveMax: boolean },
+  kind: 'assignment' | 'quiz' = 'assignment',
+): Promise<GradeCurvePreviewResponse> {
+  const res = await authorizedFetch(`${gradeCurveItemPath(courseCode, itemId, kind)}/curve/preview`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      method: body.method,
+      params: body.params,
+      allowAboveMax: body.allowAboveMax,
+    }),
+  })
+  const raw = await parseJson(res)
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  return raw as GradeCurvePreviewResponse
+}
+
+export async function postAssignmentCurve(
+  courseCode: string,
+  itemId: string,
+  body: { method: GradeCurveMethod; params: GradeCurveParams; allowAboveMax: boolean },
+  kind: 'assignment' | 'quiz' = 'assignment',
+): Promise<{ curveId: string }> {
+  const res = await authorizedFetch(`${gradeCurveItemPath(courseCode, itemId, kind)}/curve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      method: body.method,
+      params: body.params,
+      allowAboveMax: body.allowAboveMax,
+    }),
+  })
+  const raw = await parseJson(res)
+  if (!res.ok) throw new Error(readApiErrorMessage(raw))
+  return raw as { curveId: string }
+}
+
+export async function deleteGradeCurve(curveId: string): Promise<void> {
+  const res = await authorizedFetch(`/api/v1/curves/${encodeURIComponent(curveId)}`, {
+    method: 'DELETE',
+  })
   if (res.ok) return
   const raw = await parseJson(res)
   throw new Error(readApiErrorMessage(raw))

--- a/clients/web/src/lib/platform-features.ts
+++ b/clients/web/src/lib/platform-features.ts
@@ -46,6 +46,7 @@ export type PlatformFeaturesSnapshot = {
   ffUiMode?: boolean
   ffGradeSubmission?: boolean
   ffWhatifGrades?: boolean
+  ffGradeCurving?: boolean
   ffAcademicCalendar?: boolean
   ffPlagiarismChecks?: boolean
   ffCourseEvaluations?: boolean
@@ -125,6 +126,7 @@ const defaults: PlatformFeaturesSnapshot = {
   ffUiMode: false,
   ffGradeSubmission: false,
   ffWhatifGrades: false,
+  ffGradeCurving: false,
   ffAcademicCalendar: false,
   ffPlagiarismChecks: false,
   ffCourseEvaluations: false,

--- a/clients/web/src/pages/lms/course-gradebook.tsx
+++ b/clients/web/src/pages/lms/course-gradebook.tsx
@@ -1096,7 +1096,7 @@ export default function CourseGradebook() {
               column={{
                 id: curveModalColumn.id,
                 title: curveModalColumn.title,
-                kind: curveModalColumn.kind,
+                kind: curveModalColumn.kind ?? 'assignment',
                 maxPoints: curveModalColumn.maxPoints,
               }}
               activeCurveId={activeCurves[curveModalColumn.id]?.curveId ?? null}

--- a/clients/web/src/pages/lms/course-gradebook.tsx
+++ b/clients/web/src/pages/lms/course-gradebook.tsx
@@ -35,6 +35,7 @@ import { TabPresenceHint } from '../../components/presence/tab-presence-hint'
 import { FeatureHelpTrigger } from '../../components/feature-help/feature-help-trigger'
 import { GradeHistoryPanel } from '../../components/grading/grade-history-panel'
 import { GradebookImportModal } from '../../components/grading/gradebook-import-modal'
+import { GradeCurveModal } from '../../components/grading/grade-curve-modal'
 import { LmsPage } from './lms-page'
 import { IncompleteGradeModal } from './gradebook/IncompleteGradeModal'
 import {
@@ -316,7 +317,7 @@ export default function CourseGradebook() {
   const highlightStudentId = searchParams.get('student')?.trim() || null
   const highlightColumnId = searchParams.get('item')?.trim() || null
   const { allows, loading } = usePermissions()
-  const { ffGradeSubmission, ffIncompleteGradeWorkflow } = usePlatformFeatures()
+  const { ffGradeSubmission, ffIncompleteGradeWorkflow, ffGradeCurving } = usePlatformFeatures()
   const [students, setStudents] = useState<CourseGradebookGridStudent[]>([])
   const [enrollmentIdByUserId, setEnrollmentIdByUserId] = useState<Record<string, string>>({})
   const [columns, setColumns] = useState<CourseGradebookGridColumn[]>([])
@@ -352,6 +353,10 @@ export default function CourseGradebook() {
   const [gradeHistoryEvents, setGradeHistoryEvents] = useState<GradeHistoryEvent[] | null>(null)
   const [gradebookCsvEnabled, setGradebookCsvEnabled] = useState(false)
   const [importModalOpen, setImportModalOpen] = useState(false)
+  const [activeCurves, setActiveCurves] = useState<
+    Record<string, { curveId: string; method: string; appliedAt: string }>
+  >({})
+  const [curveModalColumn, setCurveModalColumn] = useState<GradebookColumn | null>(null)
   const [sectionsEnabled, setSectionsEnabled] = useState(false)
   const [sections, setSections] = useState<CourseSection[]>([])
   const [gradebookSectionId, setGradebookSectionId] = useState<string>('')
@@ -505,6 +510,7 @@ export default function CourseGradebook() {
       setDroppedGrades(data.droppedGrades)
       setGradingScheme(data.gradingScheme ?? null)
       setGradeExcused(data.excusedGrades)
+      setActiveCurves(data.activeCurves ?? {})
       const merged = mergeGradesFromApi(
         gridSt,
         gridCols,
@@ -535,6 +541,7 @@ export default function CourseGradebook() {
       setGradeHeld(undefined)
       setDroppedGrades(undefined)
       setGradeExcused(undefined)
+      setActiveCurves({})
       setGradingScheme(null)
       setAssignmentGroups([])
       setGradebookCsvEnabled(false)
@@ -953,6 +960,15 @@ export default function CourseGradebook() {
             onToggleExcused={canEditGrades ? handleToggleExcused : undefined}
             onPostAssignmentGrades={canEditGrades ? handlePostAssignmentGrades : undefined}
             postGradesPending={postGradesPending}
+            activeCurves={activeCurves}
+            onCurveGrades={
+              ffGradeCurving && canEditGrades
+                ? (columnId) => {
+                    const col = gridColumns.find((c) => c.id === columnId)
+                    if (col) setCurveModalColumn(col)
+                  }
+                : undefined
+            }
             onIncompleteAction={
               ffIncompleteGradeWorkflow && canEditGrades
                 ? (student) => {
@@ -1070,6 +1086,22 @@ export default function CourseGradebook() {
               courseCode={courseCode}
               columns={columns.map((c) => ({ id: c.id, title: c.title }))}
               onClose={() => setImportModalOpen(false)}
+              onApplied={() => void loadGrid()}
+            />
+          ) : null}
+          {courseCode && curveModalColumn ? (
+            <GradeCurveModal
+              open={curveModalColumn != null}
+              courseCode={courseCode}
+              column={{
+                id: curveModalColumn.id,
+                title: curveModalColumn.title,
+                kind: curveModalColumn.kind,
+                maxPoints: curveModalColumn.maxPoints,
+              }}
+              activeCurveId={activeCurves[curveModalColumn.id]?.curveId ?? null}
+              studentsById={Object.fromEntries(gridStudents.map((s) => [s.id, { name: s.name }]))}
+              onClose={() => setCurveModalColumn(null)}
               onApplied={() => void loadGrid()}
             />
           ) : null}

--- a/clients/web/src/pages/lms/gradebook/gradebook-grid.tsx
+++ b/clients/web/src/pages/lms/gradebook/gradebook-grid.tsx
@@ -91,6 +91,10 @@ type GradebookGridProps = {
   /** When set, show “Post grades” in column header for manual assignment columns. */
   onPostAssignmentGrades?: (itemId: string) => void
   postGradesPending?: string | null
+  /** Plan 3.17 — active curves by column id. */
+  activeCurves?: Record<string, { curveId: string; method: string; appliedAt: string }>
+  /** Open curve dialog for a column. */
+  onCurveGrades?: (columnId: string) => void
   /** Plan 14.4 — open grant/resolve incomplete modal for a student row. */
   onIncompleteAction?: (student: GradebookStudent) => void
 }
@@ -268,6 +272,8 @@ export function GradebookGrid({
   onToggleExcused,
   onPostAssignmentGrades,
   postGradesPending = null,
+  activeCurves = undefined,
+  onCurveGrades,
   onIncompleteAction,
 }: GradebookGridProps) {
   const density = useUiDensity()
@@ -1511,6 +1517,7 @@ export function GradebookGrid({
                           <span className="text-xs font-semibold text-slate-800 dark:text-neutral-200">{col.title}</span>
                           <span className="text-[0.65rem] font-normal text-slate-500 dark:text-neutral-400">
                             {col.maxPoints != null ? `Out of ${col.maxPoints}` : 'Max points not set'}
+                            {activeCurves?.[col.id] ? ' · Curved' : ''}
                           </span>
                           {col.kind === 'assignment' &&
                             col.postingPolicy === 'manual' &&
@@ -1975,6 +1982,23 @@ export function GradebookGrid({
           >
             Grade (Z → A)
           </button>
+          {onCurveGrades &&
+          (visibleColumns.find((c) => c.id === headerMenu.columnId)?.kind === 'assignment' ||
+            visibleColumns.find((c) => c.id === headerMenu.columnId)?.kind === 'quiz') ? (
+            <>
+              <div className="my-1 border-t border-slate-100 dark:border-neutral-700" />
+              <button
+                type="button"
+                className={menuItemClass()}
+                onClick={() => {
+                  onCurveGrades(headerMenu.columnId)
+                  closeHeaderMenu()
+                }}
+              >
+                {activeCurves?.[headerMenu.columnId] ? 'Edit curve…' : 'Curve grades…'}
+              </button>
+            </>
+          ) : null}
           <button type="button" className={`${menuItemClass()} text-slate-500 dark:text-neutral-500`} onClick={clearSort}>
             Reset to course order
           </button>

--- a/docs/completed/03-submissions-grading-integrity/3.17-grade-curving-scaling.md
+++ b/docs/completed/03-submissions-grading-integrity/3.17-grade-curving-scaling.md
@@ -1,6 +1,6 @@
 # 3.17 — Grade Curving & Scaling
 
-> Implementation plan. Source: gap scan 2026-06-19. No grade-curve/scaling tooling exists (the only "curve" in code is a video drop-off curve in `engagement.go`).
+> Implementation plan. Source: gap scan 2026-06-19. Shipped in migration 308 with preview/apply/undo API and gradebook UI (feature flag `ffGradeCurving`).
 
 ## Metadata
 
@@ -10,7 +10,7 @@
 | **Section** | Submissions, Grading & Academic Integrity |
 | **Severity** | MAJOR (HE) / MINOR (K12, SL) |
 | **Markets** | HE / K12 / SL |
-| **Status (today)** | MISSING |
+| **Status (today)** | COMPLETE |
 | **Estimated effort** | M (2–4w) |
 | **Owner (proposed)** | Grading team |
 | **Depends on** | 3.8 (grade posting policies), 3.10 (grade-change audit trail), 9.4 (item analysis) |

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -320,6 +320,8 @@ type Config struct {
 	FFGradeSubmission bool
 	// FFWhatifGrades enables student what-if grade projection on My Grades (plan 3.16).
 	FFWhatifGrades bool
+	// FFGradeCurving enables instructor grade curving/scaling on assignments (plan 3.17).
+	FFGradeCurving bool
 	// FFAcademicCalendar enables institutional academic calendar events, dashboard upcoming-dates panel, and iCal feed (plan 14.6).
 	FFAcademicCalendar bool
 	// FFPlagiarismChecks enables HE plagiarism workflow APIs and async scans (plan 14.8).

--- a/server/internal/gradecurve/curve.go
+++ b/server/internal/gradecurve/curve.go
@@ -1,0 +1,376 @@
+// Package gradecurve implements grade curving and scaling math (plan 3.17).
+package gradecurve
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+
+	"github.com/google/uuid"
+)
+
+// Method identifies a curve algorithm.
+type Method string
+
+const (
+	MethodFlatBonus     Method = "flat_bonus"
+	MethodLinearScale   Method = "linear_scale"
+	MethodSqrtCurve     Method = "sqrt_curve"
+	MethodSetMinimum    Method = "set_minimum"
+	MethodCustomMapping Method = "custom_mapping"
+)
+
+// Params holds method-specific curve parameters.
+type Params struct {
+	Bonus      *float64           `json:"bonus,omitempty"`
+	TargetMean *float64           `json:"targetMean,omitempty"`
+	TargetMax  *float64           `json:"targetMax,omitempty"`
+	Minimum    *float64           `json:"minimum,omitempty"`
+	Mapping    map[string]float64 `json:"mapping,omitempty"`
+}
+
+// ScoreInput is one student's raw score for curve computation.
+type ScoreInput struct {
+	StudentID uuid.UUID
+	RawScore  float64
+	Excused   bool
+}
+
+// ScoreOutput is the computed curve result for one student.
+type ScoreOutput struct {
+	StudentID     uuid.UUID `json:"studentId"`
+	RawScore      float64   `json:"rawScore"`
+	AdjustedScore float64   `json:"adjustedScore"`
+	Delta         float64   `json:"delta"`
+	Changed       bool      `json:"changed"`
+}
+
+// HistogramBucket is one bar in a distribution preview.
+type HistogramBucket struct {
+	Label string  `json:"label"`
+	Min   float64 `json:"min"`
+	Max   float64 `json:"max"`
+	Count int     `json:"count"`
+}
+
+// PreviewSummary aggregates before/after distribution stats.
+type PreviewSummary struct {
+	EligibleCount  int               `json:"eligibleCount"`
+	MeanBefore     *float64          `json:"meanBefore"`
+	MeanAfter      *float64          `json:"meanAfter"`
+	MedianBefore   *float64          `json:"medianBefore"`
+	MedianAfter    *float64          `json:"medianAfter"`
+	HistogramBefore []HistogramBucket `json:"histogramBefore"`
+	HistogramAfter  []HistogramBucket `json:"histogramAfter"`
+	Results        []ScoreOutput     `json:"results"`
+}
+
+// Options configures curve application.
+type Options struct {
+	MaxPoints     float64
+	AllowAboveMax bool
+	Method        Method
+	Params        Params
+}
+
+// ParseParams unmarshals params JSON into Params.
+func ParseParams(raw json.RawMessage) (Params, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return Params{}, nil
+	}
+	var p Params
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return Params{}, err
+	}
+	return p, nil
+}
+
+// ValidateMethod checks that method and params are compatible.
+func ValidateMethod(method Method, params Params) error {
+	switch method {
+	case MethodFlatBonus:
+		if params.Bonus == nil {
+			return fmt.Errorf("flat_bonus requires bonus")
+		}
+	case MethodLinearScale:
+		if params.TargetMean == nil && params.TargetMax == nil {
+			return fmt.Errorf("linear_scale requires targetMean or targetMax")
+		}
+		if params.TargetMean != nil && params.TargetMax != nil {
+			return fmt.Errorf("linear_scale accepts only one of targetMean or targetMax")
+		}
+	case MethodSqrtCurve:
+		return nil
+	case MethodSetMinimum:
+		if params.Minimum == nil {
+			return fmt.Errorf("set_minimum requires minimum")
+		}
+	case MethodCustomMapping:
+		if len(params.Mapping) == 0 {
+			return fmt.Errorf("custom_mapping requires mapping")
+		}
+	default:
+		return fmt.Errorf("unknown curve method %q", method)
+	}
+	return nil
+}
+
+// Preview computes adjusted scores and distribution summary without persisting.
+func Preview(scores []ScoreInput, opts Options) (PreviewSummary, error) {
+	if err := ValidateMethod(opts.Method, opts.Params); err != nil {
+		return PreviewSummary{}, err
+	}
+	eligible := filterEligible(scores)
+	adjustedByStudent := applyMethod(eligible, opts)
+	out := PreviewSummary{
+		EligibleCount: len(eligible),
+		Results:       make([]ScoreOutput, 0, len(scores)),
+	}
+	beforeVals := make([]float64, 0, len(eligible))
+	afterVals := make([]float64, 0, len(eligible))
+	for _, s := range eligible {
+		raw := s.RawScore
+		adj, ok := adjustedByStudent[s.StudentID]
+		if !ok {
+			adj = raw
+		}
+		beforeVals = append(beforeVals, raw)
+		afterVals = append(afterVals, adj)
+	}
+	for _, s := range scores {
+		if s.Excused {
+			continue
+		}
+		adj, ok := adjustedByStudent[s.StudentID]
+		if !ok {
+			continue
+		}
+		delta := round2(adj - s.RawScore)
+		out.Results = append(out.Results, ScoreOutput{
+			StudentID:     s.StudentID,
+			RawScore:      round2(s.RawScore),
+			AdjustedScore: round2(adj),
+			Delta:         delta,
+			Changed:       math.Abs(delta) > 1e-9,
+		})
+	}
+	sort.Slice(out.Results, func(i, j int) bool {
+		return out.Results[i].StudentID.String() < out.Results[j].StudentID.String()
+	})
+	out.MeanBefore = meanPtr(beforeVals)
+	out.MeanAfter = meanPtr(afterVals)
+	out.MedianBefore = medianPtr(beforeVals)
+	out.MedianAfter = medianPtr(afterVals)
+	out.HistogramBefore = histogram(beforeVals, opts.MaxPoints)
+	out.HistogramAfter = histogram(afterVals, opts.MaxPoints)
+	return out, nil
+}
+
+func filterEligible(scores []ScoreInput) []ScoreInput {
+	out := make([]ScoreInput, 0, len(scores))
+	for _, s := range scores {
+		if s.Excused {
+			continue
+		}
+		if math.IsNaN(s.RawScore) || math.IsInf(s.RawScore, 0) || s.RawScore < 0 {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func applyMethod(eligible []ScoreInput, opts Options) map[uuid.UUID]float64 {
+	out := make(map[uuid.UUID]float64, len(eligible))
+	if len(eligible) == 0 {
+		return out
+	}
+	switch opts.Method {
+	case MethodFlatBonus:
+		bonus := *opts.Params.Bonus
+		for _, s := range eligible {
+			out[s.StudentID] = capScore(s.RawScore+bonus, opts)
+		}
+	case MethodLinearScale:
+		if opts.Params.TargetMean != nil {
+			target := *opts.Params.TargetMean
+			vals := scoresOnly(eligible)
+			m := mean(vals)
+			shift := target - m
+			for _, s := range eligible {
+				out[s.StudentID] = capScore(s.RawScore+shift, opts)
+			}
+		} else {
+			targetMax := *opts.Params.TargetMax
+			curMax := maxScore(eligible)
+			if curMax <= 0 {
+				for _, s := range eligible {
+					out[s.StudentID] = capScore(s.RawScore, opts)
+				}
+				return out
+			}
+			scale := targetMax / curMax
+			for _, s := range eligible {
+				out[s.StudentID] = capScore(s.RawScore*scale, opts)
+			}
+		}
+	case MethodSqrtCurve:
+		maxPts := opts.MaxPoints
+		if maxPts <= 0 {
+			for _, s := range eligible {
+				out[s.StudentID] = capScore(s.RawScore, opts)
+			}
+			return out
+		}
+		for _, s := range eligible {
+			ratio := s.RawScore / maxPts
+			if ratio < 0 {
+				ratio = 0
+			}
+			out[s.StudentID] = capScore(math.Sqrt(ratio)*maxPts, opts)
+		}
+	case MethodSetMinimum:
+		floor := *opts.Params.Minimum
+		for _, s := range eligible {
+			v := s.RawScore
+			if v < floor {
+				v = floor
+			}
+			out[s.StudentID] = capScore(v, opts)
+		}
+	case MethodCustomMapping:
+		for _, s := range eligible {
+			key := formatMappingKey(s.RawScore)
+			if adj, ok := opts.Params.Mapping[key]; ok {
+				out[s.StudentID] = capScore(adj, opts)
+			} else {
+				out[s.StudentID] = capScore(s.RawScore, opts)
+			}
+		}
+	default:
+		for _, s := range eligible {
+			out[s.StudentID] = capScore(s.RawScore, opts)
+		}
+	}
+	return out
+}
+
+func capScore(v float64, opts Options) float64 {
+	if v < 0 {
+		v = 0
+	}
+	if !opts.AllowAboveMax && opts.MaxPoints > 0 && v > opts.MaxPoints {
+		v = opts.MaxPoints
+	}
+	return round2(v)
+}
+
+func maxScore(in []ScoreInput) float64 {
+	max := 0.0
+	for _, s := range in {
+		if s.RawScore > max {
+			max = s.RawScore
+		}
+	}
+	return max
+}
+
+func scoresOnly(in []ScoreInput) []float64 {
+	out := make([]float64, len(in))
+	for i, s := range in {
+		out[i] = s.RawScore
+	}
+	return out
+}
+
+func mean(vals []float64) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
+	sum := 0.0
+	for _, v := range vals {
+		sum += v
+	}
+	return sum / float64(len(vals))
+}
+
+func meanPtr(vals []float64) *float64 {
+	if len(vals) == 0 {
+		return nil
+	}
+	m := round2(mean(vals))
+	return &m
+}
+
+func medianPtr(vals []float64) *float64 {
+	if len(vals) == 0 {
+		return nil
+	}
+	cp := append([]float64(nil), vals...)
+	sort.Float64s(cp)
+	n := len(cp)
+	var med float64
+	if n%2 == 1 {
+		med = cp[n/2]
+	} else {
+		med = (cp[n/2-1] + cp[n/2]) / 2
+	}
+	med = round2(med)
+	return &med
+}
+
+func round2(v float64) float64 {
+	return math.Round(v*100) / 100
+}
+
+func formatMappingKey(v float64) string {
+	return strconv.FormatFloat(round2(v), 'f', -1, 64)
+}
+
+func histogram(vals []float64, maxPts float64) []HistogramBucket {
+	if maxPts <= 0 {
+		maxPts = 100
+	}
+	const buckets = 10
+	width := maxPts / buckets
+	if width <= 0 {
+		width = 1
+	}
+	out := make([]HistogramBucket, buckets)
+	for i := range out {
+		min := float64(i) * width
+		max := float64(i+1) * width
+		if i == buckets-1 {
+			max = maxPts
+		}
+		out[i] = HistogramBucket{
+			Label: fmt.Sprintf("%.0f–%.0f", min, max),
+			Min:   min,
+			Max:   max,
+		}
+	}
+	for _, v := range vals {
+		idx := int(v / width)
+		if idx >= buckets {
+			idx = buckets - 1
+		}
+		if idx < 0 {
+			idx = 0
+		}
+		out[idx].Count++
+	}
+	return out
+}
+
+// AuditReasonJSON builds a JSON reason string for grade audit events.
+func AuditReasonJSON(method Method, params Params, curveID uuid.UUID) string {
+	payload := map[string]any{
+		"curveId": curveID.String(),
+		"method":  string(method),
+		"params":  params,
+	}
+	b, _ := json.Marshal(payload)
+	return string(b)
+}

--- a/server/internal/gradecurve/curve_test.go
+++ b/server/internal/gradecurve/curve_test.go
@@ -106,11 +106,15 @@ func TestSqrtCurve(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if prev.Results[0].AdjustedScore != 50 {
-		t.Fatalf("sqrt(25/100)*100 = 50, got %v", prev.Results[0].AdjustedScore)
+	byRaw := make(map[float64]float64, len(prev.Results))
+	for _, r := range prev.Results {
+		byRaw[r.RawScore] = r.AdjustedScore
 	}
-	if prev.Results[1].AdjustedScore != 100 {
-		t.Fatalf("sqrt(100/100)*100 = 100, got %v", prev.Results[1].AdjustedScore)
+	if byRaw[25] != 50 {
+		t.Fatalf("sqrt(25/100)*100 = 50, got %v", byRaw[25])
+	}
+	if byRaw[100] != 100 {
+		t.Fatalf("sqrt(100/100)*100 = 100, got %v", byRaw[100])
 	}
 }
 

--- a/server/internal/gradecurve/curve_test.go
+++ b/server/internal/gradecurve/curve_test.go
@@ -1,0 +1,133 @@
+package gradecurve
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func scores(vals ...float64) []ScoreInput {
+	out := make([]ScoreInput, len(vals))
+	for i, v := range vals {
+		out[i] = ScoreInput{StudentID: uuid.New(), RawScore: v}
+	}
+	return out
+}
+
+func TestFlatBonusCapsAtMax(t *testing.T) {
+	in := scores(90, 95)
+	prev, err := Preview(in, Options{
+		MaxPoints:     100,
+		AllowAboveMax: false,
+		Method:        MethodFlatBonus,
+		Params:        Params{Bonus: ptrFloat(10)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prev.MeanAfter == nil || *prev.MeanAfter != 100 {
+		t.Fatalf("expected mean 100 after cap, got %v", prev.MeanAfter)
+	}
+	for _, r := range prev.Results {
+		if r.AdjustedScore > 100 {
+			t.Fatalf("score %v exceeded max", r.AdjustedScore)
+		}
+	}
+}
+
+func TestLinearScaleTargetMean(t *testing.T) {
+	in := scores(50, 60, 70, 80)
+	prev, err := Preview(in, Options{
+		MaxPoints:     100,
+		AllowAboveMax: false,
+		Method:        MethodLinearScale,
+		Params:        Params{TargetMean: ptrFloat(75)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prev.MeanBefore == nil || *prev.MeanBefore != 65 {
+		t.Fatalf("mean before: got %v want 65", prev.MeanBefore)
+	}
+	if prev.MeanAfter == nil || *prev.MeanAfter != 75 {
+		t.Fatalf("mean after: got %v want 75", prev.MeanAfter)
+	}
+}
+
+func TestSetMinimum(t *testing.T) {
+	in := scores(30, 50, 70)
+	prev, err := Preview(in, Options{
+		MaxPoints: 100,
+		Method:    MethodSetMinimum,
+		Params:    Params{Minimum: ptrFloat(50)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range prev.Results {
+		if r.RawScore < 50 && r.AdjustedScore != 50 {
+			t.Fatalf("expected floor 50 for raw %v, got %v", r.RawScore, r.AdjustedScore)
+		}
+		if r.RawScore >= 50 && r.AdjustedScore != r.RawScore {
+			t.Fatalf("expected unchanged score for raw %v, got %v", r.RawScore, r.AdjustedScore)
+		}
+	}
+}
+
+func TestExcusedExcluded(t *testing.T) {
+	s1 := uuid.New()
+	s2 := uuid.New()
+	in := []ScoreInput{
+		{StudentID: s1, RawScore: 40},
+		{StudentID: s2, RawScore: 80, Excused: true},
+	}
+	prev, err := Preview(in, Options{
+		MaxPoints: 100,
+		Method:    MethodLinearScale,
+		Params:    Params{TargetMean: ptrFloat(75)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prev.EligibleCount != 1 {
+		t.Fatalf("eligible count: got %d want 1", prev.EligibleCount)
+	}
+	if len(prev.Results) != 1 {
+		t.Fatalf("results len: got %d want 1", len(prev.Results))
+	}
+}
+
+func TestSqrtCurve(t *testing.T) {
+	in := scores(25, 100)
+	prev, err := Preview(in, Options{
+		MaxPoints: 100,
+		Method:    MethodSqrtCurve,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prev.Results[0].AdjustedScore != 50 {
+		t.Fatalf("sqrt(25/100)*100 = 50, got %v", prev.Results[0].AdjustedScore)
+	}
+	if prev.Results[1].AdjustedScore != 100 {
+		t.Fatalf("sqrt(100/100)*100 = 100, got %v", prev.Results[1].AdjustedScore)
+	}
+}
+
+func TestAllowAboveMax(t *testing.T) {
+	in := scores(95)
+	prev, err := Preview(in, Options{
+		MaxPoints:     100,
+		AllowAboveMax: true,
+		Method:        MethodFlatBonus,
+		Params:        Params{Bonus: ptrFloat(10)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prev.Results[0].AdjustedScore != 105 {
+		t.Fatalf("expected 105, got %v", prev.Results[0].AdjustedScore)
+	}
+}
+
+func ptrFloat(v float64) *float64 { return &v }

--- a/server/internal/httpserver/courses_routes.go
+++ b/server/internal/httpserver/courses_routes.go
@@ -83,6 +83,8 @@ func (d Deps) registerCourseRoutes(r chi.Router) {
 	r.Get("/api/v1/courses/{course_code}/assignments/{item_id}", d.handleGetModuleAssignment())
 	r.Patch("/api/v1/courses/{course_code}/assignments/{item_id}", d.handlePatchModuleAssignment())
 	r.Get("/api/v1/courses/{course_code}/assignments/{item_id}/grades/{student_id}/history", d.handleGetAssignmentGradeHistory())
+	r.Post("/api/v1/courses/{course_code}/assignments/{item_id}/curve/preview", d.handlePostAssignmentCurvePreview())
+	r.Post("/api/v1/courses/{course_code}/assignments/{item_id}/curve", d.handlePostAssignmentCurve())
 	r.Get("/api/v1/courses/{course_code}/quizzes/{item_id}", d.handleGetModuleQuiz())
 	r.Patch("/api/v1/courses/{course_code}/quizzes/{item_id}", d.handlePatchModuleQuiz())
 	d.registerQuizDeliveryRoutes(r)
@@ -92,6 +94,8 @@ func (d Deps) registerCourseRoutes(r chi.Router) {
 	r.Delete("/api/v1/courses/{course_code}/quizzes/{item_id}/proctoring-config", d.handleDeleteQuizProctoringConfig())
 	r.Get("/api/v1/courses/{course_code}/quizzes/{item_id}/attempts/{attempt_id}/proctoring-session", d.handleGetQuizProctoringSession())
 	r.Get("/api/v1/courses/{course_code}/quizzes/{item_id}/analytics", d.handleGetQuizAnalytics())
+	r.Post("/api/v1/courses/{course_code}/quizzes/{item_id}/curve/preview", d.handlePostAssignmentCurvePreview())
+	r.Post("/api/v1/courses/{course_code}/quizzes/{item_id}/curve", d.handlePostAssignmentCurve())
 	r.Get("/api/v1/courses/{course_code}/quizzes/{item_id}/item-analysis", d.handleGetItemAnalysis())
 	r.Post("/api/v1/courses/{course_code}/quizzes/{item_id}/item-analysis/compute", d.handleComputeItemAnalysis())
 	r.Get("/api/v1/courses/{course_code}/quizzes/{item_id}/item-analysis/export.csv", d.handleExportItemAnalysisCSV())
@@ -288,4 +292,5 @@ func (d Deps) registerCourseRoutes(r chi.Router) {
 	r.Put("/api/v1/courses/{course_code}/analytics/outcomes/settings", d.handleCourseOutcomesAnalyticsSettingsPut())
 	r.Post("/api/v1/courses/{course_code}/analytics/outcomes/refresh", d.handleCourseOutcomesAnalyticsRefreshPost())
 	r.Put("/api/v1/courses/{course_code}/outcomes/{outcome_id}/notes", d.handleCourseOutcomeImprovementNotePut())
+	r.Delete("/api/v1/curves/{curve_id}", d.handleDeleteGradeCurve())
 }

--- a/server/internal/httpserver/grade_curve.go
+++ b/server/internal/httpserver/grade_curve.go
@@ -1,0 +1,386 @@
+package httpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/courseroles"
+	"github.com/lextures/lextures/server/internal/gradecurve"
+	"github.com/lextures/lextures/server/internal/repos/course"
+	"github.com/lextures/lextures/server/internal/repos/coursemoduleassignments"
+	"github.com/lextures/lextures/server/internal/repos/gradeauditevents"
+	"github.com/lextures/lextures/server/internal/repos/gradecurves"
+	webhooksvc "github.com/lextures/lextures/server/internal/service/webhooks"
+	"github.com/lextures/lextures/server/internal/webhooks"
+)
+
+type gradeCurveRequestBody struct {
+	Method        string          `json:"method"`
+	Params        json.RawMessage `json:"params"`
+	AllowAboveMax bool            `json:"allowAboveMax"`
+}
+
+func (d Deps) requireGradeCurvingEnabled(w http.ResponseWriter) bool {
+	if !d.effectiveConfig().FFGradeCurving {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Grade curving is not enabled.")
+		return false
+	}
+	return true
+}
+
+func (d Deps) requireGradeCurveAccess(w http.ResponseWriter, r *http.Request) (courseCode string, viewer uuid.UUID, courseID uuid.UUID, itemID uuid.UUID, ok bool) {
+	if !d.requireGradeCurvingEnabled(w) {
+		return "", uuid.Nil, uuid.Nil, uuid.Nil, false
+	}
+	courseCode, viewer, ok = d.requireCourseAccess(w, r)
+	if !ok {
+		return "", uuid.Nil, uuid.Nil, uuid.Nil, false
+	}
+	has, err := courseroles.UserHasPermission(r.Context(), d.Pool, viewer, "course:"+courseCode+":item:create")
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")
+		return "", uuid.Nil, uuid.Nil, uuid.Nil, false
+	}
+	if !has {
+		apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission to curve grades.")
+		return "", uuid.Nil, uuid.Nil, uuid.Nil, false
+	}
+	itemID, err = uuid.Parse(chi.URLParam(r, "item_id"))
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid assignment ID.")
+		return "", uuid.Nil, uuid.Nil, uuid.Nil, false
+	}
+	cid, err := course.GetIDByCourseCode(r.Context(), d.Pool, courseCode)
+	if err != nil || cid == nil {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+		return "", uuid.Nil, uuid.Nil, uuid.Nil, false
+	}
+	return courseCode, viewer, *cid, itemID, true
+}
+
+func (d Deps) assignmentMaxPoints(ctx context.Context, courseID, itemID uuid.UUID) (float64, error) {
+	row, err := coursemoduleassignments.GetForCourseItem(ctx, d.Pool, courseID, itemID)
+	if err != nil {
+		return 0, err
+	}
+	if row != nil {
+		max := 100.0
+		if row.PointsWorth != nil && *row.PointsWorth > 0 {
+			max = float64(*row.PointsWorth)
+		}
+		return max, nil
+	}
+	var pts *int32
+	err = d.Pool.QueryRow(ctx, `
+SELECT m.points_worth
+FROM course.module_quizzes m
+WHERE m.structure_item_id = $1
+`, itemID).Scan(&pts)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 100, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	if pts != nil && *pts > 0 {
+		return float64(*pts), nil
+	}
+	return 100, nil
+}
+
+func (d Deps) loadCurvePreviewInputs(ctx context.Context, courseID, itemID uuid.UUID) ([]gradecurve.ScoreInput, float64, error) {
+	cells, err := gradecurves.ListCellsForAssignment(ctx, d.Pool, courseID, itemID)
+	if err != nil {
+		return nil, 0, err
+	}
+	_, rawByStudent, err := gradecurves.RawScoresForActiveCurve(ctx, d.Pool, itemID)
+	if err != nil {
+		return nil, 0, err
+	}
+	maxPts, err := d.assignmentMaxPoints(ctx, courseID, itemID)
+	if err != nil {
+		return nil, 0, err
+	}
+	return gradecurves.BuildScoreInputs(cells, rawByStudent), maxPts, nil
+}
+
+func (d Deps) parseCurveRequest(w http.ResponseWriter, r *http.Request, maxPts float64) (gradecurve.Options, error) {
+	var body gradeCurveRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+		return gradecurve.Options{}, err
+	}
+	params, err := gradecurve.ParseParams(body.Params)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid curve params.")
+		return gradecurve.Options{}, err
+	}
+	opts := gradecurve.Options{
+		MaxPoints:     maxPts,
+		AllowAboveMax: body.AllowAboveMax,
+		Method:        gradecurve.Method(body.Method),
+		Params:        params,
+	}
+	if err := gradecurve.ValidateMethod(opts.Method, opts.Params); err != nil {
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+		return gradecurve.Options{}, err
+	}
+	return opts, nil
+}
+
+// handlePostAssignmentCurvePreview is POST .../assignments/{item_id}/curve/preview.
+func (d Deps) handlePostAssignmentCurvePreview() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost+","+http.MethodOptions)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		_, _, courseID, itemID, ok := d.requireGradeCurveAccess(w, r)
+		if !ok {
+			return
+		}
+		ctx := r.Context()
+		inputs, maxPts, err := d.loadCurvePreviewInputs(ctx, courseID, itemID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load grades.")
+			return
+		}
+		opts, err := d.parseCurveRequest(w, r, maxPts)
+		if err != nil {
+			return
+		}
+		preview, err := gradecurve.Preview(inputs, opts)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		active, _ := gradecurves.GetActiveForAssignment(ctx, d.Pool, itemID)
+		type resp struct {
+			Preview      gradecurve.PreviewSummary `json:"preview"`
+			ActiveCurve  *string                   `json:"activeCurveId,omitempty"`
+			MaxPoints    float64                   `json:"maxPoints"`
+		}
+		out := resp{Preview: preview, MaxPoints: maxPts}
+		if active != nil {
+			s := active.ID.String()
+			out.ActiveCurve = &s
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+// handlePostAssignmentCurve is POST .../assignments/{item_id}/curve.
+func (d Deps) handlePostAssignmentCurve() http.HandlerFunc {
+	type resp struct {
+		CurveID string `json:"curveId"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost+","+http.MethodOptions)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		courseCode, viewer, courseID, itemID, ok := d.requireGradeCurveAccess(w, r)
+		if !ok {
+			return
+		}
+		ctx := r.Context()
+		inputs, maxPts, err := d.loadCurvePreviewInputs(ctx, courseID, itemID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load grades.")
+			return
+		}
+		opts, err := d.parseCurveRequest(w, r, maxPts)
+		if err != nil {
+			return
+		}
+		preview, err := gradecurve.Preview(inputs, opts)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		if preview.EligibleCount == 0 {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "No graded, non-excused submissions to curve.")
+			return
+		}
+
+		paramsJSON, _ := json.Marshal(opts.Params)
+		adjs := make([]gradecurves.AdjustmentRow, 0, len(preview.Results))
+		for _, res := range preview.Results {
+			adjs = append(adjs, gradecurves.AdjustmentRow{
+				StudentID:     res.StudentID,
+				RawScore:      res.RawScore,
+				AdjustedScore: res.AdjustedScore,
+			})
+		}
+
+		curveID, err := gradecurves.Apply(ctx, d.Pool, gradecurves.ApplyInput{
+			CourseID:      courseID,
+			ModuleItemID:  itemID,
+			Method:        opts.Method,
+			ParamsJSON:    paramsJSON,
+			AllowAboveMax: opts.AllowAboveMax,
+			AppliedBy:     viewer,
+			Adjustments:   adjs,
+		}, func(ctx context.Context, tx pgx.Tx, studentID uuid.UUID, points float64) error {
+			_, err := tx.Exec(ctx, `
+UPDATE course.course_grades
+SET points_earned = $1, updated_at = NOW()
+WHERE course_id = $2 AND student_user_id = $3 AND module_item_id = $4
+`, points, courseID, studentID, itemID)
+			return err
+		})
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to apply curve.")
+			return
+		}
+
+		reason := gradecurve.AuditReasonJSON(opts.Method, opts.Params, curveID)
+		changedBy := viewer
+		tx, err := d.Pool.Begin(ctx)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to write audit trail.")
+			return
+		}
+		for _, res := range preview.Results {
+			if !res.Changed {
+				continue
+			}
+			prev := res.RawScore
+			next := res.AdjustedScore
+			if err := gradeauditevents.Insert(ctx, tx, courseID, itemID, res.StudentID, &changedBy, "curved", &prev, &next, nil, nil, &reason); err != nil {
+				_ = tx.Rollback(ctx)
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to write audit trail.")
+				return
+			}
+		}
+		if err := tx.Commit(ctx); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to write audit trail.")
+			return
+		}
+
+		cfg := d.effectiveConfig()
+		var orgID uuid.UUID
+		if err := d.Pool.QueryRow(ctx, `SELECT org_id FROM course.courses WHERE id = $1`, courseID).Scan(&orgID); err == nil && orgID != uuid.Nil {
+			webhooksvc.EmitAsync(d.Pool, cfg, orgID, webhooks.EventGradeCurveApplied, webhooksvc.GradeCurveAppliedData{
+				CourseID:     courseID.String(),
+				CourseCode:   courseCode,
+				ModuleItemID: itemID.String(),
+				CurveID:      curveID.String(),
+				Method:       string(opts.Method),
+				AppliedBy:    viewer.String(),
+				AppliedAt:    time.Now().UTC().Format(time.RFC3339),
+				Affected:     len(preview.Results),
+			})
+		}
+
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(resp{CurveID: curveID.String()})
+	}
+}
+
+// handleDeleteGradeCurve is DELETE /api/v1/curves/{curve_id}.
+func (d Deps) handleDeleteGradeCurve() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodDelete {
+			w.Header().Set("Allow", http.MethodDelete+","+http.MethodOptions)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		if !d.requireGradeCurvingEnabled(w) {
+			return
+		}
+		viewer, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		curveID, err := uuid.Parse(chi.URLParam(r, "curve_id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid curve ID.")
+			return
+		}
+		ctx := r.Context()
+		curve, err := gradecurves.GetByID(ctx, d.Pool, curveID)
+		if err != nil || curve == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Curve not found.")
+			return
+		}
+		courseCodePtr, err := course.GetCourseCodeByID(ctx, d.Pool, curve.CourseID)
+		if err != nil || courseCodePtr == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Course not found.")
+			return
+		}
+		has, err := courseroles.UserHasPermission(ctx, d.Pool, viewer, "course:"+*courseCodePtr+":item:create")
+		if err != nil || !has {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission to revert curves.")
+			return
+		}
+		if curve.ModuleItemID == nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Cannot revert this curve type.")
+			return
+		}
+		itemID := *curve.ModuleItemID
+		adjs, err := gradecurves.ListAdjustmentsForCurve(ctx, d.Pool, curveID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load curve adjustments.")
+			return
+		}
+
+		if err := gradecurves.Revert(ctx, d.Pool, curveID, func(ctx context.Context, tx pgx.Tx, studentID uuid.UUID, points float64) error {
+			_, err := tx.Exec(ctx, `
+UPDATE course.course_grades
+SET points_earned = $1, updated_at = NOW()
+WHERE course_id = $2 AND student_user_id = $3 AND module_item_id = $4
+`, points, curve.CourseID, studentID, itemID)
+			return err
+		}); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to revert curve.")
+			return
+		}
+
+		reason := gradecurve.AuditReasonJSON(curve.Method, gradecurve.Params{}, curveID)
+		changedBy := viewer
+		tx, err := d.Pool.Begin(ctx)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to write audit trail.")
+			return
+		}
+		for _, adj := range adjs {
+			prev := adj.AdjustedScore
+			next := adj.RawScore
+			if err := gradeauditevents.Insert(ctx, tx, curve.CourseID, itemID, adj.StudentID, &changedBy, "curve_reverted", &prev, &next, nil, nil, &reason); err != nil {
+				_ = tx.Rollback(ctx)
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to write audit trail.")
+				return
+			}
+		}
+		if err := tx.Commit(ctx); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to write audit trail.")
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/server/internal/httpserver/gradebook_grid.go
+++ b/server/internal/httpserver/gradebook_grid.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/lextures/lextures/server/internal/apierr"
@@ -24,6 +25,7 @@ import (
 	"github.com/lextures/lextures/server/internal/repos/crosslisting"
 	"github.com/lextures/lextures/server/internal/repos/enrollment"
 	"github.com/lextures/lextures/server/internal/repos/incompletegrades"
+	"github.com/lextures/lextures/server/internal/repos/gradecurves"
 	"github.com/lextures/lextures/server/internal/repos/gradingschemes"
 	"github.com/lextures/lextures/server/internal/courseroles"
 )
@@ -63,6 +65,11 @@ func (d Deps) handleGradebookGrid() http.HandlerFunc {
 		Type      string          `json:"type"`
 		ScaleJSON json.RawMessage `json:"scaleJson"`
 	}
+	type curveColOut struct {
+		CurveID   string `json:"curveId"`
+		Method    string `json:"method"`
+		AppliedAt string `json:"appliedAt"`
+	}
 	type gridResp struct {
 		Students            []studentOut                            `json:"students"`
 		Columns             []gradebookGridColumn                   `json:"columns"`
@@ -72,6 +79,7 @@ func (d Deps) handleGradebookGrid() http.HandlerFunc {
 		GradeHeld           map[string]map[string]bool              `json:"gradeHeld,omitempty"`
 		DroppedGrades       map[string]map[string]bool              `json:"droppedGrades,omitempty"`
 		ExcusedGrades       map[string]map[string]bool              `json:"excusedGrades,omitempty"`
+		ActiveCurves        map[string]curveColOut                  `json:"activeCurves,omitempty"`
 		GradingScheme       *schemeSum                              `json:"gradingScheme,omitempty"`
 		GradebookCsvEnabled bool                                    `json:"gradebookCsvEnabled"`
 		CrossListGroupID    *string                                 `json:"crossListGroupId,omitempty"`
@@ -487,7 +495,7 @@ func (d Deps) handleGradebookGrid() http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		_ = json.NewEncoder(w).Encode(gridResp{
+		resp := gridResp{
 			Students:            students,
 			Columns:             outCols,
 			Grades:              grades,
@@ -500,7 +508,20 @@ func (d Deps) handleGradebookGrid() http.HandlerFunc {
 			GradebookCsvEnabled: d.effectiveConfig().GradebookCSVEnabled,
 			CrossListGroupID:    crossListGroupID,
 			CrossListMerged:     crossListMerged,
-		})
+		}
+		if d.effectiveConfig().FFGradeCurving {
+			if curves, err := gradecurves.ListActiveForCourse(r.Context(), d.Pool, *cid); err == nil && len(curves) > 0 {
+				resp.ActiveCurves = make(map[string]curveColOut, len(curves))
+				for itemID, c := range curves {
+					resp.ActiveCurves[itemID] = curveColOut{
+						CurveID:   c.CurveID.String(),
+						Method:    c.Method,
+						AppliedAt: c.AppliedAt.UTC().Format(time.RFC3339),
+					}
+				}
+			}
+		}
+		_ = json.NewEncoder(w).Encode(resp)
 	}
 }
 

--- a/server/internal/httpserver/platform_features.go
+++ b/server/internal/httpserver/platform_features.go
@@ -59,6 +59,7 @@ type platformFeaturesJSON struct {
 	FFUiMode                    bool `json:"ffUiMode"`
 	FFGradeSubmission           bool `json:"ffGradeSubmission"`
 	FFWhatifGrades              bool `json:"ffWhatifGrades"`
+	FFGradeCurving              bool `json:"ffGradeCurving"`
 	FFAcademicCalendar          bool `json:"ffAcademicCalendar"`
 	FFPlagiarismChecks          bool `json:"ffPlagiarismChecks"`
 	FFCourseEvaluations         bool `json:"ffCourseEvaluations"`
@@ -159,6 +160,7 @@ func platformFeaturesFromConfig(cfg config.Config) platformFeaturesJSON {
 		FFUiMode:                    cfg.FFUiMode,
 		FFGradeSubmission:           cfg.FFGradeSubmission,
 		FFWhatifGrades:              cfg.FFWhatifGrades,
+		FFGradeCurving:              cfg.FFGradeCurving,
 		FFAcademicCalendar:          cfg.FFAcademicCalendar,
 		FFPlagiarismChecks:          cfg.FFPlagiarismChecks,
 		FFCourseEvaluations:         cfg.FFCourseEvaluations,

--- a/server/internal/httpserver/settings_platform.go
+++ b/server/internal/httpserver/settings_platform.go
@@ -115,6 +115,7 @@ type platformSettingsJSON struct {
 	FFEnrollmentStateMachine        bool `json:"ffEnrollmentStateMachine"`
 	FFGradeSubmission               bool `json:"ffGradeSubmission"`
 	FFWhatifGrades                  bool `json:"ffWhatifGrades"`
+	FFGradeCurving                  bool `json:"ffGradeCurving"`
 	FFPlagiarismChecks              bool `json:"ffPlagiarismChecks"`
 	FFIncompleteGradeWorkflow       bool `json:"ffIncompleteGradeWorkflow"`
 	FFAcademicCalendar              bool `json:"ffAcademicCalendar"`
@@ -313,6 +314,7 @@ func (d Deps) handleGetPlatformSettings() http.HandlerFunc {
 			FFEnrollmentStateMachine:        merged.FFEnrollmentStateMachine,
 			FFGradeSubmission:               merged.FFGradeSubmission,
 			FFWhatifGrades:                  merged.FFWhatifGrades,
+			FFGradeCurving:                  merged.FFGradeCurving,
 			FFPlagiarismChecks:              merged.FFPlagiarismChecks,
 			FFIncompleteGradeWorkflow:       merged.FFIncompleteGradeWorkflow,
 			FFAcademicCalendar:              merged.FFAcademicCalendar,
@@ -486,6 +488,7 @@ type putPlatformBody struct {
 	FFEnrollmentStateMachine        *bool `json:"ffEnrollmentStateMachine"`
 	FFGradeSubmission               *bool `json:"ffGradeSubmission"`
 	FFWhatifGrades                  *bool `json:"ffWhatifGrades"`
+	FFGradeCurving                  *bool `json:"ffGradeCurving"`
 	FFPlagiarismChecks              *bool `json:"ffPlagiarismChecks"`
 	FFIncompleteGradeWorkflow       *bool `json:"ffIncompleteGradeWorkflow"`
 	FFAcademicCalendar              *bool `json:"ffAcademicCalendar"`
@@ -805,6 +808,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 		setBool("ffenrollmentstatemachine", body.FFEnrollmentStateMachine, func(v bool) { wr.FFEnrollmentStateMachine = &v })
 		setBool("ffgradesubmission", body.FFGradeSubmission, func(v bool) { wr.FFGradeSubmission = &v })
 		setBool("ffwhatifgrades", body.FFWhatifGrades, func(v bool) { wr.FFWhatifGrades = &v })
+		setBool("ffgradecurving", body.FFGradeCurving, func(v bool) { wr.FFGradeCurving = &v })
 		setBool("ffplagiarismchecks", body.FFPlagiarismChecks, func(v bool) { wr.FFPlagiarismChecks = &v })
 		setBool("ffincompletegradeworkflow", body.FFIncompleteGradeWorkflow, func(v bool) { wr.FFIncompleteGradeWorkflow = &v })
 		setBool("ffacademiccalendar", body.FFAcademicCalendar, func(v bool) { wr.FFAcademicCalendar = &v })
@@ -957,6 +961,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 			FFEnrollmentStateMachine:        merged.FFEnrollmentStateMachine,
 			FFGradeSubmission:               merged.FFGradeSubmission,
 			FFWhatifGrades:                  merged.FFWhatifGrades,
+			FFGradeCurving:                  merged.FFGradeCurving,
 			FFPlagiarismChecks:              merged.FFPlagiarismChecks,
 			FFIncompleteGradeWorkflow:       merged.FFIncompleteGradeWorkflow,
 			FFAcademicCalendar:              merged.FFAcademicCalendar,

--- a/server/internal/repos/gradecurves/repo.go
+++ b/server/internal/repos/gradecurves/repo.go
@@ -1,0 +1,332 @@
+package gradecurves
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/lextures/lextures/server/internal/gradecurve"
+)
+
+// Row is one applied (or reverted) grade curve.
+type Row struct {
+	ID             uuid.UUID
+	CourseID       uuid.UUID
+	ModuleItemID   *uuid.UUID
+	Scope          string
+	Method         gradecurve.Method
+	ParamsJSON     json.RawMessage
+	AllowAboveMax  bool
+	AppliedBy      uuid.UUID
+	AppliedAt      time.Time
+	RevertedAt     *time.Time
+}
+
+// AdjustmentRow stores raw vs adjusted for one student.
+type AdjustmentRow struct {
+	ID            uuid.UUID
+	CurveID       uuid.UUID
+	StudentID     uuid.UUID
+	RawScore      float64
+	AdjustedScore float64
+}
+
+// CellScore is a grade cell used as curve input.
+type CellScore struct {
+	StudentID uuid.UUID
+	Points    float64
+	Excused   bool
+}
+
+// ActiveCurveSummary is exposed on the gradebook grid.
+type ActiveCurveSummary struct {
+	CurveID   uuid.UUID
+	Method    string
+	AppliedAt time.Time
+}
+
+// ListCellsForAssignment returns scored cells for one assignment.
+func ListCellsForAssignment(ctx context.Context, pool *pgxpool.Pool, courseID, itemID uuid.UUID) ([]CellScore, error) {
+	if pool == nil {
+		return nil, errors.New("nil pool")
+	}
+	rows, err := pool.Query(ctx, `
+SELECT student_user_id, points_earned, excused
+FROM course.course_grades
+WHERE course_id = $1 AND module_item_id = $2
+`, courseID, itemID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []CellScore
+	for rows.Next() {
+		var c CellScore
+		if err := rows.Scan(&c.StudentID, &c.Points, &c.Excused); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// RawScoresForActiveCurve returns student -> raw score from the active curve, if any.
+func RawScoresForActiveCurve(ctx context.Context, pool *pgxpool.Pool, itemID uuid.UUID) (uuid.UUID, map[uuid.UUID]float64, error) {
+	curve, err := GetActiveForAssignment(ctx, pool, itemID)
+	if err != nil {
+		return uuid.Nil, nil, err
+	}
+	if curve == nil {
+		return uuid.Nil, nil, nil
+	}
+	rows, err := pool.Query(ctx, `
+SELECT student_id, raw_score
+FROM course.grade_curve_adjustments
+WHERE curve_id = $1
+`, curve.ID)
+	if err != nil {
+		return uuid.Nil, nil, err
+	}
+	defer rows.Close()
+	out := make(map[uuid.UUID]float64)
+	for rows.Next() {
+		var sid uuid.UUID
+		var raw float64
+		if err := rows.Scan(&sid, &raw); err != nil {
+			return uuid.Nil, nil, err
+		}
+		out[sid] = raw
+	}
+	return curve.ID, out, rows.Err()
+}
+
+// GetActiveForAssignment returns the non-reverted curve for an assignment, if any.
+func GetActiveForAssignment(ctx context.Context, pool *pgxpool.Pool, itemID uuid.UUID) (*Row, error) {
+	if pool == nil {
+		return nil, errors.New("nil pool")
+	}
+	var r Row
+	var moduleItemID uuid.UUID
+	err := pool.QueryRow(ctx, `
+SELECT id, course_id, module_item_id, scope, method, params_json, allow_above_max, applied_by, applied_at, reverted_at
+FROM course.grade_curves
+WHERE module_item_id = $1 AND scope = 'assessment' AND reverted_at IS NULL
+ORDER BY applied_at DESC
+LIMIT 1
+`, itemID).Scan(
+		&r.ID, &r.CourseID, &moduleItemID, &r.Scope, &r.Method, &r.ParamsJSON,
+		&r.AllowAboveMax, &r.AppliedBy, &r.AppliedAt, &r.RevertedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	r.ModuleItemID = &moduleItemID
+	return &r, nil
+}
+
+// ListActiveForCourse maps module_item_id -> active curve summary for a course.
+func ListActiveForCourse(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (map[string]ActiveCurveSummary, error) {
+	if pool == nil {
+		return nil, errors.New("nil pool")
+	}
+	rows, err := pool.Query(ctx, `
+SELECT id, module_item_id, method, applied_at
+FROM course.grade_curves
+WHERE course_id = $1 AND scope = 'assessment' AND reverted_at IS NULL AND module_item_id IS NOT NULL
+`, courseID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]ActiveCurveSummary)
+	for rows.Next() {
+		var id, itemID uuid.UUID
+		var method string
+		var appliedAt time.Time
+		if err := rows.Scan(&id, &itemID, &method, &appliedAt); err != nil {
+			return nil, err
+		}
+		out[itemID.String()] = ActiveCurveSummary{CurveID: id, Method: method, AppliedAt: appliedAt}
+	}
+	return out, rows.Err()
+}
+
+// GetByID loads a curve by primary key.
+func GetByID(ctx context.Context, pool *pgxpool.Pool, curveID uuid.UUID) (*Row, error) {
+	if pool == nil {
+		return nil, errors.New("nil pool")
+	}
+	var r Row
+	var moduleItemID *uuid.UUID
+	err := pool.QueryRow(ctx, `
+SELECT id, course_id, module_item_id, scope, method, params_json, allow_above_max, applied_by, applied_at, reverted_at
+FROM course.grade_curves
+WHERE id = $1
+`, curveID).Scan(
+		&r.ID, &r.CourseID, &moduleItemID, &r.Scope, &r.Method, &r.ParamsJSON,
+		&r.AllowAboveMax, &r.AppliedBy, &r.AppliedAt, &r.RevertedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	r.ModuleItemID = moduleItemID
+	return &r, nil
+}
+
+// ListAdjustmentsForCurve returns all adjustments for a curve.
+func ListAdjustmentsForCurve(ctx context.Context, pool *pgxpool.Pool, curveID uuid.UUID) ([]AdjustmentRow, error) {
+	if pool == nil {
+		return nil, errors.New("nil pool")
+	}
+	rows, err := pool.Query(ctx, `
+SELECT id, curve_id, student_id, raw_score, adjusted_score
+FROM course.grade_curve_adjustments
+WHERE curve_id = $1
+ORDER BY student_id
+`, curveID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AdjustmentRow
+	for rows.Next() {
+		var a AdjustmentRow
+		if err := rows.Scan(&a.ID, &a.CurveID, &a.StudentID, &a.RawScore, &a.AdjustedScore); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// ApplyInput is everything needed to persist a new curve.
+type ApplyInput struct {
+	CourseID      uuid.UUID
+	ModuleItemID  uuid.UUID
+	Method        gradecurve.Method
+	ParamsJSON    json.RawMessage
+	AllowAboveMax bool
+	AppliedBy     uuid.UUID
+	Adjustments   []AdjustmentRow
+}
+
+// Apply persists a curve and updates grade cells in one transaction.
+func Apply(ctx context.Context, pool *pgxpool.Pool, in ApplyInput, updateGrade func(ctx context.Context, tx pgx.Tx, studentID uuid.UUID, points float64) error) (uuid.UUID, error) {
+	if pool == nil {
+		return uuid.Nil, errors.New("nil pool")
+	}
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Revert any existing active curve for this assignment.
+	var prevID uuid.UUID
+	err = tx.QueryRow(ctx, `
+SELECT id FROM course.grade_curves
+WHERE module_item_id = $1 AND scope = 'assessment' AND reverted_at IS NULL
+FOR UPDATE
+`, in.ModuleItemID).Scan(&prevID)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, err
+	}
+	if err == nil {
+		if _, err := tx.Exec(ctx, `UPDATE course.grade_curves SET reverted_at = NOW() WHERE id = $1`, prevID); err != nil {
+			return uuid.Nil, err
+		}
+	}
+
+	var curveID uuid.UUID
+	err = tx.QueryRow(ctx, `
+INSERT INTO course.grade_curves (
+	course_id, module_item_id, scope, method, params_json, allow_above_max, applied_by
+) VALUES ($1, $2, 'assessment', $3, $4, $5, $6)
+RETURNING id
+`, in.CourseID, in.ModuleItemID, string(in.Method), in.ParamsJSON, in.AllowAboveMax, in.AppliedBy).Scan(&curveID)
+	if err != nil {
+		return uuid.Nil, err
+	}
+
+	for _, adj := range in.Adjustments {
+		if _, err := tx.Exec(ctx, `
+INSERT INTO course.grade_curve_adjustments (curve_id, student_id, raw_score, adjusted_score)
+VALUES ($1, $2, $3, $4)
+`, curveID, adj.StudentID, adj.RawScore, adj.AdjustedScore); err != nil {
+			return uuid.Nil, err
+		}
+		if err := updateGrade(ctx, tx, adj.StudentID, adj.AdjustedScore); err != nil {
+			return uuid.Nil, err
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return uuid.Nil, err
+	}
+	return curveID, nil
+}
+
+// Revert restores raw scores and marks the curve reverted.
+func Revert(ctx context.Context, pool *pgxpool.Pool, curveID uuid.UUID, restoreGrade func(ctx context.Context, tx pgx.Tx, studentID uuid.UUID, points float64) error) error {
+	if pool == nil {
+		return errors.New("nil pool")
+	}
+	curve, err := GetByID(ctx, pool, curveID)
+	if err != nil {
+		return err
+	}
+	if curve == nil {
+		return pgx.ErrNoRows
+	}
+	if curve.RevertedAt != nil {
+		return errors.New("curve already reverted")
+	}
+	adjs, err := ListAdjustmentsForCurve(ctx, pool, curveID)
+	if err != nil {
+		return err
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `UPDATE course.grade_curves SET reverted_at = NOW() WHERE id = $1`, curveID); err != nil {
+		return err
+	}
+	for _, adj := range adjs {
+		if err := restoreGrade(ctx, tx, adj.StudentID, adj.RawScore); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+// BuildScoreInputs merges cell scores with any active curve raw preservation.
+func BuildScoreInputs(cells []CellScore, rawByStudent map[uuid.UUID]float64) []gradecurve.ScoreInput {
+	out := make([]gradecurve.ScoreInput, 0, len(cells))
+	for _, c := range cells {
+		raw := c.Points
+		if preserved, ok := rawByStudent[c.StudentID]; ok {
+			raw = preserved
+		}
+		out = append(out, gradecurve.ScoreInput{
+			StudentID: c.StudentID,
+			RawScore:  raw,
+			Excused:   c.Excused,
+		})
+	}
+	return out
+}

--- a/server/internal/repos/platformconfig/features.go
+++ b/server/internal/repos/platformconfig/features.go
@@ -69,6 +69,7 @@ func applyPlatformBools(out *config.Config, db *Row, def Defaults) {
 	out.FFUiMode = mergeBool(db.FFUiMode, false)
 	out.FFGradeSubmission = mergeBool(db.FFGradeSubmission, false)
 	out.FFWhatifGrades = mergeBool(db.FFWhatifGrades, false)
+	out.FFGradeCurving = mergeBool(db.FFGradeCurving, false)
 	out.FFAcademicCalendar = mergeBool(db.FFAcademicCalendar, false)
 	out.FFPlagiarismChecks = mergeBool(db.FFPlagiarismChecks, false)
 	out.FFCourseEvaluations = mergeBool(db.FFCourseEvaluations, false)

--- a/server/internal/repos/platformconfig/patch.go
+++ b/server/internal/repos/platformconfig/patch.go
@@ -137,6 +137,7 @@ func patch(ctx context.Context, pool *pgxpool.Pool, w *Write) error {
 	addBool("ff_content_filter_integration", w.FFContentFilterIntegration)
 	addBool("ff_grade_submission", w.FFGradeSubmission)
 	addBool("ff_whatif_grades", w.FFWhatifGrades)
+	addBool("ff_grade_curving", w.FFGradeCurving)
 	addBool("ff_academic_calendar", w.FFAcademicCalendar)
 	addBool("ff_plagiarism_checks", w.FFPlagiarismChecks)
 	addBool("ff_course_evaluations", w.FFCourseEvaluations)

--- a/server/internal/repos/platformconfig/platformconfig.go
+++ b/server/internal/repos/platformconfig/platformconfig.go
@@ -103,6 +103,7 @@ type Row struct {
 	FFUiMode                        *bool
 	FFGradeSubmission               *bool
 	FFWhatifGrades                  *bool
+	FFGradeCurving                  *bool
 	FFAcademicCalendar              *bool
 	FFPlagiarismChecks              *bool
 	FFCourseEvaluations             *bool
@@ -253,6 +254,7 @@ type Write struct {
 	FFUiMode                        *bool
 	FFGradeSubmission               *bool
 	FFWhatifGrades                  *bool
+	FFGradeCurving                  *bool
 	FFAcademicCalendar              *bool
 	FFPlagiarismChecks              *bool
 	FFCourseEvaluations             *bool
@@ -400,6 +402,7 @@ SELECT
 	ff_content_filter_integration,
 	ff_grade_submission,
 	ff_whatif_grades,
+	ff_grade_curving,
 	ff_academic_calendar,
 	ff_plagiarism_checks,
 	ff_course_evaluations,
@@ -541,6 +544,7 @@ WHERE id = 1
 		&r.FFContentFilterIntegration,
 		&r.FFGradeSubmission,
 		&r.FFWhatifGrades,
+		&r.FFGradeCurving,
 		&r.FFAcademicCalendar,
 		&r.FFPlagiarismChecks,
 		&r.FFCourseEvaluations,
@@ -733,6 +737,7 @@ INSERT INTO settings.platform_app_settings (
 	ff_content_filter_integration,
 	ff_grade_submission,
 	ff_whatif_grades,
+	ff_grade_curving,
 	ff_academic_calendar,
 	ff_plagiarism_checks,
 	ff_course_evaluations,
@@ -879,6 +884,7 @@ ON CONFLICT (id) DO UPDATE SET
 	ff_content_filter_integration = COALESCE(EXCLUDED.ff_content_filter_integration, settings.platform_app_settings.ff_content_filter_integration),
 	ff_grade_submission = COALESCE(EXCLUDED.ff_grade_submission, settings.platform_app_settings.ff_grade_submission),
 	ff_whatif_grades = COALESCE(EXCLUDED.ff_whatif_grades, settings.platform_app_settings.ff_whatif_grades),
+	ff_grade_curving = COALESCE(EXCLUDED.ff_grade_curving, settings.platform_app_settings.ff_grade_curving),
 	ff_academic_calendar = COALESCE(EXCLUDED.ff_academic_calendar, settings.platform_app_settings.ff_academic_calendar),
 	ff_plagiarism_checks = COALESCE(EXCLUDED.ff_plagiarism_checks, settings.platform_app_settings.ff_plagiarism_checks),
 	ff_course_evaluations = COALESCE(EXCLUDED.ff_course_evaluations, settings.platform_app_settings.ff_course_evaluations),
@@ -1018,6 +1024,7 @@ ON CONFLICT (id) DO UPDATE SET
 		w.FFContentFilterIntegration,
 		w.FFGradeSubmission,
 		w.FFWhatifGrades,
+		w.FFGradeCurving,
 		w.FFAcademicCalendar,
 		w.FFPlagiarismChecks,
 		w.FFCourseEvaluations,

--- a/server/internal/service/webhooks/hooks.go
+++ b/server/internal/service/webhooks/hooks.go
@@ -85,6 +85,18 @@ type GradeReleasedData struct {
 	URL           string  `json:"url,omitempty"`
 }
 
+// GradeCurveAppliedData is the grade.curve.applied event payload (plan 3.17).
+type GradeCurveAppliedData struct {
+	CourseID     string `json:"courseId"`
+	CourseCode   string `json:"courseCode,omitempty"`
+	ModuleItemID string `json:"moduleItemId"`
+	CurveID      string `json:"curveId"`
+	Method       string `json:"method"`
+	AppliedBy    string `json:"appliedBy"`
+	AppliedAt    string `json:"appliedAt"`
+	Affected     int    `json:"affectedCount"`
+}
+
 // AnnouncementCreatedData is the announcement.created event payload.
 type AnnouncementCreatedData struct {
 	CourseID   string `json:"courseId"`
@@ -107,6 +119,11 @@ func EmitAssignmentDueSoon(pool *pgxpool.Pool, cfg config.Config, orgID uuid.UUI
 // EmitGradeReleased notifies subscribers when a grade is released to a student.
 func EmitGradeReleased(pool *pgxpool.Pool, cfg config.Config, orgID uuid.UUID, data GradeReleasedData) {
 	EmitAsync(pool, cfg, orgID, webhooks.EventGradeReleased, data)
+}
+
+// EmitGradeCurveApplied notifies subscribers when an instructor applies a grade curve (plan 3.17).
+func EmitGradeCurveApplied(pool *pgxpool.Pool, cfg config.Config, orgID uuid.UUID, data GradeCurveAppliedData) {
+	EmitAsync(pool, cfg, orgID, webhooks.EventGradeCurveApplied, data)
 }
 
 // EmitAnnouncementCreated notifies subscribers when an announcement is posted.

--- a/server/internal/webhooks/events.go
+++ b/server/internal/webhooks/events.go
@@ -23,6 +23,7 @@ const (
 	EventAssignmentCreated   EventType = "assignment.created"
 	EventAssignmentDueSoon   EventType = "assignment.due_soon"
 	EventGradeReleased       EventType = "grade.released"
+	EventGradeCurveApplied   EventType = "grade.curve.applied"
 	EventAnnouncementCreated EventType = "announcement.created"
 )
 
@@ -35,6 +36,7 @@ func AllEventTypes() []string {
 		EventAssignmentCreated,
 		EventAssignmentDueSoon,
 		EventGradeReleased,
+		EventGradeCurveApplied,
 		EventAnnouncementCreated,
 	}
 	out := make([]string, 0, len(types))
@@ -118,7 +120,7 @@ type EventGroup struct {
 // EventGroups returns event types grouped by domain prefix for admin UI.
 func EventGroups() []EventGroup {
 	return []EventGroup{
-		{Domain: "Grades", Types: []string{string(EventGradePosted), string(EventGradeReleased)}},
+		{Domain: "Grades", Types: []string{string(EventGradePosted), string(EventGradeReleased), string(EventGradeCurveApplied)}},
 		{Domain: "Enrollments", Types: []string{string(EventEnrollmentCreated)}},
 		{Domain: "Assignments", Types: []string{string(EventAssignmentSubmitted), string(EventAssignmentCreated), string(EventAssignmentDueSoon)}},
 		{Domain: "Announcements", Types: []string{string(EventAnnouncementCreated)}},

--- a/server/migrations/308_grade_curving.sql
+++ b/server/migrations/308_grade_curving.sql
@@ -1,0 +1,55 @@
+-- Plan 3.17 — Grade curving & scaling: feature flag, curve metadata, raw-score preservation.
+
+ALTER TABLE settings.platform_app_settings
+    ADD COLUMN IF NOT EXISTS ff_grade_curving BOOLEAN;
+
+COMMENT ON COLUMN settings.platform_app_settings.ff_grade_curving IS
+    'Enables instructor grade curving/scaling on assignments (plan 3.17).';
+
+CREATE TABLE course.grade_curves (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    course_id        UUID NOT NULL REFERENCES course.courses (id) ON DELETE CASCADE,
+    module_item_id   UUID REFERENCES course.course_structure_items (id) ON DELETE CASCADE,
+    scope            TEXT NOT NULL CHECK (scope IN ('assessment', 'final')),
+    section_id       UUID,
+    method           TEXT NOT NULL CHECK (method IN
+        ('flat_bonus', 'linear_scale', 'sqrt_curve', 'set_minimum', 'custom_mapping')),
+    params_json      JSONB NOT NULL DEFAULT '{}',
+    allow_above_max  BOOLEAN NOT NULL DEFAULT FALSE,
+    applied_by       UUID NOT NULL REFERENCES "user".users (id) ON DELETE RESTRICT,
+    applied_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    reverted_at      TIMESTAMPTZ
+);
+
+COMMENT ON TABLE course.grade_curves IS
+    'Instructor-applied grade curve/scaling metadata (plan 3.17).';
+
+CREATE INDEX idx_grade_curves_assessment ON course.grade_curves (module_item_id)
+    WHERE reverted_at IS NULL AND scope = 'assessment';
+
+CREATE INDEX idx_grade_curves_course ON course.grade_curves (course_id, applied_at DESC);
+
+CREATE TABLE course.grade_curve_adjustments (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    curve_id      UUID NOT NULL REFERENCES course.grade_curves (id) ON DELETE CASCADE,
+    student_id    UUID NOT NULL REFERENCES "user".users (id) ON DELETE CASCADE,
+    raw_score     NUMERIC(8, 2) NOT NULL,
+    adjusted_score NUMERIC(8, 2) NOT NULL,
+    CONSTRAINT grade_curve_adjustments_unique_student UNIQUE (curve_id, student_id)
+);
+
+COMMENT ON TABLE course.grade_curve_adjustments IS
+    'Per-student raw vs curved scores for reversible curve application (plan 3.17).';
+
+CREATE INDEX idx_grade_curve_adjustments_curve ON course.grade_curve_adjustments (curve_id);
+
+-- Extend grade audit actions (3.10) for 3.17.
+ALTER TABLE course.grade_audit_events
+    DROP CONSTRAINT IF EXISTS grade_audit_events_action_check;
+
+ALTER TABLE course.grade_audit_events
+    ADD CONSTRAINT grade_audit_events_action_check CHECK (action IN
+        (
+            'created', 'updated', 'excused', 'unexcused', 'posted', 'retracted', 'deleted',
+            'revision_requested', 'resubmission_received', 'curved', 'curve_reverted'
+        ));


### PR DESCRIPTION
## Summary
- Adds instructor grade curving/scaling for assignments and quizzes: flat bonus, linear scale (target mean/max), square-root curve, set minimum, and custom mapping.
- Preview endpoint shows distribution stats and per-student deltas before apply; apply stores raw scores in `grade_curve_adjustments` and supports undo via `DELETE /api/v1/curves/{id}`.
- Gradebook column menu opens a curve dialog with live preview; active curves show a column indicator. Feature is gated by `ffGradeCurving` (default off).

## Test plan
- [ ] Run migration `308_grade_curving.sql` and enable **Grade curving** in Settings → Global platform
- [ ] In gradebook, curve an assignment with linear scale to target mean; verify preview mean ≈ target
- [ ] Apply curve and confirm student grades update; undo and confirm raw scores restore
- [ ] Verify excused students are excluded from curve math
- [ ] Verify scores cap at max unless "Allow above max" is enabled
- [ ] Run `go test ./internal/gradecurve/... -short`


Made with [Cursor](https://cursor.com)