### PR TITLE
Extend 22.1 interface polish with transition codemod and CI check

### DIFF
--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -20,6 +20,7 @@
     "bundle:check": "node scripts/check-bundle-size.mjs",
     "i18n:check": "node scripts/check-i18n-locales.mjs",
     "contrast:check": "node scripts/check-contrast.mjs",
+    "interface-polish:check": "node scripts/check-interface-polish.mjs",
     "lighthouse:dashboard:dark": "npm run lighthouse:dashboard:dark --prefix ../../e2e"
   },
   "lint-staged": {

--- a/clients/web/scripts/check-interface-polish.mjs
+++ b/clients/web/scripts/check-interface-polish.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * CI check for make-interfaces-feel-better patterns (plan 22.1).
+ * Fails on bare Tailwind `transition` (transition-property: all).
+ *
+ * Usage: npm run interface-polish:check
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const srcRoot = join(__dirname, '..', 'src')
+
+const BARE_TRANSITION =
+  /(?:^|[\s"'`])(?:motion-safe:)?transition(?:[\s"'`]|$)/
+
+function walk(dir) {
+  /** @type {string[]} */
+  const files = []
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name)
+    if (statSync(path).isDirectory()) {
+      files.push(...walk(path))
+    } else if (/\.tsx?$/.test(name)) {
+      files.push(path)
+    }
+  }
+  return files
+}
+
+/** @type {{ file: string; line: number; text: string }[]} */
+const violations = []
+
+for (const file of walk(srcRoot)) {
+  const lines = readFileSync(file, 'utf8').split('\n')
+  lines.forEach((text, index) => {
+    if (!BARE_TRANSITION.test(text)) return
+    // Allow specific transition utilities on the same line
+    if (/transition-(?:colors|transform|opacity|\[)/.test(text)) {
+      // Still flag if bare `transition` also appears
+      const stripped = text
+        .replace(/transition-(?:colors|transform|opacity|\[[^\]]+\])/g, '')
+        .replace(/motion-safe:transition-(?:colors|transform|opacity|\[[^\]]+\])/g, '')
+      if (!/(?:^|[\s"'`])(?:motion-safe:)?transition(?:[\s"'`]|$)/.test(stripped)) return
+    }
+    violations.push({
+      file: relative(join(__dirname, '..'), file),
+      line: index + 1,
+      text: text.trim().slice(0, 120),
+    })
+  })
+}
+
+if (violations.length === 0) {
+  console.log('✓ Interface polish check passed (no bare `transition` utilities).')
+  process.exit(0)
+}
+
+console.error(`✗ Found ${violations.length} bare \`transition\` utility(ies):\n`)
+for (const v of violations.slice(0, 40)) {
+  console.error(`  ${v.file}:${v.line}`)
+  console.error(`    ${v.text}`)
+}
+if (violations.length > 40) {
+  console.error(`  … and ${violations.length - 40} more`)
+}
+console.error('\nFix: run `node scripts/fix-bare-transitions.mjs --write` or use transition-colors / transition-transform.')
+process.exit(1)

--- a/clients/web/scripts/fix-bare-transitions.mjs
+++ b/clients/web/scripts/fix-bare-transitions.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Codemod: replace bare Tailwind `transition` (maps to transition-property: all)
+ * with property-specific utilities (plan 22.1, rule 14).
+ *
+ * Usage: node scripts/fix-bare-transitions.mjs [--write]
+ */
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const srcRoot = join(__dirname, '..', 'src')
+const write = process.argv.includes('--write')
+
+/** @param {string} classStr */
+function inferTransition(classStr) {
+  const hasTransform =
+    /\b(?:rotate-|scale-|translate-|group-open:rotate|group-hover:scale|group-focus:scale)/.test(classStr) ||
+    /\$\{[^}]*rotate/.test(classStr)
+  const hasOpacity =
+    /\b(?:group-hover:opacity|group-focus-within:opacity|opacity-0|opacity-100|focus-visible:opacity)/.test(
+      classStr,
+    )
+  const hasShadow = /\bhover:shadow|shadow-card-hover|hover-shadow-card/.test(classStr)
+  const hasFilter = /\bblur-/.test(classStr)
+  const hasColor =
+    /\bhover:(?:bg|text|border)-/.test(classStr) ||
+    /\bfocus:(?:border|ring|bg|text)-/.test(classStr) ||
+    /\bfocus-visible:(?:ring|bg|text)-/.test(classStr) ||
+    /\b(?:bg|text|border)-.*(?:hover:|focus:)/.test(classStr)
+
+  const props = []
+  if (hasTransform) props.push('transform')
+  if (hasOpacity) props.push('opacity')
+  if (hasShadow) props.push('box-shadow')
+  if (hasFilter) props.push('filter')
+  if (hasColor) {
+    props.push('background-color', 'color', 'border-color')
+  }
+
+  const unique = [...new Set(props)]
+  if (unique.length === 0) return 'transition-colors'
+  if (unique.length === 1 && unique[0] === 'transform') return 'transition-transform'
+  if (unique.length === 1 && unique[0] === 'opacity') return 'transition-opacity'
+  if (unique.length === 1 && unique[0] === 'box-shadow') return 'transition-[box-shadow]'
+  if (unique.length === 1 && unique[0] === 'filter') return 'transition-[filter]'
+  if (
+    unique.length === 2 &&
+    unique.includes('transform') &&
+    unique.includes('opacity')
+  ) {
+    return 'transition-[transform,opacity]'
+  }
+  if (
+    unique.length === 2 &&
+    unique.includes('opacity') &&
+    unique.includes('background-color')
+  ) {
+    return 'transition-[opacity,background-color,color]'
+  }
+  return `transition-[${unique.join(',')}]`
+}
+
+/** Replace bare `transition` tokens in a class string segment. */
+function fixClassString(classStr) {
+  return classStr.replace(/(^|\s)(motion-safe:)?transition(\s|$)/g, (match, before, motionPrefix, after) => {
+    const prefix = motionPrefix ?? ''
+    const replacement = inferTransition(classStr)
+    return `${before}${prefix}${replacement}${after}`
+  })
+}
+
+function walk(dir) {
+  /** @type {string[]} */
+  const files = []
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name)
+    if (statSync(path).isDirectory()) {
+      files.push(...walk(path))
+    } else if (/\.tsx?$/.test(name)) {
+      files.push(path)
+    }
+  }
+  return files
+}
+
+let totalReplacements = 0
+let filesChanged = 0
+
+for (const file of walk(srcRoot)) {
+  const original = readFileSync(file, 'utf8')
+  let next = original
+  let fileReplacements = 0
+
+  // Template literals in className={`...`}
+  next = next.replace(/className=\{`([^`]*)`\}/g, (full, classStr) => {
+    const fixed = fixClassString(classStr)
+    if (fixed !== classStr) fileReplacements++
+    return `className={\`${fixed}\`}`
+  })
+
+  // Static className="..."
+  next = next.replace(/className="([^"]*)"/g, (full, classStr) => {
+    const fixed = fixClassString(classStr)
+    if (fixed !== classStr) fileReplacements++
+    return `className="${fixed}"`
+  })
+
+  // cn(...) and similar string literals passed as first arg — conservative: only quoted strings on own lines
+  next = next.replace(/'([^']*\btransition\b[^']*)'/g, (full, classStr) => {
+    if (/transition-(?:colors|transform|opacity|\[)/.test(classStr) && !/(?:^|\s)transition(?:\s|$)/.test(classStr)) {
+      return full
+    }
+    const fixed = fixClassString(classStr)
+    if (fixed !== classStr) fileReplacements++
+    return `'${fixed}'`
+  })
+
+  if (next !== original) {
+    totalReplacements += fileReplacements
+    filesChanged++
+    if (write) {
+      writeFileSync(file, next, 'utf8')
+    } else {
+      console.log(`Would update ${file} (${fileReplacements} segment(s))`)
+    }
+  }
+}
+
+const mode = write ? 'Updated' : 'Would update'
+console.log(`\n${mode} ${filesChanged} file(s), ~${totalReplacements} class segment(s).`)
+if (!write) {
+  console.log('Re-run with --write to apply changes.')
+}

