### PR TITLE
Fix broken MISSING_FEATURES.md links in plan docs

### DIFF
--- a/docs/plan/16-integrations-extensibility/16.10-zapier-make-connector.md
+++ b/docs/plan/16-integrations-extensibility/16.10-zapier-make-connector.md
@@ -1,6 +1,6 @@
 # 16.10 — Zapier / Make.com Connector
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §16.10.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §16.10.
 
 ## Metadata
 

--- a/docs/plan/16-integrations-extensibility/16.5-calendar-feeds.md
+++ b/docs/plan/16-integrations-extensibility/16.5-calendar-feeds.md
@@ -1,6 +1,6 @@
 # 16.5 — Calendar Feeds (iCal / CalDAV)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §16.5.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §16.5.
 
 ## Metadata
 

--- a/docs/plan/16-integrations-extensibility/16.6-slack-teams-discord-bots.md
+++ b/docs/plan/16-integrations-extensibility/16.6-slack-teams-discord-bots.md
@@ -1,6 +1,6 @@
 # 16.6 — Slack / Teams / Discord Classroom Bots
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §16.6.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §16.6.
 
 ## Metadata
 

--- a/docs/plan/16-integrations-extensibility/16.7-ai-provider-abstraction.md
+++ b/docs/plan/16-integrations-extensibility/16.7-ai-provider-abstraction.md
@@ -1,6 +1,6 @@
 # 16.7 — AI Provider Abstraction (Anthropic-direct, OpenAI-direct, Bedrock, Vertex; per-tenant BYOK)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §16.7.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §16.7.
 
 ## Metadata
 

--- a/docs/plan/16-integrations-extensibility/16.8-payment-provider-abstraction.md
+++ b/docs/plan/16-integrations-extensibility/16.8-payment-provider-abstraction.md
@@ -1,6 +1,6 @@
 # 16.8 — Payment Provider Abstraction (Stripe + PayPal + iDEAL)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §16.8.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §16.8.
 
 ## Metadata
 

--- a/docs/plan/16-integrations-extensibility/16.9-marketplace-plugin-system.md
+++ b/docs/plan/16-integrations-extensibility/16.9-marketplace-plugin-system.md
@@ -1,6 +1,6 @@
 # 16.9 — Marketplace / Plugin System
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §16.9.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §16.9.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.1-production-iac.md
+++ b/docs/plan/17-platform-performance-operability/17.1-production-iac.md
@@ -1,6 +1,6 @@
 # 17.1 — Production IaC
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.1.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.1.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.10-database-migration-rollback.md
+++ b/docs/plan/17-platform-performance-operability/17.10-database-migration-rollback.md
@@ -1,6 +1,6 @@
 # 17.10 — Database Migrations Rollback Strategy
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.10.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.10.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.11-backup-automation.md
+++ b/docs/plan/17-platform-performance-operability/17.11-backup-automation.md
@@ -1,6 +1,6 @@
 # 17.11 — Backup Automation & Restore Drills
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.11.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.11.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.12-multi-region-failover.md
+++ b/docs/plan/17-platform-performance-operability/17.12-multi-region-failover.md
@@ -1,6 +1,6 @@
 # 17.12 — Multi-Region Failover
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.12.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.12.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.13-status-page.md
+++ b/docs/plan/17-platform-performance-operability/17.13-status-page.md
@@ -1,6 +1,6 @@
 # 17.13 — Status Page
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.13.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.13.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.14-feature-flags.md
+++ b/docs/plan/17-platform-performance-operability/17.14-feature-flags.md
@@ -1,6 +1,6 @@
 # 17.14 — Feature Flags (Progressive Rollout)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.14.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.14.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.16-dependency-sbom-scanning.md
+++ b/docs/plan/17-platform-performance-operability/17.16-dependency-sbom-scanning.md
@@ -1,6 +1,6 @@
 # 17.16 — Dependency / SBOM Scanning (Dependabot, cargo-audit, npm audit)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.16.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.16.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.2-horizontal-scaling.md
+++ b/docs/plan/17-platform-performance-operability/17.2-horizontal-scaling.md
@@ -1,6 +1,6 @@
 # 17.2 — Horizontal Scaling (LB + Stateless + Redis Session/Cache)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.2.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.2.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.3-background-job-queue.md
+++ b/docs/plan/17-platform-performance-operability/17.3-background-job-queue.md
@@ -1,6 +1,6 @@
 # 17.3 — Background Job Queue
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.3.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.3.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.4-scheduled-jobs-cron.md
+++ b/docs/plan/17-platform-performance-operability/17.4-scheduled-jobs-cron.md
@@ -1,6 +1,6 @@
 # 17.4 — Scheduled Jobs / Cron
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.4.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.4.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.5-caching-layer.md
+++ b/docs/plan/17-platform-performance-operability/17.5-caching-layer.md
@@ -1,6 +1,6 @@
 # 17.5 — Caching Layer (HTTP Headers, Redis, CDN)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.5.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.5.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.6-rate-limiting.md
