### PR TITLE
Add UI feel & micro-detail audit plan (22.1)

### DIFF
--- a/docs/plan/22-ui-polish-feel/22.1-interface-feel-audit.md
+++ b/docs/plan/22-ui-polish-feel/22.1-interface-feel-audit.md
@@ -1,0 +1,230 @@
+# 22.1 — Interface Feel & Micro-detail Audit
+
+> UI-quality remediation plan. Source: cross-cutting audit of `clients/web/src` against the
+> "Details that make interfaces feel better" standard (`.claude/skills/make-interfaces-feel-better`).
+> **This document is a backlog for another team to implement — no code was changed.**
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | 22.1 |
+| **Section** | UI Polish & Feel |
+| **Severity** | MINOR (polish; no functional gap) |
+| **Markets** | K12 / HE / SL (all surfaces) |
+| **Status (today)** | PARTIAL — some principles satisfied globally, most applied inconsistently |
+| **Estimated effort** | M (2–4w) split across small PRs per principle |
+| **Owner (proposed)** | Web frontend / design-systems |
+| **Depends on** | — |
+| **Unblocks** | Consistent tactile feel across the LMS shell |
+
+---
+
+## 1. Problem Statement
+
+The web client (`clients/web`, React 19 + Tailwind v4, **no motion library installed**) is visually
+on-system but inconsistent on the micro-details that make an interface feel responsive and polished:
+buttons have no press feedback, content images have no edge definition, headings never balance their
+wrapping, and a handful of components use `transition: all`. None of these are bugs; together they are
+the difference between "fine" and "feels good." This plan inventories every gap with file:line
+citations so the work can be split into small, mechanical PRs.
+
+## 2. Scope of the scan
+
+- **Surface scanned:** `clients/web/src` — 1,208 `<button>` elements, 24 `<img>` elements,
+  367 `<h1>/<h2>` headings, ~192 files using shadow utilities.
+- **Tooling note:** no `motion` / `framer-motion` in `package.json`. Per the standard, animation
+  recommendations below use **CSS transitions with `cubic-bezier(0.2, 0, 0, 1)`** and keep both icons
+  in the DOM for cross-fades — *not* framer props. Rule 13 (`AnimatePresence initial={false}`) is
+  therefore **N/A**.
+- **Already compliant (no action needed):**
+  - Rule 8 (font smoothing) — `antialiased` applied to `body` in [index.css:264](../../../clients/web/src/index.css).
+  - Rule 15 (`will-change`) — only 2 usages, both `transform`, both justified
+    ([notifications-drawer.tsx:333](../../../clients/web/src/components/layout/notifications-drawer.tsx), [ReadingRuler.tsx:42](../../../clients/web/src/components/a11y/ReadingRuler.tsx)).
+  - Rule 5 (stagger) — the side-nav course list is a model implementation
+    ([index.css:137-169](../../../clients/web/src/index.css)); use it as the reference pattern.
+  - `prefers-reduced-motion` is comprehensively honored ([index.css:165-193](../../../clients/web/src/index.css)) — **every animation added below must keep working under it.**
+
+---
+
+## 3. Findings by principle
+
+Each table is **Before → After**. Rows cite the file and the specific property to change.
+
+### Rule 12 — Scale on press (biggest single win)
+
+Of 1,208 buttons, **0** have press feedback. The only 4 `active:scale` usages in the codebase use
+`scale-95`, which the standard explicitly disallows (must be `0.96`; never below `0.95`).
+
+| Before | After |
+| --- | --- |
+| 4× primary CTAs use `transition active:scale-95` — [course-outcomes-section.tsx:535](../../../clients/web/src/pages/lms/course-outcomes-section.tsx), [course-grading-settings.tsx:859](../../../clients/web/src/pages/lms/course-grading-settings.tsx), [course-settings.tsx:1473](../../../clients/web/src/pages/lms/course-settings.tsx), [course-blueprint-settings.tsx:339](../../../clients/web/src/pages/lms/course-blueprint-settings.tsx) | `active:scale-[0.96]` + `transition-transform` (replace bare `transition`, see Rule 14) |
+| `EmptyState` action buttons have `transition` but no scale — [empty-state.tsx:19](../../../clients/web/src/components/ui/empty-state.tsx) | Add `active:scale-[0.96]` to the shared `base` string |
+| `ConfirmDialog` confirm/cancel buttons — [confirm-dialog.tsx:114,127](../../../clients/web/src/components/confirm-dialog.tsx) | Add `active:scale-[0.96] transition-transform` |
+| ~1,200 other buttons have no shared primitive to inherit from | **Recommended:** introduce a `<Button>` primitive (or a `lex-btn` `@utility`) in `src/components/ui/` carrying `active:scale-[0.96]`, focus ring, and disabled styles; migrate incrementally. Add `static` opt-out for buttons inside drag handles / canvas nodes where motion distracts. |
+
+> Reduced-motion: `active:scale` is a `transition`, so it's already neutralized by the global
+> `transition-duration: 0.01ms` rule — no extra guard needed.
+
+### Rule 14 — Never use `transition: all`
+
+18 occurrences of `transition-all` across the web client. Each animates every property (layout,
+color, shadow) and should name only what changes.
+
+| Before | After |
+| --- | --- |
+| `transition-all` in [side-nav.tsx](../../../clients/web/src/components/layout/side-nav.tsx), [side-nav-footer.tsx](../../../clients/web/src/components/layout/side-nav-footer.tsx) | `transition-colors` (hover bg/text) or `transition-[width]` for collapse |
+| `transition-all` in [self-paced-progress.tsx](../../../clients/web/src/components/self-paced/self-paced-progress.tsx), [seat-time-progress-bar.tsx](../../../clients/web/src/components/seat-time/seat-time-progress-bar.tsx) | `transition-[width]` on the fill bar only |
+| `transition-all` in [rubric-grade-picker.tsx](../../../clients/web/src/components/grading/rubric-grade-picker.tsx), [gamification-dashboard-card.tsx](../../../clients/web/src/components/gamification/gamification-dashboard-card.tsx), [study-stats-card.tsx](../../../clients/web/src/components/study-stats/study-stats-card.tsx), [flashcards-modal.tsx](../../../clients/web/src/components/notebook/flashcards-modal.tsx), [block-frame.tsx](../../../clients/web/src/components/editor/block-editor/block-frame.tsx), [tutor-panel.tsx](../../../clients/web/src/components/tutor-panel.tsx), [skip-link.tsx](../../../clients/web/src/components/skip-link.tsx), [course-outcomes-section.tsx](../../../clients/web/src/pages/lms/course-outcomes-section.tsx), [course-feed-page.tsx](../../../clients/web/src/pages/lms/course-feed-page.tsx), [my-paths.tsx](../../../clients/web/src/pages/lms/my-paths.tsx) | Replace each with the explicit property set: `transition-colors`, `transition-transform`, `transition-[opacity,transform]`, etc. Audit each call site for what actually animates. |
+| Bare `transition` (defaults to `all`) on the 4 CTAs in the Rule 12 table | `transition-transform` (scale is the only animated property there) |
+
+### Rule 11 — Image outlines
+
+**0 of 24** `<img>` elements carry the prescribed subtle outline. Content images read as floating
+with no edge. Standard: `rgba(0,0,0,0.1)` in light, `rgba(255,255,255,0.1)` in dark — pure black /
+pure white, never tinted slate/neutral.
+
+| Before | After |
+| --- | --- |
+| Hero / cover images: [course-hero-image.tsx:40](../../../clients/web/src/components/course-hero-image.tsx), [explore-course-page.tsx](../../../clients/web/src/pages/explore-course-page.tsx) (`h-56 object-cover`), [library-catalog-page.tsx](../../../clients/web/src/pages/lms/library-catalog-page.tsx), [explore-catalog-page.tsx](../../../clients/web/src/pages/explore-catalog-page.tsx), [course-feed-page.tsx](../../../clients/web/src/pages/lms/course-feed-page.tsx) | Add `ring-1 ring-black/10 dark:ring-white/10` (or an `outline` utility) |
+| Inline markdown / submission images: [markdown-themed-components.tsx](../../../clients/web/src/components/markdown/markdown-themed-components.tsx), [syllabus-markdown-view.tsx](../../../clients/web/src/components/syllabus/syllabus-markdown-view.tsx), [course-file-markdown-image.tsx](../../../clients/web/src/components/syllabus/course-file-markdown-image.tsx), [annotation-viewer.tsx](../../../clients/web/src/components/annotation/annotation-viewer.tsx), [file-preview.tsx](../../../clients/web/src/components/file-preview.tsx), quiz images ([quiz-student-take-panel.tsx](../../../clients/web/src/components/quiz/quiz-student-take-panel.tsx), [quiz-student-preview-modal.tsx](../../../clients/web/src/components/quiz/quiz-student-preview-modal.tsx)) | Same `ring-1 ring-black/10 dark:ring-white/10` |
+| MFA QR uses `border border-slate-200` — [mfa-factors-panel.tsx](../../../clients/web/src/components/settings/mfa-factors-panel.tsx) | Acceptable as a functional QR boundary; **exclude** from the outline pass. |
+| Avatars / logos: [enrollment-avatar.tsx](../../../clients/web/src/components/enrollment/enrollment-avatar.tsx), [brand-logo.tsx](../../../clients/web/src/components/brand-logo.tsx), [consortium-home-branding-banner.tsx](../../../clients/web/src/components/consortium/consortium-home-branding-banner.tsx), external-link favicons | **Exclude** — logos/avatars/icons are intentionally borderless. |
+
+### Rule 10 — Text wrapping (`balance` / `pretty`)
+
+**0** usages of `text-wrap`, `text-balance`, or `text-pretty` across 367 headings.
+
+| Before | After |
+| --- | --- |
+| Page titles (`<h1>/<h2>` with `tracking-tight font-semibold`) across LMS pages | Add `text-balance` to heading classes — best applied via a shared heading component or a `@layer base` rule scoped to `.lms-scope h1, .lms-scope h2` |
+| Long body / description paragraphs (card metadata, empty-state body [empty-state.tsx:68](../../../clients/web/src/components/ui/empty-state.tsx), course descriptions) | Add `text-pretty` to avoid orphans |
+
+> Cheapest delivery: one `@layer base` block in [index.css](../../../clients/web/src/index.css) —
+> `.lms-scope :is(h1,h2,h3){ text-wrap: balance } .lms-scope p{ text-wrap: pretty }`. Verify it does
+> not fight `truncate`/`line-clamp` usages (those override wrapping anyway).
+
+### Rule 9 — Tabular numbers (partial — close gaps)
+
+Already used in **41 files** (good coverage on quiz timers, grade pickers, analytics). Audit the
+remaining live-updating numerics.
+
+| Before | After |
+| --- | --- |
+| Any countdown/timer, live participant count, progress `%`, or grade total **not** in the 41 files (e.g. seat-time/self-paced progress readouts, gamification points, presence counts) | Add `tabular-nums` to the number `<span>` to stop layout shift on tick |
+| Global safety net | Consider a `.lex-num{ font-variant-numeric: tabular-nums }` utility and apply at sites, rather than globalizing (tabular nums hurt prose readability). |
+
+### Rule 1 — Concentric border radius
+
+| Before | After |
+| --- | --- |
+| `EmptyState`: outer `<section rounded-2xl px-6>` contains an icon chip that is **also** `rounded-2xl` ([empty-state.tsx:53,58](../../../clients/web/src/components/ui/empty-state.tsx)) — same radius, nested | Outer stays `rounded-2xl` (16px); inner 48px chip → `rounded-xl` (12px) so it reads as nested, or recompute to `inner = outer − padding` |
+| `ConfirmDialog`: card `rounded-2xl p-5` (16px radius / 20px pad) with inner inputs/buttons `rounded-xl` ([confirm-dialog.tsx:81,104,114](../../../clients/web/src/components/confirm-dialog.tsx)) | Mostly fine (inner < outer); document the rule so new nested surfaces follow `outer = inner + padding` |
+| Card grids generally: 115 files use `rounded-2xl`; spot-check any card whose inner buttons/thumbnails repeat the parent radius | Recompute nested radii per the formula |
+
+### Rule 3 — Shadows over borders / layered depth
+
+Most cards use a single flat `shadow-sm` **plus** a `border-slate-200`. The standard prefers layered
+transparent shadows for natural depth; 12 files already use custom `shadow-[…]` (good examples:
+[side-nav-footer.tsx:99,71](../../../clients/web/src/components/layout/side-nav-footer.tsx)).
+
+| Before | After |
+| --- | --- |
+| `shadow-sm` + hard `border` on cards (EmptyState, most list/grid cards) | Define a layered elevation token, e.g. `--shadow-card: 0 1px 2px rgb(15 23 42 / .04), 0 4px 12px rgb(15 23 42 / .06)`, and lean on it instead of the border for separation |
+| Section dividers using `border-slate-200` (1.23:1 — already a documented decorative exception in [design-tokens.md](../../../docs/design-tokens.md)) | Keep border where it doubles as a structural divider; only swap to shadow where the border is purely for elevation |
+
+> Coordinate with [design-tokens.md](../../../docs/design-tokens.md) — the contrast contract treats
+> `slate-200` borders as decorative-only, so removing them for shadow is safe but must keep another
+> separator (spacing/bg) per SC 1.4.11.
+
+### Rule 7 — Contextual icon animations (no motion lib → CSS cross-fade)
+
+Toggling icons (e.g. show/hide password, expand/collapse chevrons, copy→check) generally swap which
+icon renders. Without a motion library, the standard says keep **both** icons mounted (one
+`absolute`) and cross-fade with `transition: opacity, transform, filter` using
+`cubic-bezier(0.2, 0, 0, 1)`, scale `0.25→1`, opacity `0→1`, blur `4px→0`.
+
+| Before | After |
+| --- | --- |
+| Copy→"Copied" feedback uses an opacity keyframe ([index.css:521-539](../../../clients/web/src/index.css)) | Already opacity-based — acceptable; optionally add scale/blur for the icon swap |
+| Chevron/disclosure toggles and password-eye toggles that conditionally render one icon | Render both, cross-fade per the values above; reuse a small `<IconSwap>` helper |
+
+### Rule 6 — Subtle exit animations
+
+Toasts/banners enter with `slide-in-from-bottom-4 fade-in duration-300`
+([course-outcomes-section.tsx:510](../../../clients/web/src/pages/lms/course-outcomes-section.tsx) and 3 sibling settings pages) but **unmount with no exit** — they pop out.
+
+| Before | After |
+| --- | --- |
+| Save-confirmation toasts mount/unmount instantly on exit (4 settings pages) | Add a brief exit: small fixed `translateY` (e.g. 8px) + fade, softer/shorter than the enter. Without framer, gate unmount behind a CSS exit class + `transitionend`, or use the `data-[state]` pattern. |
+
+### Rule 16 — Minimum hit area (40×40px)
+
+Icon-only buttons (toolbar actions, close ✕, kebab menus, table-row actions) frequently render at
+`h-5/h-6` / `p-1`, below the 40px minimum.
+
+| Before | After |
+| --- | --- |
+| Icon-only controls sized to the glyph (e.g. notifications-drawer close, editor toolbar buttons, table-row action icons) | Ensure `min-h-10 min-w-10` (or a `::before` pseudo-element extending the hit area) while keeping the glyph visually small. Never overlap two controls' hit areas. |
+| Side-nav collapsed badge tap target [side-nav-link.tsx:58](../../../clients/web/src/components/layout/side-nav-link.tsx) | Verify the link row meets 40px in collapsed mode |
+
+> This overlaps WCAG 2.5.5 (Target Size) — coordinate with the accessibility section (12.x) so the
+> fix counts toward both.
+
+### Rule 2 — Optical alignment
+
+| Before | After |
+| --- | --- |
+| Play/▶ triangles and asymmetric glyphs in [video-player/](../../../clients/web/src/components/video-player) and media controls | Nudge optically (a few px right) rather than geometric center; verify after icon swaps |
+| Icon-in-button leading icons across CTAs | Confirm `gap`/padding read centered, not just `items-center` |
+
+### Rule 4 — Interruptible animations
+
+Mostly satisfied (hover/active use CSS `transition-colors`). Watch only that newly added enter/exit
+work (Rule 6/7) uses transitions, not one-shot keyframes, for interactive state.
+
+---
+
+## 4. Prioritized rollout (small PRs)
+
+| # | PR | Principle | Effort | Notes |
+|---|---|---|---|---|
+| 1 | Shared `<Button>` primitive + `active:scale-[0.96]` | 12, 14 | S | Highest felt-impact; carries focus ring + disabled too |
+| 2 | Kill all `transition-all` (18 sites) | 14 | XS | Mechanical; pairs with PR 1 |
+| 3 | Image outlines on content images | 11 | XS | One ring utility; exclude avatars/logos/QR |
+| 4 | `text-balance`/`text-pretty` base layer | 10 | XS | Verify vs `line-clamp`/`truncate` |
+| 5 | Concentric radius fixes (EmptyState + audit) | 1 | S | |
+| 6 | `tabular-nums` gap closure | 9 | S | Audit live numerics not already covered |
+| 7 | Layered elevation token + card migration | 3 | M | Coordinate with design-tokens.md |
+| 8 | Hit-area pass on icon-only buttons | 16 | M | Counts toward WCAG 2.5.5 |
+| 9 | Toast exit + icon cross-fade helper | 6, 7 | M | CSS-only (no motion lib) |
+
+## 5. Constraints for implementers
+
+- **No new dependency.** Do not add `framer-motion`/`motion` to satisfy Rules 7/13 — use CSS.
+- **Respect reduced-motion.** [index.css:165-193](../../../clients/web/src/index.css) zeroes all
+  transitions/animations; every effect added must degrade cleanly (it will, if expressed as
+  `transition`).
+- **Respect the contrast contract.** Border→shadow swaps must not remove a required non-text
+  separator; see [design-tokens.md](../../../docs/design-tokens.md) §Known exceptions.
+- **Dark mode is class-based** (`.dark`, `.lms-scope` remaps) — every outline/shadow/color added
+  needs a `dark:` variant matching the existing remap strategy in [index.css](../../../clients/web/src/index.css).
+- **Exact values from the standard:** press scale `0.96` (never <0.95); icon cross-fade
+  scale `0.25→1`, opacity `0→1`, blur `4px→0`, easing `cubic-bezier(0.2, 0, 0, 1)`; image outline
+  pure `black/10` (light) and `white/10` (dark), never tinted.
+
+## 6. Verification
+
+- `npm run lint && npm run typecheck` in `clients/web` after each PR.
+- `npm run contrast:check` after PR 7 (elevation/border changes).
+- Manual: tab-through focus order unchanged; reduced-motion OS setting suppresses new motion;
+  dark-mode parity on every touched surface.
+- Optional: add an `oxlint`/grep CI guard banning `transition-all` and `active:scale-95` to prevent
+  regressions.
+
+## 7. References
+
+- Standard: `.claude/skills/make-interfaces-feel-better/` (`SKILL.md`, `typography.md`, `surfaces.md`, `animations.md`, `performance.md`)
+- Design system: [docs/design.md](../../design.md), [docs/design-tokens.md](../../design-tokens.md)
+- Global styles: [clients/web/src/index.css](../../../clients/web/src/index.css)
+- Reference stagger implementation: [index.css:137-169](../../../clients/web/src/index.css)


