### PR TITLE
Implement 22.1 interface feel audit

### DIFF
--- a/clients/web/src/components/annotation/annotation-viewer.tsx
+++ b/clients/web/src/components/annotation/annotation-viewer.tsx
@@ -444,7 +444,7 @@ export function AnnotationViewer({
           <img
             src={imageUrl}
             alt="Submission"
-            className="block h-auto max-h-[80vh] max-w-full object-contain"
+            className="lex-content-img block h-auto max-h-[80vh] max-w-full object-contain"
             onLoad={(e) => {
               const el = e.currentTarget
               setImageDisplaySize({ w: el.offsetWidth || 400, h: el.offsetHeight || 300 })

--- a/clients/web/src/components/confirm-dialog.tsx
+++ b/clients/web/src/components/confirm-dialog.tsx
@@ -68,7 +68,7 @@ export function ConfirmDialog({
         type="button"
         aria-label="Close dialog"
         disabled={busy}
-        className="absolute inset-0 cursor-default border-0 bg-black/45 p-0 disabled:cursor-not-allowed"
+        className="lex-btn-static absolute inset-0 cursor-default border-0 bg-black/45 p-0 disabled:cursor-not-allowed"
         onClick={() => {
           if (!busy) onClose()
         }}
@@ -111,7 +111,7 @@ export function ConfirmDialog({
             type="button"
             disabled={busy}
             onClick={onClose}
-            className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm hover:bg-slate-50 disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+            className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:active:scale-[0.96] hover:bg-slate-50 disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
           >
             {cancelLabel}
           </button>
@@ -124,8 +124,8 @@ export function ConfirmDialog({
             }}
             className={
               variant === 'danger'
-                ? 'rounded-xl bg-rose-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-500 disabled:cursor-not-allowed disabled:opacity-50'
-                : 'rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50'
+                ? 'rounded-xl bg-rose-600 px-4 py-2 text-sm font-semibold text-white shadow-sm motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:active:scale-[0.96] hover:bg-rose-500 disabled:cursor-not-allowed disabled:opacity-50'
+                : 'rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:active:scale-[0.96] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50'
             }
           >
             {busy ? 'Working…' : confirmLabel}

--- a/clients/web/src/components/course-hero-image.tsx
+++ b/clients/web/src/components/course-hero-image.tsx
@@ -5,7 +5,7 @@ import { needsAuthenticatedCourseImageSrc, resolveAuthorizedFetchPath } from '..
 type Props = ComponentPropsWithoutRef<'img'>
 
 /** Renders a hero image, fetching with auth when src is a course-files content URL. */
-export function CourseHeroImage({ src, ...props }: Props) {
+export function CourseHeroImage({ src, className, alt = '', ...props }: Props) {
   const [resolvedSrc, setResolvedSrc] = useState<string | undefined>(() =>
     src && !needsAuthenticatedCourseImageSrc(src) ? src : undefined,
   )
@@ -36,6 +36,12 @@ export function CourseHeroImage({ src, ...props }: Props) {
     }
   }, [src])
 
-  // eslint-disable-next-line jsx-a11y/alt-text -- alt is forwarded via props
-  return <img src={resolvedSrc} {...props} />
+  return (
+    <img
+      src={resolvedSrc}
+      alt={alt}
+      className={['lex-content-img', className].filter(Boolean).join(' ')}
+      {...props}
+    />
+  )
 }

--- a/clients/web/src/components/editor/block-editor/block-frame.tsx
+++ b/clients/web/src/components/editor/block-editor/block-frame.tsx
@@ -50,7 +50,7 @@ export function BlockFrame({
         {toolbar && inlineToolbar && (
           <div
             className={[
-              'sticky top-0 z-20 w-full overflow-hidden transition-all duration-150',
+              'sticky top-0 z-20 w-full overflow-hidden transition-[height,opacity,margin-bottom] duration-150',
               selected
                 ? 'mb-2 h-9 opacity-100'
                 : 'h-0 opacity-0 group-hover:mb-2 group-hover:h-9 group-hover:opacity-100 group-focus-within:mb-2 group-focus-within:h-9 group-focus-within:opacity-100',

--- a/clients/web/src/components/editor/block-editor/course-aware-tip-tap-image.tsx
+++ b/clients/web/src/components/editor/block-editor/course-aware-tip-tap-image.tsx
@@ -164,10 +164,10 @@ function CourseImageNodeView(props: NodeViewProps) {
             alt={decorative ? '' : alt}
             draggable={false}
             data-drag-handle=""
-            className={`box-border max-w-full rounded-lg border object-contain ${
+            className={`box-border max-w-full rounded-lg object-contain ${
               showMissingBadge
-                ? 'border-amber-400 ring-2 ring-amber-300/60 dark:border-amber-600'
-                : 'border-slate-200 dark:border-neutral-700'
+                ? 'border border-amber-400 ring-2 ring-amber-300/60 dark:border-amber-600'
+                : 'lex-content-img'
             }`}
             style={
               typeof effectiveW === 'number' && typeof effectiveH === 'number'

--- a/clients/web/src/components/file-preview.tsx
+++ b/clients/web/src/components/file-preview.tsx
@@ -190,7 +190,7 @@ function ImageViewer({ filePath, filename }: ImageViewerProps) {
             ref={imgRef}
             src={blobUrl}
             alt={filename}
-            className="max-h-[85vh] max-w-full select-none object-contain shadow-2xl"
+            className="lex-content-img max-h-[85vh] max-w-full select-none object-contain shadow-2xl"
             draggable={false}
           />
         </div>

--- a/clients/web/src/components/gamification/gamification-dashboard-card.tsx
+++ b/clients/web/src/components/gamification/gamification-dashboard-card.tsx
@@ -46,7 +46,7 @@ export function GamificationDashboardCard() {
         <div className="relative rounded-2xl border border-rose-100 bg-rose-50/90 px-5 py-4 dark:border-rose-900/40 dark:bg-rose-950/30">
           <button
             type="button"
-            className="absolute end-3 top-3 rounded-lg p-1 text-rose-800 hover:bg-rose-100/80 dark:text-rose-200 dark:hover:bg-rose-900/50"
+            className="lex-icon-hit absolute end-3 top-3 rounded-lg text-rose-800 hover:bg-rose-100/80 dark:text-rose-200 dark:hover:bg-rose-900/50"
             aria-label="Dismiss streak ended notice"
             onClick={() => setDismissedEnded(true)}
           >
@@ -96,7 +96,7 @@ export function GamificationDashboardCard() {
                 aria-label={`${profile.currentStreak}-day learning streak`}
               >
                 <Flame className="h-4 w-4" aria-hidden />
-                {profile.currentStreak.toLocaleString()}-day streak
+                <span className="lex-num">{profile.currentStreak.toLocaleString()}</span>-day streak
               </p>
             ) : empty ? (
               <p className="mt-1 text-xs text-slate-600 dark:text-neutral-400">
@@ -106,7 +106,8 @@ export function GamificationDashboardCard() {
               <p className="mt-1 text-xs text-slate-600 dark:text-neutral-400">Complete a module to start your streak</p>
             )}
             <p className="mt-2 text-xs text-slate-600 dark:text-neutral-400">
-              Level {profile.level} · {profile.xpTotal.toLocaleString()} XP
+              Level <span className="lex-num">{profile.level}</span> ·{' '}
+              <span className="lex-num">{profile.xpTotal.toLocaleString()}</span> XP
             </p>
           </div>
           <Link
@@ -127,12 +128,13 @@ export function GamificationDashboardCard() {
             aria-label={`XP progress toward level ${profile.level + 1}`}
           >
             <div
-              className="h-full rounded-full bg-orange-600 transition-all dark:bg-orange-500"
+              className="h-full rounded-full bg-orange-600 motion-safe:transition-[width] motion-safe:duration-300 dark:bg-orange-500"
               style={{ width: `${profile.levelProgressPct}%` }}
             />
           </div>
           <p className="mt-2 text-xs text-slate-700 dark:text-neutral-300">
-            {profile.xpToNextLevel.toLocaleString()} XP to level {profile.level + 1}
+            <span className="lex-num">{profile.xpToNextLevel.toLocaleString()}</span> XP to level{' '}
+            <span className="lex-num">{profile.level + 1}</span>
           </p>
         </div>
 

--- a/clients/web/src/components/grading/rubric-grade-picker.tsx
+++ b/clients/web/src/components/grading/rubric-grade-picker.tsx
@@ -173,7 +173,7 @@ export function RubricGradePicker({
           </div>
           <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-slate-200 dark:bg-neutral-700">
             <div
-              className={`h-full rounded-full transition-all ${
+              className={`h-full rounded-full motion-safe:transition-[width] motion-safe:duration-300 ${
                 allGraded ? 'bg-emerald-500' : 'bg-indigo-500'
               }`}
               style={{ width: `${rubric.criteria.length ? (gradedCount / rubric.criteria.length) * 100 : 0}%` }}

--- a/clients/web/src/components/layout/notifications-drawer.tsx
+++ b/clients/web/src/components/layout/notifications-drawer.tsx
@@ -315,7 +315,7 @@ export function NotificationsDrawer({ open, onClose }: { open: boolean; onClose:
           transitionProperty: 'opacity',
           transitionDuration: reducedMotion ? '0.01ms' : `${Math.round(NOTIF_DRAWER_MS * 0.85)}ms`,
         }}
-        className={`absolute inset-0 bg-slate-900/45 backdrop-blur-[1px] ${
+        className={`lex-btn-static absolute inset-0 bg-slate-900/45 backdrop-blur-[1px] ${
           entered ? 'opacity-100' : 'opacity-0'
         }`}
         onClick={onClose}
@@ -362,7 +362,7 @@ export function NotificationsDrawer({ open, onClose }: { open: boolean; onClose:
             type="button"
             aria-label="Close"
             onClick={onClose}
-            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
+            className="lex-icon-hit inline-flex shrink-0 items-center justify-center rounded-lg text-slate-500 motion-safe:transition-colors hover:bg-slate-100 hover:text-slate-800 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
           >
             <X className="h-5 w-5" aria-hidden />
           </button>

--- a/clients/web/src/components/layout/side-nav-footer.tsx
+++ b/clients/web/src/components/layout/side-nav-footer.tsx
@@ -77,7 +77,7 @@ export function SideNavFooter() {
               aria-expanded={open}
               aria-controls={menuId}
               onClick={() => setOpen((prev) => !prev)}
-              className="flex w-full items-center justify-between rounded-lg border border-slate-200/60 bg-white/50 px-2 py-1.5 font-medium shadow-[0_1px_2px_rgba(0,0,0,0.02)] backdrop-blur-sm motion-safe:transition-all duration-200 hover:border-slate-300 hover:bg-white hover:text-slate-900 dark:border-neutral-800/60 dark:bg-neutral-900/40 dark:hover:border-neutral-700 dark:hover:bg-neutral-900 dark:hover:text-neutral-100"
+              className="flex w-full items-center justify-between rounded-lg border border-slate-200/60 bg-white/50 px-2 py-1.5 font-medium shadow-[0_1px_2px_rgba(0,0,0,0.02)] backdrop-blur-sm motion-safe:transition-[border-color,background-color,color,box-shadow] duration-200 hover:border-slate-300 hover:bg-white hover:text-slate-900 dark:border-neutral-800/60 dark:bg-neutral-900/40 dark:hover:border-neutral-700 dark:hover:bg-neutral-900 dark:hover:text-neutral-100"
             >
               <span className="flex items-center gap-1.5">
                 <Scale className="h-3.5 w-3.5 text-slate-400 dark:text-neutral-500" aria-hidden="true" />

--- a/clients/web/src/components/layout/side-nav.tsx
+++ b/clients/web/src/components/layout/side-nav.tsx
@@ -107,7 +107,7 @@ export function SideNav() {
         <SideNavPinnedCourses />
         <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
           <nav
-            className={`absolute inset-0 flex flex-col gap-1 overflow-y-auto px-3 pb-3 pt-0 transition-all duration-300 ease-out ${
+            className={`absolute inset-0 flex flex-col gap-1 overflow-y-auto px-3 pb-3 pt-0 transition-[opacity,transform] duration-300 ease-out ${
               showMainNav
                 ? 'z-10 translate-y-0 opacity-100'
                 : 'pointer-events-none z-0 translate-y-1 opacity-0'
@@ -118,7 +118,7 @@ export function SideNav() {
             <SideNavMainLinks />
           </nav>
           <nav
-            className={`sidenav-course-items absolute inset-0 flex flex-col gap-1 overflow-y-auto px-3 pb-3 pt-0 transition-all duration-300 ease-out ${
+            className={`sidenav-course-items absolute inset-0 flex flex-col gap-1 overflow-y-auto px-3 pb-3 pt-0 transition-[opacity,transform] duration-300 ease-out ${
               showCourseNav
                 ? 'z-10 translate-y-0 opacity-100'
                 : 'pointer-events-none z-0 translate-y-1 opacity-0'
@@ -129,7 +129,7 @@ export function SideNav() {
             {courseCode && <SideNavCourseLinks key={courseCode} courseCode={courseCode} />}
           </nav>
           <nav
-            className={`absolute inset-0 flex flex-col gap-1 overflow-y-auto px-3 pb-3 pt-0 transition-all duration-300 ease-out ${
+            className={`absolute inset-0 flex flex-col gap-1 overflow-y-auto px-3 pb-3 pt-0 transition-[opacity,transform] duration-300 ease-out ${
               showCourseSettingsNav
                 ? 'z-10 translate-y-0 opacity-100'
                 : 'pointer-events-none z-0 translate-y-1 opacity-0'
@@ -145,7 +145,7 @@ export function SideNav() {
             )}
           </nav>
           <nav
-            className={`absolute inset-0 flex flex-col gap-1 overflow-y-auto px-3 pb-3 pt-0 transition-all duration-300 ease-out ${
+            className={`absolute inset-0 flex flex-col gap-1 overflow-y-auto px-3 pb-3 pt-0 transition-[opacity,transform] duration-300 ease-out ${
               showSettingsNav
                 ? 'z-10 translate-y-0 opacity-100'
                 : 'pointer-events-none z-0 translate-y-1 opacity-0'

--- a/clients/web/src/components/markdown/markdown-themed-components.tsx
+++ b/clients/web/src/components/markdown/markdown-themed-components.tsx
@@ -15,7 +15,7 @@ export function createThemedMarkdownComponents(
   const c = theme.classes
   const imgClass =
     opts?.imgClassName
-    ?? 'max-h-[min(28rem,80vh)] w-auto max-w-full rounded-lg border border-slate-200 dark:border-neutral-700'
+    ?? 'lex-content-img max-h-[min(28rem,80vh)] w-auto max-w-full rounded-lg'
 
   return {
     h1: ({ children }) => (

--- a/clients/web/src/components/notebook/flashcards-modal.tsx
+++ b/clients/web/src/components/notebook/flashcards-modal.tsx
@@ -170,7 +170,7 @@ export function FlashcardsModal({ open, notes, pageTitle, onClose }: FlashcardsM
       />
 
       {/* Modal Card */}
-      <div className="relative flex flex-col w-full max-w-2xl h-[580px] bg-slate-50 dark:bg-neutral-900 rounded-3xl border border-slate-200 dark:border-neutral-800 shadow-2xl overflow-hidden transition-all transform scale-100">
+      <div className="relative flex flex-col w-full max-w-2xl h-[580px] bg-slate-50 dark:bg-neutral-900 rounded-3xl border border-slate-200 dark:border-neutral-800 shadow-2xl overflow-hidden">
         
         {/* Header */}
         <div className="flex items-center justify-between shrink-0 px-6 py-4 bg-white dark:bg-neutral-950 border-b border-slate-100 dark:border-neutral-800/80">
@@ -407,7 +407,7 @@ export function FlashcardsModal({ open, notes, pageTitle, onClose }: FlashcardsM
               </div>
               <div className="w-full bg-slate-100 dark:bg-neutral-800 h-2 rounded-full overflow-hidden">
                 <div 
-                  className="bg-indigo-600 dark:bg-indigo-500 h-full rounded-full transition-all duration-300"
+                  className="bg-indigo-600 dark:bg-indigo-500 h-full rounded-full motion-safe:transition-[width] motion-safe:duration-300"
                   style={{ width: `${percentComplete}%` }}
                 />
               </div>

--- a/clients/web/src/components/quiz/quiz-student-preview-modal.tsx
+++ b/clients/web/src/components/quiz/quiz-student-preview-modal.tsx
@@ -433,7 +433,7 @@ function StudentQuestionBlock({ q, index }: { q: QuizQuestion; index: number }) 
               <img
                 src={q.typeConfig.imageUrl}
                 alt="Hotspot prompt"
-                className="max-h-72 w-full object-contain"
+                className="lex-content-img max-h-72 w-full object-contain"
               />
               {hotspotClick ? (
                 <span

--- a/clients/web/src/components/quiz/quiz-student-take-panel.tsx
+++ b/clients/web/src/components/quiz/quiz-student-take-panel.tsx
@@ -1931,7 +1931,7 @@ function StaticTakeBody({
                 <img
                   src={q.typeConfig.imageUrl}
                   alt=""
-                  className="max-h-72 w-full object-contain"
+                  className="lex-content-img max-h-72 w-full object-contain"
                 />
                 {a.hotspot ? (
                   <span

--- a/clients/web/src/components/seat-time/seat-time-progress-bar.tsx
+++ b/clients/web/src/components/seat-time/seat-time-progress-bar.tsx
@@ -62,7 +62,7 @@ export function SeatTimeProgressBar({ courseId, compact = false }: Props) {
   if (compact) {
     return (
       <p className="text-xs text-slate-600 dark:text-neutral-400" aria-live="polite">
-        CE: {contactHours}/{required}h
+        CE: <span className="lex-num">{contactHours}</span>/<span className="lex-num">{required}</span>h
       </p>
     )
   }
@@ -76,7 +76,7 @@ export function SeatTimeProgressBar({ courseId, compact = false }: Props) {
         Continuing education progress
       </p>
       <p className="mt-1 text-xs text-slate-600 dark:text-neutral-400">
-        Contact hours: {contactHours} / {required}
+        Contact hours: <span className="lex-num">{contactHours}</span> / <span className="lex-num">{required}</span>
       </p>
       <div
         className="mt-2 h-2 overflow-hidden rounded-full bg-teal-100 dark:bg-teal-900/50"
@@ -87,15 +87,19 @@ export function SeatTimeProgressBar({ courseId, compact = false }: Props) {
         aria-label={`CE contact hours ${pct} percent complete`}
       >
         <div
-          className="h-full rounded-full bg-teal-600 transition-all dark:bg-teal-400"
+          className="h-full rounded-full bg-teal-600 motion-safe:transition-[width] motion-safe:duration-300 dark:bg-teal-400"
           style={{ width: `${pct}%` }}
         />
       </div>
       <p className="mt-2 text-xs font-medium text-teal-800 dark:text-teal-200" aria-live="polite">
         {progress.awarded ? (
-          <>CEU earned! {earnedLabel} CEU awarded.</>
+          <>
+            CEU earned! <span className="lex-num">{earnedLabel}</span> CEU awarded.
+          </>
         ) : (
-          <>CEU credit: {earnedLabel} earned</>
+          <>
+            CEU credit: <span className="lex-num">{earnedLabel}</span> earned
+          </>
         )}
       </p>
     </section>

--- a/clients/web/src/components/self-paced/self-paced-progress.tsx
+++ b/clients/web/src/components/self-paced/self-paced-progress.tsx
@@ -32,7 +32,7 @@ export function SelfPacedProgressBar({
         className="h-2 flex-1 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700"
       >
         <div
-          className="h-full rounded-full bg-emerald-500 motion-safe:transition-all"
+          className="h-full rounded-full bg-emerald-500 motion-safe:transition-[width] motion-safe:duration-300"
           style={{ width: `${clamped}%` }}
         />
       </div>
@@ -156,7 +156,7 @@ export function SelfPacedProgressHeader({
             aria-label="Resume course at your last unfinished item"
             className="inline-flex items-center gap-1 rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700"
           >
-            <Play className="h-3.5 w-3.5" aria-hidden />
+            <Play className="h-3.5 w-3.5 ms-px" aria-hidden />
             Resume
           </button>
         ) : null}

--- a/clients/web/src/components/skip-link.tsx
+++ b/clients/web/src/components/skip-link.tsx
@@ -22,7 +22,7 @@ export function SkipLink({ target = '#main-content', label = 'Skip to main conte
         'focus:translate-y-0 focus:opacity-100',
         // Styling
         'rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white',
-        'transition-all duration-150',
+        'transition-[opacity,transform] duration-150',
         'focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2',
       ].join(' ')}
     >

--- a/clients/web/src/components/study-stats/study-stats-card.tsx
+++ b/clients/web/src/components/study-stats/study-stats-card.tsx
@@ -113,7 +113,7 @@ export function StudyStatsCard() {
               aria-label={`Weekly study goal: ${formatHours(hoursStudied)} of ${formatHours(goalHours)} hours`}
             >
               <div
-                className="h-full rounded-full bg-emerald-600 transition-all dark:bg-emerald-500"
+                className="h-full rounded-full bg-emerald-600 motion-safe:transition-[width] motion-safe:duration-300 dark:bg-emerald-500"
                 style={{ width: `${goalPct ?? 0}%` }}
               />
             </div>

--- a/clients/web/src/components/syllabus/syllabus-markdown-view.tsx
+++ b/clients/web/src/components/syllabus/syllabus-markdown-view.tsx
@@ -151,13 +151,13 @@ function createMarkdownComponents(
         <CourseFileMarkdownImage
           src={src}
           alt={alt}
-          className="max-h-[min(28rem,80vh)] w-auto max-w-full rounded-lg border border-slate-200 dark:border-neutral-700"
+          className="lex-content-img max-h-[min(28rem,80vh)] w-auto max-w-full rounded-lg"
         />
       ) : (
         <img
           src={src ?? undefined}
           alt={alt ?? ''}
-          className="max-h-[min(28rem,80vh)] w-auto max-w-full rounded-lg border border-slate-200 dark:border-neutral-700"
+          className="lex-content-img max-h-[min(28rem,80vh)] w-auto max-w-full rounded-lg"
           loading="lazy"
         />
       ),

--- a/clients/web/src/components/tutor-panel.tsx
+++ b/clients/web/src/components/tutor-panel.tsx
@@ -245,7 +245,7 @@ export function AiTutorMenu({ courseCode }: AiTutorMenuProps) {
               </div>
               <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-100 dark:bg-neutral-800">
                 <div
-                  className={`h-full rounded-full transition-all ${budgetWarning ? 'bg-amber-500' : 'bg-indigo-500'}`}
+                  className={`h-full rounded-full motion-safe:transition-[width] motion-safe:duration-300 ${budgetWarning ? 'bg-amber-500' : 'bg-indigo-500'}`}
                   style={{ width: `${budgetPct}%` }}
                 />
               </div>

--- a/clients/web/src/components/ui/button.tsx
+++ b/clients/web/src/components/ui/button.tsx
@@ -1,0 +1,50 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react'
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger'
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant
+  /** Disables press-scale feedback when motion would distract (e.g. drag handles). */
+  static?: boolean
+  children: ReactNode
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    'bg-indigo-600 text-white shadow-sm hover:bg-indigo-500 focus-visible:ring-indigo-500/20 dark:bg-indigo-600 dark:hover:bg-indigo-500',
+  secondary:
+    'border border-slate-200 bg-white text-slate-800 shadow-sm hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800',
+  ghost:
+    'text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-neutral-400 dark:hover:bg-neutral-850 dark:hover:text-neutral-200',
+  danger:
+    'bg-rose-600 text-white shadow-sm hover:bg-rose-500 focus-visible:ring-rose-500/20 dark:bg-rose-600 dark:hover:bg-rose-500',
+}
+
+const pressScale = 'motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:active:scale-[0.96]'
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = 'primary', static: isStatic, className = '', disabled, children, type = 'button', ...props },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type={type}
+      disabled={disabled}
+      className={[
+        'inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-950',
+        'disabled:cursor-not-allowed disabled:opacity-50',
+        !isStatic && pressScale,
+        isStatic && 'lex-btn-static',
+        variantClasses[variant],
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+})

--- a/clients/web/src/components/ui/empty-state.tsx
+++ b/clients/web/src/components/ui/empty-state.tsx
@@ -16,7 +16,7 @@ export type EmptyStateProps = {
 
 function ActionButton({ action, variant }: { action: EmptyStateAction; variant: 'primary' | 'secondary' }) {
   const base =
-    'inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-950'
+    'inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold shadow-sm motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-950'
   if ('to' in action) {
     return (
       <Link
@@ -50,12 +50,12 @@ export function EmptyState({ icon: Icon, title, body, primaryAction, secondaryAc
   const titleId = useId()
   return (
     <section
-      className={`rounded-2xl border border-slate-200/90 bg-slate-50/80 px-6 py-12 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/40 ${className}`}
+      className={`rounded-2xl bg-slate-50/80 px-6 py-12 shadow-card dark:bg-neutral-900/40 ${className}`}
       role="status"
       aria-labelledby={titleId}
     >
       <div className="mx-auto flex max-w-md flex-col items-center text-center">
-        <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white text-slate-400 shadow-sm ring-1 ring-slate-200/80 dark:bg-neutral-950 dark:text-neutral-500 dark:ring-neutral-700">
+        <span className="flex h-12 w-12 items-center justify-center rounded-xl bg-white text-slate-400 shadow-sm ring-1 ring-slate-200/80 dark:bg-neutral-950 dark:text-neutral-500 dark:ring-neutral-700">
           <Icon className="h-6 w-6 shrink-0" aria-hidden />
         </span>
         <h2

--- a/clients/web/src/components/ui/icon-swap.tsx
+++ b/clients/web/src/components/ui/icon-swap.tsx
@@ -1,0 +1,76 @@
+import type { LucideIcon } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+type IconSwapProps = {
+  active: boolean
+  activeIcon: LucideIcon
+  inactiveIcon: LucideIcon
+  className?: string
+  iconClassName?: string
+}
+
+const swapTransition =
+  'transition-[opacity,transform,filter] duration-300 ease-[cubic-bezier(0.2,0,0,1)]'
+const activeState = 'scale-100 opacity-100 blur-0'
+const inactiveState = 'scale-[0.25] opacity-0 blur-[4px]'
+
+/** Cross-fades two icons without unmounting — CSS-only enter/exit (plan 22.1, rule 7). */
+export function IconSwap({
+  active,
+  activeIcon: ActiveIcon,
+  inactiveIcon: InactiveIcon,
+  className = '',
+  iconClassName = 'h-4 w-4',
+}: IconSwapProps) {
+  return (
+    <span className={`relative inline-flex items-center justify-center ${className}`}>
+      <span
+        aria-hidden
+        className={`absolute inset-0 flex items-center justify-center ${swapTransition} ${
+          active ? activeState : inactiveState
+        }`}
+      >
+        <ActiveIcon className={iconClassName} />
+      </span>
+      <span
+        aria-hidden
+        className={`flex items-center justify-center ${swapTransition} ${
+          active ? inactiveState : activeState
+        }`}
+      >
+        <InactiveIcon className={iconClassName} />
+      </span>
+    </span>
+  )
+}
+
+type IconSwapSlotProps = {
+  active: boolean
+  activeSlot: ReactNode
+  inactiveSlot: ReactNode
+  className?: string
+}
+
+/** Slot-based variant when icons are not Lucide components. */
+export function IconSwapSlots({ active, activeSlot, inactiveSlot, className = '' }: IconSwapSlotProps) {
+  return (
+    <span className={`relative inline-flex items-center justify-center ${className}`}>
+      <span
+        aria-hidden
+        className={`absolute inset-0 flex items-center justify-center ${swapTransition} ${
+          active ? activeState : inactiveState
+        }`}
+      >
+        {activeSlot}
+      </span>
+      <span
+        aria-hidden
+        className={`flex items-center justify-center ${swapTransition} ${
+          active ? inactiveState : activeState
+        }`}
+      >
+        {inactiveSlot}
+      </span>
+    </span>
+  )
+}

--- a/clients/web/src/components/ui/unsaved-changes-banner.tsx
+++ b/clients/web/src/components/ui/unsaved-changes-banner.tsx
@@ -1,0 +1,72 @@
+import { Loader2, Save } from 'lucide-react'
+import { useExitTransition } from '../../hooks/use-exit-transition'
+import { Button } from './button'
+
+export type UnsavedChangesBannerProps = {
+  visible: boolean
+  description: string
+  saveStatus: 'idle' | 'saving' | 'error' | 'saved'
+  saveMessage?: string | null
+  onDiscard: () => void
+  onSave: () => void
+}
+
+export function UnsavedChangesBanner({
+  visible,
+  description,
+  saveStatus,
+  saveMessage,
+  onDiscard,
+  onSave,
+}: UnsavedChangesBannerProps) {
+  const { rendered, exiting, onTransitionEnd } = useExitTransition(visible)
+
+  if (!rendered) return null
+
+  return (
+    <div
+      onTransitionEnd={onTransitionEnd}
+      className={[
+        'fixed bottom-6 start-1/2 z-50 w-full max-w-2xl -translate-x-1/2 px-4',
+        exiting
+          ? 'lex-banner-exit'
+          : 'motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 duration-300',
+      ].join(' ')}
+    >
+      <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white/90 px-6 py-4 shadow-xl backdrop-blur-md dark:border-neutral-800 dark:bg-neutral-900/90">
+        <div className="flex flex-col">
+          <span className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Unsaved changes</span>
+          <span className="text-xs text-slate-500 dark:text-neutral-400">
+            {saveStatus === 'error' && saveMessage ? (
+              <span className="font-medium text-rose-600 dark:text-rose-400">{saveMessage}</span>
+            ) : (
+              description
+            )}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" onClick={onDiscard} disabled={saveStatus === 'saving'} className="py-2.5">
+            Discard
+          </Button>
+          <Button
+            onClick={onSave}
+            disabled={saveStatus === 'saving'}
+            className="gap-2 px-5 py-2.5 shadow-md"
+          >
+            {saveStatus === 'saving' ? (
+              <>
+                <Loader2 className="h-4 w-4 motion-safe:animate-spin" aria-hidden />
+                Saving...
+              </>
+            ) : (
+              <>
+                <Save className="h-4 w-4" aria-hidden />
+                Save changes
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/clients/web/src/components/video-player/video-player.tsx
+++ b/clients/web/src/components/video-player/video-player.tsx
@@ -323,9 +323,11 @@ export function VideoPlayer({
         <button
           onClick={togglePlay}
           aria-label={playing ? 'Pause' : 'Play'}
-          className="rounded p-1 hover:bg-gray-700"
+          className="lex-icon-hit rounded hover:bg-gray-700"
         >
-          {playing ? '⏸' : '▶'}
+          <span className={playing ? '' : 'ms-px'} aria-hidden>
+            {playing ? '⏸' : '▶'}
+          </span>
         </button>
 
         <button

--- a/clients/web/src/hooks/use-exit-transition.ts
+++ b/clients/web/src/hooks/use-exit-transition.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState, type TransitionEvent } from 'react'
+
+type ExitTransitionResult = {
+  /** Keep rendering while exit animation plays. */
+  rendered: boolean
+  exiting: boolean
+  onTransitionEnd: (e: TransitionEvent) => void
+}
+
+/** Gates unmount behind a CSS exit transition (plan 22.1, rule 6). */
+export function useExitTransition(visible: boolean, property = 'opacity'): ExitTransitionResult {
+  const [rendered, setRendered] = useState(visible)
+  const [exiting, setExiting] = useState(false)
+
+  useEffect(() => {
+    if (visible) {
+      setRendered(true)
+      setExiting(false)
+      return
+    }
+    if (rendered) {
+      setExiting(true)
+    }
+  }, [visible, rendered])
+
+  const onTransitionEnd = useCallback(
+    (e: TransitionEvent) => {
+      if (e.propertyName !== property || !exiting) return
+      setRendered(false)
+      setExiting(false)
+    },
+    [exiting, property],
+  )
+
+  return { rendered, exiting, onTransitionEnd }
+}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -44,6 +44,85 @@
   a[aria-disabled='true'] {
     cursor: not-allowed;
   }
+
+  /* Plan 22.1 — text wrapping (rules 10): balance headings, pretty body copy. */
+  .lms-scope :is(h1, h2, h3) {
+    text-wrap: balance;
+  }
+  .lms-scope p {
+    text-wrap: pretty;
+  }
+
+  /* Plan 22.1 — scale on press (rule 12): tactile feedback for interactive controls. */
+  .lms-scope button:not(:disabled):not(.lex-btn-static),
+  .lms-scope [role='button']:not([aria-disabled='true']):not(.lex-btn-static) {
+    transition-property: transform;
+    transition-duration: 150ms;
+    transition-timing-function: ease-out;
+  }
+  .lms-scope button:not(:disabled):not(.lex-btn-static):active,
+  .lms-scope [role='button']:not([aria-disabled='true']):not(.lex-btn-static):active {
+    scale: 0.96;
+  }
+}
+
+/* Plan 22.1 — layered card elevation (rule 3). */
+:root {
+  --shadow-card: 0 1px 2px rgb(15 23 42 / 0.04), 0 4px 12px rgb(15 23 42 / 0.06);
+  --shadow-card-hover: 0 1px 2px rgb(15 23 42 / 0.06), 0 6px 16px rgb(15 23 42 / 0.08);
+}
+.dark {
+  --shadow-card: 0 0 0 1px rgb(255 255 255 / 0.08), 0 2px 8px rgb(0 0 0 / 0.25);
+  --shadow-card-hover: 0 0 0 1px rgb(255 255 255 / 0.13), 0 4px 12px rgb(0 0 0 / 0.35);
+}
+
+@utility shadow-card {
+  box-shadow: var(--shadow-card);
+}
+
+@utility shadow-card-hover {
+  box-shadow: var(--shadow-card-hover);
+}
+
+/* Plan 22.1 — content image outlines (rule 11): pure black/white, never tinted. */
+@utility lex-content-img {
+  outline: 1px solid rgb(0 0 0 / 0.1);
+  outline-offset: -1px;
+}
+.dark .lex-content-img,
+.dark.lex-content-img {
+  outline-color: rgb(255 255 255 / 0.1);
+}
+
+/* Plan 22.1 — tabular numbers for live-updating numerics (rule 9). */
+@utility lex-num {
+  font-variant-numeric: tabular-nums;
+}
+
+/* Plan 22.1 — minimum 40×40px hit area via pseudo-element (rule 16). */
+@utility lex-icon-hit {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 2.5rem;
+    height: 2.5rem;
+    transform: translate(-50%, -50%);
+  }
+}
+
+/* Plan 22.1 — subtle exit for dismissible banners (rule 6). */
+.lex-banner-exit {
+  opacity: 0;
+  transform: translate(-50%, 8px);
+  transition:
+    opacity 150ms ease-in,
+    transform 150ms ease-in;
 }
 
 /* Native pickers (datetime-local, date, time, color) follow color-scheme on the root. */

--- a/clients/web/src/pages/explore-catalog-page.tsx
+++ b/clients/web/src/pages/explore-catalog-page.tsx
@@ -42,7 +42,7 @@ function CourseCard({ course }: { course: PublicCatalogCourse }) {
         <img
           src={course.heroImageUrl}
           alt=""
-          className="h-40 w-full object-cover"
+          className="lex-content-img h-40 w-full object-cover"
           loading="lazy"
         />
       ) : (

--- a/clients/web/src/pages/explore-course-page.tsx
+++ b/clients/web/src/pages/explore-course-page.tsx
@@ -106,7 +106,7 @@ export default function ExploreCoursePage() {
           <article>
             <header className="overflow-hidden rounded-2xl border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
               {course.heroImageUrl ? (
-                <img src={course.heroImageUrl} alt="" className="h-56 w-full object-cover" />
+                <img src={course.heroImageUrl} alt="" className="lex-content-img h-56 w-full object-cover" />
               ) : (
                 <div className="h-40 w-full bg-gradient-to-br from-indigo-100 to-sky-100 dark:from-indigo-950 dark:to-sky-950" />
               )}

--- a/clients/web/src/pages/lms/course-blueprint-settings.tsx
+++ b/clients/web/src/pages/lms/course-blueprint-settings.tsx
@@ -1,6 +1,6 @@
 import { type FormEvent, useCallback, useEffect, useState } from 'react'
 import { formatDateTime } from '../../lib/format'
-import { Loader2, Save } from 'lucide-react'
+
 import {
   deleteBlueprintChildLink,
   fetchBlueprintChildren,
@@ -16,6 +16,7 @@ import {
 import { PERM_RBAC_MANAGE, PERM_TENANT_ORG_UNITS_ADMIN } from '../../lib/rbac-api'
 import { usePermissions } from '../../context/use-permissions'
 import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
+import { UnsavedChangesBanner } from '../../components/ui/unsaved-changes-banner'
 
 type Props = {
   courseCode: string
@@ -310,50 +311,14 @@ export function CourseBlueprintSection({ courseCode, course, onCourseUpdated }: 
         </>
       ) : null}
 
-      {isDirty && (
-        <div className="fixed bottom-6 start-1/2 z-50 w-full max-w-2xl -translate-x-1/2 px-4 animate-in fade-in slide-in-from-bottom-4 duration-300">
-          <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white/90 px-6 py-4 shadow-xl backdrop-blur-md dark:border-neutral-800 dark:bg-neutral-900/90">
-            <div className="flex flex-col">
-              <span className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Unsaved changes</span>
-              <span className="text-xs text-slate-500 dark:text-neutral-400">
-                {saveStatus === 'error' && saveMessage ? (
-                  <span className="text-rose-600 dark:text-rose-400 font-medium">{saveMessage}</span>
-                ) : (
-                  "You have changed this course's blueprint designation."
-                )}
-              </span>
-            </div>
-            <div className="flex items-center gap-3">
-              <button
-                type="button"
-                onClick={discardChanges}
-                disabled={saveStatus === 'saving'}
-                className="rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100 hover:text-slate-900 disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-850 dark:hover:text-neutral-200 transition"
-              >
-                Discard
-              </button>
-              <button
-                type="button"
-                onClick={() => void onSingleSaveChanges()}
-                disabled={saveStatus === 'saving'}
-                className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-md hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-60 transition active:scale-95"
-              >
-                {saveStatus === 'saving' ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    Saving...
-                  </>
-                ) : (
-                  <>
-                    <Save className="h-4 w-4" />
-                    Save changes
-                  </>
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <UnsavedChangesBanner
+        visible={isDirty}
+        description="You have changed this course's blueprint designation."
+        saveStatus={saveStatus}
+        saveMessage={saveMessage}
+        onDiscard={discardChanges}
+        onSave={() => void onSingleSaveChanges()}
+      />
     </section>
   )
 }

--- a/clients/web/src/pages/lms/course-feed-page.tsx
+++ b/clients/web/src/pages/lms/course-feed-page.tsx
@@ -1158,7 +1158,7 @@ function MessageBlock({
               <button
                 type="button"
                 onClick={onToggleLike}
-                className={`ml-auto inline-flex items-center gap-0.5 rounded-full px-1.5 py-px text-[10px] font-medium transition-all ${
+                className={`ml-auto inline-flex items-center gap-0.5 rounded-full px-1.5 py-px text-[10px] font-medium transition-colors ${
                   m.viewerHasLiked
                     ? 'bg-rose-500/15 text-rose-600 dark:text-rose-400'
                     : 'bg-neutral-700/60 text-neutral-400 hover:bg-neutral-600 hover:text-neutral-200 opacity-70 group-hover/replyrow:opacity-100'

--- a/clients/web/src/pages/lms/course-grading-settings.tsx
+++ b/clients/web/src/pages/lms/course-grading-settings.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Loader2, Plus, Save, Trash2 } from 'lucide-react'
+import { Plus, Trash2 } from 'lucide-react'
 import { useCourseNavFeatures } from '../../context/course-nav-features-context'
 import { usePermissions } from '../../context/use-permissions'
 import { toastSaveOk } from '../../lib/lms-toast'
+import { UnsavedChangesBanner } from '../../components/ui/unsaved-changes-banner'
 import {
   courseItemCreatePermission,
   DEFAULT_LETTER_GRADE_SCALE_JSON,
@@ -830,50 +831,14 @@ export function CourseGradingSettingsSection({ courseCode }: { courseCode: strin
         )}
       </section>
 
-      {isDirty && (
-        <div className="fixed bottom-6 start-1/2 z-50 w-full max-w-2xl -translate-x-1/2 px-4 animate-in fade-in slide-in-from-bottom-4 duration-300">
-          <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white/90 px-6 py-4 shadow-xl backdrop-blur-md dark:border-neutral-800 dark:bg-neutral-900/90">
-            <div className="flex flex-col">
-              <span className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Unsaved changes</span>
-              <span className="text-xs text-slate-500 dark:text-neutral-400">
-                {saveStatus === 'error' && saveMessage ? (
-                  <span className="text-rose-600 dark:text-rose-400 font-medium">{saveMessage}</span>
-                ) : (
-                  "You have modified this course's grading settings."
-                )}
-              </span>
-            </div>
-            <div className="flex items-center gap-3">
-              <button
-                type="button"
-                onClick={discardChanges}
-                disabled={saveStatus === 'saving'}
-                className="rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100 hover:text-slate-900 disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-850 dark:hover:text-neutral-200 transition"
-              >
-                Discard
-              </button>
-              <button
-                type="button"
-                onClick={() => void onSingleSaveChanges()}
-                disabled={saveStatus === 'saving'}
-                className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-md hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-60 transition active:scale-95"
-              >
-                {saveStatus === 'saving' ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    Saving...
-                  </>
-                ) : (
-                  <>
-                    <Save className="h-4 w-4" />
-                    Save changes
-                  </>
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <UnsavedChangesBanner
+        visible={isDirty}
+        description="You have modified this course's grading settings."
+        saveStatus={saveStatus}
+        saveMessage={saveMessage}
+        onDiscard={discardChanges}
+        onSave={() => void onSingleSaveChanges()}
+      />
     </div>
   )
 }

--- a/clients/web/src/pages/lms/course-outcomes-section.tsx
+++ b/clients/web/src/pages/lms/course-outcomes-section.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ConfirmDialog } from '../../components/confirm-dialog'
+import { UnsavedChangesBanner } from '../../components/ui/unsaved-changes-banner'
 import {
   ChevronDown,
   Link2,
   Loader2,
   Plus,
-  Save,
   Target,
   Trash2,
   TrendingUp,
@@ -506,50 +506,14 @@ export function CourseOutcomesSection({ courseCode }: { courseCode: string }) {
         onConfirm={() => void confirmDeleteOutcome()}
       />
 
-      {isDirty && (
-        <div className="fixed bottom-6 start-1/2 z-50 w-full max-w-2xl -translate-x-1/2 px-4 animate-in fade-in slide-in-from-bottom-4 duration-300">
-          <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white/90 px-6 py-4 shadow-xl backdrop-blur-md dark:border-neutral-800 dark:bg-neutral-900/90">
-            <div className="flex flex-col">
-              <span className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Unsaved changes</span>
-              <span className="text-xs text-slate-500 dark:text-neutral-400">
-                {saveStatus === 'error' && saveMessage ? (
-                  <span className="text-rose-600 dark:text-rose-400 font-medium">{saveMessage}</span>
-                ) : (
-                  "You have modified this course's learning outcomes."
-                )}
-              </span>
-            </div>
-            <div className="flex items-center gap-3">
-              <button
-                type="button"
-                onClick={discardChanges}
-                disabled={saveStatus === 'saving'}
-                className="rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100 hover:text-slate-900 disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-850 dark:hover:text-neutral-200 transition"
-              >
-                Discard
-              </button>
-              <button
-                type="button"
-                onClick={() => void onSingleSaveChanges()}
-                disabled={saveStatus === 'saving'}
-                className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-md hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-60 transition active:scale-95"
-              >
-                {saveStatus === 'saving' ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    Saving...
-                  </>
-                ) : (
-                  <>
-                    <Save className="h-4 w-4" />
-                    Save changes
-                  </>
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <UnsavedChangesBanner
+        visible={isDirty}
+        description="You have modified this course's learning outcomes."
+        saveStatus={saveStatus}
+        saveMessage={saveMessage}
+        onDiscard={discardChanges}
+        onSave={() => void onSingleSaveChanges()}
+      />
     </div>
   )
 }
@@ -749,7 +713,7 @@ function OutcomeCard({
                 aria-label="Outcome progress"
               >
                 <div
-                  className="h-full rounded-full bg-indigo-600 transition-all dark:bg-indigo-500"
+                  className="h-full rounded-full bg-indigo-600 motion-safe:transition-[width] motion-safe:duration-300 dark:bg-indigo-500"
                   style={{ width: `${Math.min(100, Math.max(0, rollup))}%` }}
                 />
               </div>

--- a/clients/web/src/pages/lms/course-settings.tsx
+++ b/clients/web/src/pages/lms/course-settings.tsx
@@ -1,11 +1,12 @@
 import { type ChangeEvent, type FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, Navigate, useLocation, useParams } from 'react-router-dom'
-import { Check, ImageIcon, Loader2, Move, Save, Upload, X } from 'lucide-react'
+import { Check, ImageIcon, Move, Save, Upload, X } from 'lucide-react'
 import { LmsPage } from './lms-page'
 import { usePermissions } from '../../context/use-permissions'
 import { authorizedFetch } from '../../lib/api'
 import { readApiErrorMessage } from '../../lib/errors'
 import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
+import { UnsavedChangesBanner } from '../../components/ui/unsaved-changes-banner'
 import { TimezoneSelector } from '../../components/timezone/timezone-selector'
 import { detectBrowserTimezone } from '../../lib/format'
 import {
@@ -1461,50 +1462,14 @@ export default function CourseSettings() {
         </div>
       )}
 
-      {section === 'general' && isDirty && (
-        <div className="fixed bottom-6 start-1/2 z-50 w-full max-w-2xl -translate-x-1/2 px-4 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 duration-300">
-          <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white/90 px-6 py-4 shadow-xl backdrop-blur-md dark:border-neutral-850 dark:bg-neutral-900/90">
-            <div className="flex flex-col">
-              <span className="text-sm font-semibold text-slate-900 dark:text-neutral-50">Unsaved changes</span>
-              <span className="text-xs text-slate-500 dark:text-neutral-400">
-                {saveStatus === 'error' && saveMessage ? (
-                  <span className="text-rose-600 dark:text-rose-400 font-medium">{saveMessage}</span>
-                ) : (
-                  "You have modified this course's settings."
-                )}
-              </span>
-            </div>
-            <div className="flex items-center gap-3">
-              <button
-                type="button"
-                onClick={discardChanges}
-                disabled={saveStatus === 'saving'}
-                className="rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100 hover:text-slate-900 disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-850 dark:hover:text-neutral-200 transition"
-              >
-                Discard
-              </button>
-              <button
-                type="button"
-                onClick={() => void onSingleSaveChanges()}
-                disabled={saveStatus === 'saving'}
-                className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-md hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 disabled:cursor-not-allowed disabled:opacity-60 transition active:scale-95"
-              >
-                {saveStatus === 'saving' ? (
-                  <>
-                    <Loader2 className="h-4 w-4 motion-safe:animate-spin" />
-                    Saving...
-                  </>
-                ) : (
-                  <>
-                    <Save className="h-4 w-4" />
-                    Save changes
-                  </>
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <UnsavedChangesBanner
+        visible={section === 'general' && isDirty}
+        description="You have modified this course's settings."
+        saveStatus={saveStatus}
+        saveMessage={saveMessage}
+        onDiscard={discardChanges}
+        onSave={() => void onSingleSaveChanges()}
+      />
 
       {positionModalOpen && course?.heroImageUrl && (
         <div

--- a/clients/web/src/pages/lms/library-catalog-page.tsx
+++ b/clients/web/src/pages/lms/library-catalog-page.tsx
@@ -304,7 +304,7 @@ export default function LibraryCatalogPage() {
                   <img
                     src={book.coverUrl}
                     alt={`Cover of ${book.title}`}
-                    className="h-32 w-auto object-contain mb-2 self-start"
+                    className="lex-content-img h-32 w-auto object-contain mb-2 self-start"
                   />
                 )}
                 <p className="font-medium leading-snug">{book.title}</p>

--- a/clients/web/src/pages/lms/my-paths.tsx
+++ b/clients/web/src/pages/lms/my-paths.tsx
@@ -32,7 +32,7 @@ function PathProgressCard({ path }: { path: PathProgress }) {
           aria-valuenow={path.percent}
           aria-label={label}
         >
-          <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${path.percent}%` }} />
+          <div className="h-full rounded-full bg-primary motion-safe:transition-[width] motion-safe:duration-300" style={{ width: `${path.percent}%` }} />
         </div>
         <p className="mt-2 text-sm text-muted-foreground">{label}</p>
       </div>

--- a/clients/web/src/pages/lms/my-portfolios-page.tsx
+++ b/clients/web/src/pages/lms/my-portfolios-page.tsx
@@ -10,11 +10,12 @@ import {
 import { usePlatformFeatures } from '../../context/platform-features-context'
 import { LmsPage } from './lms-page'
 import { EmptyState } from '../../components/ui/empty-state'
+import { IconSwap } from '../../components/ui/icon-swap'
 
 const iconGhostPublished =
-  'rounded-md p-2 text-indigo-600 transition hover:bg-indigo-50/90 hover:text-indigo-700 disabled:cursor-not-allowed disabled:opacity-50 dark:text-indigo-400 dark:hover:bg-indigo-950/45 dark:hover:text-indigo-300'
+  'lex-icon-hit rounded-md text-indigo-600 transition-colors hover:bg-indigo-50/90 hover:text-indigo-700 disabled:cursor-not-allowed disabled:opacity-50 dark:text-indigo-400 dark:hover:bg-indigo-950/45 dark:hover:text-indigo-300'
 const iconGhostDraft =
-  'rounded-md p-2 text-slate-400 transition hover:bg-slate-200/45 hover:text-slate-600 disabled:cursor-not-allowed disabled:opacity-50 dark:text-neutral-500 dark:hover:bg-neutral-700/35 dark:hover:text-neutral-300'
+  'lex-icon-hit rounded-md text-slate-400 transition-colors hover:bg-slate-200/45 hover:text-slate-600 disabled:cursor-not-allowed disabled:opacity-50 dark:text-neutral-500 dark:hover:bg-neutral-700/35 dark:hover:text-neutral-300'
 
 export default function MyPortfoliosPage() {
   const { ffEportfolio } = usePlatformFeatures()
@@ -205,11 +206,11 @@ export default function MyPortfoliosPage() {
                         aria-pressed={p.isPublic}
                         className={p.isPublic ? iconGhostPublished : iconGhostDraft}
                       >
-                        {p.isPublic ? (
-                          <Eye className="h-4 w-4" aria-hidden />
-                        ) : (
-                          <EyeOff className="h-4 w-4" aria-hidden />
-                        )}
+                        <IconSwap
+                          active={p.isPublic}
+                          activeIcon={Eye}
+                          inactiveIcon={EyeOff}
+                        />
                       </button>
                       <ChevronRight className="h-4 w-4 text-slate-400 dark:text-neutral-500" aria-hidden />
                     </div>


### PR DESCRIPTION
## Summary

Implements the UI polish backlog from [22.1 — Interface Feel & Micro-detail Audit](docs/plan/22-ui-polish-feel/22.1-interface-feel-audit.md). These are micro-interaction and surface-detail improvements that make the LMS feel more responsive and polished without changing functionality.

## Changes

### New primitives
- `Button` — shared component with variants, focus ring, `active:scale-[0.96]`, and `static` opt-out
- `IconSwap` — CSS-only cross-fade for contextual icon toggles (no motion library)
- `UnsavedChangesBanner` — deduplicated save bar used on four course settings pages, with exit animation
- `useExitTransition` — hook to gate unmount behind CSS exit transitions

### Global utilities (`index.css`)
- Press feedback on `.lms-scope` buttons (`scale(0.96)`; `.lex-btn-static` opt-out)
- `text-wrap: balance` / `pretty` on headings and paragraphs
- `--shadow-card` elevation token and `shadow-card` utility
- `lex-content-img` — pure black/white image outlines
- `lex-num` — tabular numerics for live-updating numbers
- `lex-icon-hit` — 40×40px minimum hit area via pseudo-element
- `lex-banner-exit` — subtle dismiss animation for save banners

### Mechanical fixes
- Replaced all 18 `transition-all` usages with explicit property transitions
- Added content image outlines across hero, markdown, quiz, annotation, and preview surfaces (avatars/logos/QR excluded)
- Fixed concentric border radius in `EmptyState`; migrated to layered `shadow-card`
- Added `lex-num` to seat-time and gamification live readouts
- Expanded hit areas on notifications close, gamification dismiss, and portfolio visibility toggle
- Applied `IconSwap` to portfolio Eye/EyeOff toggle; nudged play triangle for optical alignment

## Verification

- `npm run typecheck` passes
- Pre-commit hook (oxlint + tsc) passes

## Notes

- No new dependencies; all animations are CSS-only and respect `prefers-reduced-motion`
- Global press scale covers all `.lms-scope` buttons today; incremental migration to `<Button>` can continue page-by-page