+++ b/docs/plan/17-platform-performance-operability/17.6-rate-limiting.md
@@ -1,6 +1,6 @@
 # 17.6 — Rate Limiting
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.6.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.6.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.7-observability.md
+++ b/docs/plan/17-platform-performance-operability/17.7-observability.md
@@ -1,6 +1,6 @@
 # 17.7 — Observability (Prometheus, OTel, Sentry, Dashboards)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.7.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.7.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.8-health-checks.md
+++ b/docs/plan/17-platform-performance-operability/17.8-health-checks.md
@@ -1,6 +1,6 @@
 # 17.8 — Health Checks (Proper Liveness/Readiness)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.8.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.8.
 
 ## Metadata
 

--- a/docs/plan/17-platform-performance-operability/17.9-blue-green-canary-deploys.md
+++ b/docs/plan/17-platform-performance-operability/17.9-blue-green-canary-deploys.md
@@ -1,6 +1,6 @@
 # 17.9 — Blue/Green / Canary Deploys
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §17.9.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.9.
 
 ## Metadata
 

--- a/docs/plan/18-admin-experience/18.1-admin-console.md
+++ b/docs/plan/18-admin-experience/18.1-admin-console.md
@@ -1,6 +1,6 @@
 # 18.1 — Admin Console
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §18.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §18.
 
 ## Metadata
 

--- a/docs/plan/18-admin-experience/18.2-bulk-user-csv-import.md
+++ b/docs/plan/18-admin-experience/18.2-bulk-user-csv-import.md
@@ -1,6 +1,6 @@
 # 18.2 — Bulk User CSV Import / Merge
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §18.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §18.
 
 ## Metadata
 

--- a/docs/plan/18-admin-experience/18.3-impersonation.md
+++ b/docs/plan/18-admin-experience/18.3-impersonation.md
@@ -1,6 +1,6 @@
 # 18.3 — Impersonation / "View as Student"
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §18.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §18.
 
 ## Metadata
 

--- a/docs/plan/18-admin-experience/18.4-org-wide-search.md
+++ b/docs/plan/18-admin-experience/18.4-org-wide-search.md
@@ -1,6 +1,6 @@
 # 18.4 — Org-Wide Search / Cross-Course Discovery for Admins
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §18.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §18.
 
 ## Metadata
 

--- a/docs/plan/18-admin-experience/18.5-email-template-editor.md
+++ b/docs/plan/18-admin-experience/18.5-email-template-editor.md
@@ -1,6 +1,6 @@
 # 18.5 — Email Template Editor with Merge Fields
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §18.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §18.
 
 ## Metadata
 

--- a/docs/plan/18-admin-experience/18.6-maintenance-banner.md
+++ b/docs/plan/18-admin-experience/18.6-maintenance-banner.md
@@ -1,6 +1,6 @@
 # 18.6 — Outage / Maintenance Banner Controls
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §18.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §18.
 
 ## Metadata
 

--- a/docs/plan/18-admin-experience/18.7-custom-fields.md
+++ b/docs/plan/18-admin-experience/18.7-custom-fields.md
@@ -1,6 +1,6 @@
 # 18.7 — Custom Fields / Metadata on User, Course, and Enrollment
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §18.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §18.
 
 ## Metadata
 

--- a/docs/plan/18-admin-experience/18.8-license-seat-management.md
+++ b/docs/plan/18-admin-experience/18.8-license-seat-management.md
@@ -1,6 +1,6 @@
 # 18.8 — License / Seat Management
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §18.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §18.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.1-persistent-ai-tutor.md
+++ b/docs/plan/19-ai-capabilities/19.1-persistent-ai-tutor.md
@@ -1,6 +1,6 @@
 # 19.1 — Persistent AI Tutor Across Sessions
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.10-model-governance.md
+++ b/docs/plan/19-ai-capabilities/19.10-model-governance.md
@@ -1,6 +1,6 @@
 # 19.10 — Per-Tenant Model & Prompt Governance
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.11-pii-redaction-proxy.md
+++ b/docs/plan/19-ai-capabilities/19.11-pii-redaction-proxy.md
@@ -1,6 +1,6 @@
 # 19.11 — PII Redaction Proxy Before Any Prompt
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.12-citation-enforcement.md
+++ b/docs/plan/19-ai-capabilities/19.12-citation-enforcement.md
@@ -1,6 +1,6 @@
 # 19.12 — Citation Enforcement (RAG Grounding)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.13-eval-harness.md
+++ b/docs/plan/19-ai-capabilities/19.13-eval-harness.md
@@ -1,6 +1,6 @@
 # 19.13 — Eval Harness for AI Features (Regression Suite)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.14-cost-usage-controls.md