--- a/clients/web/src/components/a11y/read-aloud-controls.tsx
+++ b/clients/web/src/components/a11y/read-aloud-controls.tsx
@@ -1,5 +1,6 @@
 import { Pause, Play, RotateCcw, Volume2 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { IconSwap } from '../ui/icon-swap'
 import {
   fetchReadingPreferences,
   fetchMyAccommodationSummary,
@@ -107,7 +108,7 @@ export function ReadAloudControls({ lang = 'en-US' }: ReadAloudControlsProps) {
           setExpanded(true)
           tts.toggle()
         }}
-        className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+        className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
         aria-label={playing ? 'Pause read aloud' : 'Read aloud'}
         aria-pressed={playing}
       >
@@ -141,7 +142,7 @@ export function ReadAloudControls({ lang = 'en-US' }: ReadAloudControlsProps) {
               onClick={() => tts.toggle()}
               className="inline-flex items-center gap-1.5 rounded-lg bg-indigo-600 px-3 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
             >
-              {playing ? <Pause className="h-4 w-4" aria-hidden /> : <Play className="h-4 w-4" aria-hidden />}
+              <IconSwap active={playing} activeIcon={Pause} inactiveIcon={Play} iconClassName="h-4 w-4" />
               {playing ? 'Pause' : 'Play'}
             </button>
             <button

--- a/clients/web/src/components/annotation/annotation-comment-panel.tsx
+++ b/clients/web/src/components/annotation/annotation-comment-panel.tsx
@@ -35,7 +35,7 @@ export function AnnotationCommentPanel({
                 <button
                   type="button"
                   onClick={() => onSelect(a.id)}
-                  className={`w-full rounded-lg border px-2 py-2 text-start text-xs transition ${
+                  className={`w-full rounded-lg border px-2 py-2 text-start text-xs transition-[background-color,color,border-color] ${
                     selectedId === a.id
                       ? 'border-indigo-500 bg-indigo-50 dark:border-indigo-400 dark:bg-indigo-950/40'
                       : 'border-slate-200 hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-900'

--- a/clients/web/src/components/annotation/annotation-toolbar.tsx
+++ b/clients/web/src/components/annotation/annotation-toolbar.tsx
@@ -33,7 +33,7 @@ export function AnnotationToolbar({
     <div
       role="toolbar"
       aria-label="Annotation tools"
-      className="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white/90 p-2 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/90"
+      className="flex flex-wrap items-center gap-2 rounded-2xl bg-white/90 p-2 shadow-card dark:bg-neutral-900/90"
     >
       {tools.map((t) => (
         <button
@@ -43,7 +43,7 @@ export function AnnotationToolbar({
           aria-pressed={tool === t.id}
           aria-label={t.hint}
           onClick={() => onToolChange(t.id)}
-          className={`rounded-lg px-3 py-1.5 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 disabled:opacity-50 ${
+          className={`rounded-lg px-3 py-1.5 text-xs font-semibold transition-[background-color,color,border-color] focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 disabled:opacity-50 ${
             tool === t.id
               ? 'bg-indigo-600 text-white'
               : 'bg-slate-100 text-slate-800 hover:bg-slate-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700'

--- a/clients/web/src/components/annotation/grader-agent/assignment-picker.tsx
+++ b/clients/web/src/components/annotation/grader-agent/assignment-picker.tsx
@@ -189,7 +189,7 @@ export function AssignmentPicker({
                       onChange(assignment.id)
                       setOpen(false)
                     }}
-                    className={`flex w-full items-center gap-2 px-3 py-2 text-start text-xs transition ${
+                    className={`flex w-full items-center gap-2 px-3 py-2 text-start text-xs transition-[background-color,color,border-color] ${
                       highlighted
                         ? 'bg-indigo-50 font-semibold text-indigo-900 dark:bg-indigo-950/50 dark:text-indigo-100'
                         : active

--- a/clients/web/src/components/annotation/grader-agent/create-grading-agent-modal.tsx
+++ b/clients/web/src/components/annotation/grader-agent/create-grading-agent-modal.tsx
@@ -133,7 +133,7 @@ export function CreateGradingAgentModal({
           <legend className="sr-only">{t('gradingAgent.settings.create.sourceLegend')}</legend>
           <label
             htmlFor={sourceTemplateId}
-            className={`flex cursor-pointer items-start gap-3 rounded-xl border px-4 py-3 transition ${
+            className={`flex cursor-pointer items-start gap-3 rounded-xl border px-4 py-3 transition-[background-color,color,border-color] ${
               source === 'template'
                 ? 'border-indigo-400 bg-indigo-50/70 dark:border-indigo-500 dark:bg-indigo-950/30'
                 : 'border-slate-200 hover:border-slate-300 dark:border-neutral-700 dark:hover:border-neutral-600'
@@ -163,7 +163,7 @@ export function CreateGradingAgentModal({
 
           <label
             htmlFor={sourceAssignmentId}
-            className={`flex cursor-pointer items-start gap-3 rounded-xl border px-4 py-3 transition ${
+            className={`flex cursor-pointer items-start gap-3 rounded-xl border px-4 py-3 transition-[background-color,color,border-color] ${
               source === 'assignment'
                 ? 'border-indigo-400 bg-indigo-50/70 dark:border-indigo-500 dark:bg-indigo-950/30'
                 : 'border-slate-200 hover:border-slate-300 dark:border-neutral-700 dark:hover:border-neutral-600'
@@ -191,7 +191,7 @@ export function CreateGradingAgentModal({
 
           <label
             htmlFor={sourceAsTemplateId}
-            className={`flex cursor-pointer items-start gap-3 rounded-xl border px-4 py-3 transition ${
+            className={`flex cursor-pointer items-start gap-3 rounded-xl border px-4 py-3 transition-[background-color,color,border-color] ${
               source === 'asTemplate'
                 ? 'border-indigo-400 bg-indigo-50/70 dark:border-indigo-500 dark:bg-indigo-950/30'
                 : 'border-slate-200 hover:border-slate-300 dark:border-neutral-700 dark:hover:border-neutral-600'

--- a/clients/web/src/components/annotation/grader-agent/save-workflow-menu.tsx
+++ b/clients/web/src/components/annotation/grader-agent/save-workflow-menu.tsx
@@ -56,7 +56,7 @@ export function SaveWorkflowMenu({
           aria-expanded={open}
           aria-controls={open ? menuId : undefined}
           onClick={() => setOpen((o) => !o)}
-          className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+          className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
         >
           {saving ? (
             <>
@@ -66,7 +66,7 @@ export function SaveWorkflowMenu({
           ) : (
             <>
               {t('gradingAgent.save')}
-              <ChevronDown className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`} aria-hidden />
+              <ChevronDown className={`h-4 w-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`} aria-hidden />
             </>
           )}
         </button>
@@ -84,7 +84,7 @@ export function SaveWorkflowMenu({
                 setOpen(false)
                 void onSave()
               }}
-              className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
             >
               {t('gradingAgent.save.option')}
             </button>
@@ -95,7 +95,7 @@ export function SaveWorkflowMenu({
                 setOpen(false)
                 setTemplateDialogOpen(true)
               }}
-              className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
             >
               {t('gradingAgent.save.asTemplate')}
             </button>
@@ -112,7 +112,7 @@ export function SaveWorkflowMenu({
                     setOpen(false)
                     void onAccept()
                   }}
-                  className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-indigo-700 transition hover:bg-indigo-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-indigo-300 dark:hover:bg-indigo-950/40"
+                  className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-indigo-700 transition-[background-color,color,border-color] hover:bg-indigo-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-indigo-300 dark:hover:bg-indigo-950/40"
                 >
                   {t('gradingAgent.accept')}
                 </button>

--- a/clients/web/src/components/annotation/submission-grading-panel.tsx
+++ b/clients/web/src/components/annotation/submission-grading-panel.tsx
@@ -621,7 +621,7 @@ export function SubmissionGradingPanel({
                 aria-selected={gradeMode === 'rubric'}
                 disabled={formDisabled}
                 onClick={() => setGradeMode('rubric')}
-                className={`flex-1 rounded-lg px-3 py-2 text-sm font-semibold transition disabled:opacity-50 ${
+                className={`flex-1 rounded-lg px-3 py-2 text-sm font-semibold transition-[background-color,color,border-color] disabled:opacity-50 ${
                   gradeMode === 'rubric'
                     ? 'bg-white text-indigo-700 shadow-sm dark:bg-neutral-800 dark:text-indigo-300'
                     : 'text-slate-600 hover:text-slate-900 dark:text-neutral-400 dark:hover:text-neutral-100'
@@ -635,7 +635,7 @@ export function SubmissionGradingPanel({
                 aria-selected={gradeMode === 'points'}
                 disabled={formDisabled}
                 onClick={() => setGradeMode('points')}
-                className={`flex-1 rounded-lg px-3 py-2 text-sm font-semibold transition disabled:opacity-50 ${
+                className={`flex-1 rounded-lg px-3 py-2 text-sm font-semibold transition-[background-color,color,border-color] disabled:opacity-50 ${
                   gradeMode === 'points'
                     ? 'bg-white text-indigo-700 shadow-sm dark:bg-neutral-800 dark:text-indigo-300'
                     : 'text-slate-600 hover:text-slate-900 dark:text-neutral-400 dark:hover:text-neutral-100'

--- a/clients/web/src/components/annotation/submission-navigator.tsx
+++ b/clients/web/src/components/annotation/submission-navigator.tsx
@@ -213,7 +213,7 @@ export function SubmissionStudentPicker({
                       onIndexChange(i)
                       setOpen(false)
                     }}
-                    className={`flex w-full items-center gap-2 px-3 py-2 text-start text-xs transition ${
+                    className={`flex w-full items-center gap-2 px-3 py-2 text-start text-xs transition-[background-color,color,border-color] ${
                       highlighted
                         ? 'bg-indigo-50 font-semibold text-indigo-900 dark:bg-indigo-950/50 dark:text-indigo-100'
                         : active

--- a/clients/web/src/components/annotation/submission-preview-sidebar.tsx
+++ b/clients/web/src/components/annotation/submission-preview-sidebar.tsx
@@ -96,7 +96,7 @@ export function SubmissionPreviewSidebar({
           role="tab"
           aria-selected={tab === 'grade'}
           onClick={() => setTab('grade')}
-          className={`flex-1 rounded-lg px-3 py-2 text-sm font-semibold transition ${
+          className={`flex-1 rounded-lg px-3 py-2 text-sm font-semibold transition-[background-color,color,border-color] ${
             tab === 'grade'
               ? 'bg-white text-indigo-700 shadow-sm dark:bg-neutral-800 dark:text-indigo-300'
               : 'text-slate-600 hover:bg-white/70 dark:text-neutral-400 dark:hover:bg-neutral-800/60'
@@ -114,7 +114,7 @@ export function SubmissionPreviewSidebar({
           role="tab"
           aria-selected={tab === 'files'}
           onClick={() => setTab('files')}
-          className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-sm font-semibold transition ${
+          className={`flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-sm font-semibold transition-[background-color,color,border-color] ${
             tab === 'files'
               ? 'bg-white text-indigo-700 shadow-sm dark:bg-neutral-800 dark:text-indigo-300'
               : 'text-slate-600 hover:bg-white/70 dark:text-neutral-400 dark:hover:bg-neutral-800/60'

--- a/clients/web/src/components/assignment/assignment-page-actions-menu.tsx
+++ b/clients/web/src/components/assignment/assignment-page-actions-menu.tsx
@@ -45,10 +45,10 @@ export function AssignmentPageActionsMenu({
         aria-expanded={open}
         aria-controls={open ? menuId : undefined}
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex h-10 items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+        className="inline-flex h-10 items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
       >
         Actions
-        <ChevronDown className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`} aria-hidden />
+        <ChevronDown className={`h-4 w-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`} aria-hidden />
       </button>
       {open && (
         <div
@@ -64,7 +64,7 @@ export function AssignmentPageActionsMenu({
               onEdit()
               setOpen(false)
             }}
-            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
+            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
           >
             <Pencil className="h-4 w-4 shrink-0 text-slate-500 dark:text-neutral-400" aria-hidden />
             Edit
@@ -77,7 +77,7 @@ export function AssignmentPageActionsMenu({
                 onGradingAgent()
                 setOpen(false)
               }}
-              className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
             >
               <Sparkles className="h-4 w-4 shrink-0 text-slate-500 dark:text-neutral-400" aria-hidden />
               {t('gradingAgent.button')}

--- a/clients/web/src/components/assignment/assignment-page-settings-panel.tsx
+++ b/clients/web/src/components/assignment/assignment-page-settings-panel.tsx
@@ -90,7 +90,7 @@ function SettingsAccordion({ title, children }: { title: string; children: React
       <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-2 text-[13px] font-medium text-slate-600 outline-none transition-colors hover:bg-slate-50/80 hover:text-slate-800 dark:text-neutral-400 dark:hover:bg-neutral-800/30 dark:hover:text-neutral-200 [&::-webkit-details-marker]:hidden">
         <span>{title}</span>
         <ChevronDown
-          className="h-3.5 w-3.5 shrink-0 text-slate-400/80 transition duration-200 group-open:rotate-180 dark:text-neutral-500"
+          className="h-3.5 w-3.5 shrink-0 text-slate-400/80 transition-transform duration-200 group-open:rotate-180 dark:text-neutral-500"
           aria-hidden
         />
       </summary>
@@ -137,12 +137,12 @@ function ToggleRow({
         aria-checked={checked}
         disabled={disabled}
         onClick={() => onChange(!checked)}
-        className={`relative mt-0.5 h-5 w-9 shrink-0 rounded-full transition disabled:cursor-not-allowed disabled:opacity-50 ${
+        className={`relative mt-0.5 h-5 w-9 shrink-0 rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
           checked ? 'bg-indigo-500' : 'bg-slate-300 dark:bg-neutral-600'
         }`}
       >
         <span
-          className={`absolute top-0.5 h-4 w-4 rounded-full bg-white transition ${
+          className={`absolute top-0.5 h-4 w-4 rounded-full bg-white transition-colors ${
             checked ? 'start-4.5' : 'start-0.5'
           }`}
         />

--- a/clients/web/src/components/auth/auth-field-classes.ts
+++ b/clients/web/src/components/auth/auth-field-classes.ts
@@ -4,13 +4,13 @@ export const authCardClass =
   'rounded-xl border border-stone-200/90 bg-white p-7 shadow-[0_1px_2px_rgba(28,25,23,0.06)] dark:border-neutral-700 dark:bg-neutral-900 dark:shadow-none'
 
 export const authFieldClass =
-  'w-full rounded-lg border border-stone-200 bg-white px-3 py-2.5 text-stone-900 shadow-sm outline-none transition placeholder:text-stone-400 focus:border-teal-700 focus:ring-2 focus:ring-teal-700/15 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-teal-500 dark:focus:ring-teal-500/20'
+  'w-full rounded-lg border border-stone-200 bg-white px-3 py-2.5 text-stone-900 shadow-sm outline-none transition-[background-color,color,border-color] placeholder:text-stone-400 focus:border-teal-700 focus:ring-2 focus:ring-teal-700/15 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-teal-500 dark:focus:ring-teal-500/20'
 
 export const authPrimaryButtonClass =
-  'flex w-full items-center justify-center rounded-lg bg-teal-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-teal-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-teal-700 dark:hover:bg-teal-600 dark:focus-visible:outline-teal-700'
+  'flex w-full items-center justify-center rounded-lg bg-teal-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-teal-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-teal-700 dark:hover:bg-teal-600 dark:focus-visible:outline-teal-700'
 
 export const authMutedLinkClass =
   'font-medium text-teal-900 underline-offset-4 hover:text-teal-800 hover:underline dark:text-teal-300 dark:hover:text-teal-200'
 
 export const authOutlineButtonClass =
-  'flex w-full items-center justify-center rounded-lg border border-stone-200 bg-white px-4 py-2.5 text-sm font-semibold text-stone-800 shadow-sm transition hover:border-teal-600/35 hover:bg-stone-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-teal-500/40 dark:hover:bg-neutral-800'
+  'flex w-full items-center justify-center rounded-lg border border-stone-200 bg-white px-4 py-2.5 text-sm font-semibold text-stone-800 shadow-sm transition-[background-color,color,border-color] hover:border-teal-600/35 hover:bg-stone-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-teal-500/40 dark:hover:bg-neutral-800'

--- a/clients/web/src/components/auth/magic-link-request-form.tsx
+++ b/clients/web/src/components/auth/magic-link-request-form.tsx
@@ -72,7 +72,7 @@ export function MagicLinkRequestForm({ redirectTo, defaultEmail = '' }: Props) {
           required
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-indigo-500/20 transition placeholder:text-slate-400 focus:border-indigo-400 focus:ring-2"
+          className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-slate-900 outline-none ring-indigo-500/20 transition-[background-color,color,border-color] placeholder:text-slate-400 focus:border-indigo-400 focus:ring-2"
           placeholder="you@school.edu"
         />
       </div>
@@ -84,7 +84,7 @@ export function MagicLinkRequestForm({ redirectTo, defaultEmail = '' }: Props) {
       <button
         type="submit"
         disabled={status === 'loading'}
-        className="flex w-full items-center justify-center rounded-xl border border-indigo-200 bg-indigo-50 px-4 py-2.5 text-sm font-semibold text-indigo-800 shadow-sm transition hover:bg-indigo-100 disabled:cursor-not-allowed disabled:opacity-60"
+        className="flex w-full items-center justify-center rounded-xl border border-indigo-200 bg-indigo-50 px-4 py-2.5 text-sm font-semibold text-indigo-800 shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-100 disabled:cursor-not-allowed disabled:opacity-60"
       >
         {status === 'loading' ? 'Sending link…' : 'Send magic link'}
       </button>

--- a/clients/web/src/components/canvas/canvas-import-progress-log.tsx
+++ b/clients/web/src/components/canvas/canvas-import-progress-log.tsx
@@ -59,7 +59,7 @@ export function CanvasImportProgressLog({
         </span>
         <ChevronDown
           className={[
-            'h-4 w-4 shrink-0 text-slate-500 transition dark:text-neutral-400',
+            'h-4 w-4 shrink-0 text-slate-500 transition-colors dark:text-neutral-400',
             expanded ? 'rotate-180' : '',
           ].join(' ')}
           aria-hidden

--- a/clients/web/src/components/cloud-import-menu.tsx
+++ b/clients/web/src/components/cloud-import-menu.tsx
@@ -94,7 +94,7 @@ export function CloudImportMenu({
             <Download className="h-4 w-4" aria-hidden />
             Import
             <ChevronDown
-              className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`}
+              className={`h-4 w-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
               aria-hidden
             />
           </>
@@ -114,7 +114,7 @@ export function CloudImportMenu({
               role="menuitem"
               aria-haspopup="dialog"
               onClick={() => void handlePick(provider.provider, provider)}
-              className="flex w-full flex-col gap-0.5 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:hover:bg-neutral-800"
+              className="flex w-full flex-col gap-0.5 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:hover:bg-neutral-800"
             >
               <span className="font-medium text-slate-900 dark:text-neutral-100">
                 {CLOUD_PROVIDER_LABELS[provider.provider]}

--- a/clients/web/src/components/command-palette/command-palette-dialog.tsx
+++ b/clients/web/src/components/command-palette/command-palette-dialog.tsx
@@ -456,7 +456,7 @@ export function CommandPaletteDialog() {
                     role="option"
                     aria-selected={selected}
                     ref={selected ? activeRowRef : undefined}
-                    className={`flex w-full items-start gap-3 rounded-xl px-3 py-2.5 text-start text-sm transition ${selected
+                    className={`flex w-full items-start gap-3 rounded-xl px-3 py-2.5 text-start text-sm transition-[background-color,color,border-color] ${selected
                       ? 'bg-indigo-50 text-slate-900 dark:bg-indigo-950/70 dark:text-neutral-100'
                       : 'text-slate-700 hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800/80'
                       }`}
@@ -513,7 +513,7 @@ export function CommandPaletteDialog() {
                     role="option"
                     aria-selected={selected}
                     ref={selected ? activeRowRef : undefined}
-                    className={`flex w-full items-start gap-3 rounded-xl px-3 py-2.5 text-start text-sm transition ${selected
+                    className={`flex w-full items-start gap-3 rounded-xl px-3 py-2.5 text-start text-sm transition-[background-color,color,border-color] ${selected
                       ? 'bg-indigo-50 text-slate-900 dark:bg-indigo-950/70 dark:text-neutral-100'
                       : 'text-slate-700 hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800/80'
                       }`}

--- a/clients/web/src/components/conference/slot-picker.tsx
+++ b/clients/web/src/components/conference/slot-picker.tsx
@@ -73,7 +73,7 @@ export function SlotPicker({
                 if (canBook) onBook(slot)
                 else if (canCancel) onCancel(slot)
               }}
-              className={`flex items-center gap-2 rounded-xl border px-3 py-3 text-left text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
+              className={`flex items-center gap-2 rounded-xl border px-3 py-3 text-left text-sm transition-[background-color,color,border-color] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
                 isMine
                   ? 'border-sky-300 bg-sky-50 dark:border-sky-700 dark:bg-sky-950/30'
                   : slot.status === 'open'

--- a/clients/web/src/components/content-page/content-page-reader.tsx
+++ b/clients/web/src/components/content-page/content-page-reader.tsx
@@ -734,7 +734,7 @@ export function ContentPageReader({
                   type="button"
                   disabled={busy}
                   onClick={() => void onHighlight()}
-                  className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-semibold text-amber-900 transition hover:bg-amber-50 disabled:opacity-50 dark:text-amber-100 dark:hover:bg-amber-950/50"
+                  className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-semibold text-amber-900 transition-[background-color,color,border-color] hover:bg-amber-50 disabled:opacity-50 dark:text-amber-100 dark:hover:bg-amber-950/50"
                 >
                   <Highlighter className="h-3.5 w-3.5" aria-hidden />
                   Highlight
@@ -743,7 +743,7 @@ export function ContentPageReader({
                   type="button"
                   disabled={busy}
                   onClick={openNoteModal}
-                  className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-semibold text-indigo-800 transition hover:bg-indigo-50 disabled:opacity-50 dark:text-indigo-200 dark:hover:bg-indigo-950/40"
+                  className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-semibold text-indigo-800 transition-[background-color,color,border-color] hover:bg-indigo-50 disabled:opacity-50 dark:text-indigo-200 dark:hover:bg-indigo-950/40"
                 >
                   <StickyNote className="h-3.5 w-3.5" aria-hidden />
                   Add note
@@ -755,7 +755,7 @@ export function ContentPageReader({
                   type="button"
                   disabled={busy}
                   onClick={openNoteFromHighlightToolbar}
-                  className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-semibold text-indigo-800 transition hover:bg-indigo-50 disabled:opacity-50 dark:text-indigo-200 dark:hover:bg-indigo-950/40"
+                  className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-semibold text-indigo-800 transition-[background-color,color,border-color] hover:bg-indigo-50 disabled:opacity-50 dark:text-indigo-200 dark:hover:bg-indigo-950/40"
                 >
                   <StickyNote className="h-3.5 w-3.5" aria-hidden />
                   Add note
@@ -764,7 +764,7 @@ export function ContentPageReader({
                   type="button"
                   disabled={busy}
                   onClick={() => void removeCurrentHighlight()}
-                  className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-semibold text-rose-800 transition hover:bg-rose-50 disabled:opacity-50 dark:text-rose-200 dark:hover:bg-rose-950/40"
+                  className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-semibold text-rose-800 transition-[background-color,color,border-color] hover:bg-rose-50 disabled:opacity-50 dark:text-rose-200 dark:hover:bg-rose-950/40"
                   aria-label="Remove highlight"
                 >
                   <Trash2 className="h-3.5 w-3.5" aria-hidden />

--- a/clients/web/src/components/course-item-prompt-editor.tsx
+++ b/clients/web/src/components/course-item-prompt-editor.tsx
@@ -454,7 +454,7 @@ export function CourseItemPromptEditor({
                 role="option"
                 id={`${listId}-opt-${idx}`}
                 aria-selected={idx === activeIndex}
-                className={`flex w-full flex-col items-start gap-0.5 px-3 py-2 text-start text-sm transition ${
+                className={`flex w-full flex-col items-start gap-0.5 px-3 py-2 text-start text-sm transition-[background-color,color,border-color] ${
                   idx === activeIndex ? 'bg-indigo-50 text-indigo-950' : 'text-slate-800 hover:bg-slate-50'
                 }`}
                 onMouseDown={(e) => {

--- a/clients/web/src/components/dashboard/degree-progress-card.tsx
+++ b/clients/web/src/components/dashboard/degree-progress-card.tsx
@@ -71,7 +71,7 @@ export function DegreeProgressCard() {
         </div>
       ) : null}
 
-      <div className="mt-3 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-neutral-700 dark:bg-neutral-900">
+      <div className="mt-3 rounded-2xl bg-white p-5 shadow-card dark:bg-neutral-900">
         {hasAudit ? (
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
             <div
@@ -146,7 +146,7 @@ export function DegreeProgressCard() {
             href={apptUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-4 inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+            className="mt-4 inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500"
           >
             Schedule advising appointment
             <ExternalLink className="h-4 w-4" aria-hidden />

--- a/clients/web/src/components/dashboard/grading-backlog-list.tsx
+++ b/clients/web/src/components/dashboard/grading-backlog-list.tsx
@@ -50,7 +50,7 @@ export function GradingBacklogList({ items, showCourse = false, emptyMessage }: 
           <li key={itemKey}>
             <Link
               to={hrefForGradingItem(courseCode, item)}
-              className="flex items-start justify-between gap-3 rounded-xl border border-amber-100 bg-amber-50/60 px-3 py-2.5 text-sm transition hover:border-amber-200 hover:bg-amber-50 dark:border-amber-900/40 dark:bg-amber-950/30 dark:hover:border-amber-800 dark:hover:bg-amber-950/50"
+              className="flex items-start justify-between gap-3 rounded-xl border border-amber-100 bg-amber-50/60 px-3 py-2.5 text-sm transition-[background-color,color,border-color] hover:border-amber-200 hover:bg-amber-50 dark:border-amber-900/40 dark:bg-amber-950/30 dark:hover:border-amber-800 dark:hover:bg-amber-950/50"
             >
               <span className="min-w-0">
                 {showCourse && item.courseTitle ? (

--- a/clients/web/src/components/dashboard/notebook-tasks-card.tsx
+++ b/clients/web/src/components/dashboard/notebook-tasks-card.tsx
@@ -103,13 +103,13 @@ export function NotebookTasksCard({ courseTitles }: NotebookTasksCardProps) {
           return (
             <li
               key={task.id}
-              className="flex items-start gap-3 rounded-xl border border-slate-200 bg-white px-3 py-3 shadow-sm dark:border-neutral-700 dark:bg-neutral-900"
+              className="flex items-start gap-3 rounded-xl bg-white px-3 py-3 shadow-card dark:bg-neutral-900"
             >
               <button
                 type="button"
                 disabled={busy}
                 onClick={() => void onComplete(task)}
-                className="mt-0.5 shrink-0 rounded p-0.5 text-slate-400 transition hover:bg-slate-100 hover:text-indigo-600 disabled:opacity-50 dark:hover:bg-neutral-800 dark:hover:text-indigo-400"
+                className="mt-0.5 shrink-0 rounded p-0.5 text-slate-400 transition-[background-color,color,border-color] hover:bg-slate-100 hover:text-indigo-600 disabled:opacity-50 dark:hover:bg-neutral-800 dark:hover:text-indigo-400"
                 aria-label={`Complete task: ${label}`}
               >
                 <Square className="h-4 w-4" aria-hidden />

--- a/clients/web/src/components/editor/block-editor/editor-sidebar.tsx
+++ b/clients/web/src/components/editor/block-editor/editor-sidebar.tsx
@@ -36,7 +36,7 @@ export function EditorSidebar({
           type="button"
           role="tab"
           aria-selected={tab === 'document'}
-          className={`flex-1 px-3 py-2.5 text-center text-xs font-semibold uppercase tracking-wide transition ${
+          className={`flex-1 px-3 py-2.5 text-center text-xs font-semibold uppercase tracking-wide transition-[background-color,color,border-color] ${
             tab === 'document'
               ? 'border-b-2 border-indigo-600 text-slate-900 dark:border-indigo-500 dark:text-neutral-100'
               : 'border-b-2 border-transparent text-slate-500 hover:text-slate-800 dark:text-neutral-400 dark:hover:text-neutral-200'
@@ -49,7 +49,7 @@ export function EditorSidebar({
           type="button"
           role="tab"
           aria-selected={tab === 'block'}
-          className={`flex-1 px-3 py-2.5 text-center text-xs font-semibold uppercase tracking-wide transition ${
+          className={`flex-1 px-3 py-2.5 text-center text-xs font-semibold uppercase tracking-wide transition-[background-color,color,border-color] ${
             tab === 'block'
               ? 'border-b-2 border-indigo-600 text-slate-900 dark:border-indigo-500 dark:text-neutral-100'
               : 'border-b-2 border-transparent text-slate-500 hover:text-slate-800 dark:text-neutral-400 dark:hover:text-neutral-200'

--- a/clients/web/src/components/editor/block-editor/markdown-body-editor.tsx
+++ b/clients/web/src/components/editor/block-editor/markdown-body-editor.tsx
@@ -889,7 +889,7 @@ export function MarkdownBodyEditor({
                     role="option"
                     id={`${slashListId}-opt-${idx}`}
                     aria-selected={idx === slashActiveIndex}
-                    className={`flex w-full flex-col items-start gap-0.5 px-3 py-2 text-start text-sm transition ${
+                    className={`flex w-full flex-col items-start gap-0.5 px-3 py-2 text-start text-sm transition-[background-color,color,border-color] ${
                       idx === slashActiveIndex
                         ? 'bg-indigo-50 text-indigo-950 dark:bg-indigo-950/50 dark:text-indigo-50'
                         : 'text-slate-800 hover:bg-slate-50 dark:text-neutral-100 dark:hover:bg-neutral-800'
@@ -944,7 +944,7 @@ export function MarkdownBodyEditor({
                     role="option"
                     id={`${listId}-opt-${idx}`}
                     aria-selected={idx === activeIndex}
-                    className={`flex w-full flex-col items-start gap-0.5 px-3 py-2 text-start text-sm transition ${
+                    className={`flex w-full flex-col items-start gap-0.5 px-3 py-2 text-start text-sm transition-[background-color,color,border-color] ${
                       idx === activeIndex
                         ? 'bg-indigo-50 text-indigo-950 dark:bg-indigo-950/50 dark:text-indigo-50'
                         : 'text-slate-800 hover:bg-slate-50 dark:text-neutral-100 dark:hover:bg-neutral-800'

--- a/clients/web/src/components/editor/block-editor/markdown-image-upload-modal.tsx
+++ b/clients/web/src/components/editor/block-editor/markdown-image-upload-modal.tsx
@@ -149,7 +149,7 @@ export function MarkdownImageUploadModal({ open, onClose, onUpload }: MarkdownIm
             if (busy) return
             void uploadFiles([...e.dataTransfer.files])
           }}
-          className={`flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed px-6 py-10 text-center transition ${
+          className={`flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed px-6 py-10 text-center transition-[background-color,color,border-color] ${
             dragOver
               ? 'border-indigo-400 bg-indigo-50/80 dark:border-indigo-500 dark:bg-indigo-950/30'
               : 'border-slate-200 bg-slate-50/70 hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-950/50 dark:hover:border-neutral-600 dark:hover:bg-neutral-950'

--- a/clients/web/src/components/editor/block-editor/sidebar-section.tsx
+++ b/clients/web/src/components/editor/block-editor/sidebar-section.tsx
@@ -20,7 +20,7 @@ export function SidebarSection({ title, defaultOpen = true, children }: SidebarS
       >
         {title}
         <ChevronDown
-          className={`h-4 w-4 shrink-0 text-slate-500 transition dark:text-neutral-400 ${open ? 'rotate-180' : ''}`}
+          className={`h-4 w-4 shrink-0 text-slate-500 transition-transform dark:text-neutral-400 ${open ? 'rotate-180' : ''}`}
           aria-hidden
         />
       </button>

--- a/clients/web/src/components/editor/extensions/notebook-task-node-view.tsx
+++ b/clients/web/src/components/editor/extensions/notebook-task-node-view.tsx
@@ -134,7 +134,7 @@ export function NotebookTaskNodeView(props: NodeViewProps) {
   return (
     <NodeViewWrapper
       as="div"
-      className="lex-notebook-task group my-2 flex items-start gap-2 rounded-lg border border-transparent px-1 py-1 transition hover:border-slate-200 dark:hover:border-neutral-700"
+      className="lex-notebook-task group my-2 flex items-start gap-2 rounded-lg border border-transparent px-1 py-1 transition-[background-color,color,border-color] hover:border-slate-200 dark:hover:border-neutral-700"
       data-type="notebook-task"
     >
       <div className="min-w-0 flex-1">
@@ -157,11 +157,11 @@ export function NotebookTaskNodeView(props: NodeViewProps) {
         ) : null}
       </div>
       {editable ? (
-        <div className="relative shrink-0 opacity-0 transition group-hover:opacity-100 group-focus-within:opacity-100" ref={menuRef}>
+        <div className="relative shrink-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100" ref={menuRef}>
           <button
             type="button"
             onClick={onOpenDueMenu}
-            className="inline-flex items-center rounded-md p-1 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+            className="inline-flex items-center rounded-md p-1 text-slate-400 transition-[background-color,color,border-color] hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
             aria-expanded={menuOpen}
             aria-haspopup="menu"
             aria-controls={menuId}

--- a/clients/web/src/components/feature-help/feature-help-dock.tsx
+++ b/clients/web/src/components/feature-help/feature-help-dock.tsx
@@ -41,7 +41,7 @@ export function FeatureHelpDock() {
           <button
             type="button"
             onClick={() => closeHelp()}
-            className="rounded-lg p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
+            className="rounded-lg p-2 text-slate-500 transition-[background-color,color,border-color] hover:bg-slate-100 hover:text-slate-800 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
             aria-label="Close"
           >
             <X className="h-5 w-5" aria-hidden />

--- a/clients/web/src/components/feature-help/feature-help-trigger.tsx
+++ b/clients/web/src/components/feature-help/feature-help-trigger.tsx
@@ -14,7 +14,7 @@ export function FeatureHelpTrigger({
     <button
       type="button"
       onClick={() => openHelp(topic)}
-      className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 shadow-sm transition hover:border-indigo-200 hover:text-indigo-700 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-400 dark:hover:border-indigo-500/40 dark:hover:text-indigo-200"
+      className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:text-indigo-700 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-400 dark:hover:border-indigo-500/40 dark:hover:text-indigo-200"
       aria-label={label}
     >
       <CircleHelp className="h-4 w-4" aria-hidden />

--- a/clients/web/src/components/grading/rubric-grade-picker.tsx
+++ b/clients/web/src/components/grading/rubric-grade-picker.tsx
@@ -68,7 +68,7 @@ function CriterionPicker({
                 aria-checked={active}
                 disabled={disabled}
                 onClick={() => onSelect(lvl.points)}
-                className={`border-slate-200 px-2 py-2.5 text-center transition disabled:opacity-50 dark:border-neutral-700 ${
+                className={`border-slate-200 px-2 py-2.5 text-center transition-[background-color,color,border-color] disabled:opacity-50 dark:border-neutral-700 ${
                   i > 0 ? 'border-s' : ''
                 } ${
                   active
@@ -104,7 +104,7 @@ function CriterionPicker({
                 aria-checked={active}
                 disabled={disabled}
                 onClick={() => onSelect(lvl.points)}
-                className={`w-full rounded-lg border px-3 py-2.5 text-start transition disabled:opacity-50 ${
+                className={`w-full rounded-lg border px-3 py-2.5 text-start transition-[background-color,color,border-color] disabled:opacity-50 ${
                   active
                     ? 'border-indigo-500 bg-indigo-50 ring-1 ring-indigo-500/25 dark:border-indigo-400 dark:bg-indigo-950/50 dark:ring-indigo-400/25'
                     : 'border-slate-200 bg-slate-50 hover:border-slate-300 hover:bg-white dark:border-neutral-600 dark:bg-neutral-900 dark:hover:border-neutral-500 dark:hover:bg-neutral-800'

--- a/clients/web/src/components/grading/what-if-grades-panel.tsx
+++ b/clients/web/src/components/grading/what-if-grades-panel.tsx
@@ -90,7 +90,7 @@ export function WhatIfGradesPanel({
         <button
           type="button"
           aria-pressed={whatIfMode}
-          className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition ${
+          className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-[background-color,color,border-color] ${
             whatIfMode
               ? 'border-indigo-300 bg-indigo-50 text-indigo-900 dark:border-indigo-700 dark:bg-indigo-950/60 dark:text-indigo-100'
               : 'border-slate-200 bg-white text-slate-800 hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800'

--- a/clients/web/src/components/image-model-picker.tsx
+++ b/clients/web/src/components/image-model-picker.tsx
@@ -147,7 +147,7 @@ export function ImageModelPicker({
           )}
         </span>
         <ChevronDown
-          className={`mt-0.5 h-4 w-4 shrink-0 text-slate-400 transition ${open ? 'rotate-180' : ''}`}
+          className={`mt-0.5 h-4 w-4 shrink-0 text-slate-400 transition-transform ${open ? 'rotate-180' : ''}`}
           aria-hidden
         />
       </button>
@@ -179,7 +179,7 @@ export function ImageModelPicker({
                 aria-pressed={pillFree}
                 onClick={() => setPillFree((v) => !v)}
                 onMouseDown={(e) => e.stopPropagation()}
-                className={`rounded-full border px-2 py-0.5 text-xs font-medium transition ${
+                className={`rounded-full border px-2 py-0.5 text-xs font-medium transition-[background-color,color,border-color] ${
                   pillFree
                     ? 'border-indigo-300 bg-indigo-100 text-indigo-900'
                     : 'border-slate-200 bg-white text-slate-600 hover:bg-slate-50'
@@ -192,7 +192,7 @@ export function ImageModelPicker({
                 aria-pressed={pillPopularity}
                 onClick={() => setPillPopularity((v) => !v)}
                 onMouseDown={(e) => e.stopPropagation()}
-                className={`rounded-full border px-2 py-0.5 text-xs font-medium transition ${
+                className={`rounded-full border px-2 py-0.5 text-xs font-medium transition-[background-color,color,border-color] ${
                   pillPopularity
                     ? 'border-indigo-300 bg-indigo-100 text-indigo-900'
                     : 'border-slate-200 bg-white text-slate-600 hover:bg-slate-50'
@@ -225,7 +225,7 @@ export function ImageModelPicker({
                       onChange(m.id)
                       setOpen(false)
                     }}
-                    className={`w-full px-2.5 py-2 text-start transition hover:bg-slate-50 ${
+                    className={`w-full px-2.5 py-2 text-start transition-[background-color,color,border-color] hover:bg-slate-50 ${
                       isSel ? 'bg-indigo-50/80' : ''
                     }`}
                   >

--- a/clients/web/src/components/keyboard-shortcuts/keyboard-shortcuts-sheet.tsx
+++ b/clients/web/src/components/keyboard-shortcuts/keyboard-shortcuts-sheet.tsx
@@ -99,7 +99,7 @@ export function KeyboardShortcutsSheet({
             ref={closeBtnRef}
             type="button"
             onClick={() => onClose()}
-            className="w-full rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/40 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+            className="w-full rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/40 dark:bg-indigo-500 dark:hover:bg-indigo-400"
           >
             Close
           </button>

--- a/clients/web/src/components/layout/help-widget.tsx
+++ b/clients/web/src/components/layout/help-widget.tsx
@@ -55,7 +55,7 @@ function HelpWidgetTrigger({
       aria-haspopup="dialog"
       onClick={onToggle}
       data-testid="help-widget-trigger"
-      className={`relative inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 ${
+      className={`relative inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition-[background-color,color,border-color] focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 ${
         open
           ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
           : 'text-slate-600 hover:bg-slate-100 dark:text-neutral-300 dark:hover:bg-neutral-800'

--- a/clients/web/src/components/layout/notifications-drawer.tsx
+++ b/clients/web/src/components/layout/notifications-drawer.tsx
@@ -85,7 +85,7 @@ export function NotificationsDrawerTrigger({
   return (
     <button
       type="button"
-      className="relative inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl text-slate-600 transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 dark:text-neutral-300 dark:hover:bg-neutral-800"
+      className="relative inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl text-slate-600 transition-[background-color,color,border-color] hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 dark:text-neutral-300 dark:hover:bg-neutral-800"
       aria-label={badge > 0 ? `Notifications (${badge} unread)` : 'Notifications'}
       aria-expanded={open}
       aria-haspopup="dialog"
@@ -385,7 +385,7 @@ export function NotificationsDrawer({ open, onClose }: { open: boolean; onClose:
                 aria-label={label}
                 title={label}
                 onClick={() => setFilter(id)}
-                className={`relative flex flex-col items-center justify-center gap-1 py-2.5 transition ${
+                className={`relative flex flex-col items-center justify-center gap-1 py-2.5 transition-[background-color,color,border-color] ${
                   active
                     ? 'text-indigo-600 dark:text-indigo-400'
                     : 'text-slate-400 hover:bg-slate-50 hover:text-slate-700 dark:text-neutral-500 dark:hover:bg-neutral-800/60 dark:hover:text-neutral-200'
@@ -427,7 +427,7 @@ export function NotificationsDrawer({ open, onClose }: { open: boolean; onClose:
                         if (!n.isRead) void markAlertRead(n.id)
                         onClose()
                       }}
-                      className={`flex gap-3 rounded-xl px-2 py-2.5 text-start transition hover:bg-slate-50 dark:hover:bg-neutral-800 ${n.isRead ? 'opacity-60' : ''}`}
+                      className={`flex gap-3 rounded-xl px-2 py-2.5 text-start transition-[background-color,color,border-color] hover:bg-slate-50 dark:hover:bg-neutral-800 ${n.isRead ? 'opacity-60' : ''}`}
                     >
                       <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-600 dark:bg-neutral-800 dark:text-neutral-300">
                         <BellRing className="h-5 w-5" aria-hidden />
@@ -479,7 +479,7 @@ export function NotificationsDrawer({ open, onClose }: { open: boolean; onClose:
                       onClose()
                     }}
                     className={[
-                      'flex gap-3 rounded-xl px-2 py-2.5 text-start transition hover:bg-slate-50 dark:hover:bg-neutral-800',
+                      'flex gap-3 rounded-xl px-2 py-2.5 text-start transition-[background-color,color,border-color] hover:bg-slate-50 dark:hover:bg-neutral-800',
                       unreadAlert ? '' : row.kind === 'alert' ? 'opacity-60' : '',
                     ].join(' ')}
                   >

--- a/clients/web/src/components/layout/quiz-focus-top-bar.tsx
+++ b/clients/web/src/components/layout/quiz-focus-top-bar.tsx
@@ -52,7 +52,7 @@ export function QuizFocusTopBar({ model }: { model: QuizShellFocusMode }) {
             type="button"
             onClick={onToggleFlagForReview}
             aria-pressed={flaggedForCurrent}
-            className={`inline-flex shrink-0 items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-semibold transition sm:text-sm ${
+            className={`inline-flex shrink-0 items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-semibold transition-[background-color,color,border-color] sm:text-sm ${
               flaggedForCurrent
                 ? 'border-amber-300 bg-amber-400/20 text-amber-50'
                 : 'border-white/25 bg-white/5 text-inherit hover:bg-white/10'

--- a/clients/web/src/components/layout/reading-focus-toggle.tsx
+++ b/clients/web/src/components/layout/reading-focus-toggle.tsx
@@ -9,7 +9,7 @@ export function ReadingFocusToggle() {
     <button
       type="button"
       onClick={() => setReadingFocus(true)}
-      className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+      className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
     >
       <BookOpen className="h-4 w-4 text-indigo-600 dark:text-indigo-400" aria-hidden />
       Reading focus

--- a/clients/web/src/components/layout/reading-focus-top-bar.tsx
+++ b/clients/web/src/components/layout/reading-focus-top-bar.tsx
@@ -12,7 +12,7 @@ export function ReadingFocusTopBar() {
       <button
         type="button"
         onClick={() => setReadingFocus(false)}
-        className="inline-flex shrink-0 items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+        className="inline-flex shrink-0 items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
       >
         <PanelLeft className="h-4 w-4" aria-hidden />
         Show navigation

--- a/clients/web/src/components/layout/side-nav-command-palette.tsx
+++ b/clients/web/src/components/layout/side-nav-command-palette.tsx
@@ -18,7 +18,7 @@ export function SideNavCommandPaletteTrigger() {
           data-command-palette-anchor="sidebar"
           data-onboarding="command-palette"
           onClick={() => open()}
-          className={`flex items-center rounded-full bg-[#E8E9EB] text-start text-sm text-slate-700 outline-none transition hover:bg-[#E0E2E5] focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:bg-neutral-800 dark:text-neutral-400 dark:hover:bg-neutral-700 dark:focus-visible:ring-neutral-500/40 ${
+          className={`flex items-center rounded-full bg-[#E8E9EB] text-start text-sm text-slate-700 outline-none transition-[background-color,color,border-color] hover:bg-[#E0E2E5] focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:bg-neutral-800 dark:text-neutral-400 dark:hover:bg-neutral-700 dark:focus-visible:ring-neutral-500/40 ${
             sideNavCollapsed ? 'h-10 w-10 justify-center p-0 mx-auto' : 'w-full gap-2.5 py-2 ps-3 pe-2'
           }`}
           title={undefined}
@@ -55,7 +55,7 @@ export function TopBarMobileCommandPaletteButton() {
       aria-label="Search courses, people, pages, and actions"
       data-command-palette-anchor="topbar"
       onClick={() => open()}
-      className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-slate-600 transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/35 md:hidden dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus-visible:ring-neutral-500/40"
+      className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-slate-600 transition-[background-color,color,border-color] hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/35 md:hidden dark:text-neutral-300 dark:hover:bg-neutral-800 dark:focus-visible:ring-neutral-500/40"
     >
       <Search className="h-5 w-5" strokeWidth={1.75} aria-hidden />
     </button>

--- a/clients/web/src/components/layout/side-nav-footer.tsx
+++ b/clients/web/src/components/layout/side-nav-footer.tsx
@@ -107,7 +107,7 @@ export function SideNavFooter() {
                   target="_blank"
                   rel="noopener noreferrer"
                   role="menuitem"
-                  className="flex items-center gap-2 rounded-lg px-2.5 py-2 text-slate-700 transition hover:bg-slate-50 hover:text-slate-950 dark:text-neutral-300 dark:hover:bg-neutral-800/50 dark:hover:text-neutral-50"
+                  className="flex items-center gap-2 rounded-lg px-2.5 py-2 text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 hover:text-slate-950 dark:text-neutral-300 dark:hover:bg-neutral-800/50 dark:hover:text-neutral-50"
                   onClick={() => setOpen(false)}
                 >
                   <FileText className="h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500" aria-hidden="true" />
@@ -118,7 +118,7 @@ export function SideNavFooter() {
                   target="_blank"
                   rel="noopener noreferrer"
                   role="menuitem"
-                  className="flex items-center gap-2 rounded-lg px-2.5 py-2 text-slate-700 transition hover:bg-slate-50 hover:text-slate-950 dark:text-neutral-300 dark:hover:bg-neutral-800/50 dark:hover:text-neutral-50"
+                  className="flex items-center gap-2 rounded-lg px-2.5 py-2 text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 hover:text-slate-950 dark:text-neutral-300 dark:hover:bg-neutral-800/50 dark:hover:text-neutral-50"
                   onClick={() => setOpen(false)}
                 >
                   <Shield className="h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500" aria-hidden="true" />
@@ -129,7 +129,7 @@ export function SideNavFooter() {
                   target="_blank"
                   rel="noopener noreferrer"
                   role="menuitem"
-                  className="flex items-center gap-2 rounded-lg px-2.5 py-2 text-slate-700 transition hover:bg-slate-50 hover:text-slate-950 dark:text-neutral-300 dark:hover:bg-neutral-800/50 dark:hover:text-neutral-50"
+                  className="flex items-center gap-2 rounded-lg px-2.5 py-2 text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 hover:text-slate-950 dark:text-neutral-300 dark:hover:bg-neutral-800/50 dark:hover:text-neutral-50"
                   onClick={() => setOpen(false)}
                 >
                   <Globe className="h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500" aria-hidden="true" />
@@ -141,7 +141,7 @@ export function SideNavFooter() {
                   target="_blank"
                   rel="noopener noreferrer"
                   role="menuitem"
-                  className="flex items-center gap-2 rounded-lg px-2.5 py-2 text-slate-700 transition hover:bg-slate-50 hover:text-slate-950 dark:text-neutral-300 dark:hover:bg-neutral-800/50 dark:hover:text-neutral-50"
+                  className="flex items-center gap-2 rounded-lg px-2.5 py-2 text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 hover:text-slate-950 dark:text-neutral-300 dark:hover:bg-neutral-800/50 dark:hover:text-neutral-50"
                   onClick={() => setOpen(false)}
                 >
                   <Scale className="h-4 w-4 shrink-0 text-slate-400 dark:text-neutral-500" aria-hidden="true" />

--- a/clients/web/src/components/layout/side-nav-pinned-courses.tsx
+++ b/clients/web/src/components/layout/side-nav-pinned-courses.tsx
@@ -50,7 +50,7 @@ export function SideNavPinnedCourses() {
               aria-label={title}
               aria-current={active ? 'page' : undefined}
               className={[
-                'group relative block overflow-hidden rounded-xl ring-1 ring-black/[0.06] transition hover:ring-indigo-400/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:ring-white/10 dark:hover:ring-indigo-400/40',
+                'group relative block overflow-hidden rounded-xl ring-1 ring-black/[0.06] transition-[background-color,color,border-color] hover:ring-indigo-400/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:ring-white/10 dark:hover:ring-indigo-400/40',
                 sideNavCollapsed ? 'h-9 w-9' : 'h-10 w-full',
                 active ? 'ring-2 ring-indigo-500 dark:ring-indigo-400' : '',
               ]
@@ -68,7 +68,7 @@ export function SideNavPinnedCourses() {
               />
               <span
                 className={[
-                  'pointer-events-none absolute inset-0 bg-gradient-to-t from-black/35 to-transparent opacity-0 transition group-hover:opacity-100',
+                  'pointer-events-none absolute inset-0 bg-gradient-to-t from-black/35 to-transparent opacity-0 transition-[opacity,background-color,color,border-color] group-hover:opacity-100',
                   active ? 'opacity-100' : '',
                 ]
                   .filter(Boolean)

--- a/clients/web/src/components/layout/side-nav.tsx
+++ b/clients/web/src/components/layout/side-nav.tsx
@@ -87,7 +87,7 @@ export function SideNav() {
           <SideNavTooltip content="Lextures">
             <NavLink
               to="/"
-              className={`flex min-h-0 min-w-0 flex-1 items-center gap-3 rounded-2xl p-1 outline-none ring-slate-400/30 transition hover:bg-white/50 focus-visible:ring-2 dark:ring-neutral-500/40 dark:hover:bg-white/5 ${
+              className={`flex min-h-0 min-w-0 flex-1 items-center gap-3 rounded-2xl p-1 outline-none ring-slate-400/30 transition-[background-color,color,border-color] hover:bg-white/50 focus-visible:ring-2 dark:ring-neutral-500/40 dark:hover:bg-white/5 ${
                 sideNavCollapsed ? 'justify-center pe-1' : 'pe-2'
               }`}
               end

--- a/clients/web/src/components/layout/top-bar-breadcrumbs.tsx
+++ b/clients/web/src/components/layout/top-bar-breadcrumbs.tsx
@@ -448,7 +448,7 @@ export function TopBarBreadcrumbs() {
               ) : (
                 <Link
                   to={c.to}
-                  className="truncate transition hover:text-indigo-600 dark:hover:text-indigo-400"
+                  className="truncate transition-[background-color,color,border-color] hover:text-indigo-600 dark:hover:text-indigo-400"
                 >
                   {c.label}
                 </Link>

--- a/clients/web/src/components/layout/top-bar.tsx
+++ b/clients/web/src/components/layout/top-bar.tsx
@@ -103,7 +103,7 @@ function UserMenu() {
         aria-controls={open ? menuId : undefined}
         aria-label="User menu"
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white py-1.5 ps-1.5 pe-2.5 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:border-neutral-500 dark:hover:bg-neutral-700"
+        className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white py-1.5 ps-1.5 pe-2.5 text-sm font-medium text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:border-slate-300 hover:bg-slate-50 focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:border-neutral-500 dark:hover:bg-neutral-700"
       >
         <EnrollmentAvatar
           userId={viewerId}
@@ -113,7 +113,7 @@ function UserMenu() {
         />
         <span className="hidden max-w-[10rem] truncate sm:inline">{name}</span>
         <ChevronDown
-          className={`h-4 w-4 shrink-0 text-slate-500 transition dark:text-neutral-400 ${open ? 'rotate-180' : ''}`}
+          className={`h-4 w-4 shrink-0 text-slate-500 transition-transform dark:text-neutral-400 ${open ? 'rotate-180' : ''}`}
           aria-hidden
         />
       </button>
@@ -135,7 +135,7 @@ function UserMenu() {
             to="/settings/account"
             role="menuitem"
             onClick={() => setOpen(false)}
-            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm text-slate-700 transition hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-700"
+            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-700"
           >
             <User className="h-4 w-4 shrink-0 text-slate-500 dark:text-neutral-400" aria-hidden />
             Profile
@@ -144,7 +144,7 @@ function UserMenu() {
             type="button"
             role="menuitem"
             onClick={signOut}
-            className="flex w-full items-center gap-2 border-t border-slate-100 px-2.5 py-2 text-start text-sm text-slate-700 transition hover:bg-slate-50 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-700"
+            className="flex w-full items-center gap-2 border-t border-slate-100 px-2.5 py-2 text-start text-sm text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-700"
           >
             <LogOut className="h-4 w-4 shrink-0 text-slate-500 dark:text-neutral-400" aria-hidden />
             Sign out
@@ -203,12 +203,12 @@ function CourseEnrollmentViewDropdown() {
         aria-controls={open ? menuId : undefined}
         aria-label={`View course as ${label}. Open menu to switch between teacher and student preview.`}
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex max-w-full items-center gap-1.5 rounded-xl bg-indigo-600 px-2 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white dark:focus-visible:ring-neutral-400/40 md:gap-2 md:px-3 md:py-2 md:text-sm"
+        className="inline-flex max-w-full items-center gap-1.5 rounded-xl bg-indigo-600 px-2 py-1.5 text-xs font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white dark:focus-visible:ring-neutral-400/40 md:gap-2 md:px-3 md:py-2 md:text-sm"
       >
         <span className="max-md:sr-only">View as: </span>
         {label}
         <ChevronDown
-          className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`}
+          className={`h-4 w-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
           aria-hidden
         />
       </button>
@@ -227,7 +227,7 @@ function CourseEnrollmentViewDropdown() {
               setCourseViewAs(courseCode, 'teacher')
               setOpen(false)
             }}
-            className={`flex w-full flex-col gap-0.5 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:hover:bg-neutral-700 ${
+            className={`flex w-full flex-col gap-0.5 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:hover:bg-neutral-700 ${
               courseViewMode === 'teacher' ? 'bg-indigo-50 dark:bg-neutral-800' : ''
             }`}
           >
@@ -243,7 +243,7 @@ function CourseEnrollmentViewDropdown() {
               setCourseViewAs(courseCode, 'student')
               setOpen(false)
             }}
-            className={`flex w-full flex-col gap-0.5 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:hover:bg-neutral-700 ${
+            className={`flex w-full flex-col gap-0.5 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:hover:bg-neutral-700 ${
               courseViewMode === 'student' ? 'bg-indigo-50 dark:bg-neutral-800' : ''
             }`}
           >
@@ -275,7 +275,7 @@ export function TopBar() {
     <header className="lms-chrome flex h-14 shrink-0 items-center gap-1.5 border-b border-slate-200 bg-white px-2 shadow-sm shadow-slate-900/5 print:hidden sm:gap-3 sm:px-4 md:gap-4 md:px-6 dark:border-neutral-700 dark:bg-neutral-900 dark:shadow-black/20">
       <button
         type="button"
-        className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl text-slate-600 transition hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 md:hidden dark:text-neutral-300 dark:hover:bg-neutral-800"
+        className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl text-slate-600 transition-[background-color,color,border-color] hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 md:hidden dark:text-neutral-300 dark:hover:bg-neutral-800"
         aria-label={mobileNavOpen ? 'Close navigation menu' : 'Open navigation menu'}
         aria-expanded={mobileNavOpen}
         aria-controls="shell-nav"
@@ -296,7 +296,7 @@ export function TopBar() {
             aria-haspopup="dialog"
             onClick={() => setReadingPanelOpen((o) => !o)}
             data-testid="reading-preferences-trigger"
-            className={`inline-flex h-9 w-9 items-center justify-center rounded-xl text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 ${
+            className={`inline-flex h-9 w-9 items-center justify-center rounded-xl text-sm font-semibold transition-[background-color,color,border-color] focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 ${
               readingPanelOpen
                 ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
                 : 'text-slate-600 hover:bg-slate-100 dark:text-neutral-300 dark:hover:bg-neutral-800'

--- a/clients/web/src/components/legal/legal-update-banner.tsx
+++ b/clients/web/src/components/legal/legal-update-banner.tsx
@@ -70,7 +70,7 @@ export function LegalUpdateBanner() {
             type="button"
             onClick={() => void handleAcknowledge()}
             disabled={dismissing}
-            className="rounded-md bg-amber-800 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-amber-900 disabled:opacity-60 dark:bg-amber-700 dark:hover:bg-amber-600"
+            className="rounded-md bg-amber-800 px-3 py-1.5 text-sm font-medium text-white transition-[background-color,color,border-color] hover:bg-amber-900 disabled:opacity-60 dark:bg-amber-700 dark:hover:bg-amber-600"
           >
             I acknowledge
           </button>

--- a/clients/web/src/components/notebook/course-notebook-sidebar.tsx
+++ b/clients/web/src/components/notebook/course-notebook-sidebar.tsx
@@ -125,7 +125,7 @@ function NotebookTreeRow({
   return (
     <li ref={setNodeRef} style={style} className="list-none">
       <div
-        className={`group flex items-center gap-0 rounded-lg pe-1 transition ${
+        className={`group flex items-center gap-0 rounded-lg pe-1 transition-[background-color,color,border-color] ${
           showDropHint
             ? 'bg-amber-50 ring-2 ring-amber-400/70 dark:bg-amber-950/40 dark:ring-amber-500/60'
             : isSelected
@@ -150,12 +150,12 @@ function NotebookTreeRow({
               e.stopPropagation()
               onToggleCollapse(page.id)
             }}
-            className="me-1 flex h-7 w-4 shrink-0 items-center justify-center rounded-md text-slate-400 transition hover:bg-white hover:text-slate-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+            className="me-1 flex h-7 w-4 shrink-0 items-center justify-center rounded-md text-slate-400 transition-[background-color,color,border-color] hover:bg-white hover:text-slate-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
             aria-label={collapsed ? `Expand ${page.title}` : `Collapse ${page.title}`}
             aria-expanded={!collapsed}
           >
             <ChevronRight
-              className={`h-3.5 w-3.5 transition ${collapsed ? '' : 'rotate-90'}`}
+              className={`h-3.5 w-3.5 transition-transform ${collapsed ? '' : 'rotate-90'}`}
               aria-hidden
             />
           </button>
@@ -202,7 +202,7 @@ function NotebookTreeRow({
             e.stopPropagation()
             onAddChild(page.id)
           }}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 opacity-0 transition hover:bg-white hover:text-indigo-600 group-hover:opacity-100 dark:hover:bg-neutral-800 dark:hover:text-indigo-300"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 opacity-0 transition-[opacity,background-color,color,border-color] hover:bg-white hover:text-indigo-600 group-hover:opacity-100 dark:hover:bg-neutral-800 dark:hover:text-indigo-300"
           aria-label={`Add page under ${page.title}`}
           title="Add page"
         >
@@ -215,7 +215,7 @@ function NotebookTreeRow({
               e.stopPropagation()
               onAddChildGroup(page.id)
             }}
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 opacity-0 transition hover:bg-white hover:text-amber-600 group-hover:opacity-100 dark:hover:bg-neutral-800 dark:hover:text-amber-300"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 opacity-0 transition-[opacity,background-color,color,border-color] hover:bg-white hover:text-amber-600 group-hover:opacity-100 dark:hover:bg-neutral-800 dark:hover:text-amber-300"
             aria-label={`Add subgroup under ${page.title}`}
             title="Add subgroup"
           >
@@ -228,7 +228,7 @@ function NotebookTreeRow({
             e.stopPropagation()
             onDelete(page.id)
           }}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 opacity-0 transition hover:bg-rose-50 hover:text-rose-600 group-hover:opacity-100 dark:hover:bg-rose-950/40 dark:hover:text-rose-300"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 opacity-0 transition-[opacity,background-color,color,border-color] hover:bg-rose-50 hover:text-rose-600 group-hover:opacity-100 dark:hover:bg-rose-950/40 dark:hover:text-rose-300"
           aria-label={`Delete ${page.title}`}
           title="Delete"
         >
@@ -542,7 +542,7 @@ export function CourseNotebookSidebar({
         <button
           type="button"
           onClick={onAddRootPage}
-          className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-start text-sm font-medium text-slate-600 transition hover:bg-white hover:text-indigo-700 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:hover:text-indigo-200"
+          className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-start text-sm font-medium text-slate-600 transition-[background-color,color,border-color] hover:bg-white hover:text-indigo-700 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:hover:text-indigo-200"
         >
           <Plus className="h-4 w-4 shrink-0" aria-hidden />
           New page
@@ -550,7 +550,7 @@ export function CourseNotebookSidebar({
         <button
           type="button"
           onClick={onAddRootGroup}
-          className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-start text-sm font-medium text-slate-600 transition hover:bg-white hover:text-amber-700 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:hover:text-amber-200"
+          className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-start text-sm font-medium text-slate-600 transition-[background-color,color,border-color] hover:bg-white hover:text-amber-700 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:hover:text-amber-200"
         >
           <Folder className="h-4 w-4 shrink-0 text-amber-500 dark:text-amber-400" aria-hidden />
           New group

--- a/clients/web/src/components/notebook/flashcards-modal.tsx
+++ b/clients/web/src/components/notebook/flashcards-modal.tsx
@@ -191,7 +191,7 @@ export function FlashcardsModal({ open, notes, pageTitle, onClose }: FlashcardsM
             type="button"
             onClick={onClose}
             aria-label="Close flashcards panel"
-            className="flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
+            className="flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition-[background-color,color,border-color] hover:bg-slate-100 hover:text-slate-800 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
           >
             <X className="h-5 w-5" aria-hidden />
           </button>
@@ -239,7 +239,7 @@ export function FlashcardsModal({ open, notes, pageTitle, onClose }: FlashcardsM
               <button
                 type="button"
                 onClick={generateFlashcards}
-                className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+                className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-400"
               >
                 <RefreshCw className="h-4 w-4" aria-hidden />
                 Try again
@@ -277,7 +277,7 @@ export function FlashcardsModal({ open, notes, pageTitle, onClose }: FlashcardsM
                     <button
                       type="button"
                       onClick={handleResetStudy}
-                      className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700"
+                      className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700"
                     >
                       <RotateCw className="h-4 w-4" aria-hidden />
                       Study again
@@ -285,7 +285,7 @@ export function FlashcardsModal({ open, notes, pageTitle, onClose }: FlashcardsM
                     <button
                       type="button"
                       onClick={generateFlashcards}
-                      className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+                      className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-medium text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-400"
                     >
                       <RefreshCw className="h-4 w-4" aria-hidden />
                       Regenerate
@@ -342,7 +342,7 @@ export function FlashcardsModal({ open, notes, pageTitle, onClose }: FlashcardsM
                       <button
                         type="button"
                         onClick={handleToggleLearned}
-                        className={`inline-flex items-center gap-2 rounded-full px-5 py-1.5 text-xs font-semibold shadow-sm transition ${
+                        className={`inline-flex items-center gap-2 rounded-full px-5 py-1.5 text-xs font-semibold shadow-sm transition-[background-color,color,border-color] ${
                           learned[currentIndex]
                             ? 'bg-emerald-100 text-emerald-800 hover:bg-emerald-200 dark:bg-emerald-950 dark:text-emerald-300 dark:hover:bg-emerald-900/60'
                             : 'bg-slate-200 text-slate-700 hover:bg-slate-300 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700'
@@ -359,7 +359,7 @@ export function FlashcardsModal({ open, notes, pageTitle, onClose }: FlashcardsM
                         type="button"
                         onClick={handlePrev}
                         disabled={currentIndex === 0}
-                        className="flex h-10 w-10 items-center justify-center rounded-full bg-white border border-slate-200 text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:pointer-events-none disabled:opacity-40 dark:bg-neutral-950 dark:border-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                        className="flex h-10 w-10 items-center justify-center rounded-full bg-white border border-slate-200 text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:pointer-events-none disabled:opacity-40 dark:bg-neutral-950 dark:border-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-800"
                         aria-label="Previous card"
                       >
                         <ArrowLeft className="h-5 w-5" aria-hidden />
@@ -378,7 +378,7 @@ export function FlashcardsModal({ open, notes, pageTitle, onClose }: FlashcardsM
                         type="button"
                         onClick={handleNext}
                         disabled={currentIndex === totalCards - 1}
-                        className="flex h-10 w-10 items-center justify-center rounded-full bg-white border border-slate-200 text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:pointer-events-none disabled:opacity-40 dark:bg-neutral-950 dark:border-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                        className="flex h-10 w-10 items-center justify-center rounded-full bg-white border border-slate-200 text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:pointer-events-none disabled:opacity-40 dark:bg-neutral-950 dark:border-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-800"
                         aria-label="Next card"
                       >
                         <ArrowRight className="h-5 w-5" aria-hidden />
@@ -416,7 +416,7 @@ export function FlashcardsModal({ open, notes, pageTitle, onClose }: FlashcardsM
             <button
               type="button"
               onClick={generateFlashcards}
-              className="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700 shrink-0"
+              className="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700 shrink-0"
               title="Regenerate flashcards"
             >
               <RefreshCw className="h-3.5 w-3.5" />

--- a/clients/web/src/components/notebook/notebook-group-panel.tsx
+++ b/clients/web/src/components/notebook/notebook-group-panel.tsx
@@ -39,7 +39,7 @@ export function NotebookGroupPanel({
               <button
                 type="button"
                 onClick={() => onAddPage(group.id)}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
               >
                 <Plus className="h-4 w-4" aria-hidden />
                 Add page
@@ -47,7 +47,7 @@ export function NotebookGroupPanel({
               <button
                 type="button"
                 onClick={() => onAddGroup(group.id)}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
               >
                 <Plus className="h-4 w-4" aria-hidden />
                 Add subgroup
@@ -68,7 +68,7 @@ export function NotebookGroupPanel({
                 <button
                   type="button"
                   onClick={() => onSelectPage(child.id)}
-                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-start text-sm text-slate-700 transition hover:bg-slate-100 dark:text-neutral-200 dark:hover:bg-neutral-800/80"
+                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-start text-sm text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-100 dark:text-neutral-200 dark:hover:bg-neutral-800/80"
                 >
                   {isNotebookGroup(child) ? (
                     <Folder className="h-4 w-4 shrink-0 text-amber-500 dark:text-amber-400" aria-hidden />

--- a/clients/web/src/components/notebook/notebook-page-actions-menu.tsx
+++ b/clients/web/src/components/notebook/notebook-page-actions-menu.tsx
@@ -52,7 +52,7 @@ export function NotebookPageActionsMenu({
       <button
         type="button"
         onClick={onToggle}
-        className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800"
+        className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800"
         aria-expanded={open}
         aria-haspopup="menu"
       >
@@ -72,7 +72,7 @@ export function NotebookPageActionsMenu({
                 closeAll()
                 onFlashcards()
               }}
-              className="flex w-full items-center gap-2 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
+              className="flex w-full items-center gap-2 px-3 py-2 text-sm text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
             >
               <Sparkles className="h-4 w-4 text-indigo-500" aria-hidden />
               Create Flash Cards
@@ -91,7 +91,7 @@ export function NotebookPageActionsMenu({
                   aria-expanded={moveOpen}
                   aria-haspopup="menu"
                   onClick={() => setMoveOpen((v) => !v)}
-                  className="flex w-full items-center gap-2 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                  className="flex w-full items-center gap-2 px-3 py-2 text-sm text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
                 >
                   <Folder className="h-4 w-4 text-amber-500 dark:text-amber-400" aria-hidden />
                   <span className="flex-1 text-start">Move to group</span>
@@ -119,7 +119,7 @@ export function NotebookPageActionsMenu({
                               closeAll()
                               onMoveToGroup(activePage.id, group.id)
                             }}
-                            className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-start text-sm transition hover:bg-slate-50 disabled:cursor-default disabled:opacity-50 dark:hover:bg-neutral-800"
+                            className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-default disabled:opacity-50 dark:hover:bg-neutral-800"
                           >
                             <span className="font-medium text-slate-800 dark:text-neutral-100">
                               {group.title || 'Untitled group'}
@@ -143,7 +143,7 @@ export function NotebookPageActionsMenu({
                     closeAll()
                     onMoveToRoot(activePage.id)
                   }}
-                  className="flex w-full items-center gap-2 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                  className="flex w-full items-center gap-2 px-3 py-2 text-sm text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
                 >
                   Move to top level
                 </button>

--- a/clients/web/src/components/oer/oer-search-panel.tsx
+++ b/clients/web/src/components/oer/oer-search-panel.tsx
@@ -168,7 +168,7 @@ export function OERSearchPanel({ open, courseCode, moduleId, onClose, onImported
                 role="tab"
                 aria-selected={activeTab === tab.id}
                 onClick={() => setActiveTab(tab.id)}
-                className={`rounded-lg px-3 py-1.5 text-xs font-medium transition ${
+                className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-[background-color,color,border-color] ${
                   activeTab === tab.id
                     ? 'bg-indigo-600 text-white'
                     : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-neutral-800 dark:text-neutral-200'

--- a/clients/web/src/components/oidc-sign-in-buttons.tsx
+++ b/clients/web/src/components/oidc-sign-in-buttons.tsx
@@ -55,7 +55,7 @@ export function OidcSignInButtons({ nextPath }: Props) {
     <div className="mb-6 space-y-2">
       {cleverOn && (
         <a
-          className="flex w-full items-center justify-center gap-2 rounded-xl border border-[#436CF6] bg-[#436CF6] px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-[#3a5fd9]"
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-[#436CF6] bg-[#436CF6] px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-[#3a5fd9]"
           href={p('/auth/clever/login')}
           aria-label="Sign in using your Clever account"
         >
@@ -64,7 +64,7 @@ export function OidcSignInButtons({ nextPath }: Props) {
       )}
       {classlinkOn && (
         <a
-          className="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-800 bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-800 bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-slate-800"
           href={p('/auth/oidc/classlink/login')}
           aria-label="Sign in with ClassLink"
         >
@@ -73,7 +73,7 @@ export function OidcSignInButtons({ nextPath }: Props) {
       )}
       {s.enabled && s.google && (
         <a
-          className="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50"
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-slate-300 hover:bg-slate-50"
           href={p('/auth/oidc/google/login')}
           aria-label="Sign in with Google"
         >
@@ -83,7 +83,7 @@ export function OidcSignInButtons({ nextPath }: Props) {
       )}
       {s.enabled && s.microsoft && (
         <a
-          className="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50"
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-slate-300 hover:bg-slate-50"
           href={p('/auth/oidc/microsoft/login')}
           aria-label="Sign in with Microsoft"
         >
@@ -93,7 +93,7 @@ export function OidcSignInButtons({ nextPath }: Props) {
       )}
       {s.enabled && s.apple && (
         <a
-          className="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-900 bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-900 bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-slate-800"
           href={p('/auth/oidc/apple/login')}
           aria-label="Sign in with Apple"
         >
@@ -104,7 +104,7 @@ export function OidcSignInButtons({ nextPath }: Props) {
         s.custom?.map((c) => (
           <a
             key={c.id}
-            className="flex w-full items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-indigo-300 hover:bg-slate-50"
+            className="flex w-full items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-300 hover:bg-slate-50"
             href={p(`/auth/oidc/custom/login?configId=${encodeURIComponent(c.id)}`)}
             aria-label={`Sign in with ${c.displayName}`}
           >

--- a/clients/web/src/components/onboarding/start-here-card.tsx
+++ b/clients/web/src/components/onboarding/start-here-card.tsx
@@ -52,7 +52,7 @@ export function StartHereCard() {
         </p>
         <Link
           to={`/courses/${encodeURIComponent(goals.recommendedCourseCode)}`}
-          className="mt-4 inline-flex items-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-500"
+          className="mt-4 inline-flex items-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-emerald-500"
         >
           Open course
           <ArrowRight className="h-4 w-4" aria-hidden />

--- a/clients/web/src/components/quiz/quiz-analytics-modal.tsx
+++ b/clients/web/src/components/quiz/quiz-analytics-modal.tsx
@@ -77,7 +77,7 @@ export function QuizAnalyticsModal({ open, onClose, courseCode, itemId, quizTitl
               onClick={() => void load()}
               disabled={loading}
               aria-label="Refresh analytics"
-              className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 disabled:opacity-50 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+              className="rounded-lg p-1.5 text-slate-500 transition-[background-color,color,border-color] hover:bg-slate-100 hover:text-slate-800 disabled:opacity-50 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
             >
               <RefreshCw className={`h-5 w-5 ${loading ? 'animate-spin' : ''}`} aria-hidden />
             </button>
@@ -85,7 +85,7 @@ export function QuizAnalyticsModal({ open, onClose, courseCode, itemId, quizTitl
               type="button"
               onClick={onClose}
               aria-label="Close analytics"
-              className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+              className="rounded-lg p-1.5 text-slate-500 transition-[background-color,color,border-color] hover:bg-slate-100 hover:text-slate-800 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
             >
               <X className="h-5 w-5" aria-hidden />
             </button>

--- a/clients/web/src/components/quiz/quiz-item-analysis-panel.tsx
+++ b/clients/web/src/components/quiz/quiz-item-analysis-panel.tsx
@@ -89,7 +89,7 @@ export function QuizItemAnalysisPanel({ courseCode, itemId }: Props) {
             onClick={() => void handleCompute()}
             disabled={computing || loading}
             aria-label="Recompute item statistics"
-            className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-300"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium text-slate-600 transition-[background-color,color,border-color] hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-300"
           >
             <RefreshCw className={`h-3.5 w-3.5 ${computing ? 'animate-spin' : ''}`} aria-hidden />
             {computing ? 'Computing…' : 'Recompute'}
@@ -99,7 +99,7 @@ export function QuizItemAnalysisPanel({ courseCode, itemId }: Props) {
               type="button"
               onClick={handleExportCSV}
               aria-label="Export item analysis as CSV"
-              className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-300"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium text-slate-600 transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-300"
             >
               <Download className="h-3.5 w-3.5" aria-hidden />
               Export CSV

--- a/clients/web/src/components/quiz/quiz-page-settings-panel.tsx
+++ b/clients/web/src/components/quiz/quiz-page-settings-panel.tsx
@@ -63,7 +63,7 @@ function SettingsAccordion({ title, children }: { title: string; children: React
       <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-2 text-[13px] font-medium text-slate-600 outline-none transition-colors hover:bg-slate-50/80 hover:text-slate-800 dark:text-neutral-400 dark:hover:bg-neutral-800/30 dark:hover:text-neutral-200 [&::-webkit-details-marker]:hidden">
         <span>{title}</span>
         <ChevronDown
-          className="h-3.5 w-3.5 shrink-0 text-slate-400/80 transition duration-200 group-open:rotate-180 dark:text-neutral-500"
+          className="h-3.5 w-3.5 shrink-0 text-slate-400/80 transition-transform duration-200 group-open:rotate-180 dark:text-neutral-500"
           aria-hidden
         />
       </summary>
@@ -110,12 +110,12 @@ function ToggleRow({
         aria-checked={checked}
         disabled={disabled}
         onClick={() => onChange(!checked)}
-        className={`relative mt-0.5 h-5 w-9 shrink-0 rounded-full transition disabled:cursor-not-allowed disabled:opacity-50 ${
+        className={`relative mt-0.5 h-5 w-9 shrink-0 rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
           checked ? 'bg-indigo-500' : 'bg-slate-300 dark:bg-neutral-600'
         }`}
       >
         <span
-          className={`absolute top-0.5 h-4 w-4 rounded-full bg-white transition ${
+          className={`absolute top-0.5 h-4 w-4 rounded-full bg-white transition-colors ${
             checked ? 'start-4.5' : 'start-0.5'
           }`}
         />

--- a/clients/web/src/components/quiz/quiz-student-preview-modal.tsx
+++ b/clients/web/src/components/quiz/quiz-student-preview-modal.tsx
@@ -144,7 +144,7 @@ function StudentQuestionBlock({ q, index }: { q: QuizQuestion; index: number }) 
             choices.map((label, i) => (
               <label
                 key={`${q.id}-c-${i}`}
-                className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-slate-50/50 px-3 py-2.5 text-sm text-slate-800 transition hover:border-slate-300"
+                className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-slate-50/50 px-3 py-2.5 text-sm text-slate-800 transition-[background-color,color,border-color] hover:border-slate-300"
               >
                 <input
                   type="checkbox"
@@ -161,7 +161,7 @@ function StudentQuestionBlock({ q, index }: { q: QuizQuestion; index: number }) 
             choices.map((label, i) => (
               <label
                 key={`${q.id}-c-${i}`}
-                className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-slate-50/50 px-3 py-2.5 text-sm text-slate-800 transition hover:border-slate-300"
+                className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-slate-50/50 px-3 py-2.5 text-sm text-slate-800 transition-[background-color,color,border-color] hover:border-slate-300"
               >
                 <input
                   type="radio"
@@ -851,7 +851,7 @@ function AdaptivePreviewPanel({
             {current.choices.map((label, i) => (
               <label
                 key={`ad-c-${i}`}
-                className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-slate-50/50 px-3 py-2.5 text-sm text-slate-800 transition hover:border-slate-300"
+                className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 bg-slate-50/50 px-3 py-2.5 text-sm text-slate-800 transition-[background-color,color,border-color] hover:border-slate-300"
               >
                 <input
                   type="radio"

--- a/clients/web/src/components/reviews/review-form.tsx
+++ b/clients/web/src/components/reviews/review-form.tsx
@@ -83,7 +83,7 @@ export function ReviewForm({
                 {[1, 2, 3, 4, 5].map((value) => (
                   <label
                     key={value}
-                    className={`flex min-h-11 min-w-11 cursor-pointer items-center justify-center rounded-xl border px-3 py-2 text-sm font-medium transition ${
+                    className={`flex min-h-11 min-w-11 cursor-pointer items-center justify-center rounded-xl border px-3 py-2 text-sm font-medium transition-[background-color,color,border-color] ${
                       rating === value
                         ? 'border-amber-500 bg-amber-50 text-amber-800 dark:border-amber-400 dark:bg-amber-950 dark:text-amber-200'
                         : 'border-slate-200 text-slate-600 hover:border-slate-300 dark:border-neutral-700 dark:text-neutral-300'

--- a/clients/web/src/components/self-paced/self-paced-dashboard-section.tsx
+++ b/clients/web/src/components/self-paced/self-paced-dashboard-section.tsx
@@ -93,7 +93,7 @@ export function SelfPacedDashboardSection() {
             <Link
               to={`/courses/${encodeURIComponent(row.courseCode)}/modules`}
               aria-label={`Resume ${row.title}`}
-              className="inline-flex shrink-0 items-center gap-1 rounded-xl bg-emerald-600 px-3 py-2 text-xs font-semibold text-white transition hover:bg-emerald-500"
+              className="inline-flex shrink-0 items-center gap-1 rounded-xl bg-emerald-600 px-3 py-2 text-xs font-semibold text-white transition-[background-color,color,border-color] hover:bg-emerald-500"
             >
               {row.completed ? 'Review' : 'Resume'}
               <ArrowRight className="h-3.5 w-3.5" aria-hidden />

--- a/clients/web/src/components/settings/ai-reports-panel.tsx
+++ b/clients/web/src/components/settings/ai-reports-panel.tsx
@@ -88,7 +88,7 @@ export function AiReportsPanel() {
             key={p.id}
             type="button"
             onClick={() => setPreset(p.id)}
-            className={`rounded-xl border px-3 py-2 text-sm font-semibold shadow-sm transition ${
+            className={`rounded-xl border px-3 py-2 text-sm font-semibold shadow-sm transition-[background-color,color,border-color] ${
               preset === p.id
                 ? 'border-indigo-300 bg-indigo-50 text-indigo-900 dark:border-indigo-500/50 dark:bg-indigo-950/60 dark:text-indigo-100'
                 : 'border-slate-200 bg-white text-slate-700 hover:border-indigo-200 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200'

--- a/clients/web/src/components/settings/archived-courses-panel.tsx
+++ b/clients/web/src/components/settings/archived-courses-panel.tsx
@@ -81,7 +81,7 @@ export function ArchivedCoursesPanel() {
           type="button"
           onClick={() => void load()}
           disabled={loading}
-          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
         >
           <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden />
           Refresh

--- a/clients/web/src/components/settings/create-access-key-modal.tsx
+++ b/clients/web/src/components/settings/create-access-key-modal.tsx
@@ -308,7 +308,7 @@ export function CreateAccessKeyModal({ open, scopes, onClose, onCreated }: Creat
                         const checked = selectedScopes.includes(s.id)
                         return (
                           <li key={s.id}>
-                            <label className="flex cursor-pointer gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2.5 transition hover:border-indigo-200 dark:border-neutral-600 dark:bg-neutral-900 dark:hover:border-indigo-800/60">
+                            <label className="flex cursor-pointer gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2.5 transition-[background-color,color,border-color] hover:border-indigo-200 dark:border-neutral-600 dark:bg-neutral-900 dark:hover:border-indigo-800/60">
                               <input
                                 type="checkbox"
                                 checked={checked}
@@ -347,7 +347,7 @@ export function CreateAccessKeyModal({ open, scopes, onClose, onCreated }: Creat
                   role="radio"
                   aria-checked={courseLimitMode === 'all'}
                   onClick={() => setCourseLimitMode('all')}
-                  className={`cursor-pointer rounded-xl border px-3 py-3 text-start transition ${
+                  className={`cursor-pointer rounded-xl border px-3 py-3 text-start transition-[background-color,color,border-color] ${
                     courseLimitMode === 'all'
                       ? 'border-indigo-500 bg-indigo-50 ring-1 ring-indigo-500/30 dark:border-indigo-400 dark:bg-indigo-950/40'
                       : 'border-slate-200 bg-white hover:border-slate-300 dark:border-neutral-600 dark:bg-neutral-900'
@@ -365,7 +365,7 @@ export function CreateAccessKeyModal({ open, scopes, onClose, onCreated }: Creat
                   role="radio"
                   aria-checked={courseLimitMode === 'specific'}
                   onClick={() => setCourseLimitMode('specific')}
-                  className={`cursor-pointer rounded-xl border px-3 py-3 text-start transition ${
+                  className={`cursor-pointer rounded-xl border px-3 py-3 text-start transition-[background-color,color,border-color] ${
                     courseLimitMode === 'specific'
                       ? 'border-indigo-500 bg-indigo-50 ring-1 ring-indigo-500/30 dark:border-indigo-400 dark:bg-indigo-950/40'
                       : 'border-slate-200 bg-white hover:border-slate-300 dark:border-neutral-600 dark:bg-neutral-900'

--- a/clients/web/src/components/settings/feature-toggle-row.tsx
+++ b/clients/web/src/components/settings/feature-toggle-row.tsx
@@ -38,7 +38,7 @@ export function FeatureToggleRow({
         }`}
       >
         <span
-          className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition ${
+          className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition-transform ${
             enabled ? 'translate-x-5' : 'translate-x-0.5'
           }`}
         />

--- a/clients/web/src/components/settings/mfa-factors-panel.tsx
+++ b/clients/web/src/components/settings/mfa-factors-panel.tsx
@@ -234,7 +234,7 @@ export function MfaFactorsPanel() {
       {totpQrUrl && (
         <form className="mt-6 space-y-3" onSubmit={confirmTotp}>
           <p className="text-sm text-slate-600">Scan the QR code, then enter the 6-digit code to confirm.</p>
-          <img src={totpQrUrl} alt="Authenticator QR" className="h-44 w-44 rounded-lg border border-slate-200" />
+          <img src={totpQrUrl} alt="Authenticator QR" className="lex-content-img h-44 w-44 rounded-lg" />
           <input
             inputMode="numeric"
             autoComplete="one-time-code"

--- a/clients/web/src/components/settings/notification-preferences-panel.tsx
+++ b/clients/web/src/components/settings/notification-preferences-panel.tsx
@@ -184,7 +184,7 @@ export function NotificationPreferencesPanel() {
                       }`}
                     >
                       <span
-                        className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow transition ${
+                        className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
                           row.emailEnabled ? 'translate-x-5' : 'translate-x-0'
                         }`}
                       />
@@ -207,7 +207,7 @@ export function NotificationPreferencesPanel() {
                       }`}
                     >
                       <span
-                        className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow transition ${
+                        className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
                           row.pushEnabled ? 'translate-x-5' : 'translate-x-0'
                         }`}
                       />
@@ -230,7 +230,7 @@ export function NotificationPreferencesPanel() {
                       }`}
                     >
                       <span
-                        className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow transition ${
+                        className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
                           row.smsEnabled ? 'translate-x-5' : 'translate-x-0'
                         }`}
                       />

--- a/clients/web/src/components/settings/org-role-grants-panel.tsx
+++ b/clients/web/src/components/settings/org-role-grants-panel.tsx
@@ -198,7 +198,7 @@ export function OrgRoleGrantsPanel() {
           <button
             type="submit"
             disabled={saving}
-            className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white"
+            className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white"
           >
             {saving ? 'Saving…' : 'Save grant'}
           </button>

--- a/clients/web/src/components/settings/org-units-panel.tsx
+++ b/clients/web/src/components/settings/org-units-panel.tsx
@@ -261,7 +261,7 @@ export function OrgUnitsPanel() {
               type="button"
               disabled={orgTypeSaving}
               onClick={() => void saveOrgType(t)}
-              className={`rounded-xl border px-4 py-2 text-sm font-medium transition disabled:opacity-50 ${
+              className={`rounded-xl border px-4 py-2 text-sm font-medium transition-[background-color,color,border-color] disabled:opacity-50 ${
                 orgType === t
                   ? 'border-indigo-600 bg-indigo-600 text-white'
                   : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800'
@@ -282,7 +282,7 @@ export function OrgUnitsPanel() {
           type="button"
           onClick={() => void loadTree()}
           disabled={loading || !orgId}
-          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
         >
           <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden />
           Refresh
@@ -362,7 +362,7 @@ export function OrgUnitsPanel() {
             <button
               type="submit"
               disabled={creatingRoot || !rootName.trim() || !orgId}
-              className="inline-flex shrink-0 items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex shrink-0 items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
               Create
             </button>

--- a/clients/web/src/components/settings/organizations-panel.tsx
+++ b/clients/web/src/components/settings/organizations-panel.tsx
@@ -126,7 +126,7 @@ export function OrganizationsPanel() {
           type="button"
           onClick={() => void load()}
           disabled={loading}
-          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
         >
           <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden />
           Refresh
@@ -171,7 +171,7 @@ export function OrganizationsPanel() {
           <button
             type="submit"
             disabled={creating || !newName.trim() || !!slugError}
-            className="inline-flex shrink-0 items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex shrink-0 items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Building2 className="h-4 w-4" aria-hidden />
             Create

--- a/clients/web/src/components/settings/platform-settings-panel.tsx
+++ b/clients/web/src/components/settings/platform-settings-panel.tsx
@@ -629,7 +629,7 @@ export function PlatformSettingsPanel() {
           <button
             type="submit"
             disabled={saving}
-            className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white"
+            className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white"
           >
             {saving ? 'Saving…' : 'Save changes'}
           </button>

--- a/clients/web/src/components/settings/roles-permissions-panel.tsx
+++ b/clients/web/src/components/settings/roles-permissions-panel.tsx
@@ -297,7 +297,7 @@ export function RolesPermissionsPanel() {
               value={newPermStr}
               onChange={(e) => setNewPermStr(e.target.value)}
               placeholder="course:*:enrollments:create"
-              className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 font-mono text-sm text-slate-950 shadow-sm outline-none ring-indigo-500/0 transition focus:border-indigo-300 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500"
+              className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 font-mono text-sm text-slate-950 shadow-sm outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-300 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500"
             />
           </div>
           <div className="min-w-0 flex-1">
@@ -309,13 +309,13 @@ export function RolesPermissionsPanel() {
               value={newPermDesc}
               onChange={(e) => setNewPermDesc(e.target.value)}
               placeholder="Create enrollments in any course"
-              className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-950 shadow-sm outline-none ring-indigo-500/0 transition focus:border-indigo-300 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500"
+              className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-950 shadow-sm outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-300 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500"
             />
           </div>
           <button
             type="submit"
             disabled={creating}
-            className="inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:bg-indigo-500"
+            className="inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:bg-indigo-500"
           >
             <Plus className="h-4 w-4" aria-hidden />
             Add permission
@@ -343,13 +343,13 @@ export function RolesPermissionsPanel() {
               value={newRoleName}
               onChange={(e) => setNewRoleName(e.target.value)}
               placeholder="e.g. Department admin"
-              className="w-full min-w-0 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-950 shadow-sm outline-none ring-indigo-500/0 transition focus:border-indigo-300 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500"
+              className="w-full min-w-0 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-950 shadow-sm outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-300 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500"
             />
           </div>
           <button
             type="submit"
             disabled={creating || !newRoleName.trim()}
-            className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:border-indigo-500/50 dark:hover:bg-indigo-950/50 dark:hover:text-indigo-200"
+            className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:border-indigo-500/50 dark:hover:bg-indigo-950/50 dark:hover:text-indigo-200"
           >
             <Plus className="h-4 w-4" aria-hidden />
             Add role
@@ -393,7 +393,7 @@ export function RolesPermissionsPanel() {
                   <button
                     type="button"
                     onClick={() => setRoleSettingsModal(role)}
-                    className="inline-flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-slate-800 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:border-indigo-500/50 dark:hover:bg-indigo-950/50 dark:hover:text-indigo-200"
+                    className="inline-flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:border-indigo-500/50 dark:hover:bg-indigo-950/50 dark:hover:text-indigo-200"
                   >
                     <Settings className="h-3.5 w-3.5" aria-hidden />
                     Settings
@@ -419,7 +419,7 @@ export function RolesPermissionsPanel() {
                         <button
                           type="button"
                           onClick={() => setManageUsersModal({ roleId: role.id, roleName: role.name })}
-                          className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-800 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:border-indigo-500/50 dark:hover:bg-indigo-950/50 dark:hover:text-indigo-200"
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:border-indigo-500/50 dark:hover:bg-indigo-950/50 dark:hover:text-indigo-200"
                         >
                           <Users className="h-3.5 w-3.5" aria-hidden />
                           Manage Users
@@ -428,7 +428,7 @@ export function RolesPermissionsPanel() {
                           type="button"
                           onClick={() => openAddModal(role.id)}
                           disabled={permissions.length === 0 || savingRolePerms}
-                          className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-800 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:border-indigo-500/50 dark:hover:bg-indigo-950/50 dark:hover:text-indigo-200"
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:border-indigo-500/50 dark:hover:bg-indigo-950/50 dark:hover:text-indigo-200"
                         >
                           <Plus className="h-3.5 w-3.5" aria-hidden />
                           Add
@@ -605,7 +605,7 @@ function RoleSettingsModal({ role, onClose, onSaved }: RoleSettingsModalProps) {
                 id="role-settings-name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-950 shadow-sm outline-none ring-indigo-500/0 transition focus:border-indigo-300 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500"
+                className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-950 shadow-sm outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-300 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500"
                 autoComplete="off"
                 disabled={saving}
               />
@@ -620,7 +620,7 @@ function RoleSettingsModal({ role, onClose, onSaved }: RoleSettingsModalProps) {
                 onChange={(e) => setDescription(e.target.value)}
                 rows={3}
                 placeholder="What this role is for (shown only in Settings)."
-                className="mt-1 w-full resize-y rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-950 shadow-sm outline-none ring-indigo-500/0 transition focus:border-indigo-300 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500"
+                className="mt-1 w-full resize-y rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-950 shadow-sm outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-300 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500"
                 disabled={saving}
               />
             </div>
@@ -638,7 +638,7 @@ function RoleSettingsModal({ role, onClose, onSaved }: RoleSettingsModalProps) {
                 aria-labelledby="role-settings-scope-label"
                 value={scope}
                 onChange={(e) => setScope(e.target.value as RoleScope)}
-                className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-950 shadow-sm outline-none ring-indigo-500/0 transition focus:border-indigo-300 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500"
+                className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-950 shadow-sm outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-300 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500"
                 disabled={saving}
               >
                 <option value="global">Global</option>
@@ -655,14 +655,14 @@ function RoleSettingsModal({ role, onClose, onSaved }: RoleSettingsModalProps) {
             <button
               type="button"
               onClick={onClose}
-              className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+              className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={saving || !name.trim()}
-              className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {saving ? 'Saving…' : 'Save'}
             </button>
@@ -795,7 +795,7 @@ function AddPermissionsModal({
             value={filter}
             onChange={(e) => onFilterChange(e.target.value)}
             placeholder="Filter by permission or description…"
-            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-950 shadow-sm outline-none ring-indigo-500/0 transition focus:border-indigo-300 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500"
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-950 shadow-sm outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-300 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500"
             autoFocus
           />
         </div>
@@ -836,7 +836,7 @@ function AddPermissionsModal({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+            className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
           >
             Cancel
           </button>
@@ -844,7 +844,7 @@ function AddPermissionsModal({
             type="button"
             disabled={saving || selectedIds.size === 0}
             onClick={onConfirm}
-            className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+            className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
           >
             {saving ? 'Saving…' : `Add${selectedIds.size > 0 ? ` (${selectedIds.size})` : ''}`}
           </button>
@@ -1104,7 +1104,7 @@ function ManageUsersModal({ roleId, roleName, onClose }: ManageUsersModalProps) 
                       type="button"
                       onClick={() => void handleAdd(u.id)}
                       disabled={busyId === u.id}
-                      className="shrink-0 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-1.5 text-xs font-semibold text-indigo-800 transition hover:bg-indigo-100 disabled:opacity-50 dark:border-indigo-500/40 dark:bg-indigo-950/50 dark:text-indigo-200 dark:hover:bg-indigo-900/60"
+                      className="shrink-0 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-1.5 text-xs font-semibold text-indigo-800 transition-[background-color,color,border-color] hover:bg-indigo-100 disabled:opacity-50 dark:border-indigo-500/40 dark:bg-indigo-950/50 dark:text-indigo-200 dark:hover:bg-indigo-900/60"
                     >
                       {busyId === u.id ? '…' : 'Add'}
                     </button>
@@ -1119,7 +1119,7 @@ function ManageUsersModal({ roleId, roleName, onClose }: ManageUsersModalProps) 
           <button
             type="button"
             onClick={onClose}
-            className="w-full rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 dark:bg-indigo-600 dark:hover:bg-indigo-500 sm:w-auto"
+            className="w-full rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-slate-800 dark:bg-indigo-600 dark:hover:bg-indigo-500 sm:w-auto"
           >
             Done
           </button>

--- a/clients/web/src/components/settings/scim-settings-panel.tsx
+++ b/clients/web/src/components/settings/scim-settings-panel.tsx
@@ -154,7 +154,7 @@ export function ScimSettingsPanel() {
           <button
             type="submit"
             disabled={!instOk}
-            className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white"
+            className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white"
           >
             Generate token
           </button>

--- a/clients/web/src/components/syllabus/syllabus-block-editor.tsx
+++ b/clients/web/src/components/syllabus/syllabus-block-editor.tsx
@@ -199,7 +199,7 @@ function SyllabusDocumentPanel({
             <button
               type="button"
               onClick={copyMarkdown}
-              className="min-w-0 flex-1 text-start text-[13px] text-slate-600 underline-offset-2 transition hover:text-indigo-600 hover:underline dark:text-neutral-300 dark:hover:text-indigo-400"
+              className="min-w-0 flex-1 text-start text-[13px] text-slate-600 underline-offset-2 transition-[background-color,color,border-color] hover:text-indigo-600 hover:underline dark:text-neutral-300 dark:hover:text-indigo-400"
             >
               Copy as Markdown
             </button>
@@ -219,7 +219,7 @@ function SyllabusDocumentPanel({
             <button
               type="button"
               onClick={copyHtml}
-              className="min-w-0 flex-1 text-start text-[13px] text-slate-600 underline-offset-2 transition hover:text-indigo-600 hover:underline dark:text-neutral-300 dark:hover:text-indigo-400"
+              className="min-w-0 flex-1 text-start text-[13px] text-slate-600 underline-offset-2 transition-[background-color,color,border-color] hover:text-indigo-600 hover:underline dark:text-neutral-300 dark:hover:text-indigo-400"
             >
               Copy as HTML
             </button>
@@ -241,7 +241,7 @@ function SyllabusDocumentPanel({
                 type="button"
                 onClick={pasteFromClipboard}
                 disabled={disabled}
-                className="min-w-0 flex-1 text-start text-[13px] text-slate-600 underline-offset-2 transition hover:text-indigo-600 hover:underline disabled:no-underline disabled:opacity-40 dark:text-neutral-300 dark:hover:text-indigo-400"
+                className="min-w-0 flex-1 text-start text-[13px] text-slate-600 underline-offset-2 transition-[background-color,color,border-color] hover:text-indigo-600 hover:underline disabled:no-underline disabled:opacity-40 dark:text-neutral-300 dark:hover:text-indigo-400"
               >
                 Paste from Clipboard
               </button>
@@ -383,7 +383,7 @@ function BlockInsertionRow({ onAdd, disabled }: { onAdd: () => void; disabled?: 
           type="button"
           disabled={disabled}
           onClick={onAdd}
-          className="relative z-10 flex h-9 w-9 items-center justify-center rounded-full border border-slate-300 bg-[#f0f0f0] text-slate-600 shadow-sm transition hover:border-slate-400 hover:bg-white hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:border-neutral-500 dark:hover:bg-neutral-700 dark:hover:text-neutral-50"
+          className="relative z-10 flex h-9 w-9 items-center justify-center rounded-full border border-slate-300 bg-[#f0f0f0] text-slate-600 shadow-sm transition-[background-color,color,border-color] hover:border-slate-400 hover:bg-white hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:border-neutral-500 dark:hover:bg-neutral-700 dark:hover:text-neutral-50"
           aria-label="Add section"
         >
           <Plus className="h-5 w-5" strokeWidth={2} aria-hidden />
@@ -393,7 +393,7 @@ function BlockInsertionRow({ onAdd, disabled }: { onAdd: () => void; disabled?: 
         type="button"
         disabled={disabled}
         onClick={onAdd}
-        className="mt-4 w-full border-0 bg-transparent py-1 text-start text-[13px] text-slate-400 transition hover:text-slate-600 disabled:cursor-not-allowed disabled:opacity-50 dark:text-neutral-500 dark:hover:text-neutral-300"
+        className="mt-4 w-full border-0 bg-transparent py-1 text-start text-[13px] text-slate-400 transition-[background-color,color,border-color] hover:text-slate-600 disabled:cursor-not-allowed disabled:opacity-50 dark:text-neutral-500 dark:hover:text-neutral-300"
       >
         Type / to add a section
       </button>

--- a/clients/web/src/components/timezone/timezone-selector.tsx
+++ b/clients/web/src/components/timezone/timezone-selector.tsx
@@ -11,7 +11,7 @@ type Props = {
 }
 
 const fieldClass =
-  'w-full rounded-lg border border-stone-300 bg-white px-2 py-1.5 text-sm text-stone-900 shadow-sm outline-none transition placeholder:text-stone-400 focus:border-teal-700 focus:ring-2 focus:ring-teal-700/15 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-teal-500 dark:focus:ring-teal-500/20'
+  'w-full rounded-lg border border-stone-300 bg-white px-2 py-1.5 text-sm text-stone-900 shadow-sm outline-none transition-[background-color,color,border-color] placeholder:text-stone-400 focus:border-teal-700 focus:ring-2 focus:ring-teal-700/15 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-teal-500 dark:focus:ring-teal-500/20'
 
 function formatTimezoneLabel(id: string): string {
   return id.replace(/_/g, ' ')

--- a/clients/web/src/components/tutor-panel.tsx
+++ b/clients/web/src/components/tutor-panel.tsx
@@ -30,7 +30,7 @@ function AiTutorTrigger({ open, onToggle }: { open: boolean; onToggle: () => voi
       aria-expanded={open}
       aria-haspopup="dialog"
       onClick={onToggle}
-      className={`relative inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 ${
+      className={`relative inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition-[background-color,color,border-color] focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 ${
         open
           ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
           : 'text-slate-600 hover:bg-slate-100 dark:text-neutral-300 dark:hover:bg-neutral-800'

--- a/clients/web/src/context/canvas-import-context.tsx
+++ b/clients/web/src/context/canvas-import-context.tsx
@@ -694,7 +694,7 @@ export function CanvasImportHeaderWidget() {
         aria-expanded={popoverOpen}
         aria-haspopup="dialog"
         onClick={togglePopover}
-        className={`relative inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 ${
+        className={`relative inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition-[background-color,color,border-color] focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 ${
           popoverOpen
             ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
             : 'text-slate-600 hover:bg-slate-100 dark:text-neutral-300 dark:hover:bg-neutral-800'

--- a/clients/web/src/hooks/use-exit-transition.ts
+++ b/clients/web/src/hooks/use-exit-transition.ts
@@ -7,7 +7,7 @@ type ExitTransitionResult = {
   onTransitionEnd: (e: TransitionEvent) => void
 }
 
-/** Gates unmount behind a CSS exit transition (plan 22.1, rule 6). */
+/** Gates unmount behind a CSS exit transition-colors (plan 22.1, rule 6). */
 export function useExitTransition(visible: boolean, property = 'opacity'): ExitTransitionResult {
   const [rendered, setRendered] = useState(visible)
   const [exiting, setExiting] = useState(false)

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -46,10 +46,12 @@
   }
 
   /* Plan 22.1 — text wrapping (rules 10): balance headings, pretty body copy. */
-  .lms-scope :is(h1, h2, h3) {
+  .lms-scope :is(h1, h2, h3),
+  .lex-auth-scene :is(h1, h2, h3) {
     text-wrap: balance;
   }
-  .lms-scope p {
+  .lms-scope :is(p, li, figcaption, blockquote),
+  .lex-auth-scene :is(p, li, figcaption, blockquote) {
     text-wrap: pretty;
   }
 
@@ -66,14 +68,20 @@
   }
 }
 
-/* Plan 22.1 — layered card elevation (rule 3). */
+/* Plan 22.1 — layered card elevation (rule 3): pure black/white rgba, never tinted neutrals. */
 :root {
-  --shadow-card: 0 1px 2px rgb(15 23 42 / 0.04), 0 4px 12px rgb(15 23 42 / 0.06);
-  --shadow-card-hover: 0 1px 2px rgb(15 23 42 / 0.06), 0 6px 16px rgb(15 23 42 / 0.08);
+  --shadow-card:
+    0 0 0 1px rgb(0 0 0 / 0.06),
+    0 1px 2px -1px rgb(0 0 0 / 0.06),
+    0 2px 4px 0 rgb(0 0 0 / 0.04);
+  --shadow-card-hover:
+    0 0 0 1px rgb(0 0 0 / 0.08),
+    0 1px 2px -1px rgb(0 0 0 / 0.08),
+    0 2px 4px 0 rgb(0 0 0 / 0.06);
 }
 .dark {
-  --shadow-card: 0 0 0 1px rgb(255 255 255 / 0.08), 0 2px 8px rgb(0 0 0 / 0.25);
-  --shadow-card-hover: 0 0 0 1px rgb(255 255 255 / 0.13), 0 4px 12px rgb(0 0 0 / 0.35);
+  --shadow-card: 0 0 0 1px rgb(255 255 255 / 0.08);
+  --shadow-card-hover: 0 0 0 1px rgb(255 255 255 / 0.13);
 }
 
 @utility shadow-card {
@@ -82,6 +90,19 @@
 
 @utility shadow-card-hover {
   box-shadow: var(--shadow-card-hover);
+}
+
+@utility lex-surface {
+  box-shadow: var(--shadow-card);
+  transition-property: box-shadow;
+  transition-duration: 150ms;
+  transition-timing-function: ease-out;
+}
+
+@utility hover-shadow-card {
+  &:hover {
+    box-shadow: var(--shadow-card-hover);
+  }
 }
 
 /* Plan 22.1 — content image outlines (rule 11): pure black/white, never tinted. */

--- a/clients/web/src/pages/explore-catalog-page.tsx
+++ b/clients/web/src/pages/explore-catalog-page.tsx
@@ -37,7 +37,7 @@ function priceParams(price: string): { priceMax?: number } {
 function CourseCard({ course }: { course: PublicCatalogCourse }) {
   const priceId = useId()
   return (
-    <article className="flex flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900">
+    <article className="flex flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-[box-shadow,background-color,color,border-color] hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900">
       {course.heroImageUrl ? (
         <img
           src={course.heroImageUrl}

--- a/clients/web/src/pages/lms/CourseAttendance.tsx
+++ b/clients/web/src/pages/lms/CourseAttendance.tsx
@@ -67,7 +67,7 @@ function CollectionMethodCard({
       role="radio"
       aria-checked={selected}
       onClick={onSelect}
-      className={`flex min-w-0 flex-1 flex-col rounded-xl border p-4 text-start transition ${
+      className={`flex min-w-0 flex-1 flex-col rounded-xl border p-4 text-start transition-[background-color,color,border-color] ${
         selected
           ? 'border-indigo-500 bg-indigo-50/80 ring-2 ring-indigo-500/30 dark:border-indigo-400 dark:bg-indigo-950/40'
           : 'border-slate-200 bg-white hover:border-slate-300 dark:border-neutral-700 dark:bg-neutral-900/40 dark:hover:border-neutral-600'
@@ -465,7 +465,7 @@ export default function CourseAttendance() {
                     <button
                       type="button"
                       onClick={() => setActiveSessionId(s.id)}
-                      className={`flex w-full items-center justify-between gap-3 px-4 py-3.5 text-start transition hover:bg-slate-50 dark:hover:bg-neutral-900/60 ${
+                      className={`flex w-full items-center justify-between gap-3 px-4 py-3.5 text-start transition-[background-color,color,border-color] hover:bg-slate-50 dark:hover:bg-neutral-900/60 ${
                         activeSessionId === s.id ? 'bg-indigo-50 dark:bg-indigo-950/30' : 'bg-white dark:bg-neutral-950'
                       }`}
                     >

--- a/clients/web/src/pages/lms/CourseEvaluation.tsx
+++ b/clients/web/src/pages/lms/CourseEvaluation.tsx
@@ -42,7 +42,7 @@ function RatingQuestion({
         {ratings.map((r) => (
           <label
             key={r}
-            className={`flex cursor-pointer items-center gap-1.5 rounded-lg border px-3 py-2 text-sm transition ${
+            className={`flex cursor-pointer items-center gap-1.5 rounded-lg border px-3 py-2 text-sm transition-[background-color,color,border-color] ${
               value === r
                 ? 'border-indigo-500 bg-indigo-50 font-semibold text-indigo-700 ring-2 ring-indigo-400/30 dark:border-indigo-400 dark:bg-indigo-950/40 dark:text-indigo-300'
                 : 'border-slate-200 bg-white text-slate-700 hover:border-slate-300 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300'
@@ -301,7 +301,7 @@ export default function CourseEvaluation() {
           <button
             type="submit"
             disabled={submitting}
-            className="w-full rounded-xl bg-indigo-600 px-6 py-3 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:opacity-60 dark:bg-indigo-500 dark:hover:bg-indigo-600"
+            className="w-full rounded-xl bg-indigo-600 px-6 py-3 text-sm font-semibold text-white transition-[background-color,color,border-color] hover:bg-indigo-700 disabled:opacity-60 dark:bg-indigo-500 dark:hover:bg-indigo-600"
           >
             {submitting ? 'Submitting…' : 'Submit Evaluation'}
           </button>

--- a/clients/web/src/pages/lms/CourseReportCards.tsx
+++ b/clients/web/src/pages/lms/CourseReportCards.tsx
@@ -18,13 +18,13 @@ const INPUT_CLASS =
   'rounded-lg border border-slate-200 bg-white px-2 py-1 text-sm text-slate-900 outline-none ring-indigo-500/20 focus:border-indigo-400 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100'
 
 const BTN_PRIMARY =
-  'inline-flex items-center rounded-lg bg-indigo-600 px-2 py-1 text-xs font-semibold text-white transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50'
+  'inline-flex items-center rounded-lg bg-indigo-600 px-2 py-1 text-xs font-semibold text-white transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50'
 
 const BTN_SECONDARY =
-  'inline-flex items-center rounded-lg border border-slate-200 bg-white px-2 py-1 text-xs font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800'
+  'inline-flex items-center rounded-lg border border-slate-200 bg-white px-2 py-1 text-xs font-medium text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800'
 
 const BTN_SUCCESS =
-  'inline-flex items-center rounded-lg bg-emerald-600 px-2 py-1 text-xs font-semibold text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50'
+  'inline-flex items-center rounded-lg bg-emerald-600 px-2 py-1 text-xs font-semibold text-white transition-[background-color,color,border-color] hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50'
 
 function studentLabel(s: RosterEntry): string {
   return s.displayName?.trim() || s.email
@@ -424,7 +424,7 @@ export default function CourseReportCards() {
                                   type="button"
                                   onClick={() => void handleAISuggest(student.userId, card.id)}
                                   disabled={!!isAILoading}
-                                  className="inline-flex items-center rounded-lg bg-violet-600 px-2 py-1 text-xs font-semibold text-white transition hover:bg-violet-500 disabled:cursor-not-allowed disabled:opacity-50"
+                                  className="inline-flex items-center rounded-lg bg-violet-600 px-2 py-1 text-xs font-semibold text-white transition-[background-color,color,border-color] hover:bg-violet-500 disabled:cursor-not-allowed disabled:opacity-50"
                                   aria-label="Get AI comment suggestion"
                                 >
                                   {isAILoading ? 'AI…' : 'AI Suggest'}
@@ -463,7 +463,7 @@ export default function CourseReportCards() {
                                     href={`/api/v1/report-cards/${card.id}/pdf`}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="inline-flex items-center rounded-lg bg-slate-600 px-2 py-1 text-xs font-semibold text-white transition hover:bg-slate-500 dark:bg-neutral-700 dark:hover:bg-neutral-600"
+                                    className="inline-flex items-center rounded-lg bg-slate-600 px-2 py-1 text-xs font-semibold text-white transition-[background-color,color,border-color] hover:bg-slate-500 dark:bg-neutral-700 dark:hover:bg-neutral-600"
                                   >
                                     PDF
                                   </a>
@@ -497,7 +497,7 @@ export default function CourseReportCards() {
               type="button"
               onClick={() => void handleRelease()}
               disabled={releasing}
-              className="inline-flex items-center rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {releasing ? 'Releasing…' : `Release ${approvedCount} Approved Card(s) to Parents`}
             </button>

--- a/clients/web/src/pages/lms/add-course-item-menu.tsx
+++ b/clients/web/src/pages/lms/add-course-item-menu.tsx
@@ -46,12 +46,12 @@ export function AddCourseItemMenu({
           if (disabled) return
           setOpen((o) => !o)
         }}
-        className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-2 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto sm:justify-start sm:px-3 sm:py-2"
+        className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-2 py-1.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto sm:justify-start sm:px-3 sm:py-2"
       >
         <Plus className="h-4 w-4 shrink-0" aria-hidden />
         <span>Actions</span>
         <ChevronDown
-          className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`}
+          className={`h-4 w-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
           aria-hidden
         />
       </button>
@@ -70,7 +70,7 @@ export function AddCourseItemMenu({
               onAdd()
               setOpen(false)
             }}
-            className="flex w-full flex-col gap-0.5 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:hover:bg-neutral-700"
+            className="flex w-full flex-col gap-0.5 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:hover:bg-neutral-700"
           >
             <span className="font-semibold text-slate-950 dark:text-neutral-100">Add Module</span>
             <span className="text-xs text-slate-500 dark:text-neutral-400">Group course activities and items</span>
@@ -86,7 +86,7 @@ export function AddCourseItemMenu({
                   onCollapseExpandAllModules()
                   setOpen(false)
                 }}
-                className="flex w-full flex-col gap-0.5 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:bg-neutral-700"
+                className="flex w-full flex-col gap-0.5 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:bg-neutral-700"
               >
                 <span className="font-semibold text-slate-950 dark:text-neutral-100">
                   {allModulesCollapsed ? 'Expand all modules' : 'Collapse all modules'}
@@ -105,7 +105,7 @@ export function AddCourseItemMenu({
             role="menuitemcheckbox"
             aria-checked={dragHandlesVisible}
             onClick={onToggleDragHandles}
-            className="flex w-full items-start gap-2 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:hover:bg-neutral-700"
+            className="flex w-full items-start gap-2 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:hover:bg-neutral-700"
           >
             <span
               className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border ${

--- a/clients/web/src/pages/lms/add-module-item-menu.tsx
+++ b/clients/web/src/pages/lms/add-module-item-menu.tsx
@@ -84,13 +84,13 @@ export function AddModuleItemMenu({
           if (disabled) return
           setOpen((o) => !o)
         }}
-        className="inline-flex max-w-full items-center gap-1.5 rounded-lg border border-slate-200/70 bg-white/90 px-2 py-1.5 text-xs font-medium text-slate-700 shadow-none transition hover:border-slate-300/80 hover:bg-slate-50/90 disabled:cursor-not-allowed disabled:opacity-60 sm:px-2.5 sm:text-sm dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-neutral-500 dark:hover:bg-neutral-800"
+        className="inline-flex max-w-full items-center gap-1.5 rounded-lg border border-slate-200/70 bg-white/90 px-2 py-1.5 text-xs font-medium text-slate-700 shadow-none transition-[background-color,color,border-color] hover:border-slate-300/80 hover:bg-slate-50/90 disabled:cursor-not-allowed disabled:opacity-60 sm:px-2.5 sm:text-sm dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-neutral-500 dark:hover:bg-neutral-800"
       >
         <Plus className="h-4 w-4 shrink-0" aria-hidden />
         <span className="truncate sm:hidden">Add item</span>
         <span className="hidden truncate sm:inline">Add module item</span>
         <ChevronDown
-          className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`}
+          className={`h-4 w-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
           aria-hidden
         />
       </button>
@@ -106,7 +106,7 @@ export function AddModuleItemMenu({
             type="button"
             role="menuitem"
             onClick={() => pick('heading')}
-            className="flex w-full items-start gap-3 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:hover:bg-neutral-700"
+            className="flex w-full items-start gap-3 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:hover:bg-neutral-700"
           >
             <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-400">
               <Heading className="h-4 w-4" aria-hidden />
@@ -120,7 +120,7 @@ export function AddModuleItemMenu({
             type="button"
             role="menuitem"
             onClick={() => pick('content_page')}
-            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
           >
             <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-indigo-200/80 bg-indigo-50 text-indigo-600 dark:border-indigo-500/35 dark:bg-indigo-950 dark:text-indigo-300">
               <FileText className="h-4 w-4" aria-hidden />
@@ -134,7 +134,7 @@ export function AddModuleItemMenu({
             type="button"
             role="menuitem"
             onClick={() => pick('assignment')}
-            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
           >
             <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-amber-200/90 bg-amber-50 text-amber-800 dark:border-amber-500/40 dark:bg-amber-950 dark:text-amber-200">
               <ClipboardList className="h-4 w-4" aria-hidden />
@@ -148,7 +148,7 @@ export function AddModuleItemMenu({
             type="button"
             role="menuitem"
             onClick={() => pick('quiz')}
-            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
           >
             <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-emerald-200/90 bg-emerald-50 text-emerald-700 dark:border-emerald-500/35 dark:bg-emerald-950 dark:text-emerald-200">
               <CircleHelp className="h-4 w-4" aria-hidden />
@@ -168,7 +168,7 @@ export function AddModuleItemMenu({
                 onFindOpenResources()
                 setOpen(false)
               }}
-              className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+              className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
             >
               <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-teal-200/90 bg-teal-50 text-teal-700 dark:border-teal-500/40 dark:bg-teal-950 dark:text-teal-200">
                 <BookOpen className="h-4 w-4" aria-hidden />
@@ -185,7 +185,7 @@ export function AddModuleItemMenu({
             type="button"
             role="menuitem"
             onClick={() => pick('external_link')}
-            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
           >
             <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-violet-200/90 bg-violet-50 text-violet-700 dark:border-violet-500/40 dark:bg-violet-950 dark:text-violet-200">
               <ExternalLink className="h-4 w-4" aria-hidden />
@@ -202,7 +202,7 @@ export function AddModuleItemMenu({
               type="button"
               role="menuitem"
               onClick={() => pick('h5p')}
-              className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+              className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
             >
               <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-teal-200/90 bg-teal-50 text-teal-800 dark:border-teal-500/40 dark:bg-teal-950 dark:text-teal-200">
                 <Puzzle className="h-4 w-4" aria-hidden />
@@ -220,7 +220,7 @@ export function AddModuleItemMenu({
               type="button"
               role="menuitem"
               onClick={() => pick('scorm')}
-              className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+              className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
             >
               <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-violet-200/90 bg-violet-50 text-violet-800 dark:border-violet-500/40 dark:bg-violet-950 dark:text-violet-200">
                 <BookCopy className="h-4 w-4" aria-hidden />
@@ -237,7 +237,7 @@ export function AddModuleItemMenu({
             type="button"
             role="menuitem"
             onClick={() => pick('vibe_activity')}
-            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
           >
             <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-rose-200/90 bg-rose-50 text-rose-700 dark:border-rose-500/40 dark:bg-rose-950 dark:text-rose-200">
               <Sparkles className="h-4 w-4" aria-hidden />
@@ -254,7 +254,7 @@ export function AddModuleItemMenu({
               type="button"
               role="menuitem"
               onClick={() => pick('library_resource')}
-              className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+              className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
             >
               <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-cyan-200/90 bg-cyan-50 text-cyan-700 dark:border-cyan-500/40 dark:bg-cyan-950 dark:text-cyan-200">
                 <BookMarked className="h-4 w-4" aria-hidden />
@@ -272,7 +272,7 @@ export function AddModuleItemMenu({
               type="button"
               role="menuitem"
               onClick={() => pick('textbook_resource')}
-              className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+              className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
             >
               <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-orange-200/90 bg-orange-50 text-orange-700 dark:border-orange-500/40 dark:bg-orange-950 dark:text-orange-200">
                 <BookCopy className="h-4 w-4" aria-hidden />
@@ -293,7 +293,7 @@ export function AddModuleItemMenu({
               if (!ltiToolsAvailable) return
               pick('lti_link')
             }}
-            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:hover:bg-neutral-700"
+            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:hover:bg-neutral-700"
           >
             <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-purple-200/90 bg-purple-50 text-purple-800 dark:border-purple-500/40 dark:bg-purple-950 dark:text-purple-200">
               <Plug className="h-4 w-4" aria-hidden />

--- a/clients/web/src/pages/lms/admin/org-branding.tsx
+++ b/clients/web/src/pages/lms/admin/org-branding.tsx
@@ -320,7 +320,7 @@ export default function OrgBranding() {
             <button
               type="submit"
               disabled={saving}
-              className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+              className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-indigo-500 dark:hover:bg-indigo-400"
             >
               {saving ? (
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />

--- a/clients/web/src/pages/lms/ask-ai-page.tsx
+++ b/clients/web/src/pages/lms/ask-ai-page.tsx
@@ -228,7 +228,7 @@ export default function AskAiPage() {
                       ? 'e.g. What themes did I write about across my courses?'
                       : 'Save notes in your global or a course notebook first — then you can ask here.'
                   }
-                  className="w-full resize-y rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none ring-indigo-500/0 transition focus:border-indigo-300 focus:ring-4 focus:ring-indigo-500/15 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500/50 dark:disabled:bg-neutral-900 dark:disabled:text-neutral-500"
+                  className="w-full resize-y rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-300 focus:ring-4 focus:ring-indigo-500/15 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500/50 dark:disabled:bg-neutral-900 dark:disabled:text-neutral-500"
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                       e.preventDefault()
@@ -241,7 +241,7 @@ export default function AskAiPage() {
                     type="button"
                     onClick={() => void submitAsk()}
                     disabled={!hasNotes || askLoading || !askText.trim()}
-                    className="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 disabled:pointer-events-none disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+                    className="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-700 disabled:pointer-events-none disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
                   >
                     {askLoading ? 'Thinking…' : 'Ask'}
                   </button>

--- a/clients/web/src/pages/lms/calendar-actions-menu.tsx
+++ b/clients/web/src/pages/lms/calendar-actions-menu.tsx
@@ -67,11 +67,11 @@ export function CalendarActionsMenu(props: Props) {
         aria-expanded={open}
         aria-controls={open ? menuId : undefined}
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800 sm:w-auto"
+        className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800 sm:w-auto"
       >
         <span>Actions</span>
         <ChevronDown
-          className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`}
+          className={`h-4 w-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
           aria-hidden
         />
       </button>
@@ -88,7 +88,7 @@ export function CalendarActionsMenu(props: Props) {
             role="menuitem"
             disabled={downloading}
             onClick={() => void handleDownloadFeed()}
-            className="flex w-full items-start gap-2.5 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:bg-neutral-700"
+            className="flex w-full items-start gap-2.5 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:bg-neutral-700"
           >
             <Download className="mt-0.5 h-4 w-4 shrink-0 text-slate-500 dark:text-neutral-400" aria-hidden />
             <span className="flex min-w-0 flex-col gap-0.5">

--- a/clients/web/src/pages/lms/calendar.tsx
+++ b/clients/web/src/pages/lms/calendar.tsx
@@ -270,14 +270,14 @@ export default function Calendar() {
                 <button
                   type="button"
                   onClick={showAllCourses}
-                  className="rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-semibold text-slate-700 transition hover:bg-white dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+                  className="rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-semibold text-slate-700 transition-[background-color,color,border-color] hover:bg-white dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
                 >
                   Show all
                 </button>
                 <button
                   type="button"
                   onClick={hideAllCourses}
-                  className="rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-semibold text-slate-700 transition hover:bg-white dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+                  className="rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-semibold text-slate-700 transition-[background-color,color,border-color] hover:bg-white dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
                 >
                   Hide all
                 </button>
@@ -289,7 +289,7 @@ export default function Calendar() {
                   const err = structureErrors[c.id]
                   return (
                     <li key={c.id}>
-                      <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-transparent px-2 py-2 transition hover:border-slate-200 hover:bg-slate-50/80 dark:hover:border-neutral-600 dark:hover:bg-neutral-800/60">
+                      <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-transparent px-2 py-2 transition-[background-color,color,border-color] hover:border-slate-200 hover:bg-slate-50/80 dark:hover:border-neutral-600 dark:hover:bg-neutral-800/60">
                         <input
                           type="checkbox"
                           className="mt-1 h-4 w-4 shrink-0 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-neutral-600 dark:bg-neutral-900 dark:text-indigo-500 dark:focus:ring-indigo-400"

--- a/clients/web/src/pages/lms/course-archived-content-section.tsx
+++ b/clients/web/src/pages/lms/course-archived-content-section.tsx
@@ -174,7 +174,7 @@ export function CourseArchivedContentSection({ courseCode }: { courseCode: strin
             type="button"
             onClick={() => setFactoryResetConfirmOpen(true)}
             disabled={archiveCourseBusy || factoryResetBusy}
-            className="rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm font-semibold text-amber-900 shadow-sm transition hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-900/50 dark:bg-neutral-900/40 dark:text-amber-200 dark:hover:bg-amber-950/30"
+            className="rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm font-semibold text-amber-900 shadow-sm transition-[background-color,color,border-color] hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-900/50 dark:bg-neutral-900/40 dark:text-amber-200 dark:hover:bg-amber-950/30"
           >
             Factory Reset Course
           </button>
@@ -182,7 +182,7 @@ export function CourseArchivedContentSection({ courseCode }: { courseCode: strin
             type="button"
             onClick={() => setDeleteCourseConfirmOpen(true)}
             disabled={archiveCourseBusy || factoryResetBusy}
-            className="rounded-xl border border-rose-200 bg-white px-4 py-2.5 text-sm font-semibold text-rose-700 shadow-sm transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-rose-900/60 dark:bg-neutral-900/40 dark:text-rose-300 dark:hover:bg-rose-950/40"
+            className="rounded-xl border border-rose-200 bg-white px-4 py-2.5 text-sm font-semibold text-rose-700 shadow-sm transition-[background-color,color,border-color] hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-rose-900/60 dark:bg-neutral-900/40 dark:text-rose-300 dark:hover:bg-rose-950/40"
           >
             Delete Course
           </button>
@@ -232,7 +232,7 @@ export function CourseArchivedContentSection({ courseCode }: { courseCode: strin
                       type="button"
                       onClick={() => void onUnarchive(row)}
                       disabled={busyId === row.id}
-                      className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700"
+                      className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700"
                     >
                       {busyId === row.id ? 'Restoring…' : 'Unarchive'}
                     </button>

--- a/clients/web/src/pages/lms/course-at-risk.tsx
+++ b/clients/web/src/pages/lms/course-at-risk.tsx
@@ -248,7 +248,7 @@ function AtRiskEmptyState({
       <button
         type="button"
         onClick={onRunReport}
-        className="mt-6 inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+        className="mt-6 inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500"
       >
         <RefreshCw className="h-4 w-4" aria-hidden />
         {atRiskI18n.emptyRunReportCta}
@@ -357,7 +357,7 @@ export default function CourseAtRiskPage() {
           onClick={() => setConfigOpen(true)}
           disabled={loading || reportRunning}
           aria-label={atRiskI18n.runScoring}
-          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50/60 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
+          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50/60 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
         >
           <RefreshCw className="h-4 w-4" aria-hidden />
           {atRiskI18n.runScoring}

--- a/clients/web/src/pages/lms/course-blueprint-settings.tsx
+++ b/clients/web/src/pages/lms/course-blueprint-settings.tsx
@@ -195,7 +195,7 @@ export function CourseBlueprintSection({ courseCode, course, onCourseUpdated }: 
             }`}
           >
             <span
-              className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+              className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition-transform duration-200 ease-in-out ${
                 isBlueprintDraft ? 'translate-x-5' : 'translate-x-0'
               }`}
             />

--- a/clients/web/src/pages/lms/course-calendar.tsx
+++ b/clients/web/src/pages/lms/course-calendar.tsx
@@ -96,23 +96,23 @@ type CalendarAssignmentHoverOpen = {
 }
 
 const MONTH_CHIP_PALETTE = [
-  'block w-full truncate rounded-md bg-indigo-50/90 px-1 py-0.5 text-start text-[11px] font-semibold leading-tight text-indigo-900 transition hover:bg-indigo-100 hover:ring-1 hover:ring-indigo-200/80 dark:bg-indigo-950/50 dark:text-indigo-100 dark:hover:bg-indigo-900/60 dark:hover:ring-indigo-500/40',
-  'block w-full truncate rounded-md bg-violet-50/90 px-1 py-0.5 text-start text-[11px] font-semibold leading-tight text-violet-900 transition hover:bg-violet-100 hover:ring-1 hover:ring-violet-200/80 dark:bg-violet-950/50 dark:text-violet-100 dark:hover:bg-violet-900/60 dark:hover:ring-violet-500/40',
-  'block w-full truncate rounded-md bg-emerald-50/90 px-1 py-0.5 text-start text-[11px] font-semibold leading-tight text-emerald-900 transition hover:bg-emerald-100 hover:ring-1 hover:ring-emerald-200/80 dark:bg-emerald-950/50 dark:text-emerald-100 dark:hover:bg-emerald-900/60 dark:hover:ring-emerald-500/40',
-  'block w-full truncate rounded-md bg-amber-50/90 px-1 py-0.5 text-start text-[11px] font-semibold leading-tight text-amber-950 transition hover:bg-amber-100 hover:ring-1 hover:ring-amber-200/80 dark:bg-amber-950/50 dark:text-amber-100 dark:hover:bg-amber-900/60 dark:hover:ring-amber-500/40',
-  'block w-full truncate rounded-md bg-rose-50/90 px-1 py-0.5 text-start text-[11px] font-semibold leading-tight text-rose-900 transition hover:bg-rose-100 hover:ring-1 hover:ring-rose-200/80 dark:bg-rose-950/50 dark:text-rose-100 dark:hover:bg-rose-900/60 dark:hover:ring-rose-500/40',
-  'block w-full truncate rounded-md bg-sky-50/90 px-1 py-0.5 text-start text-[11px] font-semibold leading-tight text-sky-900 transition hover:bg-sky-100 hover:ring-1 hover:ring-sky-200/80 dark:bg-sky-950/50 dark:text-sky-100 dark:hover:bg-sky-900/60 dark:hover:ring-sky-500/40',
-  'block w-full truncate rounded-md bg-fuchsia-50/90 px-1 py-0.5 text-start text-[11px] font-semibold leading-tight text-fuchsia-900 transition hover:bg-fuchsia-100 hover:ring-1 hover:ring-fuchsia-200/80 dark:bg-fuchsia-950/50 dark:text-fuchsia-100 dark:hover:bg-fuchsia-900/60 dark:hover:ring-fuchsia-500/40',
+  'block w-full truncate rounded-md bg-indigo-50/90 px-1 py-0.5 text-start text-[11px] font-semibold leading-tight text-indigo-900 transition-[background-color,color,border-color] hover:bg-indigo-100 hover:ring-1 hover:ring-indigo-200/80 dark:bg-indigo-950/50 dark:text-indigo-100 dark:hover:bg-indigo-900/60 dark:hover:ring-indigo-500/40',
+  'block w-full truncate rounded-md bg-violet-50/90 px-1 py-0.5 text-start text-[11px] font-semibold leading-tight text-violet-900 transition-[background-color,color,border-color] hover:bg-violet-100 hover:ring-1 hover:ring-violet-200/80 dark:bg-violet-950/50 dark:text-violet-100 dark:hover:bg-violet-900/60 dark:hover:ring-violet-500/40',
+  'block w-full truncate rounded-md bg-emerald-50/90 px-1 py-0.5 text-start text-[11px] font-semibold leading-tight text-emerald-900 transition-[background-color,color,border-color] hover:bg-emerald-100 hover:ring-1 hover:ring-emerald-200/80 dark:bg-emerald-950/50 dark:text-emerald-100 dark:hover:bg-emerald-900/60 dark:hover:ring-emerald-500/40',
+  'block w-full truncate rounded-md bg-amber-50/90 px-1 py-0.5 text-start text-[11px] font-semibold leading-tight text-amber-950 transition-[background-color,color,border-color] hover:bg-amber-100 hover:ring-1 hover:ring-amber-200/80 dark:bg-amber-950/50 dark:text-amber-100 dark:hover:bg-amber-900/60 dark:hover:ring-amber-500/40',
+  'block w-full truncate rounded-md bg-rose-50/90 px-1 py-0.5 text-start text-[11px] font-semibold leading-tight text-rose-900 transition-[background-color,color,border-color] hover:bg-rose-100 hover:ring-1 hover:ring-rose-200/80 dark:bg-rose-950/50 dark:text-rose-100 dark:hover:bg-rose-900/60 dark:hover:ring-rose-500/40',
+  'block w-full truncate rounded-md bg-sky-50/90 px-1 py-0.5 text-start text-[11px] font-semibold leading-tight text-sky-900 transition-[background-color,color,border-color] hover:bg-sky-100 hover:ring-1 hover:ring-sky-200/80 dark:bg-sky-950/50 dark:text-sky-100 dark:hover:bg-sky-900/60 dark:hover:ring-sky-500/40',
+  'block w-full truncate rounded-md bg-fuchsia-50/90 px-1 py-0.5 text-start text-[11px] font-semibold leading-tight text-fuchsia-900 transition-[background-color,color,border-color] hover:bg-fuchsia-100 hover:ring-1 hover:ring-fuchsia-200/80 dark:bg-fuchsia-950/50 dark:text-fuchsia-100 dark:hover:bg-fuchsia-900/60 dark:hover:ring-fuchsia-500/40',
 ] as const
 
 const WEEK_CARD_PALETTE = [
-  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-indigo-500/50 dark:hover:bg-indigo-950/40',
-  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-violet-200 hover:bg-violet-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-violet-500/50 dark:hover:bg-violet-950/40',
-  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-emerald-200 hover:bg-emerald-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-emerald-500/50 dark:hover:bg-emerald-950/40',
-  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-amber-200 hover:bg-amber-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-amber-500/50 dark:hover:bg-amber-950/40',
-  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-rose-200 hover:bg-rose-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-rose-500/50 dark:hover:bg-rose-950/40',
-  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-sky-200 hover:bg-sky-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-sky-500/50 dark:hover:bg-sky-950/40',
-  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition hover:border-fuchsia-200 hover:bg-fuchsia-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-fuchsia-500/50 dark:hover:bg-fuchsia-950/40',
+  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-indigo-500/50 dark:hover:bg-indigo-950/40',
+  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition-[background-color,color,border-color] hover:border-violet-200 hover:bg-violet-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-violet-500/50 dark:hover:bg-violet-950/40',
+  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition-[background-color,color,border-color] hover:border-emerald-200 hover:bg-emerald-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-emerald-500/50 dark:hover:bg-emerald-950/40',
+  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition-[background-color,color,border-color] hover:border-amber-200 hover:bg-amber-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-amber-500/50 dark:hover:bg-amber-950/40',
+  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition-[background-color,color,border-color] hover:border-rose-200 hover:bg-rose-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-rose-500/50 dark:hover:bg-rose-950/40',
+  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition-[background-color,color,border-color] hover:border-sky-200 hover:bg-sky-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-sky-500/50 dark:hover:bg-sky-950/40',
+  'group flex flex-col gap-0.5 rounded-xl border border-slate-200/90 bg-white px-4 py-3 shadow-sm transition-[background-color,color,border-color] hover:border-fuchsia-200 hover:bg-fuchsia-50/40 dark:border-neutral-600 dark:bg-neutral-800/80 dark:hover:border-fuchsia-500/50 dark:hover:bg-fuchsia-950/40',
 ] as const
 
 function monthChipClassForAssignment(a: CourseCalendarAssignment, canDrag: boolean): string {
@@ -541,7 +541,7 @@ export function CourseCalendar({
             <div className="flex shrink-0 items-center gap-1">
               <button
                 type="button"
-                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
                 aria-label="Previous month"
                 onClick={() => setMonthAnchor((m) => addMonths(m, -1))}
               >
@@ -549,7 +549,7 @@ export function CourseCalendar({
               </button>
               <button
                 type="button"
-                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
                 aria-label="Next month"
                 onClick={() => setMonthAnchor((m) => addMonths(m, 1))}
               >
@@ -636,7 +636,7 @@ export function CourseCalendar({
             <div className="flex shrink-0 items-center gap-1">
               <button
                 type="button"
-                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
                 aria-label="Previous week"
                 onClick={() => {
                   const n = new Date(weekCursor)
@@ -648,7 +648,7 @@ export function CourseCalendar({
               </button>
               <button
                 type="button"
-                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
                 aria-label="Next week"
                 onClick={() => {
                   const n = new Date(weekCursor)
@@ -710,7 +710,7 @@ function ViewTab({ active, onClick, icon, label }: ViewTabProps) {
       role="tab"
       aria-selected={active}
       onClick={onClick}
-      className={`inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition ${
+      className={`inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-[background-color,color,border-color] ${
         active
           ? 'bg-white text-indigo-800 shadow-sm ring-1 ring-slate-200/90 dark:bg-neutral-900 dark:text-indigo-300 dark:ring-neutral-600'
           : 'text-slate-600 hover:bg-white/70 hover:text-slate-950 dark:text-neutral-400 dark:hover:bg-neutral-700 dark:hover:text-neutral-100'

--- a/clients/web/src/pages/lms/course-caption-policy-section.tsx
+++ b/clients/web/src/pages/lms/course-caption-policy-section.tsx
@@ -50,7 +50,7 @@ export function CourseCaptionPolicySection({ courseCode, course, onCourseUpdated
           }`}
         >
           <span
-            className={`inline-block h-6 w-6 transform rounded-full bg-white shadow transition ${
+            className={`inline-block h-6 w-6 transform rounded-full bg-white shadow transition-transform ${
               enabled ? 'translate-x-5' : 'translate-x-0.5'
             }`}
           />

--- a/clients/web/src/pages/lms/course-catalog-import-from-course-modal.tsx
+++ b/clients/web/src/pages/lms/course-catalog-import-from-course-modal.tsx
@@ -289,7 +289,7 @@ function CourseCatalogImportFromCourseModalInner({
               type="button"
               onClick={() => void onSubmit()}
               disabled={!sourceCourseCode.trim() || !newTitle.trim()}
-              className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <Copy className="h-4 w-4 shrink-0" aria-hidden />
               Create course

--- a/clients/web/src/pages/lms/course-catalog-import-menu.tsx
+++ b/clients/web/src/pages/lms/course-catalog-import-menu.tsx
@@ -28,12 +28,12 @@ export function CourseCatalogImportMenu({ onImportCanvas, onImportFromCourse }: 
         aria-expanded={open}
         aria-controls={open ? menuId : undefined}
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800 sm:w-auto"
+        className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800 sm:w-auto"
       >
         <Download className="h-4 w-4 shrink-0" aria-hidden />
         <span>Import</span>
         <ChevronDown
-          className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`}
+          className={`h-4 w-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
           aria-hidden
         />
       </button>
@@ -52,7 +52,7 @@ export function CourseCatalogImportMenu({ onImportCanvas, onImportFromCourse }: 
               onImportFromCourse()
               setOpen(false)
             }}
-            className="flex w-full flex-col gap-0.5 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:hover:bg-neutral-700"
+            className="flex w-full flex-col gap-0.5 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:hover:bg-neutral-700"
           >
             <span className="font-semibold text-slate-950 dark:text-neutral-100">From another course</span>
             <span className="text-xs text-slate-500 dark:text-neutral-400">
@@ -66,7 +66,7 @@ export function CourseCatalogImportMenu({ onImportCanvas, onImportFromCourse }: 
               onImportCanvas()
               setOpen(false)
             }}
-            className="flex w-full flex-col gap-0.5 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:hover:bg-neutral-700"
+            className="flex w-full flex-col gap-0.5 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:hover:bg-neutral-700"
           >
             <span className="font-semibold text-slate-950 dark:text-neutral-100">Canvas LMS</span>
             <span className="text-xs text-slate-500 dark:text-neutral-400">

--- a/clients/web/src/pages/lms/course-catalog-kanban.tsx
+++ b/clients/web/src/pages/lms/course-catalog-kanban.tsx
@@ -183,7 +183,7 @@ function KanbanColumnDropZone({
     <div
       ref={setNodeRef}
       className={[
-        'flex min-h-[6rem] flex-col gap-2 rounded-lg transition',
+        'flex min-h-[6rem] flex-col gap-2 rounded-lg transition-colors',
         isOver ? 'bg-indigo-50/80 ring-1 ring-indigo-300/60 dark:bg-indigo-950/20 dark:ring-indigo-500/30' : '',
       ]
         .filter(Boolean)
@@ -230,7 +230,7 @@ function KanbanColumn({
         <button
           type="button"
           onClick={onToggleCollapsed}
-          className="flex h-full min-h-[12rem] flex-col items-center justify-start gap-3 rounded-xl border border-slate-200 bg-slate-100/90 px-1.5 py-3 text-slate-600 transition hover:border-slate-300 hover:bg-slate-100 dark:border-neutral-700 dark:bg-neutral-800/90 dark:text-neutral-300 dark:hover:border-neutral-600 dark:hover:bg-neutral-800"
+          className="flex h-full min-h-[12rem] flex-col items-center justify-start gap-3 rounded-xl border border-slate-200 bg-slate-100/90 px-1.5 py-3 text-slate-600 transition-[background-color,color,border-color] hover:border-slate-300 hover:bg-slate-100 dark:border-neutral-700 dark:bg-neutral-800/90 dark:text-neutral-300 dark:hover:border-neutral-600 dark:hover:bg-neutral-800"
           aria-label={`Expand ${title} column (${courses.length} courses). ${hint}`}
           title={`${title} (${courses.length})`}
         >
@@ -299,7 +299,7 @@ function KanbanColumn({
             <button
               type="button"
               onClick={onToggleCollapsed}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-slate-500 transition hover:bg-slate-200/80 hover:text-slate-800 dark:text-neutral-400 dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-slate-500 transition-[background-color,color,border-color] hover:bg-slate-200/80 hover:text-slate-800 dark:text-neutral-400 dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
               aria-label={`Collapse ${title} column`}
               title={`Collapse ${title}`}
             >

--- a/clients/web/src/pages/lms/course-catalog-nickname-editor.tsx
+++ b/clients/web/src/pages/lms/course-catalog-nickname-editor.tsx
@@ -72,7 +72,7 @@ export function CourseCatalogNicknameEditor({
         setError(null)
         setOpen(true)
       }}
-      className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 dark:text-neutral-500 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+      className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-slate-400 transition-[background-color,color,border-color] hover:bg-slate-100 hover:text-slate-700 dark:text-neutral-500 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
       aria-label={`Edit nickname for ${course.title}`}
       title="Edit nickname"
     >

--- a/clients/web/src/pages/lms/course-catalog-pin-button.tsx
+++ b/clients/web/src/pages/lms/course-catalog-pin-button.tsx
@@ -42,7 +42,7 @@ export function CourseCatalogPinButton({
       aria-pressed={pinned}
       title={pinned ? 'Unpin from sidebar' : 'Pin to sidebar'}
       className={[
-        'inline-flex h-8 w-8 items-center justify-center rounded-full transition focus:outline-none disabled:opacity-60',
+        'inline-flex h-8 w-8 items-center justify-center rounded-full transition-colors focus:outline-none disabled:opacity-60',
         variant === 'overlay'
           ? [
               'backdrop-blur-sm focus-visible:ring-2 focus-visible:ring-white/80',

--- a/clients/web/src/pages/lms/course-catalog-view-menu.tsx
+++ b/clients/web/src/pages/lms/course-catalog-view-menu.tsx
@@ -66,12 +66,12 @@ export function CourseCatalogViewMenu({ value, onChange }: Props) {
         aria-controls={open ? menuId : undefined}
         aria-label={`View courses as ${activeOption.label}. Open menu to change catalog layout.`}
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800 sm:w-auto"
+        className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800 sm:w-auto"
       >
         <ActiveIcon className="h-4 w-4 shrink-0" aria-hidden />
         <span>View</span>
         <ChevronDown
-          className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`}
+          className={`h-4 w-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
           aria-hidden
         />
       </button>
@@ -96,7 +96,7 @@ export function CourseCatalogViewMenu({ value, onChange }: Props) {
                   setOpen(false)
                 }}
                 className={[
-                  'flex w-full items-start gap-2.5 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:hover:bg-neutral-700',
+                  'flex w-full items-start gap-2.5 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:hover:bg-neutral-700',
                   value === option.id ? 'bg-indigo-50 dark:bg-neutral-800' : '',
                 ]
                   .filter(Boolean)

--- a/clients/web/src/pages/lms/course-catalog.tsx
+++ b/clients/web/src/pages/lms/course-catalog.tsx
@@ -324,7 +324,7 @@ export default function CourseCatalogPage() {
               key={sec.id}
               type="button"
               onClick={() => setSelectedId(sec.id)}
-              className="rounded-2xl border border-slate-200 bg-white p-4 text-left shadow-sm transition hover:border-indigo-200 hover:shadow-md dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-indigo-800"
+              className="rounded-2xl border border-slate-200 bg-white p-4 text-left shadow-sm transition-[box-shadow,background-color,color,border-color] hover:border-indigo-200 hover:shadow-md dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-indigo-800"
             >
               <div className="flex items-start justify-between gap-2">
                 <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-neutral-400">

--- a/clients/web/src/pages/lms/course-create.tsx
+++ b/clients/web/src/pages/lms/course-create.tsx
@@ -340,7 +340,7 @@ export default function CourseCreate() {
       actions={
         <Link
           to="/courses"
-          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-indigo-500/40 dark:hover:bg-indigo-950/40"
+          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-indigo-500/40 dark:hover:bg-indigo-950/40"
         >
           <ArrowLeft className="h-4 w-4" aria-hidden />
           Back to courses
@@ -385,7 +385,7 @@ export default function CourseCreate() {
                   placeholder="Introduction to Biology"
                   aria-invalid={error ? true : undefined}
                   aria-describedby={error ? formErrorId : undefined}
-                  className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-900 shadow-sm outline-none ring-indigo-500/0 transition focus:border-indigo-300 focus:ring-2 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500/60"
+                  className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-900 shadow-sm outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-300 focus:ring-2 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500/60"
                 />
               </div>
 
@@ -405,7 +405,7 @@ export default function CourseCreate() {
                   placeholder="Optional overview for the course catalog."
                   aria-invalid={error ? true : undefined}
                   aria-describedby={error ? formErrorId : undefined}
-                  className="mt-1.5 w-full resize-y rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-900 shadow-sm outline-none ring-indigo-500/0 transition focus:border-indigo-300 focus:ring-2 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500/60"
+                  className="mt-1.5 w-full resize-y rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-900 shadow-sm outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-300 focus:ring-2 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500/60"
                 />
               </div>
 
@@ -418,7 +418,7 @@ export default function CourseCreate() {
                 </p>
                 <div className="grid gap-3 sm:grid-cols-2">
                   <label
-                    className={`flex cursor-pointer flex-col rounded-2xl border p-4 text-start shadow-sm transition ${
+                    className={`flex cursor-pointer flex-col rounded-2xl border p-4 text-start shadow-sm transition-[background-color,color,border-color] ${
                       courseMode === 'traditional'
                         ? 'border-indigo-400 bg-indigo-50/80 ring-2 ring-indigo-300/60 dark:border-indigo-500/70 dark:bg-indigo-950/30 dark:ring-indigo-500/40'
                         : 'border-slate-200 bg-white hover:border-slate-300 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-neutral-600'
@@ -440,7 +440,7 @@ export default function CourseCreate() {
                     </span>
                   </label>
                   <label
-                    className={`flex cursor-pointer flex-col rounded-2xl border p-4 text-start shadow-sm transition ${
+                    className={`flex cursor-pointer flex-col rounded-2xl border p-4 text-start shadow-sm transition-[background-color,color,border-color] ${
                       courseMode === 'competency_based'
                         ? 'border-indigo-400 bg-indigo-50/80 ring-2 ring-indigo-300/60 dark:border-indigo-500/70 dark:bg-indigo-950/30 dark:ring-indigo-500/40'
                         : 'border-slate-200 bg-white hover:border-slate-300 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-neutral-600'
@@ -476,7 +476,7 @@ export default function CourseCreate() {
                     id="course-term"
                     value={selectedTermId}
                     onChange={(e) => setSelectedTermId(e.target.value)}
-                    className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 shadow-sm outline-none ring-indigo-500/0 transition focus:border-indigo-300 focus:ring-2 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500/60"
+                    className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 shadow-sm outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-300 focus:ring-2 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500/60"
                     aria-label="Academic term for default schedule dates"
                   >
                     <option value="">No term — self-paced or ongoing</option>
@@ -504,7 +504,7 @@ export default function CourseCreate() {
                   id="course-grade-level"
                   value={selectedGradeLevel}
                   onChange={(e) => setSelectedGradeLevel(e.target.value)}
-                  className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 shadow-sm outline-none ring-indigo-500/0 transition focus:border-indigo-300 focus:ring-2 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500/60"
+                  className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900 shadow-sm outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-300 focus:ring-2 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500/60"
                   aria-label="Grade level"
                 >
                   <option value="">No grade level — higher ed or unspecified</option>
@@ -533,14 +533,14 @@ export default function CourseCreate() {
                 <button
                   type="submit"
                   disabled={submitting}
-                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   Continue
                   <ChevronRight className="h-4 w-4" aria-hidden />
                 </button>
                 <Link
                   to="/courses"
-                  className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+                  className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
                 >
                   Cancel
                 </Link>
@@ -558,7 +558,7 @@ export default function CourseCreate() {
                 <button
                   type="button"
                   onClick={() => setSelectedTemplateId(BLANK_TEMPLATE_ID)}
-                  className={`flex flex-col rounded-2xl border p-4 text-start shadow-sm transition ${
+                  className={`flex flex-col rounded-2xl border p-4 text-start shadow-sm transition-[background-color,color,border-color] ${
                     selectedTemplateId === BLANK_TEMPLATE_ID
                       ? 'border-indigo-400 bg-indigo-50/80 ring-2 ring-indigo-300/60 dark:border-indigo-500/70 dark:bg-indigo-950/30 dark:ring-indigo-500/40'
                       : 'border-slate-200 bg-white hover:border-slate-300 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-neutral-600'
@@ -585,7 +585,7 @@ export default function CourseCreate() {
                       key={tmpl.id}
                       type="button"
                       onClick={() => setSelectedTemplateId(tmpl.id)}
-                      className={`flex flex-col rounded-2xl border p-4 text-start shadow-sm transition ${
+                      className={`flex flex-col rounded-2xl border p-4 text-start shadow-sm transition-[background-color,color,border-color] ${
                         selected
                           ? 'border-indigo-400 bg-indigo-50/80 ring-2 ring-indigo-300/60 dark:border-indigo-500/70 dark:bg-indigo-950/30 dark:ring-indigo-500/40'
                           : 'border-slate-200 bg-white hover:border-slate-300 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-neutral-600'
@@ -613,7 +613,7 @@ export default function CourseCreate() {
                   type="button"
                   disabled={submitting}
                   onClick={() => void continueFromSyllabusStep()}
-                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   Continue
                   <ChevronRight className="h-4 w-4" aria-hidden />
@@ -622,7 +622,7 @@ export default function CourseCreate() {
                   type="button"
                   disabled={submitting}
                   onClick={goBack}
-                  className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+                  className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
                 >
                   Back
                 </button>
@@ -648,7 +648,7 @@ export default function CourseCreate() {
                   onChange={(e) => setFirstModuleTitle(e.target.value)}
                   maxLength={500}
                   placeholder="e.g. Week 1: Introduction"
-                  className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-900 shadow-sm outline-none ring-indigo-500/0 transition focus:border-indigo-300 focus:ring-2 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500/60"
+                  className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm text-slate-900 shadow-sm outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-300 focus:ring-2 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500/60"
                 />
               </div>
               <div className="flex flex-wrap gap-3">
@@ -656,7 +656,7 @@ export default function CourseCreate() {
                   type="button"
                   disabled={submitting}
                   onClick={() => void finishTraditional(false)}
-                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   <Sparkles className="h-4 w-4" aria-hidden />
                   {firstModuleTitle.trim() ? 'Create module & open course' : 'Open course'}
@@ -665,7 +665,7 @@ export default function CourseCreate() {
                   type="button"
                   disabled={submitting}
                   onClick={() => void finishTraditional(true)}
-                  className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+                  className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
                 >
                   Skip module
                 </button>
@@ -673,7 +673,7 @@ export default function CourseCreate() {
                   type="button"
                   disabled={submitting}
                   onClick={goBack}
-                  className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+                  className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
                 >
                   Back
                 </button>
@@ -701,7 +701,7 @@ export default function CourseCreate() {
                       {competencies.length > 1 ? (
                         <button
                           type="button"
-                          className="inline-flex items-center gap-1 rounded-lg border border-rose-200 px-2 py-1 text-xs font-semibold text-rose-800 transition hover:bg-rose-50 dark:border-rose-900/40 dark:text-rose-100 dark:hover:bg-rose-950/40"
+                          className="inline-flex items-center gap-1 rounded-lg border border-rose-200 px-2 py-1 text-xs font-semibold text-rose-800 transition-[background-color,color,border-color] hover:bg-rose-50 dark:border-rose-900/40 dark:text-rose-100 dark:hover:bg-rose-950/40"
                           onClick={() => setCompetencies((rows) => rows.filter((_, i) => i !== ci))}
                         >
                           <Trash2 className="h-3.5 w-3.5" aria-hidden />
@@ -886,7 +886,7 @@ export default function CourseCreate() {
 
               <button
                 type="button"
-                className="inline-flex items-center gap-2 rounded-xl border border-dashed border-indigo-300 px-4 py-2 text-sm font-semibold text-indigo-800 transition hover:bg-indigo-50 dark:border-indigo-500/40 dark:text-indigo-100 dark:hover:bg-indigo-950/30"
+                className="inline-flex items-center gap-2 rounded-xl border border-dashed border-indigo-300 px-4 py-2 text-sm font-semibold text-indigo-800 transition-[background-color,color,border-color] hover:bg-indigo-50 dark:border-indigo-500/40 dark:text-indigo-100 dark:hover:bg-indigo-950/30"
                 onClick={() => setCompetencies((rows) => [...rows, emptyCompetency()])}
               >
                 <Plus className="h-4 w-4" aria-hidden />
@@ -898,7 +898,7 @@ export default function CourseCreate() {
                   type="button"
                   disabled={submitting}
                   onClick={() => void finishCompetencyBased()}
-                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   <Sparkles className="h-4 w-4" aria-hidden />
                   Create competencies & open course
@@ -907,7 +907,7 @@ export default function CourseCreate() {
                   type="button"
                   disabled={submitting}
                   onClick={goBack}
-                  className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+                  className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
                 >
                   Back
                 </button>

--- a/clients/web/src/pages/lms/course-detail.tsx
+++ b/clients/web/src/pages/lms/course-detail.tsx
@@ -679,7 +679,7 @@ export default function CourseDetail() {
                       >
                         <Link
                           to={hrefForRecommendationItem(courseCode, r)}
-                          className="block rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50/40 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-indigo-800 dark:hover:bg-indigo-950/30"
+                          className="block rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50/40 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-indigo-800 dark:hover:bg-indigo-950/30"
                         >
                           <span className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">
                             {surfaceLabel(r.surface)}
@@ -706,7 +706,7 @@ export default function CourseDetail() {
                     </p>
                     <Link
                       to={hrefForLastVisited(courseCode, lastVisited.kind, lastVisited.itemId)}
-                      className="mt-4 inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+                      className="mt-4 inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500"
                     >
                       Continue
                       <ArrowRight className="h-4 w-4" aria-hidden />

--- a/clients/web/src/pages/lms/course-diagnostic-page.tsx
+++ b/clients/web/src/pages/lms/course-diagnostic-page.tsx
@@ -249,7 +249,7 @@ export default function CourseDiagnosticPage() {
               type="button"
               disabled={submitting}
               onClick={() => void onStart()}
-              className="inline-flex rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:opacity-50"
+              className="inline-flex rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:opacity-50"
             >
               Start placement assessment
             </button>
@@ -257,7 +257,7 @@ export default function CourseDiagnosticPage() {
               type="button"
               disabled={submitting}
               onClick={() => void onSkip()}
-              className="inline-flex rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+              className="inline-flex rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
             >
               Skip — start from the beginning
             </button>
@@ -294,7 +294,7 @@ export default function CourseDiagnosticPage() {
                   <button
                     type="button"
                     onClick={() => setChoice(i)}
-                    className={`flex w-full items-start gap-3 rounded-xl border px-4 py-3 text-start text-sm transition ${
+                    className={`flex w-full items-start gap-3 rounded-xl border px-4 py-3 text-start text-sm transition-[background-color,color,border-color] ${
                       selected
                         ? 'border-indigo-500 bg-indigo-50 dark:border-indigo-400 dark:bg-indigo-950/40'
                         : 'border-slate-200 bg-white hover:border-slate-300 dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-600'
@@ -319,7 +319,7 @@ export default function CourseDiagnosticPage() {
               type="button"
               disabled={submitting || choice == null}
               onClick={() => void onSubmitAnswer()}
-              className="inline-flex rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:opacity-50"
+              className="inline-flex rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:opacity-50"
             >
               Submit answer
             </button>
@@ -364,7 +364,7 @@ export default function CourseDiagnosticPage() {
           {continueHref && (
             <Link
               to={continueHref}
-              className="inline-flex rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+              className="inline-flex rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500"
             >
               Continue to your starting point
             </Link>

--- a/clients/web/src/pages/lms/course-enrollments.tsx
+++ b/clients/web/src/pages/lms/course-enrollments.tsx
@@ -990,7 +990,7 @@ export default function CourseEnrollments() {
                 role="tab"
                 aria-selected={mainTab === 'roster'}
                 onClick={() => setMainTab('roster')}
-                className={`rounded-t-lg px-4 py-2 text-sm font-semibold transition ${
+                className={`rounded-t-lg px-4 py-2 text-sm font-semibold transition-[background-color,color,border-color] ${
                   mainTab === 'roster'
                     ? 'border border-b-0 border-slate-200 bg-white text-slate-900 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100'
                     : 'text-slate-500 hover:text-slate-800 dark:text-neutral-400 dark:hover:text-neutral-200'
@@ -1003,7 +1003,7 @@ export default function CourseEnrollments() {
                 role="tab"
                 aria-selected={mainTab === 'groups'}
                 onClick={() => setMainTab('groups')}
-                className={`rounded-t-lg px-4 py-2 text-sm font-semibold transition ${
+                className={`rounded-t-lg px-4 py-2 text-sm font-semibold transition-[background-color,color,border-color] ${
                   mainTab === 'groups'
                     ? 'border border-b-0 border-slate-200 bg-white text-slate-900 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100'
                     : 'text-slate-500 hover:text-slate-800 dark:text-neutral-400 dark:hover:text-neutral-200'
@@ -1151,7 +1151,7 @@ export default function CourseEnrollments() {
                                 <button
                                   type="button"
                                   onClick={() => openSectionTransferModal(e)}
-                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition-[opacity,background-color,color,border-color] hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
                                   aria-label={`Change section for ${e.displayName?.trim() || 'this student'}`}
                                 >
                                   <Shuffle className="h-4 w-4" aria-hidden />
@@ -1163,7 +1163,7 @@ export default function CourseEnrollments() {
                                 <button
                                   type="button"
                                   onClick={() => openGroupAssignModal(e)}
-                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition-[opacity,background-color,color,border-color] hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
                                   aria-label={`Assign groups for ${e.displayName?.trim() || 'this person'}`}
                                 >
                                   <UsersRound className="h-4 w-4" aria-hidden />
@@ -1181,7 +1181,7 @@ export default function CourseEnrollments() {
                                     setEditMessage(null)
                                     setDemoteStatus('idle')
                                   }}
-                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100"
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition-[opacity,background-color,color,border-color] hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100"
                                   aria-label={`Edit role for ${e.displayName?.trim() || 'this person'}`}
                                 >
                                   <Pencil className="h-4 w-4" aria-hidden />
@@ -1193,7 +1193,7 @@ export default function CourseEnrollments() {
                                 <button
                                   type="button"
                                   onClick={() => openMessageModal(e)}
-                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition-[opacity,background-color,color,border-color] hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
                                   aria-label={`Send message to ${e.displayName?.trim() || 'this person'}`}
                                 >
                                   <Mail className="h-4 w-4" aria-hidden />
@@ -1211,7 +1211,7 @@ export default function CourseEnrollments() {
                                     setStateChangeStatus('idle')
                                     setStateChangeMessage(null)
                                   }}
-                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition-[opacity,background-color,color,border-color] hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
                                   aria-label={`Change enrollment status for ${e.displayName?.trim() || 'this student'}`}
                                 >
                                   <ClipboardList className="h-4 w-4" aria-hidden />
@@ -1222,7 +1222,7 @@ export default function CourseEnrollments() {
                               <IconActionTooltip label="Gradebook">
                                 <Link
                                   to={`/courses/${encodeURIComponent(courseCode)}/gradebook?student=${encodeURIComponent(e.userId)}`}
-                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition-[opacity,background-color,color,border-color] hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
                                   aria-label={`View gradebook for ${e.displayName?.trim() || 'this student'}`}
                                 >
                                   <ClipboardList className="h-4 w-4" aria-hidden />
@@ -1233,7 +1233,7 @@ export default function CourseEnrollments() {
                               <IconActionTooltip label="Student report">
                                 <Link
                                   to={`/courses/${encodeURIComponent(courseCode)}/students/${encodeURIComponent(e.id)}/progress`}
-                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition-[opacity,background-color,color,border-color] hover:bg-indigo-50 hover:text-indigo-800 group-hover:opacity-100 focus-visible:opacity-100 dark:hover:bg-indigo-950/40 dark:hover:text-indigo-200"
                                   aria-label={`View report for ${e.displayName?.trim() || 'this student'}`}
                                 >
                                   <BarChart3 className="h-4 w-4" aria-hidden />
@@ -1246,7 +1246,7 @@ export default function CourseEnrollments() {
                                   type="button"
                                   onClick={() => setRemoveConfirmTarget(e)}
                                   disabled={removingId === e.id}
-                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition hover:bg-rose-50 hover:text-rose-700 group-hover:opacity-100 focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
+                                  className="inline-flex rounded-lg p-1.5 text-slate-400 opacity-0 transition-[opacity,background-color,color,border-color] hover:bg-rose-50 hover:text-rose-700 group-hover:opacity-100 focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
                                   aria-label={`Remove ${e.role} enrollment for ${e.displayName?.trim() || 'this person'}`}
                                 >
                                   <Trash2 className="h-4 w-4" aria-hidden />

--- a/clients/web/src/pages/lms/course-export-import-section.tsx
+++ b/clients/web/src/pages/lms/course-export-import-section.tsx
@@ -163,7 +163,7 @@ export function CourseExportImportSection({ courseCode }: { courseCode: string }
             type="button"
             onClick={() => void onExport()}
             disabled={busy !== 'idle'}
-            className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
           >
             <Download className="h-4 w-4" aria-hidden />
             {busy === 'exporting' ? 'Preparing…' : 'Download JSON export'}
@@ -323,7 +323,7 @@ export function CourseExportImportSection({ courseCode }: { courseCode: string }
                 onChange={(e) => setCanvasBaseUrl(e.target.value)}
                 placeholder="https://yourschool.instructure.com"
                 autoComplete="off"
-                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner outline-none ring-indigo-500/0 transition focus:border-indigo-400 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-400 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
               />
             </label>
             <label className="block">
@@ -337,7 +337,7 @@ export function CourseExportImportSection({ courseCode }: { courseCode: string }
                 onChange={(e) => setCanvasCourseId(e.target.value)}
                 placeholder="e.g. 1234567"
                 autoComplete="off"
-                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner outline-none ring-indigo-500/0 transition focus:border-indigo-400 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-400 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
               />
             </label>
             <label className="block">
@@ -350,7 +350,7 @@ export function CourseExportImportSection({ courseCode }: { courseCode: string }
                 onChange={(e) => setCanvasToken(e.target.value)}
                 placeholder="Canvas API token"
                 autoComplete="off"
-                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner outline-none ring-indigo-500/0 transition focus:border-indigo-400 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-400 focus:ring-2 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
               />
             </label>
           </div>
@@ -410,7 +410,7 @@ export function CourseExportImportSection({ courseCode }: { courseCode: string }
                 !canvasToken.trim()
               }
               aria-busy={busy === 'importingCanvas'}
-              className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {busy === 'importingCanvas' ? (
                 <span
@@ -454,7 +454,7 @@ export function CourseExportImportSection({ courseCode }: { courseCode: string }
               type="button"
               onClick={() => fileRef.current?.click()}
               disabled={busy !== 'idle'}
-              className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700"
+              className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700"
             >
               <Upload className="h-4 w-4" aria-hidden />
               {busy === 'importing' ? 'Importing…' : 'Choose JSON file…'}

--- a/clients/web/src/pages/lms/course-feed-page.tsx
+++ b/clients/web/src/pages/lms/course-feed-page.tsx
@@ -971,7 +971,7 @@ export default function CourseFeedPage() {
                           className="group/replylink ms-14 mt-1 flex items-center gap-1.5 rounded-lg py-0.5 ps-1 pe-1.5 text-start text-xs font-medium text-indigo-600 hover:bg-indigo-50/80 dark:text-indigo-400 dark:hover:bg-indigo-950/40"
                           aria-expanded={expandedReplyRoots.has(m.id)}
                         >
-                          <span className="flex h-5 w-5 items-center justify-center rounded-full bg-slate-100 text-slate-500 ring-1 ring-slate-200/80 transition group-hover/replylink:bg-white group-hover/replylink:text-indigo-600 dark:bg-neutral-800 dark:text-neutral-400 dark:ring-neutral-700 dark:group-hover/replylink:bg-neutral-900 dark:group-hover/replylink:text-indigo-300">
+                          <span className="flex h-5 w-5 items-center justify-center rounded-full bg-slate-100 text-slate-500 ring-1 ring-slate-200/80 transition-colors group-hover/replylink:bg-white group-hover/replylink:text-indigo-600 dark:bg-neutral-800 dark:text-neutral-400 dark:ring-neutral-700 dark:group-hover/replylink:bg-neutral-900 dark:group-hover/replylink:text-indigo-300">
                             <MessageCircle className="h-3 w-3 shrink-0" aria-hidden />
                           </span>
                           {expandedReplyRoots.has(m.id)

--- a/clients/web/src/pages/lms/course-files-page.tsx
+++ b/clients/web/src/pages/lms/course-files-page.tsx
@@ -946,7 +946,7 @@ function SelectionActionsMenu({
       >
         Actions
         <ChevronDown
-          className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`}
+          className={`h-4 w-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
           aria-hidden
         />
       </button>

--- a/clients/web/src/pages/lms/course-gradebook.tsx
+++ b/clients/web/src/pages/lms/course-gradebook.tsx
@@ -237,7 +237,7 @@ function RubricGradeForm({
                     key={`${c.id}-${i}`}
                     type="button"
                     onClick={() => setLocal((prev) => ({ ...prev, [c.id]: lvl.points }))}
-                    className={`max-w-full rounded-md border px-2.5 py-1.5 text-start text-xs font-medium transition ${
+                    className={`max-w-full rounded-md border px-2.5 py-1.5 text-start text-xs font-medium transition-[background-color,color,border-color] ${
                       local[c.id] === lvl.points
                         ? 'border-indigo-500 bg-indigo-50 text-indigo-950 dark:border-indigo-400 dark:bg-indigo-950/60 dark:text-indigo-100'
                         : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700'
@@ -834,7 +834,7 @@ export default function CourseGradebook() {
                 <span className="sr-only">Toggle combined cross-list gradebook</span>
                 <span
                   aria-hidden
-                  className={`pointer-events-none inline-block h-6 w-6 translate-y-0.5 rounded-full bg-white shadow transition ${
+                  className={`pointer-events-none inline-block h-6 w-6 translate-y-0.5 rounded-full bg-white shadow transition-transform ${
                     crossListMerge ? 'translate-x-5' : 'translate-x-1'
                   }`}
                 />

--- a/clients/web/src/pages/lms/course-live-page.tsx
+++ b/clients/web/src/pages/lms/course-live-page.tsx
@@ -86,7 +86,7 @@ function MeetingCard({ meeting, isStaff, onJoin, onCancel }: MeetingCardProps) {
 
   return (
     <div
-      className={`rounded-xl border p-4 transition ${
+      className={`rounded-xl border p-4 transition-colors ${
         isActive
           ? 'border-emerald-300 bg-emerald-50/60 dark:border-emerald-700 dark:bg-emerald-950/30'
           : 'border-neutral-200 bg-white dark:border-neutral-700 dark:bg-neutral-800/50'
@@ -116,7 +116,7 @@ function MeetingCard({ meeting, isStaff, onJoin, onCancel }: MeetingCardProps) {
               type="button"
               onClick={() => onJoin(meeting)}
               aria-label={`Join live session: ${meeting.title}`}
-              className={`rounded-lg px-3 py-1.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 ${
+              className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-[background-color,color,border-color] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 ${
                 isActive || isComingSoon
                   ? 'bg-emerald-600 text-white hover:bg-emerald-700 dark:bg-emerald-500 dark:hover:bg-emerald-600'
                   : 'bg-neutral-100 text-neutral-700 hover:bg-neutral-200 dark:bg-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-600'

--- a/clients/web/src/pages/lms/course-mastery-heatmap.tsx
+++ b/clients/web/src/pages/lms/course-mastery-heatmap.tsx
@@ -150,7 +150,7 @@ export default function CourseMasteryHeatmap() {
           onClick={() => void handleRefresh()}
           disabled={refreshing}
           aria-label="Refresh heatmap data"
-          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50/60 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-indigo-500/40 dark:hover:bg-indigo-950/40"
+          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50/60 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-indigo-500/40 dark:hover:bg-indigo-950/40"
         >
           <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} aria-hidden />
           {refreshing ? 'Refreshing…' : 'Refresh'}
@@ -267,7 +267,7 @@ export default function CourseMasteryHeatmap() {
                             disabled={drillLoading}
                             aria-label={ariaLabel}
                             title={ariaLabel}
-                            className={`inline-flex h-8 w-14 items-center justify-center rounded-md text-xs font-semibold text-white transition hover:ring-2 hover:ring-offset-1 hover:ring-indigo-400 ${masteryColorClass(cell.assessed, cell.masteryScore)}`}
+                            className={`inline-flex h-8 w-14 items-center justify-center rounded-md text-xs font-semibold text-white transition-[background-color,color,border-color] hover:ring-2 hover:ring-offset-1 hover:ring-indigo-400 ${masteryColorClass(cell.assessed, cell.masteryScore)}`}
                           >
                             {cell.assessed && cell.masteryScore !== null
                               ? pct(cell.masteryScore)

--- a/clients/web/src/pages/lms/course-module-assignment-page.tsx
+++ b/clients/web/src/pages/lms/course-module-assignment-page.tsx
@@ -686,7 +686,7 @@ export default function CourseModuleAssignmentPage() {
               type="button"
               onClick={cancelEdit}
               disabled={saving}
-              className="rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
             >
               Cancel
             </button>
@@ -694,7 +694,7 @@ export default function CourseModuleAssignmentPage() {
               type="button"
               onClick={() => void save()}
               disabled={saving}
-              className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {saving ? 'Saving…' : 'Save'}
             </button>
@@ -713,7 +713,7 @@ export default function CourseModuleAssignmentPage() {
               <button
                 type="button"
                 onClick={openSubmissionPreview}
-                className="inline-flex h-10 items-center gap-2 rounded-xl border border-indigo-200 bg-indigo-50 px-4 text-sm font-semibold text-indigo-900 shadow-sm transition hover:bg-indigo-100 dark:border-indigo-900 dark:bg-indigo-950/60 dark:text-indigo-100 dark:hover:bg-indigo-950"
+                className="inline-flex h-10 items-center gap-2 rounded-xl border border-indigo-200 bg-indigo-50 px-4 text-sm font-semibold text-indigo-900 shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-100 dark:border-indigo-900 dark:bg-indigo-950/60 dark:text-indigo-100 dark:hover:bg-indigo-950"
               >
                 <Eye className="h-4 w-4" aria-hidden />
                 {gradeSubmissionsLabel}
@@ -723,7 +723,7 @@ export default function CourseModuleAssignmentPage() {
             {viewerCanModerate && moderatedGrading ? (
               <Link
                 to={moderationDashboardPath}
-                className="inline-flex items-center rounded-xl border border-indigo-200 bg-indigo-50 px-4 py-2.5 text-sm font-semibold text-indigo-900 shadow-sm transition hover:bg-indigo-100 dark:border-indigo-900 dark:bg-indigo-950/60 dark:text-indigo-100 dark:hover:bg-indigo-950"
+                className="inline-flex items-center rounded-xl border border-indigo-200 bg-indigo-50 px-4 py-2.5 text-sm font-semibold text-indigo-900 shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-100 dark:border-indigo-900 dark:bg-indigo-950/60 dark:text-indigo-100 dark:hover:bg-indigo-950"
               >
                 Reconciliation
               </Link>

--- a/clients/web/src/pages/lms/course-module-content-page.tsx
+++ b/clients/web/src/pages/lms/course-module-content-page.tsx
@@ -404,7 +404,7 @@ export default function CourseModuleContentPage() {
               type="button"
               onClick={cancelEdit}
               disabled={saving}
-              className="rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
             >
               Cancel
             </button>
@@ -439,7 +439,7 @@ export default function CourseModuleContentPage() {
               onClick={() => void save()}
               disabled={saving || saveBlockedByAltText}
               title={saveBlockedByAltText ? 'Add alt text to all images before saving' : undefined}
-              className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {saving ? 'Saving…' : 'Save'}
             </button>
@@ -452,7 +452,7 @@ export default function CourseModuleContentPage() {
               type="button"
               onClick={beginEdit}
               disabled={loading}
-              className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <Pencil className="h-4 w-4" aria-hidden />
               Edit
@@ -474,7 +474,7 @@ export default function CourseModuleContentPage() {
                     ? 'Content saved for offline access'
                     : 'Save this page for offline access'
                 }
-                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
               >
                 {offlineStatus === 'saving' ? (
                   <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />

--- a/clients/web/src/pages/lms/course-module-external-link-page.tsx
+++ b/clients/web/src/pages/lms/course-module-external-link-page.tsx
@@ -206,7 +206,7 @@ export default function CourseModuleExternalLinkPage() {
                       href={data.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+                      className="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500"
                     >
                       {openLabel}
                     </a>

--- a/clients/web/src/pages/lms/course-module-quiz-page.tsx
+++ b/clients/web/src/pages/lms/course-module-quiz-page.tsx
@@ -97,10 +97,10 @@ function QuestionTypeDropdown({
         aria-expanded={open}
         aria-controls={open ? menuId : undefined}
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex w-full items-center justify-between gap-2 rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-sm font-medium text-slate-800 transition hover:border-slate-300 hover:bg-slate-50"
+        className="inline-flex w-full items-center justify-between gap-2 rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:border-slate-300 hover:bg-slate-50"
       >
         <span>{selectedLabel}</span>
-        <ChevronDown className={`h-4 w-4 transition ${open ? 'rotate-180' : ''}`} aria-hidden />
+        <ChevronDown className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`} aria-hidden />
       </button>
       {open && (
         <div
@@ -119,7 +119,7 @@ function QuestionTypeDropdown({
                 onChange(opt.value)
                 setOpen(false)
               }}
-              className="flex w-full items-center justify-between px-2.5 py-2 text-start text-sm text-slate-800 transition hover:bg-slate-50"
+              className="flex w-full items-center justify-between px-2.5 py-2 text-start text-sm text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50"
             >
               <span>{opt.label}</span>
               {opt.value === value ? <Check className="h-4 w-4 text-indigo-600" aria-hidden /> : null}
@@ -173,10 +173,10 @@ function QuizEditorMoreMenu({
         aria-expanded={open}
         aria-controls={open ? menuId : undefined}
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-2 py-1.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+        className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-2 py-1.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
       >
         More
-        <ChevronDown className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`} aria-hidden />
+        <ChevronDown className={`h-4 w-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`} aria-hidden />
       </button>
       {open && (
         <div
@@ -192,7 +192,7 @@ function QuizEditorMoreMenu({
               onEditIntro()
               setOpen(false)
             }}
-            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
+            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
           >
             <Pencil className="h-4 w-4 shrink-0 text-slate-500 dark:text-neutral-400" aria-hidden />
             Edit
@@ -204,7 +204,7 @@ function QuizEditorMoreMenu({
               onGenerate()
               setOpen(false)
             }}
-            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
+            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
           >
             <Sparkles className="h-4 w-4 shrink-0 text-slate-500 dark:text-neutral-400" aria-hidden />
             Generate questions
@@ -216,7 +216,7 @@ function QuizEditorMoreMenu({
               onAnalytics()
               setOpen(false)
             }}
-            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
+            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
           >
             <BarChart3 className="h-4 w-4 shrink-0 text-slate-500 dark:text-neutral-400" aria-hidden />
             Analytics
@@ -233,7 +233,7 @@ function QuizEditorMoreMenu({
               onPreview()
               setOpen(false)
             }}
-            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
+            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-200 dark:hover:bg-neutral-800"
           >
             <Eye className="h-4 w-4 shrink-0 text-slate-500 dark:text-neutral-400" aria-hidden />
             Preview
@@ -983,7 +983,7 @@ export default function CourseModuleQuizPage() {
               onChange={(e) => setDraftTitle(e.target.value)}
               disabled={saving}
               autoComplete="off"
-              className="w-full min-w-0 border-0 border-b border-transparent bg-transparent p-0 pb-0.5 text-2xl font-semibold tracking-tight text-slate-900 outline-none ring-0 transition placeholder:text-slate-400 focus:border-indigo-500 disabled:opacity-60 dark:border-transparent dark:text-neutral-100 dark:focus:border-indigo-400"
+              className="w-full min-w-0 border-0 border-b border-transparent bg-transparent p-0 pb-0.5 text-2xl font-semibold tracking-tight text-slate-900 outline-none ring-0 transition-[background-color,color,border-color] placeholder:text-slate-400 focus:border-indigo-500 disabled:opacity-60 dark:border-transparent dark:text-neutral-100 dark:focus:border-indigo-400"
               placeholder="Quiz title"
             />
           </h1>
@@ -998,7 +998,7 @@ export default function CourseModuleQuizPage() {
               type="button"
               onClick={cancelEditContent}
               disabled={saving}
-              className="rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
             >
               Cancel
             </button>
@@ -1006,7 +1006,7 @@ export default function CourseModuleQuizPage() {
               type="button"
               onClick={() => void saveContent()}
               disabled={saving || !canSaveContent}
-              className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {saving ? 'Saving…' : 'Save'}
             </button>
@@ -1027,7 +1027,7 @@ export default function CourseModuleQuizPage() {
                   type="button"
                   onClick={openQuestionsEditor}
                   disabled={loading}
-                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   Edit questions
                 </button>
@@ -1122,7 +1122,7 @@ export default function CourseModuleQuizPage() {
                           ? 'Quiz saved for offline access'
                           : 'Save quiz intro for offline access'
                       }
-                      className="inline-flex items-center gap-1.5 rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                      className="inline-flex items-center gap-1.5 rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
                     >
                       {offlineStatus === 'saving' ? (
                         <Loader2 className="h-4 w-4 motion-safe:animate-spin" aria-hidden />
@@ -1139,7 +1139,7 @@ export default function CourseModuleQuizPage() {
                     disabled={loading || !isOnline}
                     aria-disabled={!isOnline}
                     title={!isOnline ? 'Available when online' : undefined}
-                    className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     {!isOnline && <WifiOff className="h-4 w-4" aria-hidden />}
                     Start Quiz
@@ -1615,12 +1615,12 @@ export default function CourseModuleQuizPage() {
                           setQuestionsDraft(questions.map((q) => ({ ...q, choices: [...q.choices] })))
                         }
                       }}
-                      className={`relative mt-0.5 h-6 w-11 shrink-0 rounded-full transition disabled:opacity-50 ${
+                      className={`relative mt-0.5 h-6 w-11 shrink-0 rounded-full transition-colors disabled:opacity-50 ${
                         qeAdaptiveOn ? 'bg-indigo-500' : 'bg-slate-300'
                       }`}
                     >
                       <span
-                        className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition ${
+                        className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-colors ${
                           qeAdaptiveOn ? 'start-5' : 'start-0.5'
                         }`}
                       />
@@ -1780,7 +1780,7 @@ export default function CourseModuleQuizPage() {
                         onClick={() =>
                           setQuestionsDraft((prev) => prev.filter((it) => it.id !== q.id))
                         }
-                        className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium text-rose-700 transition hover:bg-rose-50"
+                        className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium text-rose-700 transition-[background-color,color,border-color] hover:bg-rose-50"
                       >
                         <Trash2 className="h-3.5 w-3.5" aria-hidden />
                         Remove
@@ -1853,12 +1853,12 @@ export default function CourseModuleQuizPage() {
                                   ),
                                 )
                               }
-                              className={`relative h-5 w-9 shrink-0 rounded-full transition ${
+                              className={`relative h-5 w-9 shrink-0 rounded-full transition-colors ${
                                 q.multipleAnswer ? 'bg-indigo-500' : 'bg-slate-300'
                               }`}
                             >
                               <span
-                                className={`absolute top-0.5 h-4 w-4 rounded-full bg-white transition ${
+                                className={`absolute top-0.5 h-4 w-4 rounded-full bg-white transition-colors ${
                                   q.multipleAnswer ? 'start-4.5' : 'start-0.5'
                                 }`}
                               />
@@ -1877,12 +1877,12 @@ export default function CourseModuleQuizPage() {
                                   ),
                                 )
                               }
-                              className={`relative h-5 w-9 shrink-0 rounded-full transition ${
+                              className={`relative h-5 w-9 shrink-0 rounded-full transition-colors ${
                                 q.answerWithImage ? 'bg-indigo-500' : 'bg-slate-300'
                               }`}
                             >
                               <span
-                                className={`absolute top-0.5 h-4 w-4 rounded-full bg-white transition ${
+                                className={`absolute top-0.5 h-4 w-4 rounded-full bg-white transition-colors ${
                                   q.answerWithImage ? 'start-4.5' : 'start-0.5'
                                 }`}
                               />
@@ -1913,7 +1913,7 @@ export default function CourseModuleQuizPage() {
                                     ),
                                   )
                                 }
-                                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:border-slate-300"
+                                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition-[background-color,color,border-color] hover:border-slate-300"
                               >
                                 <span
                                   className={`h-3 w-3 rounded-full ${
@@ -1971,7 +1971,7 @@ export default function CourseModuleQuizPage() {
                                 title={
                                   q.choices.length <= 1 ? 'At least one choice is required' : 'Delete option'
                                 }
-                                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-slate-400 opacity-0 transition hover:bg-rose-50 hover:text-rose-700 focus-visible:opacity-100 enabled:group-hover:opacity-100 enabled:group-focus-within:opacity-100 disabled:invisible disabled:pointer-events-none"
+                                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-slate-400 opacity-0 transition-[opacity,background-color,color,border-color] hover:bg-rose-50 hover:text-rose-700 focus-visible:opacity-100 enabled:group-hover:opacity-100 enabled:group-focus-within:opacity-100 disabled:invisible disabled:pointer-events-none"
                               >
                                 <Trash2 className="h-4 w-4" aria-hidden />
                               </button>
@@ -1987,7 +1987,7 @@ export default function CourseModuleQuizPage() {
                               ),
                             )
                           }
-                          className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 transition hover:text-indigo-700"
+                          className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 transition-[background-color,color,border-color] hover:text-indigo-700"
                         >
                           <Plus className="h-4 w-4" aria-hidden />
                           Add option
@@ -2067,7 +2067,7 @@ export default function CourseModuleQuizPage() {
                               }),
                             )
                           }
-                          className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 transition hover:text-indigo-700"
+                          className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 transition-[background-color,color,border-color] hover:text-indigo-700"
                         >
                           <Plus className="h-4 w-4" aria-hidden />
                           Add ordering item
@@ -2431,7 +2431,7 @@ export default function CourseModuleQuizPage() {
                               }),
                             )
                           }
-                          className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 transition hover:text-indigo-700"
+                          className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 transition-[background-color,color,border-color] hover:text-indigo-700"
                         >
                           <Plus className="h-4 w-4" aria-hidden />
                           Add pair
@@ -2669,7 +2669,7 @@ export default function CourseModuleQuizPage() {
                     <button
                       type="button"
                       onClick={() => setQuestionsDraft((prev) => [...prev, makeQuestion()])}
-                      className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50"
+                      className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50"
                     >
                       <Plus className="h-4 w-4" />
                       Add question
@@ -2680,7 +2680,7 @@ export default function CourseModuleQuizPage() {
                       onClick={openImportQuestions}
                       aria-expanded={importQuestionsOpen}
                       aria-haspopup="dialog"
-                      className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50"
+                      className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50"
                     >
                       <Plus className="h-4 w-4" />
                       Import Questions
@@ -2759,7 +2759,7 @@ export default function CourseModuleQuizPage() {
               type="button"
               onClick={() => void loadBankQuestionsForImport(importQuestionsQuery)}
               disabled={importQuestionsLoading}
-              className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 disabled:opacity-60"
+              className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-100 disabled:opacity-60"
             >
               {importQuestionsLoading ? 'Searching…' : 'Search'}
             </button>
@@ -2771,7 +2771,7 @@ export default function CourseModuleQuizPage() {
             {importRows.map((row) => (
               <div
                 key={row.id}
-                className={`flex items-start gap-3 rounded-lg border px-3 py-2 transition ${
+                className={`flex items-start gap-3 rounded-lg border px-3 py-2 transition-colors ${
                   selectedImportQuestionId === row.id
                     ? 'border-indigo-300 bg-indigo-50/40'
                     : 'border-slate-200 bg-white'

--- a/clients/web/src/pages/lms/course-module-textbook-resource-page.tsx
+++ b/clients/web/src/pages/lms/course-module-textbook-resource-page.tsx
@@ -225,7 +225,7 @@ export default function CourseModuleTextbookResourcePage() {
                     type="button"
                     onClick={() => void onOpen()}
                     aria-label={`Open ${data.metadata?.title || 'textbook'}${data.metadata?.chapter ? `, ${data.metadata.chapter}` : ''} in ${PROVIDER_LABELS[data.provider]}`}
-                    className="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+                    className="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500"
                   >
                     Open in {PROVIDER_LABELS[data.provider]}
                   </button>

--- a/clients/web/src/pages/lms/course-modules.tsx
+++ b/clients/web/src/pages/lms/course-modules.tsx
@@ -53,6 +53,7 @@ import {
 import { AddCourseItemMenu } from './add-course-item-menu'
 import { AddModuleItemMenu, type ModuleItemKind } from './add-module-item-menu'
 import { CourseModulesLoadingSkeleton } from '../../components/ui/lms-content-skeletons'
+import { IconSwap } from '../../components/ui/icon-swap'
 import { FeatureHelpTrigger } from '../../components/feature-help/feature-help-trigger'
 import { toast, toastWithUndo } from '../../lib/lms-toast'
 import { LmsPage } from './lms-page'
@@ -128,11 +129,11 @@ const MODULE_SORT_ID = 'sortable-modules'
 
 /** Quiet icon-only controls (no box borders) for module + item toolbars. */
 const iconGhost =
-  'rounded-md p-2.5 text-slate-500 transition hover:bg-slate-200/45 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-50 sm:p-1.5 dark:text-neutral-400 dark:hover:bg-neutral-700/35 dark:hover:text-neutral-200'
+  'rounded-md p-2.5 text-slate-500 transition-[background-color,color,border-color] hover:bg-slate-200/45 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-50 sm:p-1.5 dark:text-neutral-400 dark:hover:bg-neutral-700/35 dark:hover:text-neutral-200'
 const iconGhostPublished =
-  'rounded-md p-2.5 text-indigo-600 transition hover:bg-indigo-50/90 hover:text-indigo-700 disabled:cursor-not-allowed disabled:opacity-50 sm:p-1.5 dark:text-indigo-400 dark:hover:bg-indigo-950/45 dark:hover:text-indigo-300'
+  'rounded-md p-2.5 text-indigo-600 transition-[background-color,color,border-color] hover:bg-indigo-50/90 hover:text-indigo-700 disabled:cursor-not-allowed disabled:opacity-50 sm:p-1.5 dark:text-indigo-400 dark:hover:bg-indigo-950/45 dark:hover:text-indigo-300'
 const iconGhostDraft =
-  'rounded-md p-2.5 text-slate-400 transition hover:bg-slate-200/45 hover:text-slate-600 disabled:cursor-not-allowed disabled:opacity-50 sm:p-1.5 dark:text-neutral-500 dark:hover:bg-neutral-700/35 dark:hover:text-neutral-300'
+  'rounded-md p-2.5 text-slate-400 transition-[background-color,color,border-color] hover:bg-slate-200/45 hover:text-slate-600 disabled:cursor-not-allowed disabled:opacity-50 sm:p-1.5 dark:text-neutral-500 dark:hover:bg-neutral-700/35 dark:hover:text-neutral-300'
 
 function findModuleIdForChildItem(
   childId: string,
@@ -786,11 +787,12 @@ function ModulePublishMenu({
           item.published ? iconGhostPublished : iconGhostDraft
         }`}
       >
-        {item.published ? (
-          <Eye className="h-4 w-4" strokeWidth={2} aria-hidden />
-        ) : (
-          <EyeOff className="h-4 w-4" strokeWidth={2} aria-hidden />
-        )}
+        <IconSwap
+          active={item.published}
+          activeIcon={Eye}
+          inactiveIcon={EyeOff}
+          iconClassName="h-4 w-4"
+        />
       </button>
       {menuOpen && (
         <div
@@ -808,7 +810,7 @@ function ModulePublishMenu({
                   onUnpublishModuleOnly()
                   setMenuOpen(false)
                 }}
-                className="flex w-full px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
+                className="flex w-full px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
               >
                 Unpublish Module Only
               </button>
@@ -819,7 +821,7 @@ function ModulePublishMenu({
                   onUnpublishAllItems()
                   setMenuOpen(false)
                 }}
-                className="flex w-full border-t border-slate-100 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:border-neutral-700 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
+                className="flex w-full border-t border-slate-100 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
               >
                 Unpublish All Items
               </button>
@@ -833,7 +835,7 @@ function ModulePublishMenu({
                   onPublishModuleOnly()
                   setMenuOpen(false)
                 }}
-                className="flex w-full px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
+                className="flex w-full px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
               >
                 Publish Module Only
               </button>
@@ -844,7 +846,7 @@ function ModulePublishMenu({
                   onPublishAllItems()
                   setMenuOpen(false)
                 }}
-                className="flex w-full border-t border-slate-100 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:border-neutral-700 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
+                className="flex w-full border-t border-slate-100 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
               >
                 Publish All Items
               </button>
@@ -899,11 +901,12 @@ function ModuleItemRowActions({
         aria-pressed={child.published}
         className={`flex shrink-0 items-center justify-center ${child.published ? iconGhostPublished : iconGhostDraft}`}
       >
-        {child.published ? (
-          <Eye className="h-4 w-4" strokeWidth={2} aria-hidden />
-        ) : (
-          <EyeOff className="h-4 w-4" strokeWidth={2} aria-hidden />
-        )}
+        <IconSwap
+          active={child.published}
+          activeIcon={Eye}
+          inactiveIcon={EyeOff}
+          iconClassName="h-4 w-4"
+        />
       </button>
       <div ref={rootRef} className="relative">
         <button
@@ -935,7 +938,7 @@ function ModuleItemRowActions({
                 onEditTitle()
                 setMenuOpen(false)
               }}
-              className="flex w-full px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
+              className="flex w-full px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
             >
               Edit title
             </button>
@@ -946,7 +949,7 @@ function ModuleItemRowActions({
                 onArchive()
                 setMenuOpen(false)
               }}
-              className="flex w-full border-t border-slate-100 px-2.5 py-2 text-start text-sm font-medium text-rose-700 transition hover:bg-rose-50 dark:border-neutral-700 dark:text-rose-300 dark:hover:bg-rose-950/50"
+              className="flex w-full border-t border-slate-100 px-2.5 py-2 text-start text-sm font-medium text-rose-700 transition-[background-color,color,border-color] hover:bg-rose-50 dark:border-neutral-700 dark:text-rose-300 dark:hover:bg-rose-950/50"
             >
               Delete
             </button>
@@ -1001,7 +1004,7 @@ function SortableChildRow({
           {(!disabled || dragHandlesVisible || isDragging) && (
             <button
               type="button"
-              className={`flex h-11 w-11 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg border-0 bg-transparent p-0 text-slate-400 shadow-none transition hover:text-slate-600 active:cursor-grabbing focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 sm:h-9 sm:w-9 dark:text-neutral-500 dark:hover:text-neutral-300 ${
+              className={`flex h-11 w-11 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg border-0 bg-transparent p-0 text-slate-400 shadow-none transition-[opacity,background-color,color,border-color] hover:text-slate-600 active:cursor-grabbing focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 sm:h-9 sm:w-9 dark:text-neutral-500 dark:hover:text-neutral-300 ${
                 gripAlwaysOn
                   ? 'opacity-100'
                   : 'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto'
@@ -1144,7 +1147,7 @@ function ModuleCardBody({
                 onClick={onToggleCollapsed}
                 aria-expanded={!collapsed}
                 aria-controls={moduleItemsRegionId}
-                className="w-full min-w-0 rounded-xl px-1 py-0.5 text-start transition hover:bg-slate-200/40 dark:hover:bg-neutral-700/50"
+                className="w-full min-w-0 rounded-xl px-1 py-0.5 text-start transition-[background-color,color,border-color] hover:bg-slate-200/40 dark:hover:bg-neutral-700/50"
               >
                 <span className="flex items-start gap-2">
                   <span
@@ -1547,7 +1550,7 @@ function SortableModuleCard({
           canEditModules ? (
             <button
               type="button"
-              className={`mt-0.5 flex h-11 w-11 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg border-0 bg-transparent p-0 text-slate-400 shadow-none transition hover:text-slate-600 active:cursor-grabbing focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 sm:h-9 sm:w-9 dark:text-neutral-500 dark:hover:text-neutral-300 ${
+              className={`mt-0.5 flex h-11 w-11 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg border-0 bg-transparent p-0 text-slate-400 shadow-none transition-[opacity,background-color,color,border-color] hover:text-slate-600 active:cursor-grabbing focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 sm:h-9 sm:w-9 dark:text-neutral-500 dark:hover:text-neutral-300 ${
                 gripsPinned || isDragging
                   ? 'opacity-100'
                   : 'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto'

--- a/clients/web/src/pages/lms/course-office-hours-page.tsx
+++ b/clients/web/src/pages/lms/course-office-hours-page.tsx
@@ -61,7 +61,7 @@ function SlotCard({ slot, window: win, isStaff, myUserId, onBook, onCancel }: Sl
   return (
     <div
       role="gridcell"
-      className={`rounded-xl border p-4 transition ${
+      className={`rounded-xl border p-4 transition-colors ${
         isMyBooking
           ? 'border-sky-300 bg-sky-50/60 dark:border-sky-700 dark:bg-sky-950/30'
           : slot.status === 'available'
@@ -295,7 +295,7 @@ function CreateWindowModal({ courseCode, onClose, onCreated }: CreateWindowModal
             <button
               type="button"
               onClick={() => setMode('recurring')}
-              className={`flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition ${
+              className={`flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition-[background-color,color,border-color] ${
                 mode === 'recurring'
                   ? 'border-emerald-500 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300'
                   : 'border-neutral-300 text-neutral-600 hover:border-neutral-400 dark:border-neutral-600 dark:text-neutral-300'
@@ -306,7 +306,7 @@ function CreateWindowModal({ courseCode, onClose, onCreated }: CreateWindowModal
             <button
               type="button"
               onClick={() => setMode('oneoff')}
-              className={`flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition ${
+              className={`flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition-[background-color,color,border-color] ${
                 mode === 'oneoff'
                   ? 'border-emerald-500 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300'
                   : 'border-neutral-300 text-neutral-600 hover:border-neutral-400 dark:border-neutral-600 dark:text-neutral-300'
@@ -418,7 +418,7 @@ function CreateWindowModal({ courseCode, onClose, onCreated }: CreateWindowModal
               }`}
             >
               <span
-                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition ${
+                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition-transform ${
                   isVirtual ? 'translate-x-4' : 'translate-x-0'
                 }`}
               />

--- a/clients/web/src/pages/lms/course-outcomes-report.tsx
+++ b/clients/web/src/pages/lms/course-outcomes-report.tsx
@@ -227,7 +227,7 @@ export default function CourseOutcomesReport() {
             onClick={() => void handleRefresh()}
             disabled={refreshing}
             aria-label="Refresh outcomes report"
-            className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50/60 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
+            className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50/60 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
           >
             <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} aria-hidden />
             {refreshing ? 'Refreshing…' : 'Refresh'}

--- a/clients/web/src/pages/lms/course-outcomes-section.tsx
+++ b/clients/web/src/pages/lms/course-outcomes-section.tsx
@@ -299,7 +299,7 @@ export function CourseOutcomesSection({ courseCode }: { courseCode: string }) {
         <details className="group mt-4 border-t border-slate-100 pt-4 dark:border-neutral-800">
           <summary className="flex cursor-pointer list-none items-center gap-2 text-sm font-medium text-indigo-700 outline-none hover:text-indigo-600 dark:text-indigo-300 dark:hover:text-indigo-200 [&::-webkit-details-marker]:hidden">
             <ChevronDown
-              className="h-4 w-4 shrink-0 text-indigo-500 transition group-open:rotate-180 dark:text-indigo-400"
+              className="h-4 w-4 shrink-0 text-indigo-500 transition-transform group-open:rotate-180 dark:text-indigo-400"
               aria-hidden
             />
             How scores roll up into outcome progress
@@ -425,7 +425,7 @@ export function CourseOutcomesSection({ courseCode }: { courseCode: string }) {
                 <button
                   type="submit"
                   disabled={creating || !newTitle.trim()}
-                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   <Plus className="h-4 w-4" aria-hidden />
                   {creating ? 'Adding…' : 'Create outcome'}
@@ -434,13 +434,13 @@ export function CourseOutcomesSection({ courseCode }: { courseCode: string }) {
             </form>
           ) : (
             <details className="group rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-950">
-              <summary className="flex cursor-pointer list-none items-center justify-between gap-3 rounded-2xl px-5 py-4 text-sm font-semibold text-slate-900 outline-none ring-indigo-500/0 transition hover:bg-slate-50/80 dark:text-neutral-100 dark:hover:bg-neutral-900/60 [&::-webkit-details-marker]:hidden">
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-3 rounded-2xl px-5 py-4 text-sm font-semibold text-slate-900 outline-none ring-indigo-500/0 transition-[background-color,color,border-color] hover:bg-slate-50/80 dark:text-neutral-100 dark:hover:bg-neutral-900/60 [&::-webkit-details-marker]:hidden">
                 <span className="inline-flex items-center gap-2">
                   <Plus className="h-4 w-4 text-indigo-600 dark:text-indigo-400" aria-hidden />
                   Add another outcome
                 </span>
                 <ChevronDown
-                  className="h-4 w-4 shrink-0 text-slate-400 transition group-open:rotate-180 dark:text-neutral-500"
+                  className="h-4 w-4 shrink-0 text-slate-400 transition-transform group-open:rotate-180 dark:text-neutral-500"
                   aria-hidden
                 />
               </summary>
@@ -477,7 +477,7 @@ export function CourseOutcomesSection({ courseCode }: { courseCode: string }) {
                   <button
                     type="submit"
                     disabled={creating || !newTitle.trim()}
-                    className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     <Plus className="h-4 w-4" aria-hidden />
                     {creating ? 'Adding…' : 'Create outcome'}

--- a/clients/web/src/pages/lms/course-settings.tsx
+++ b/clients/web/src/pages/lms/course-settings.tsx
@@ -999,7 +999,7 @@ export default function CourseSettings() {
                       }`}
                   >
                     <span
-                      className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition ${published ? 'translate-x-5' : 'translate-x-0.5'
+                      className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition-transform ${published ? 'translate-x-5' : 'translate-x-0.5'
                         }`}
                     />
                   </button>
@@ -1127,7 +1127,7 @@ export default function CourseSettings() {
                       }`}
                   >
                     <span
-                      className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition ${scheduleMode === 'relative' ? 'translate-x-5' : 'translate-x-0.5'
+                      className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition-transform ${scheduleMode === 'relative' ? 'translate-x-5' : 'translate-x-0.5'
                         }`}
                     />
                   </button>
@@ -1215,12 +1215,12 @@ export default function CourseSettings() {
                   <button
                     type="button"
                     onClick={openImageModal}
-                    className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-350 dark:hover:border-indigo-900 dark:hover:bg-indigo-950 dark:hover:text-indigo-100"
+                    className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-350 dark:hover:border-indigo-900 dark:hover:bg-indigo-950 dark:hover:text-indigo-100"
                   >
                     <ImageIcon className="h-4 w-4" aria-hidden />
                     Generate image
                   </button>
-                  <label className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-350 dark:hover:border-indigo-900 dark:hover:bg-indigo-950 dark:hover:text-indigo-100">
+                  <label className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-350 dark:hover:border-indigo-900 dark:hover:bg-indigo-950 dark:hover:text-indigo-100">
                     <Upload className="h-4 w-4" aria-hidden />
                     {heroUploadStatus === 'uploading' ? 'Uploading…' : 'Upload image'}
                     <input
@@ -1236,7 +1236,7 @@ export default function CourseSettings() {
                     onClick={openPositionModal}
                     disabled={!course.heroImageUrl}
                     title={!course.heroImageUrl ? 'Add a hero image first' : undefined}
-                    className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-350 dark:hover:border-indigo-900 dark:hover:bg-indigo-950 dark:hover:text-indigo-100"
+                    className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-350 dark:hover:border-indigo-900 dark:hover:bg-indigo-950 dark:hover:text-indigo-100"
                   >
                     <Move className="h-4 w-4" aria-hidden />
                     Position image
@@ -1275,7 +1275,7 @@ export default function CourseSettings() {
                         type="button"
                         onClick={() => selectMarkdownPreset(meta.id)}
                         disabled={saveStatus === 'saving'}
-                        className={`relative flex flex-col rounded-xl border p-4 text-start transition ${selected
+                        className={`relative flex flex-col rounded-xl border p-4 text-start transition-[background-color,color,border-color] ${selected
                           ? 'border-indigo-500 bg-indigo-50/60 ring-2 ring-indigo-500/30 dark:border-indigo-500 dark:bg-indigo-950/30'
                           : 'border-slate-200 bg-white hover:border-indigo-200 hover:bg-slate-50/80 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:border-indigo-850 dark:hover:bg-neutral-900/50'
                           } disabled:opacity-60`}
@@ -1672,7 +1672,7 @@ export default function CourseSettings() {
                       type="button"
                       onClick={() => void onSaveHeroImage()}
                       disabled={saveHeroStatus === 'saving'}
-                      className="inline-flex items-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-900 shadow-sm transition hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-60"
+                      className="inline-flex items-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-900 shadow-sm transition-[background-color,color,border-color] hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       <Save className="h-4 w-4" aria-hidden />
                       {saveHeroStatus === 'saving' ? 'Saving…' : 'Save image'}

--- a/clients/web/src/pages/lms/course-student-reports-page.tsx
+++ b/clients/web/src/pages/lms/course-student-reports-page.tsx
@@ -147,7 +147,7 @@ export default function CourseStudentReportsPage() {
                     <td className="px-2 py-3 text-end align-middle">
                       <Link
                         to={reportPath}
-                        className="inline-flex items-center gap-1 rounded-lg px-2 py-1.5 text-sm font-medium text-indigo-700 opacity-0 transition hover:bg-indigo-50 group-hover:opacity-100 focus-visible:opacity-100 dark:text-indigo-300 dark:hover:bg-indigo-950/40"
+                        className="inline-flex items-center gap-1 rounded-lg px-2 py-1.5 text-sm font-medium text-indigo-700 opacity-0 transition-[opacity,background-color,color,border-color] hover:bg-indigo-50 group-hover:opacity-100 focus-visible:opacity-100 dark:text-indigo-300 dark:hover:bg-indigo-950/40"
                         aria-label={`View report for ${name}`}
                       >
                         <BarChart3 className="h-4 w-4" aria-hidden />

--- a/clients/web/src/pages/lms/course-syllabus-acceptance-overlay.tsx
+++ b/clients/web/src/pages/lms/course-syllabus-acceptance-overlay.tsx
@@ -115,7 +115,7 @@ export function CourseSyllabusAcceptanceOverlay({ courseCode }: { courseCode: st
             type="button"
             onClick={() => void handleAcceptSyllabus()}
             disabled={accepting}
-            className="w-full rounded-xl bg-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+            className="w-full rounded-xl bg-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
           >
             {accepting ? 'Saving…' : 'I have read and accept the syllabus'}
           </button>

--- a/clients/web/src/pages/lms/course-syllabus.tsx
+++ b/clients/web/src/pages/lms/course-syllabus.tsx
@@ -175,7 +175,7 @@ export default function CourseSyllabus() {
               type="button"
               onClick={cancelEdit}
               disabled={saving}
-              className="rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
             >
               Cancel
             </button>
@@ -183,7 +183,7 @@ export default function CourseSyllabus() {
               type="button"
               onClick={() => void save()}
               disabled={saving}
-              className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {saving ? 'Saving…' : 'Save'}
             </button>
@@ -196,7 +196,7 @@ export default function CourseSyllabus() {
               type="button"
               onClick={beginEdit}
               disabled={loading}
-              className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <Pencil className="h-4 w-4" aria-hidden />
               Edit

--- a/clients/web/src/pages/lms/course-whats-working.tsx
+++ b/clients/web/src/pages/lms/course-whats-working.tsx
@@ -232,7 +232,7 @@ export default function CourseWhatsWorking() {
           onClick={() => void handleRefresh()}
           disabled={refreshing}
           aria-label="Refresh insights"
-          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50/60 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
+          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50/60 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
         >
           <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} aria-hidden />
           {refreshing ? 'Refreshing…' : 'Refresh'}

--- a/clients/web/src/pages/lms/courses.tsx
+++ b/clients/web/src/pages/lms/courses.tsx
@@ -1103,7 +1103,7 @@ export default function Courses() {
           {showCourseCreateActions ? (
             <Link
               to="/courses/create"
-              className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+              className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500"
             >
               <Plus className="h-4 w-4" aria-hidden />
               New course

--- a/clients/web/src/pages/lms/dashboard.tsx
+++ b/clients/web/src/pages/lms/dashboard.tsx
@@ -670,7 +670,7 @@ export default function Dashboard() {
           <div className="mt-5 flex flex-wrap justify-center gap-3">
             <Link
               to="/courses"
-              className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+              className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500"
             >
               Browse courses
               <ArrowRight className="h-4 w-4" aria-hidden />
@@ -685,7 +685,7 @@ export default function Dashboard() {
             <div className="flex flex-wrap gap-3">
               <Link
                 to="/inbox"
-                className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800"
+                className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800"
               >
                 <Inbox className="h-4 w-4 text-indigo-500" aria-hidden />
                 Inbox
@@ -697,7 +697,7 @@ export default function Dashboard() {
               </Link>
               <Link
                 to="/courses"
-                className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800"
+                className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800"
               >
                 <BookOpen className="h-4 w-4 text-indigo-500" aria-hidden />
                 All courses
@@ -705,7 +705,7 @@ export default function Dashboard() {
               {ffEportfolio ? (
                 <Link
                   to="/portfolios"
-                  className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800"
+                  className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800"
                 >
                   <FolderOpen className="h-4 w-4 text-indigo-500" aria-hidden />
                   My Portfolio
@@ -714,7 +714,7 @@ export default function Dashboard() {
               {ffAdvisingIntegration ? (
                 <Link
                   to="/advising-notes"
-                  className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800"
+                  className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800"
                 >
                   <GraduationCap className="h-4 w-4 text-indigo-500" aria-hidden />
                   Advising notes
@@ -778,7 +778,7 @@ export default function Dashboard() {
                         rank: 0,
                       }).catch(() => {})
                     }}
-                    className="mt-4 inline-flex items-center gap-2 rounded-xl bg-violet-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-violet-500"
+                    className="mt-4 inline-flex items-center gap-2 rounded-xl bg-violet-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-violet-500"
                   >
                     Go
                     <ArrowRight className="h-4 w-4" aria-hidden />
@@ -914,7 +914,7 @@ export default function Dashboard() {
                 </div>
                 <Link
                   to="/review"
-                  className="inline-flex shrink-0 items-center gap-2 rounded-xl bg-amber-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-600"
+                  className="inline-flex shrink-0 items-center gap-2 rounded-xl bg-amber-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-amber-600"
                 >
                   {reviewStats.dueToday > 0 ? 'Start review' : 'Open review'}
                   <ArrowRight className="h-4 w-4" aria-hidden />
@@ -983,7 +983,7 @@ export default function Dashboard() {
                     <li key={sec.id}>
                       <Link
                         to={href}
-                        className="flex flex-col gap-2 rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm transition hover:border-indigo-200 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-indigo-800 sm:flex-row sm:items-center sm:justify-between"
+                        className="flex flex-col gap-2 rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-indigo-800 sm:flex-row sm:items-center sm:justify-between"
                       >
                         <div className="min-w-0">
                           <p className="text-xs font-medium text-slate-500 dark:text-neutral-400">
@@ -1028,7 +1028,7 @@ export default function Dashboard() {
                 </p>
                 <Link
                   to={hrefForLastVisited(continueTarget.courseCode, continueTarget.kind, continueTarget.itemId)}
-                  className="mt-4 inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+                  className="mt-4 inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500"
                 >
                   Continue
                   <ArrowRight className="h-4 w-4" aria-hidden />
@@ -1100,7 +1100,7 @@ export default function Dashboard() {
                             <li key={`${row.course.courseCode}-${it.id}`}>
                               <Link
                                 to={href}
-                                className="flex flex-col gap-1 rounded-xl border border-slate-100 px-3 py-3 transition hover:border-indigo-200 hover:bg-indigo-50/40 dark:border-neutral-800 dark:hover:border-indigo-900/50 dark:hover:bg-indigo-950/20 sm:flex-row sm:items-center sm:justify-between"
+                                className="flex flex-col gap-1 rounded-xl border border-slate-100 px-3 py-3 transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50/40 dark:border-neutral-800 dark:hover:border-indigo-900/50 dark:hover:bg-indigo-950/20 sm:flex-row sm:items-center sm:justify-between"
                               >
                                 <div className="min-w-0">
                                   <p className="text-xs font-medium text-slate-500 dark:text-neutral-400">
@@ -1215,21 +1215,21 @@ export default function Dashboard() {
                           <div className="mt-4 flex flex-wrap gap-2">
                             <Link
                               to={`${base}/modules`}
-                              className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                              className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
                             >
                               <ClipboardList className="h-3.5 w-3.5" aria-hidden />
                               Modules
                             </Link>
                             <Link
                               to={`${base}/feed`}
-                              className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                              className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
                             >
                               <MessageCircle className="h-3.5 w-3.5" aria-hidden />
                               Feed
                             </Link>
                             <Link
                               to={`${base}/my-grades`}
-                              className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                              className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
                             >
                               <Sparkles className="h-3.5 w-3.5" aria-hidden />
                               Grades
@@ -1368,13 +1368,13 @@ export default function Dashboard() {
                         <div className="mt-4 flex flex-wrap gap-2">
                           <Link
                             to={`${base}/gradebook`}
-                            className="inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+                            className="inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500"
                           >
                             Open gradebook
                           </Link>
                           <Link
                             to={`${base}/modules`}
-                            className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                            className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
                           >
                             Modules
                           </Link>
@@ -1401,7 +1401,7 @@ export default function Dashboard() {
                 type="button"
                 onClick={loadMoreCourses}
                 disabled={loadingMoreCourses}
-                className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800"
+                className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-slate-300 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-neutral-600 dark:hover:bg-neutral-800"
               >
                 {loadingMoreCourses
                   ? 'Loading…'

--- a/clients/web/src/pages/lms/enrollment-groups-panel.tsx
+++ b/clients/web/src/pages/lms/enrollment-groups-panel.tsx
@@ -200,10 +200,10 @@ function GroupSetActionsMenu({
           if (disabled) return
           setOpen((o) => !o)
         }}
-        className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-2 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto sm:justify-start sm:px-3 sm:py-2"
+        className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-2 py-1.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto sm:justify-start sm:px-3 sm:py-2"
       >
         <span>Actions</span>
-        <ChevronDown className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`} aria-hidden />
+        <ChevronDown className={`h-4 w-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`} aria-hidden />
       </button>
 
       {open ? (
@@ -221,7 +221,7 @@ function GroupSetActionsMenu({
               onNewSet()
               setOpen(false)
             }}
-            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
+            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
           >
             <Plus className="h-4 w-4 shrink-0" aria-hidden />
             New set
@@ -236,7 +236,7 @@ function GroupSetActionsMenu({
                   onRenameSet()
                   setOpen(false)
                 }}
-                className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
+                className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
               >
                 Rename set
               </button>
@@ -248,7 +248,7 @@ function GroupSetActionsMenu({
                   onDeleteSet()
                   setOpen(false)
                 }}
-                className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-rose-700 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-rose-300 dark:hover:bg-rose-950/40"
+                className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-rose-700 transition-[background-color,color,border-color] hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-rose-300 dark:hover:bg-rose-950/40"
               >
                 <Trash2 className="h-4 w-4 shrink-0" aria-hidden />
                 Delete set
@@ -262,7 +262,7 @@ function GroupSetActionsMenu({
                   onNewGroup()
                   setOpen(false)
                 }}
-                className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
+                className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
               >
                 <Plus className="h-4 w-4 shrink-0" aria-hidden />
                 New group
@@ -276,7 +276,7 @@ function GroupSetActionsMenu({
                   onAssignUnassigned()
                   setOpen(false)
                 }}
-                className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
+                className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
               >
                 <Shuffle className="h-4 w-4 shrink-0" aria-hidden />
                 Assign unassigned students

--- a/clients/web/src/pages/lms/enrollments-actions-menu.tsx
+++ b/clients/web/src/pages/lms/enrollments-actions-menu.tsx
@@ -50,11 +50,11 @@ export function EnrollmentsActionsMenu({
           if (disabled) return
           setOpen((o) => !o)
         }}
-        className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-2 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto sm:justify-start sm:px-3 sm:py-2"
+        className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-2 py-1.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto sm:justify-start sm:px-3 sm:py-2"
       >
         <span>Actions</span>
         <ChevronDown
-          className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`}
+          className={`h-4 w-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
           aria-hidden
         />
       </button>
@@ -75,7 +75,7 @@ export function EnrollmentsActionsMenu({
                 onEnrollAsStudent()
                 setOpen(false)
               }}
-              className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
+              className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
             >
               <GraduationCap className="h-4 w-4 shrink-0" aria-hidden />
               {enrollAsStudentBusy ? 'Enrolling…' : 'Enroll as Student'}
@@ -89,7 +89,7 @@ export function EnrollmentsActionsMenu({
               onAddEnrollment()
               setOpen(false)
             }}
-            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
+            className="flex w-full items-center gap-2 px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
           >
             <UserPlus className="h-4 w-4 shrink-0" aria-hidden />
             Add enrollment
@@ -107,7 +107,7 @@ export function EnrollmentsActionsMenu({
                   onEnableGroups()
                   setOpen(false)
                 }}
-                className="flex w-full items-start gap-2 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:bg-neutral-700/80"
+                className="flex w-full items-start gap-2 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:bg-neutral-700/80"
               >
                 <span
                   className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border ${

--- a/clients/web/src/pages/lms/gradebook/gradebook-grid.tsx
+++ b/clients/web/src/pages/lms/gradebook/gradebook-grid.tsx
@@ -180,7 +180,7 @@ function HeaderSortMenuPortal({
 
 function menuButtonClass(active: boolean) {
   return [
-    'inline-flex w-full max-w-full items-center justify-between gap-1 rounded-md px-1 py-0.5 text-start font-[inherit] transition',
+    'inline-flex w-full max-w-full items-center justify-between gap-1 rounded-md px-1 py-0.5 text-start font-[inherit] transition-colors',
     active
       ? 'bg-indigo-100 text-indigo-950 ring-1 ring-indigo-300 dark:bg-indigo-950/80 dark:text-indigo-100 dark:ring-indigo-600'
       : 'text-inherit hover:bg-slate-200/80 dark:hover:bg-neutral-700/80',
@@ -1182,7 +1182,7 @@ export function GradebookGrid({
             Former students ({formerStudents.length})
           </span>
           <ChevronDown
-            className={`h-4 w-4 shrink-0 transition ${formerCollapsed ? '' : 'rotate-180'}`}
+            className={`h-4 w-4 shrink-0 transition-transform ${formerCollapsed ? '' : 'rotate-180'}`}
             aria-hidden
           />
         </button>
@@ -1345,7 +1345,7 @@ export function GradebookGrid({
                 : 'Show assignments as rows and students as columns'
             }
             className={[
-              'inline-flex shrink-0 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition',
+              'inline-flex shrink-0 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition-colors',
               transposed
                 ? 'border-indigo-300 bg-indigo-50 text-indigo-950 dark:border-indigo-600 dark:bg-indigo-950/50 dark:text-indigo-100'
                 : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700/80',
@@ -1374,7 +1374,7 @@ export function GradebookGrid({
                 : 'Color each score cell from cool (low) to warm (high) within its column'
             }
             className={[
-              'inline-flex shrink-0 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition',
+              'inline-flex shrink-0 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition-colors',
               colorScaleEnabled
                 ? 'border-indigo-300 bg-indigo-50 text-indigo-950 dark:border-indigo-600 dark:bg-indigo-950/50 dark:text-indigo-100'
                 : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700/80',
@@ -1748,7 +1748,7 @@ export function GradebookGrid({
                         aria-selected={
                           inRect || showEditor || (isFocusCell && !editing && selectionRect == null)
                         }
-                        className={`relative ${pad} min-w-[5.5rem] border-s border-slate-100 text-end tabular-nums outline-none transition dark:border-neutral-700/80 ${cellSurface} ${fillExtSurface} ${droppedSurface}`}
+                        className={`relative ${pad} min-w-[5.5rem] border-s border-slate-100 text-end tabular-nums outline-none transition-colors dark:border-neutral-700/80 ${cellSurface} ${fillExtSurface} ${droppedSurface}`}
                         title={
                           cellDropped
                             ? 'This score is excluded from the course total by the group’s drop or replace policy.'

--- a/clients/web/src/pages/lms/inbox.tsx
+++ b/clients/web/src/pages/lms/inbox.tsx
@@ -263,7 +263,7 @@ export default function Inbox() {
               setComposeOpen(true)
               setComposeError(null)
             }}
-            className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-3.5 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+            className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-3.5 py-2 text-sm font-medium text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
           >
             <Mail className="h-4 w-4 shrink-0" aria-hidden />
             Compose
@@ -304,7 +304,7 @@ export default function Inbox() {
                   setSelectedId(null)
                   setMobilePane('list')
                 }}
-                className={`flex items-center gap-2 rounded-lg px-3 py-2 text-start text-sm font-medium transition md:w-full ${
+                className={`flex items-center gap-2 rounded-lg px-3 py-2 text-start text-sm font-medium transition-[background-color,color,border-color] md:w-full ${
                   folder === id
                     ? 'bg-indigo-50 text-indigo-800'
                     : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
@@ -361,7 +361,7 @@ export default function Inbox() {
                     return (
                       <li
                         key={m.id}
-                        className={`flex border-b border-slate-100 transition hover:bg-slate-50 ${
+                        className={`flex border-b border-slate-100 transition-[background-color,color,border-color] hover:bg-slate-50 ${
                           active ? 'bg-indigo-50/60' : ''
                         } ${!m.read ? 'bg-slate-50/90' : ''}`}
                       >

--- a/clients/web/src/pages/lms/inclusive-access-banner.tsx
+++ b/clients/web/src/pages/lms/inclusive-access-banner.tsx
@@ -80,7 +80,7 @@ export function InclusiveAccessBanner({ status, storageKey }: Props) {
               <button
                 type="button"
                 onClick={confirmKeep}
-                className="rounded-xl bg-amber-600 px-3.5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-500"
+                className="rounded-xl bg-amber-600 px-3.5 py-2 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-amber-500"
               >
                 Keep included access
               </button>
@@ -88,7 +88,7 @@ export function InclusiveAccessBanner({ status, storageKey }: Props) {
                 <button
                   type="button"
                   onClick={() => setConfirmingOptOut(true)}
-                  className="rounded-xl border border-amber-400 bg-white px-3.5 py-2 text-sm font-semibold text-amber-800 transition hover:bg-amber-100 dark:border-amber-500/50 dark:bg-amber-900/30 dark:text-amber-100"
+                  className="rounded-xl border border-amber-400 bg-white px-3.5 py-2 text-sm font-semibold text-amber-800 transition-[background-color,color,border-color] hover:bg-amber-100 dark:border-amber-500/50 dark:bg-amber-900/30 dark:text-amber-100"
                 >
                   Opt out…
                 </button>
@@ -106,14 +106,14 @@ export function InclusiveAccessBanner({ status, storageKey }: Props) {
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={confirmKeep}
-                  className="rounded-xl bg-rose-600 px-3.5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-rose-500"
+                  className="rounded-xl bg-rose-600 px-3.5 py-2 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-rose-500"
                 >
                   Continue to opt-out form
                 </a>
                 <button
                   type="button"
                   onClick={() => setConfirmingOptOut(false)}
-                  className="rounded-xl border border-amber-400 bg-white px-3.5 py-2 text-sm font-semibold text-amber-800 transition hover:bg-amber-100 dark:border-amber-500/50 dark:bg-amber-900/30 dark:text-amber-100"
+                  className="rounded-xl border border-amber-400 bg-white px-3.5 py-2 text-sm font-semibold text-amber-800 transition-[background-color,color,border-color] hover:bg-amber-100 dark:border-amber-500/50 dark:bg-amber-900/30 dark:text-amber-100"
                 >
                   Cancel
                 </button>

--- a/clients/web/src/pages/lms/moderation-dashboard.tsx
+++ b/clients/web/src/pages/lms/moderation-dashboard.tsx
@@ -74,7 +74,7 @@ export default function ModerationDashboard() {
       actions={
         <Link
           to={back}
-          className="rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:hover:bg-neutral-900"
+          className="rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-600 dark:bg-neutral-950 dark:text-neutral-100 dark:hover:bg-neutral-900"
         >
           Back to assignment
         </Link>

--- a/clients/web/src/pages/lms/my-notebooks-page.tsx
+++ b/clients/web/src/pages/lms/my-notebooks-page.tsx
@@ -239,7 +239,7 @@ export default function MyNotebooksPage() {
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Search my notes…"
                 autoComplete="off"
-                className="w-full rounded-xl border border-slate-200 bg-white py-2.5 ps-10 pe-3 text-sm text-slate-900 shadow-sm outline-none ring-indigo-500/0 transition placeholder:text-slate-400 focus:border-indigo-300 focus:ring-4 focus:ring-indigo-500/15 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500/50"
+                className="w-full rounded-xl border border-slate-200 bg-white py-2.5 ps-10 pe-3 text-sm text-slate-900 shadow-sm outline-none ring-indigo-500/0 transition-[background-color,color,border-color] placeholder:text-slate-400 focus:border-indigo-300 focus:ring-4 focus:ring-indigo-500/15 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:focus:border-indigo-500/50"
               />
             </div>
           </div>
@@ -249,7 +249,7 @@ export default function MyNotebooksPage() {
               type="button"
               onClick={() => setAskCardOpen(true)}
               aria-expanded={false}
-              className="flex w-full items-start gap-3 rounded-2xl border border-indigo-200/90 bg-gradient-to-b from-indigo-50/80 to-white p-4 text-start shadow-sm transition hover:border-indigo-300 hover:shadow-md dark:border-indigo-500/25 dark:from-indigo-950/40 dark:to-neutral-950 dark:hover:border-indigo-400/40 sm:p-5"
+              className="flex w-full items-start gap-3 rounded-2xl border border-indigo-200/90 bg-gradient-to-b from-indigo-50/80 to-white p-4 text-start shadow-sm transition-[box-shadow,background-color,color,border-color] hover:border-indigo-300 hover:shadow-md dark:border-indigo-500/25 dark:from-indigo-950/40 dark:to-neutral-950 dark:hover:border-indigo-400/40 sm:p-5"
             >
               <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-indigo-100 text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-200">
                 <Sparkles className="h-4 w-4" aria-hidden />
@@ -286,7 +286,7 @@ export default function MyNotebooksPage() {
                       type="button"
                       onClick={() => setAskCardOpen(false)}
                       aria-label="Close ask panel"
-                      className="-me-1 -mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
+                      className="-me-1 -mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-slate-500 transition-[background-color,color,border-color] hover:bg-slate-100 hover:text-slate-800 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
                     >
                       <X className="h-4 w-4" aria-hidden />
                     </button>
@@ -302,7 +302,7 @@ export default function MyNotebooksPage() {
                         ? 'e.g. What themes did I write about in my literature course?'
                         : 'Save notes in your global or a course notebook to use this.'
                     }
-                    className="w-full resize-y rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none ring-indigo-500/0 transition focus:border-indigo-300 focus:ring-4 focus:ring-indigo-500/15 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500/50 dark:disabled:bg-neutral-900 dark:disabled:text-neutral-500"
+                    className="w-full resize-y rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none ring-indigo-500/0 transition-[background-color,color,border-color] focus:border-indigo-300 focus:ring-4 focus:ring-indigo-500/15 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-indigo-500/50 dark:disabled:bg-neutral-900 dark:disabled:text-neutral-500"
                     onKeyDown={(e) => {
                       if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                         e.preventDefault()
@@ -315,7 +315,7 @@ export default function MyNotebooksPage() {
                       type="button"
                       onClick={() => void submitAsk()}
                       disabled={!hasNotes || askLoading || !askText.trim()}
-                      className="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 disabled:pointer-events-none disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+                      className="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-700 disabled:pointer-events-none disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
                     >
                       {askLoading ? 'Thinking…' : 'Ask'}
                     </button>
@@ -406,7 +406,7 @@ export default function MyNotebooksPage() {
             <li key={e.courseCode}>
               <Link
                 to={hrefForStudentNotebook(e.courseCode)}
-                className="flex h-full flex-col rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-indigo-200 hover:shadow-md dark:border-neutral-700 dark:bg-neutral-950 dark:hover:border-indigo-500/40"
+                className="flex h-full flex-col rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition-[box-shadow,background-color,color,border-color] hover:border-indigo-200 hover:shadow-md dark:border-neutral-700 dark:bg-neutral-950 dark:hover:border-indigo-500/40"
               >
                 <div className="flex items-start gap-3">
                   <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-indigo-50 text-indigo-700 dark:bg-indigo-950/80 dark:text-indigo-200">

--- a/clients/web/src/pages/lms/my-portfolios-page.tsx
+++ b/clients/web/src/pages/lms/my-portfolios-page.tsx
@@ -93,7 +93,7 @@ export default function MyPortfoliosPage() {
       actions={
         <button
           onClick={() => setShowAdd((v) => !v)}
-          className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 shadow-sm transition"
+          className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 shadow-sm transition-[background-color,color,border-color]"
         >
           <Plus className="h-4 w-4" aria-hidden />
           New Portfolio
@@ -139,7 +139,7 @@ export default function MyPortfoliosPage() {
               <button
                 type="submit"
                 disabled={saving}
-                className="rounded-xl bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 shadow-sm transition disabled:opacity-50"
+                className="rounded-xl bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 shadow-sm transition-[background-color,color,border-color] disabled:opacity-50"
               >
                 {saving ? 'Creating…' : 'Create'}
               </button>
@@ -149,7 +149,7 @@ export default function MyPortfoliosPage() {
                   setShowAdd(false)
                   setFormError(null)
                 }}
-                className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50 transition dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50 transition-[background-color,color,border-color] dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800"
               >
                 Cancel
               </button>
@@ -180,7 +180,7 @@ export default function MyPortfoliosPage() {
               <li key={p.id} className="group">
                 <Link
                   to={`/portfolios/${p.id}`}
-                  className="block w-full rounded-2xl border border-slate-200/70 bg-slate-50/60 p-4 shadow-sm transition hover:border-slate-300/80 hover:bg-slate-100/60 dark:border-neutral-700/80 dark:bg-neutral-800/85 dark:hover:border-neutral-600/80 dark:hover:bg-neutral-800"
+                  className="block w-full rounded-2xl border border-slate-200/70 bg-slate-50/60 p-4 shadow-sm transition-[background-color,color,border-color] hover:border-slate-300/80 hover:bg-slate-100/60 dark:border-neutral-700/80 dark:bg-neutral-800/85 dark:hover:border-neutral-600/80 dark:hover:bg-neutral-800"
                 >
                   <div className="flex items-center gap-3">
                     <div className="min-w-0 flex-1">

--- a/clients/web/src/pages/lms/parent/conference-booking.tsx
+++ b/clients/web/src/pages/lms/parent/conference-booking.tsx
@@ -179,7 +179,7 @@ export default function ConferenceBooking() {
                   role="option"
                   aria-selected={active}
                   onClick={() => setParams({ student: c.studentUserId })}
-                  className={`rounded-full px-4 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
+                  className={`rounded-full px-4 py-2 text-sm font-medium transition-[background-color,color,border-color] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
                     active
                       ? 'bg-indigo-600 text-white'
                       : 'bg-neutral-100 text-neutral-800 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-100'

--- a/clients/web/src/pages/lms/portfolio-artifact-content-page.tsx
+++ b/clients/web/src/pages/lms/portfolio-artifact-content-page.tsx
@@ -149,7 +149,7 @@ export default function PortfolioArtifactContentPage() {
               type="button"
               onClick={cancelEdit}
               disabled={saving}
-              className="rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+              className="rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
             >
               Cancel
             </button>
@@ -157,7 +157,7 @@ export default function PortfolioArtifactContentPage() {
               type="button"
               onClick={() => void save()}
               disabled={saving}
-              className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {saving ? 'Saving…' : 'Save'}
             </button>
@@ -169,7 +169,7 @@ export default function PortfolioArtifactContentPage() {
               type="button"
               onClick={beginEdit}
               disabled={loading || Boolean(loadError)}
-              className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+              className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
             >
               <Pencil className="h-4 w-4" aria-hidden />
               Edit

--- a/clients/web/src/pages/lms/portfolio-editor-page.tsx
+++ b/clients/web/src/pages/lms/portfolio-editor-page.tsx
@@ -55,6 +55,7 @@ import { usePlatformFeatures } from '../../context/platform-features-context'
 import { LmsPage } from './lms-page'
 import { ModuleNameModal } from './module-name-modal'
 import { EmptyState } from '../../components/ui/empty-state'
+import { IconSwap } from '../../components/ui/icon-swap'
 
 type PortfolioArtifactKind = 'heading' | 'content_page' | 'url'
 
@@ -90,11 +91,11 @@ function artifactTypeLabel(a: Artifact): string {
 }
 
 const iconGhostPublished =
-  'rounded-md p-2 text-indigo-600 transition hover:bg-indigo-50/90 hover:text-indigo-700 disabled:cursor-not-allowed disabled:opacity-50 dark:text-indigo-400 dark:hover:bg-indigo-950/45 dark:hover:text-indigo-300'
+  'rounded-md p-2 text-indigo-600 transition-[background-color,color,border-color] hover:bg-indigo-50/90 hover:text-indigo-700 disabled:cursor-not-allowed disabled:opacity-50 dark:text-indigo-400 dark:hover:bg-indigo-950/45 dark:hover:text-indigo-300'
 const iconGhostDraft =
-  'rounded-md p-2 text-slate-400 transition hover:bg-slate-200/45 hover:text-slate-600 disabled:cursor-not-allowed disabled:opacity-50 dark:text-neutral-500 dark:hover:bg-neutral-700/35 dark:hover:text-neutral-300'
+  'rounded-md p-2 text-slate-400 transition-[background-color,color,border-color] hover:bg-slate-200/45 hover:text-slate-600 disabled:cursor-not-allowed disabled:opacity-50 dark:text-neutral-500 dark:hover:bg-neutral-700/35 dark:hover:text-neutral-300'
 const iconGhost =
-  'rounded-md p-2 text-slate-500 transition hover:bg-slate-200/45 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-700/35 dark:hover:text-neutral-200'
+  'rounded-md p-2 text-slate-500 transition-[background-color,color,border-color] hover:bg-slate-200/45 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-700/35 dark:hover:text-neutral-200'
 
 function ArtifactTypeIcon({ type }: { type: ArtifactType }) {
   if (type === 'url') {
@@ -155,11 +156,12 @@ function ArtifactItemActions({
         aria-pressed={artifact.isPublic}
         className={artifact.isPublic ? iconGhostPublished : iconGhostDraft}
       >
-        {artifact.isPublic ? (
-          <Eye className="h-4 w-4" strokeWidth={2} aria-hidden />
-        ) : (
-          <EyeOff className="h-4 w-4" strokeWidth={2} aria-hidden />
-        )}
+        <IconSwap
+          active={artifact.isPublic}
+          activeIcon={Eye}
+          inactiveIcon={EyeOff}
+          iconClassName="h-4 w-4"
+        />
       </button>
       <div ref={rootRef} className="relative">
         <button
@@ -185,7 +187,7 @@ function ArtifactItemActions({
                 type="button"
                 role="menuitem"
                 onClick={() => { onEditTitle(); setMenuOpen(false) }}
-                className="flex w-full px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
+                className="flex w-full px-2.5 py-2 text-start text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-50 dark:text-neutral-100 dark:hover:bg-neutral-700/80"
               >
                 Edit title
               </button>
@@ -194,7 +196,7 @@ function ArtifactItemActions({
               type="button"
               role="menuitem"
               onClick={() => { onDelete(); setMenuOpen(false) }}
-              className="flex w-full items-center gap-2 border-t border-slate-100 px-2.5 py-2 text-start text-sm font-medium text-rose-700 transition hover:bg-rose-50 dark:border-neutral-700 dark:text-rose-300 dark:hover:bg-rose-950/50"
+              className="flex w-full items-center gap-2 border-t border-slate-100 px-2.5 py-2 text-start text-sm font-medium text-rose-700 transition-[background-color,color,border-color] hover:bg-rose-50 dark:border-neutral-700 dark:text-rose-300 dark:hover:bg-rose-950/50"
             >
               <Trash2 className="h-4 w-4" aria-hidden /> Delete
             </button>
@@ -248,12 +250,12 @@ function AddArtifactMenu({
           if (disabled) return
           setOpen((o) => !o)
         }}
-        className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200/70 bg-white/90 px-2 py-1.5 text-xs font-medium text-slate-700 shadow-none transition hover:border-slate-300/80 hover:bg-slate-50/90 disabled:cursor-not-allowed disabled:opacity-60 sm:px-2.5 sm:text-sm dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-neutral-500 dark:hover:bg-neutral-800"
+        className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200/70 bg-white/90 px-2 py-1.5 text-xs font-medium text-slate-700 shadow-none transition-[background-color,color,border-color] hover:border-slate-300/80 hover:bg-slate-50/90 disabled:cursor-not-allowed disabled:opacity-60 sm:px-2.5 sm:text-sm dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-neutral-500 dark:hover:bg-neutral-800"
       >
         <Plus className="h-4 w-4 shrink-0" aria-hidden />
         <span className="truncate">Add artifact</span>
         <ChevronDown
-          className={`h-4 w-4 shrink-0 transition ${open ? 'rotate-180' : ''}`}
+          className={`h-4 w-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
           aria-hidden
         />
       </button>
@@ -269,7 +271,7 @@ function AddArtifactMenu({
             type="button"
             role="menuitem"
             onClick={() => pick('heading')}
-            className="flex w-full items-start gap-3 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:hover:bg-neutral-700"
+            className="flex w-full items-start gap-3 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:hover:bg-neutral-700"
           >
             <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-400">
               <Heading className="h-4 w-4" aria-hidden />
@@ -283,7 +285,7 @@ function AddArtifactMenu({
             type="button"
             role="menuitem"
             onClick={() => pick('content_page')}
-            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
           >
             <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-indigo-200/80 bg-indigo-50 text-indigo-600 dark:border-indigo-500/35 dark:bg-indigo-950 dark:text-indigo-300">
               <FileText className="h-4 w-4" aria-hidden />
@@ -297,7 +299,7 @@ function AddArtifactMenu({
             type="button"
             role="menuitem"
             onClick={() => pick('url')}
-            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
+            className="flex w-full items-start gap-3 border-t border-slate-100 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-700"
           >
             <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-sky-200/90 bg-sky-50 text-sky-700 dark:border-sky-500/40 dark:bg-sky-950 dark:text-sky-200">
               <ExternalLink className="h-4 w-4" aria-hidden />
@@ -315,7 +317,7 @@ function AddArtifactMenu({
                 role="menuitemcheckbox"
                 aria-checked={dragHandlesVisible}
                 onClick={onToggleDragHandles}
-                className="flex w-full items-start gap-2 px-2.5 py-2 text-start text-sm transition hover:bg-slate-50 dark:hover:bg-neutral-700"
+                className="flex w-full items-start gap-2 px-2.5 py-2 text-start text-sm transition-[background-color,color,border-color] hover:bg-slate-50 dark:hover:bg-neutral-700"
               >
                 <span
                   className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border ${
@@ -464,7 +466,7 @@ function SortableArtifactRow({
           {(!disabled || dragHandlesVisible || isDragging) && (
             <button
               type="button"
-              className={`flex h-11 w-11 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg border-0 bg-transparent p-0 text-slate-400 shadow-none transition hover:text-slate-600 active:cursor-grabbing focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 sm:h-9 sm:w-9 dark:text-neutral-500 dark:hover:text-neutral-300 ${
+              className={`flex h-11 w-11 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg border-0 bg-transparent p-0 text-slate-400 shadow-none transition-[opacity,background-color,color,border-color] hover:text-slate-600 active:cursor-grabbing focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 sm:h-9 sm:w-9 dark:text-neutral-500 dark:hover:text-neutral-300 ${
                 gripAlwaysOn
                   ? 'opacity-100'
                   : 'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto'
@@ -591,14 +593,14 @@ function AddArtifactForm({
         <button
           type="submit"
           disabled={saving}
-          className="rounded-xl bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 shadow-sm transition disabled:opacity-50"
+          className="rounded-xl bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 shadow-sm transition-[background-color,color,border-color] disabled:opacity-50"
         >
           {saving ? 'Adding…' : 'Add'}
         </button>
         <button
           type="button"
           onClick={onCancel}
-          className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50 transition dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800"
+          className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-50 transition-[background-color,color,border-color] dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800"
         >
           Cancel
         </button>
@@ -625,21 +627,19 @@ function PortfolioPublishButton({
       }
       aria-label={portfolio.isPublic ? 'Published' : 'Draft'}
       aria-pressed={portfolio.isPublic}
-      className={`inline-flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-semibold shadow-sm transition ${
+      className={`inline-flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-semibold shadow-sm transition-[background-color,color,border-color] ${
         portfolio.isPublic
           ? 'border-indigo-200 bg-indigo-50 text-indigo-700 hover:bg-indigo-100 dark:border-indigo-900/40 dark:bg-indigo-950/30 dark:text-indigo-300 dark:hover:bg-indigo-900/40'
           : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800'
       }`}
     >
-      {portfolio.isPublic ? (
-        <>
-          <Eye className="h-4 w-4" aria-hidden /> Published
-        </>
-      ) : (
-        <>
-          <EyeOff className="h-4 w-4" aria-hidden /> Draft
-        </>
-      )}
+      <IconSwap
+        active={portfolio.isPublic}
+        activeIcon={Eye}
+        inactiveIcon={EyeOff}
+        iconClassName="h-4 w-4"
+      />
+      {portfolio.isPublic ? 'Published' : 'Draft'}
     </button>
   )
 }
@@ -968,7 +968,7 @@ export default function PortfolioEditorPage() {
               disabled={anyModalBusy}
               title="Rename portfolio"
               aria-label="Rename portfolio"
-              className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-slate-100 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-neutral-800"
+              className="rounded-lg p-1.5 text-muted-foreground transition-[background-color,color,border-color] hover:bg-slate-100 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-neutral-800"
             >
               <Pencil className="h-4 w-4" aria-hidden />
             </button>
@@ -1002,7 +1002,7 @@ export default function PortfolioEditorPage() {
                 </code>
                 <button
                   onClick={() => void copyLink()}
-                  className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition-[background-color,color,border-color] hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800"
                 >
                   {copied ? (
                     <Check className="h-3.5 w-3.5 text-emerald-600" aria-hidden />

--- a/clients/web/src/pages/lms/reports.tsx
+++ b/clients/web/src/pages/lms/reports.tsx
@@ -96,7 +96,7 @@ export default function Reports() {
               key={p}
               type="button"
               onClick={() => setPreset(p)}
-              className={`rounded-xl border px-3 py-2 text-sm font-semibold shadow-sm transition ${
+              className={`rounded-xl border px-3 py-2 text-sm font-semibold shadow-sm transition-[background-color,color,border-color] ${
                 preset === p
                   ? 'border-indigo-300 bg-indigo-50 text-indigo-900 dark:border-indigo-500/50 dark:bg-indigo-950/60 dark:text-indigo-100'
                   : 'border-slate-200 bg-white text-slate-700 hover:border-indigo-200 hover:bg-indigo-50/60 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-indigo-500/40 dark:hover:bg-indigo-950/40'
@@ -119,7 +119,7 @@ export default function Reports() {
               }
             }}
             aria-label="Export learning activity report as PDF"
-            className="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50/60 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-indigo-500/40 dark:hover:bg-indigo-950/40"
+            className="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50/60 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:border-indigo-500/40 dark:hover:bg-indigo-950/40"
           >
             <Download className="h-4 w-4" aria-hidden />
             {exporting ? 'Generating…' : 'Export PDF'}

--- a/clients/web/src/pages/lms/review-session-page.tsx
+++ b/clients/web/src/pages/lms/review-session-page.tsx
@@ -132,7 +132,7 @@ export default function ReviewSessionPage() {
             <div className="mt-3 whitespace-pre-wrap text-base text-slate-900 dark:text-neutral-50">{current.stem}</div>
             <button
               type="button"
-              className="mt-6 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-800 transition hover:bg-slate-100 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+              className="mt-6 rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-800 transition-[background-color,color,border-color] hover:bg-slate-100 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
               onClick={() => setRevealed((r) => !r)}
             >
               {revealed ? 'Hide answer' : 'Show answer (Space)'}
@@ -200,7 +200,7 @@ function GradeButton({
       type="button"
       onClick={onClick}
       aria-label={`${label}, keyboard shortcut ${shortcut}`}
-      className={`rounded-xl px-3 py-3 text-center text-sm font-semibold text-white shadow-sm transition ${color}`}
+      className={`rounded-xl px-3 py-3 text-center text-sm font-semibold text-white shadow-sm transition-colors ${color}`}
     >
       <span className="block">{label}</span>
       <span className="mt-1 block text-[10px] font-normal opacity-90">Key {shortcut}</span>

--- a/clients/web/src/pages/lms/settings.tsx
+++ b/clients/web/src/pages/lms/settings.tsx
@@ -1139,7 +1139,7 @@ export default function Settings() {
                 <button
                   type="submit"
                   disabled={saveDisabled}
-                  className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white dark:shadow-none"
+                  className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white dark:shadow-none"
                 >
                   {aiSaving ? 'Saving…' : 'Save'}
                 </button>
@@ -1211,7 +1211,7 @@ export default function Settings() {
                   <button
                     type="submit"
                     disabled={systemPromptsSaving || !systemPromptKey}
-                    className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white dark:shadow-none"
+                    className="rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white dark:shadow-none"
                   >
                     {systemPromptsSaving ? 'Saving…' : 'Save'}
                   </button>
@@ -1259,7 +1259,7 @@ export default function Settings() {
                   <button
                     type="button"
                     onClick={() => setDensity('comfortable')}
-                    className={`rounded-lg px-4 py-2 text-sm font-medium transition ${
+                    className={`rounded-lg px-4 py-2 text-sm font-medium transition-[background-color,color,border-color] ${
                       density === 'comfortable'
                         ? 'bg-white text-slate-900 shadow-sm dark:bg-neutral-600 dark:text-neutral-50 dark:shadow-md dark:ring-1 dark:ring-inset dark:ring-white/10'
                         : 'text-slate-600 hover:text-slate-900 dark:text-neutral-400 dark:hover:text-neutral-200'
@@ -1270,7 +1270,7 @@ export default function Settings() {
                   <button
                     type="button"
                     onClick={() => setDensity('compact')}
-                    className={`rounded-lg px-4 py-2 text-sm font-medium transition ${
+                    className={`rounded-lg px-4 py-2 text-sm font-medium transition-[background-color,color,border-color] ${
                       density === 'compact'
                         ? 'bg-white text-slate-900 shadow-sm dark:bg-neutral-600 dark:text-neutral-50 dark:shadow-md dark:ring-1 dark:ring-inset dark:ring-white/10'
                         : 'text-slate-600 hover:text-slate-900 dark:text-neutral-400 dark:hover:text-neutral-200'
@@ -1284,7 +1284,7 @@ export default function Settings() {
                   <button
                     type="button"
                     onClick={() => void persistUiTheme('light')}
-                    className={`rounded-lg px-4 py-2 text-sm font-medium transition ${
+                    className={`rounded-lg px-4 py-2 text-sm font-medium transition-[background-color,color,border-color] ${
                       uiTheme === 'light'
                         ? 'bg-white text-slate-900 shadow-sm dark:bg-neutral-600 dark:text-neutral-50 dark:shadow-md dark:ring-1 dark:ring-inset dark:ring-white/10'
                         : 'text-slate-600 hover:text-slate-900 dark:text-neutral-400 dark:hover:text-neutral-200'
@@ -1295,7 +1295,7 @@ export default function Settings() {
                   <button
                     type="button"
                     onClick={() => void persistUiTheme('dark')}
-                    className={`rounded-lg px-4 py-2 text-sm font-medium transition ${
+                    className={`rounded-lg px-4 py-2 text-sm font-medium transition-[background-color,color,border-color] ${
                       uiTheme === 'dark'
                         ? 'bg-white text-slate-900 shadow-sm dark:bg-neutral-600 dark:text-neutral-50 dark:shadow-md dark:ring-1 dark:ring-inset dark:ring-white/10'
                         : 'text-slate-600 hover:text-slate-900 dark:text-neutral-400 dark:hover:text-neutral-200'
@@ -1330,7 +1330,7 @@ export default function Settings() {
                   <button
                     type="button"
                     onClick={() => void persistShowHelpPopover(true)}
-                    className={`rounded-lg px-4 py-2 text-sm font-medium transition ${
+                    className={`rounded-lg px-4 py-2 text-sm font-medium transition-[background-color,color,border-color] ${
                       showHelpPopover
                         ? 'bg-white text-slate-900 shadow-sm dark:bg-neutral-600 dark:text-neutral-50 dark:shadow-md dark:ring-1 dark:ring-inset dark:ring-white/10'
                         : 'text-slate-600 hover:text-slate-900 dark:text-neutral-400 dark:hover:text-neutral-200'
@@ -1341,7 +1341,7 @@ export default function Settings() {
                   <button
                     type="button"
                     onClick={() => void persistShowHelpPopover(false)}
-                    className={`rounded-lg px-4 py-2 text-sm font-medium transition ${
+                    className={`rounded-lg px-4 py-2 text-sm font-medium transition-[background-color,color,border-color] ${
                       !showHelpPopover
                         ? 'bg-white text-slate-900 shadow-sm dark:bg-neutral-600 dark:text-neutral-50 dark:shadow-md dark:ring-1 dark:ring-inset dark:ring-white/10'
                         : 'text-slate-600 hover:text-slate-900 dark:text-neutral-400 dark:hover:text-neutral-200'
@@ -1500,7 +1500,7 @@ export default function Settings() {
                     <button
                       type="submit"
                       disabled={cpBusy}
-                      className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-indigo-200 hover:bg-indigo-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-indigo-400 dark:hover:bg-neutral-800"
+                      className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-200 hover:bg-indigo-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-indigo-400 dark:hover:bg-neutral-800"
                     >
                       {cpBusy ? 'Updating…' : 'Update password'}
                     </button>
@@ -1591,7 +1591,7 @@ export default function Settings() {
                     form={accountFormId}
                     type="submit"
                     disabled={accountSaving}
-                    className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white dark:shadow-none"
+                    className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white dark:shadow-none"
                   >
                     <Save className="h-4 w-4" aria-hidden />
                     {accountSaving ? 'Saving…' : 'Save'}
@@ -1613,7 +1613,7 @@ export default function Settings() {
                         type="button"
                         onClick={() => void revokeAllOtherSessions()}
                         disabled={sessionsLoading || sessions.filter((s) => !s.isCurrent).length === 0}
-                        className="shrink-0 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition hover:border-rose-200 hover:bg-rose-50 hover:text-rose-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-rose-500/50 dark:hover:bg-rose-950/40"
+                        className="shrink-0 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-rose-200 hover:bg-rose-50 hover:text-rose-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:border-rose-500/50 dark:hover:bg-rose-950/40"
                       >
                         Sign out everywhere else
                       </button>

--- a/clients/web/src/pages/mfa-login.tsx
+++ b/clients/web/src/pages/mfa-login.tsx
@@ -298,7 +298,7 @@ export default function MfaLogin() {
                 type="button"
                 onClick={() => void startTotpEnrol()}
                 disabled={status === 'loading'}
-                className="flex w-full items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-indigo-300 hover:bg-slate-50 disabled:opacity-60"
+                className="flex w-full items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-300 hover:bg-slate-50 disabled:opacity-60"
               >
                 Use authenticator app (QR code)
               </button>
@@ -306,7 +306,7 @@ export default function MfaLogin() {
                 type="button"
                 onClick={() => void runPasskeyCeremony()}
                 disabled={webauthnBusy}
-                className="flex w-full items-center justify-center rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:opacity-60"
+                className="flex w-full items-center justify-center rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:opacity-60"
               >
                 {webauthnBusy ? 'Waiting for passkey…' : 'Register a passkey'}
               </button>
@@ -350,7 +350,7 @@ export default function MfaLogin() {
             <button
               type="submit"
               disabled={status === 'loading' || code.length !== 6}
-              className="flex w-full items-center justify-center rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+              className="flex w-full items-center justify-center rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {status === 'loading' ? 'Verifying…' : mfaFlow.mode === 'setup' ? 'Confirm enrolment' : 'Continue'}
             </button>
@@ -370,7 +370,7 @@ export default function MfaLogin() {
                 type="button"
                 onClick={() => void runPasskeyCeremony()}
                 disabled={webauthnBusy}
-                className="mb-4 flex w-full items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-indigo-300 hover:bg-slate-50 disabled:opacity-60"
+                className="mb-4 flex w-full items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition-[background-color,color,border-color] hover:border-indigo-300 hover:bg-slate-50 disabled:opacity-60"
               >
                 {webauthnBusy ? 'Waiting for passkey…' : 'Use passkey'}
               </button>

--- a/clients/web/src/pages/portfolio/public-portfolio-page.tsx
+++ b/clients/web/src/pages/portfolio/public-portfolio-page.tsx
@@ -105,7 +105,7 @@ export default function PublicPortfolioPage() {
               <article
                 key={a.id}
                 role="article"
-                className="rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
+                className="rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm transition-[transform,box-shadow,background-color,color,border-color] hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
               >
                 <div className="flex min-w-0 items-center gap-3">
                   <span
@@ -131,7 +131,7 @@ export default function PublicPortfolioPage() {
               <article
                 key={a.id}
                 role="article"
-                className="flex flex-col rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
+                className="flex flex-col rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm transition-[transform,box-shadow,background-color,color,border-color] hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-700"
               >
                 <h2 className="flex items-center gap-2 text-base font-semibold text-slate-900 dark:text-neutral-100">
                   <FileText className="h-4 w-4 text-indigo-500" aria-hidden />

--- a/clients/web/src/pages/sso-error.tsx
+++ b/clients/web/src/pages/sso-error.tsx
@@ -26,7 +26,7 @@ export default function SsoError() {
         <div className="mt-8">
           <Link
             to="/login"
-            className="inline-flex rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500"
+            className="inline-flex rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-[background-color,color,border-color] hover:bg-indigo-500"
           >
             Back to sign in
           </Link>


### PR DESCRIPTION
## Summary
- Merged latest `main` (grader agent criterion/originality/gate nodes) and resolved stash conflicts by keeping upstream grader-agent changes
- Replaced ~480 bare Tailwind `transition` utilities with property-specific transitions across 139 web client files
- Updated `shadow-card` tokens to pure black/white rgba, extended typography utilities to auth pages, and added `IconSwap` for play/pause and visibility toggles
- Added `scripts/fix-bare-transitions.mjs` codemod and `npm run interface-polish:check` CI guard

## Test plan
- [x] `npm run interface-polish:check` passes
- [x] `npm run typecheck` passes (pre-commit hook)
- [ ] Spot-check read-aloud play/pause icon cross-fade
- [ ] Spot-check portfolio/module visibility Eye/EyeOff toggles
- [ ] Verify dashboard cards render with shadow-card (no missing borders on dark mode)


Made with [Cursor](https://cursor.com)