### PR DESCRIPTION
## What

Adds a cross-cutting UI-quality audit of `clients/web/src` against the *make-interfaces-feel-better* standard, documented as a new plan: [`docs/plan/22-ui-polish-feel/22.1-interface-feel-audit.md`](docs/plan/22-ui-polish-feel/22.1-interface-feel-audit.md).

**No application code is changed.** This is a remediation backlog for another team to implement.

## Why

The web client is visually on-system but inconsistent on the micro-details that make an interface feel responsive (press feedback, image edges, heading wrap, etc.). This doc inventories every gap with `file:line` citations so the work can be split into small, mechanical PRs.

## Findings (summary)

- **Scale on press:** 0 of 1,208 buttons have feedback; the 4 that exist use `scale-95` (standard requires `0.96`).
- **`transition: all`:** 18 occurrences to replace with explicit properties.
- **Image outlines:** 0 of 24 `<img>` carry the subtle outline.
- **Text wrapping:** 0 usages of `text-balance`/`text-pretty` across 367 headings.
- Plus concentric radius, tabular-nums gaps, layered shadows, icon cross-fades, toast exits, and 40×40 hit areas.
- **Already compliant (flagged):** font smoothing, `will-change`, side-nav stagger, reduced-motion handling.

## Reviewer notes

- App is React 19 + Tailwind v4 with **no motion library**, so animation recommendations are CSS-based (not framer-motion); Rule 13 is N/A.
- Doc ends with a prioritized 9-PR rollout, implementer constraints (no new deps, respect reduced-motion + contrast contract + dark-mode remaps), and a verification checklist.
- Used a leaner structure than `_TEMPLATE.md` (a feature template) since this is a polish backlog, while keeping the metadata-header convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)