+++ b/docs/plan/19-ai-capabilities/19.14-cost-usage-controls.md
@@ -1,6 +1,6 @@
 # 19.14 — Cost & Usage Controls (Per-Student Token Budgets)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.15-ai-proctoring.md
+++ b/docs/plan/19-ai-capabilities/19.15-ai-proctoring.md
@@ -1,6 +1,6 @@
 # 19.15 — First-Party AI Proctoring (Screen, Input, Focus, Webcam, Microphone Monitoring)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.2-auto-generated-lesson-plans.md
+++ b/docs/plan/19-ai-capabilities/19.2-auto-generated-lesson-plans.md
@@ -1,6 +1,6 @@
 # 19.2 — Auto-Generated Lesson Plans, Assessments, and Differentiation
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.3-ai-assisted-grading.md
+++ b/docs/plan/19-ai-capabilities/19.3-ai-assisted-grading.md
@@ -1,6 +1,6 @@
 # 19.3 — AI-Assisted Grading of Free-Text & File Submissions with Instructor Approval Queue
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.4-ai-misconception-detection.md
+++ b/docs/plan/19-ai-capabilities/19.4-ai-misconception-detection.md
@@ -1,6 +1,6 @@
 # 19.4 — AI-Detected Misconceptions Rolling Up to Gradebook
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.5-ai-summarization-translation.md
+++ b/docs/plan/19-ai-capabilities/19.5-ai-summarization-translation.md
@@ -1,6 +1,6 @@
 # 19.5 — AI Summarization & Translation of Any Content
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.6-voice-video-ai.md
+++ b/docs/plan/19-ai-capabilities/19.6-voice-video-ai.md
@@ -1,6 +1,6 @@
 # 19.6 — Voice / Video AI (Speech Grading, Pronunciation Feedback)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.7-image-handwriting-grading.md
+++ b/docs/plan/19-ai-capabilities/19.7-image-handwriting-grading.md
@@ -1,6 +1,6 @@
 # 19.7 — Image / Handwriting Capture & Grading (Math Worked Solutions)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.8-teacher-copilot-editor.md
+++ b/docs/plan/19-ai-capabilities/19.8-teacher-copilot-editor.md
@@ -1,6 +1,6 @@
 # 19.8 — Teacher Copilot in the Editor (System-Wide Sidebar Copilot)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/19-ai-capabilities/19.9-ai-content-provenance.md
+++ b/docs/plan/19-ai-capabilities/19.9-ai-content-provenance.md
@@ -1,6 +1,6 @@
 # 19.9 — AI-Content Provenance (Sign Generated Artifacts)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §19.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §19.
 
 ## Metadata
 

--- a/docs/plan/21-mobile-offline-cross-platform/21.1-native-mobile-apps.md
+++ b/docs/plan/21-mobile-offline-cross-platform/21.1-native-mobile-apps.md
@@ -1,6 +1,6 @@
 # 21.1 — Native Mobile Apps (iOS / Android)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §21.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §21.
 
 ## Metadata
 

--- a/docs/plan/21-mobile-offline-cross-platform/21.2-mobile-responsive-review.md
+++ b/docs/plan/21-mobile-offline-cross-platform/21.2-mobile-responsive-review.md
@@ -1,6 +1,6 @@
 # 21.2 — Mobile-Responsive Review of Existing UI
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §21.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §21.
 
 ## Metadata
 

--- a/docs/plan/21-mobile-offline-cross-platform/21.4-app-store-presence.md
+++ b/docs/plan/21-mobile-offline-cross-platform/21.4-app-store-presence.md
@@ -1,6 +1,6 @@
 # 21.4 — App-store Presence
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §21.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §21.
 
 ## Metadata
 

--- a/docs/plan/21-mobile-offline-cross-platform/21.5-push-notification-service.md
+++ b/docs/plan/21-mobile-offline-cross-platform/21.5-push-notification-service.md
@@ -1,6 +1,6 @@
 # 21.5 — Push Notification Service (APNs / FCM)
 
-> Implementation plan. Source: [docs/MISSING_FEATURES.md](../MISSING_FEATURES.md) §21.
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §21.
 
 ## Metadata
 


### PR DESCRIPTION
## Summary
- Corrects relative paths to `docs/MISSING_FEATURES.md` in 48 plan documents under `docs/plan/16-*`, `17-*`, `18-*`, `19-*`, and `21-*`
- Nested plan directories require `../../MISSING_FEATURES.md` instead of `../MISSING_FEATURES.md` for the source link to resolve

## Test plan
- [ ] Spot-check a few plan doc links in GitHub preview (e.g. `docs/plan/19-ai-capabilities/19.3-ai-assisted-grading.md`)
- [ ] Confirm links navigate to `docs/MISSING_FEATURES.md` correctly


Made with [Cursor](https://cursor.com)