### PR TITLE
feat(billing): Tax compliance via Stripe Tax (15.13)

### DIFF
--- a/clients/web/src/app.tsx
+++ b/clients/web/src/app.tsx
@@ -72,6 +72,7 @@ export default function App() {
             <Route path="/me/ce-transcript" element={<Pages.CeTranscript />} />
             <Route path="/me/billing" element={<Pages.BillingSettingsPage />} />
             <Route path="/me/creator/earnings" element={<Pages.CreatorEarningsPage />} />
+            <Route path="/admin/tax" element={<Pages.OrgTaxSettingsPage />} />
             <Route path="/checkout/success" element={<Pages.CheckoutSuccessPage />} />
             <Route path="/checkout/cancel" element={<Pages.CheckoutCancelPage />} />
             <Route path="/transcripts" element={<Pages.TranscriptsPage />} />

--- a/clients/web/src/components/billing/checkout-tax-form.tsx
+++ b/clients/web/src/components/billing/checkout-tax-form.tsx
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useId, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { formatMoney } from '../../lib/billing-api'
+import { fetchTaxQuote, validateTaxID, type TaxAddress, type TaxQuote } from '../../lib/tax-api'
+
+type Props = {
+  courseId: string
+  onQuoteChange?: (quote: TaxQuote | null) => void
+}
+
+const COUNTRY_OPTIONS = [
+  { code: 'US', label: 'United States' },
+  { code: 'GB', label: 'United Kingdom' },
+  { code: 'DE', label: 'Germany' },
+  { code: 'FR', label: 'France' },
+  { code: 'CA', label: 'Canada' },
+  { code: 'AU', label: 'Australia' },
+]
+
+export function CheckoutTaxForm({ courseId, onQuoteChange }: Props) {
+  const countryId = useId()
+  const regionId = useId()
+  const vatId = useId()
+  const [country, setCountry] = useState('')
+  const [region, setRegion] = useState('')
+  const [vatNumber, setVatNumber] = useState('')
+  const [isBusiness, setIsBusiness] = useState(false)
+  const [quote, setQuote] = useState<TaxQuote | null>(null)
+  const [status, setStatus] = useState<'idle' | 'computing' | 'computed' | 'error'>('idle')
+  const [error, setError] = useState<string | null>(null)
+  const [vatMessage, setVatMessage] = useState<string | null>(null)
+
+  const address = useCallback((): TaxAddress => ({
+    country,
+    region: region || undefined,
+  }), [country, region])
+
+  const computeQuote = useCallback(async () => {
+    if (!country) {
+      setQuote(null)
+      setStatus('idle')
+      onQuoteChange?.(null)
+      return
+    }
+    setStatus('computing')
+    setError(null)
+    try {
+      const result = await fetchTaxQuote({
+        courseId,
+        address: address(),
+        taxId: isBusiness ? vatNumber : undefined,
+      })
+      setQuote(result)
+      setStatus('computed')
+      onQuoteChange?.(result)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Tax calculation failed.')
+      setStatus('error')
+      setQuote(null)
+      onQuoteChange?.(null)
+    }
+  }, [address, courseId, country, isBusiness, onQuoteChange, vatNumber])
+
+  useEffect(() => {
+    const timer = setTimeout(() => void computeQuote(), 400)
+    return () => clearTimeout(timer)
+  }, [computeQuote])
+
+  async function handleValidateVAT() {
+    if (!vatNumber.trim() || !country) return
+    try {
+      const result = await validateTaxID({ courseId, address: address(), taxId: vatNumber })
+      setVatMessage(result.message ?? (result.valid ? 'Tax ID accepted.' : 'Invalid tax ID.'))
+    } catch (e) {
+      setVatMessage(e instanceof Error ? e.message : 'Validation failed.')
+    }
+  }
+
+  return (
+    <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+      <h3 className="text-base font-medium text-slate-900 dark:text-neutral-100">Billing address</h3>
+      <p className="text-sm text-slate-600 dark:text-neutral-400">
+        Enter your country so we can calculate applicable tax before checkout.
+      </p>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label htmlFor={countryId} className="block text-sm font-medium text-slate-700 dark:text-neutral-300">
+            Country
+          </label>
+          <select
+            id={countryId}
+            value={country}
+            onChange={(e) => setCountry(e.target.value)}
+            className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+            required
+          >
+            <option value="">Select country</option>
+            {COUNTRY_OPTIONS.map((c) => (
+              <option key={c.code} value={c.code}>
+                {c.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor={regionId} className="block text-sm font-medium text-slate-700 dark:text-neutral-300">
+            State / region
+          </label>
+          <input
+            id={regionId}
+            type="text"
+            value={region}
+            onChange={(e) => setRegion(e.target.value)}
+            className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+            autoComplete="address-level1"
+          />
+        </div>
+      </div>
+
+      <label className="flex items-center gap-2 text-sm text-slate-700 dark:text-neutral-300">
+        <input
+          type="checkbox"
+          checked={isBusiness}
+          onChange={(e) => setIsBusiness(e.target.checked)}
+          className="rounded border-slate-300"
+        />
+        I&apos;m a business — add VAT / GST ID
+      </label>
+
+      {isBusiness ? (
+        <div>
+          <label htmlFor={vatId} className="block text-sm font-medium text-slate-700 dark:text-neutral-300">
+            VAT / GST ID
+          </label>
+          <div className="mt-1 flex gap-2">
+            <input
+              id={vatId}
+              type="text"
+              value={vatNumber}
+              onChange={(e) => setVatNumber(e.target.value)}
+              className="flex-1 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+            />
+            <button
+              type="button"
+              onClick={() => void handleValidateVAT()}
+              className="rounded-lg border border-slate-300 px-3 py-2 text-sm hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+            >
+              Validate
+            </button>
+          </div>
+          {vatMessage ? (
+            <p className="mt-2 text-sm text-slate-600 dark:text-neutral-400" role="status">
+              {vatMessage}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {error ? (
+        <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+          {error}
+        </p>
+      ) : null}
+
+      {status === 'computing' ? (
+        <p className="flex items-center gap-2 text-sm text-slate-600 dark:text-neutral-400" role="status">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          Computing tax…
+        </p>
+      ) : null}
+
+      {quote && status === 'computed' ? (
+        <div className="rounded-lg bg-slate-50 p-4 dark:bg-neutral-950" aria-live="polite">
+          <dl className="space-y-2 text-sm">
+            {quote.lines.map((line) => (
+              <div key={line.label} className="flex justify-between">
+                <dt className="text-slate-600 dark:text-neutral-400">{line.label}</dt>
+                <dd className="font-medium text-slate-900 dark:text-neutral-100">
+                  {formatMoney(line.amountCents, quote.currency)}
+                </dd>
+              </div>
+            ))}
+            <div className="flex justify-between border-t border-slate-200 pt-2 dark:border-neutral-800">
+              <dt className="font-medium text-slate-900 dark:text-neutral-100">Total</dt>
+              <dd className="font-semibold text-slate-900 dark:text-neutral-100">
+                {formatMoney(quote.totalCents, quote.currency)}
+              </dd>
+            </div>
+          </dl>
+          {quote.reverseCharge ? (
+            <p className="mt-2 text-xs text-emerald-700 dark:text-emerald-300">Reverse charge applies.</p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/clients/web/src/components/settings/platform-feature-definitions.ts
+++ b/clients/web/src/components/settings/platform-feature-definitions.ts
@@ -132,6 +132,12 @@ const PLATFORM_FEATURE_DEFINITIONS_UNSORTED: PlatformFeatureDefinition[] = [
       'Creator earnings ledger, affiliate referral links, and Stripe Connect payouts for course sales.',
   },
   {
+    key: 'ffTaxCollection',
+    label: 'Tax collection (Stripe Tax)',
+    description:
+      'Calculate and collect sales tax, VAT, and GST at checkout; issue tax-compliant invoices and jurisdiction reports.',
+  },
+  {
     key: 'ffCoCurricularTranscript',
     label: 'Co-curricular transcript (CLR)',
     description:

--- a/clients/web/src/components/settings/platform-settings-panel.tsx
+++ b/clients/web/src/components/settings/platform-settings-panel.tsx
@@ -69,6 +69,7 @@ function emptyForm(): PlatformSettingsPayload {
     ffConsortiumSharing: false,
     ffStripeBilling: false,
     ffRevenueShare: false,
+    ffTaxCollection: false,
     ffLearningPaths: false,
     ffConditionalRelease: false,
     ffPeerReview: false,

--- a/clients/web/src/components/settings/platform-settings-types.ts
+++ b/clients/web/src/components/settings/platform-settings-types.ts
@@ -47,6 +47,7 @@ export type PlatformSettingsPayload = {
   ffConsortiumSharing: boolean
   ffStripeBilling: boolean
   ffRevenueShare: boolean
+  ffTaxCollection: boolean
   ffLearningPaths: boolean
   ffConditionalRelease: boolean
   ffPeerReview: boolean

--- a/clients/web/src/context/platform-features-context.tsx
+++ b/clients/web/src/context/platform-features-context.tsx
@@ -77,6 +77,7 @@ export type PlatformFeatures = {
   ffConsortiumSharing: boolean
   ffStripeBilling: boolean
   ffRevenueShare: boolean
+  ffTaxCollection: boolean
   ffLearningPaths: boolean
   ffConditionalRelease: boolean
   ffPeerReview: boolean
@@ -159,6 +160,7 @@ const defaultFeatures: PlatformFeatures = {
   ffConsortiumSharing: false,
   ffStripeBilling: false,
   ffRevenueShare: false,
+  ffTaxCollection: false,
   ffLearningPaths: false,
   ffConditionalRelease: false,
   ffPeerReview: false,
@@ -246,6 +248,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
   ffConsortiumSharing: false,
   ffStripeBilling: false,
   ffRevenueShare: false,
+  ffTaxCollection: false,
   ffLearningPaths: false,
   ffConditionalRelease: false,
   ffPeerReview: false,
@@ -334,6 +337,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffConsortiumSharing: data.ffConsortiumSharing === true,
           ffStripeBilling: data.ffStripeBilling === true,
           ffRevenueShare: data.ffRevenueShare === true,
+          ffTaxCollection: data.ffTaxCollection === true,
           ffLearningPaths: data.ffLearningPaths === true,
           ffConditionalRelease: data.ffConditionalRelease === true,
           ffPeerReview: data.ffPeerReview === true,
@@ -386,6 +390,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           ffConsortiumSharing: next.ffConsortiumSharing === true,
           ffStripeBilling: next.ffStripeBilling === true,
           ffRevenueShare: next.ffRevenueShare === true,
+          ffTaxCollection: next.ffTaxCollection === true,
           ffLearningPaths: next.ffLearningPaths === true,
           ffConditionalRelease: next.ffConditionalRelease === true,
           ffPeerReview: next.ffPeerReview === true,

--- a/clients/web/src/lazy-pages.ts
+++ b/clients/web/src/lazy-pages.ts
@@ -129,6 +129,7 @@ export const PublicPortfolioPage = lazy(() => import('./pages/portfolio/public-p
 export const PublicPortfolioContentPage = lazy(() => import('./pages/portfolio/public-portfolio-content-page'))
 export const BillingSettingsPage = lazy(() => import('./pages/lms/billing-settings'))
 export const CreatorEarningsPage = lazy(() => import('./pages/lms/creator-earnings-page'))
+export const OrgTaxSettingsPage = lazy(() => import('./pages/lms/org-tax-settings-page'))
 export const CheckoutSuccessPage = lazy(() => import('./pages/checkout/success'))
 export const CheckoutCancelPage = lazy(() => import('./pages/checkout/cancel'))
 export const CliAuthPage = lazy(() => import('./pages/cli-auth'))

--- a/clients/web/src/lib/billing-api.ts
+++ b/clients/web/src/lib/billing-api.ts
@@ -6,6 +6,12 @@ export type Entitlement = {
   entitlementType: string
   courseId?: string
   amountPaidCents: number
+  subtotalCents?: number
+  taxAmountCents?: number
+  taxType?: string
+  taxJurisdiction?: string
+  reverseCharge?: boolean
+  invoiceId?: string
   currency: string
   validFrom: string
   validUntil?: string

--- a/clients/web/src/lib/platform-features.ts
+++ b/clients/web/src/lib/platform-features.ts
@@ -64,6 +64,7 @@ export type PlatformFeaturesSnapshot = {
   ffConsortiumSharing?: boolean
   ffStripeBilling?: boolean
   ffRevenueShare?: boolean
+  ffTaxCollection?: boolean
   ffLearningPaths?: boolean
   ffConditionalRelease?: boolean
   ffPeerReview?: boolean
@@ -145,6 +146,7 @@ const defaults: PlatformFeaturesSnapshot = {
   ffConsortiumSharing: false,
   ffStripeBilling: false,
   ffRevenueShare: false,
+  ffTaxCollection: false,
   ffLearningPaths: false,
   ffConditionalRelease: false,
   ffPeerReview: false,

--- a/clients/web/src/lib/tax-api.ts
+++ b/clients/web/src/lib/tax-api.ts
@@ -1,0 +1,141 @@
+import { authorizedFetch } from './api'
+import { readApiErrorMessage } from './errors'
+
+export type TaxAddress = {
+  country: string
+  region?: string
+  line1?: string
+  city?: string
+  postalCode?: string
+}
+
+export type TaxQuoteLine = {
+  label: string
+  amountCents: number
+}
+
+export type TaxQuote = {
+  subtotalCents: number
+  taxAmountCents: number
+  totalCents: number
+  currency: string
+  taxRate?: number
+  taxJurisdiction?: string
+  taxType: string
+  taxInclusive: boolean
+  reverseCharge: boolean
+  lines: TaxQuoteLine[]
+  calculationId?: string
+}
+
+export type TaxIDValidation = {
+  valid: boolean
+  reverseCharge: boolean
+  taxIdType?: string
+  message?: string
+}
+
+export type OrgTaxSettings = {
+  orgId: string
+  enabled: boolean
+  registeredJurisdictions: string[]
+  defaultTaxCategory: string
+  priceDisplay: 'inclusive' | 'exclusive'
+  filingMode: string
+  recordRetentionYears: number
+  sellerName: string
+  sellerAddress: string
+  sellerTaxId: string
+}
+
+export type TaxReportRow = {
+  jurisdiction: string
+  taxType: string
+  transactionCount: number
+  taxCollectedCents: number
+  subtotalCents: number
+}
+
+export async function fetchTaxQuote(payload: {
+  courseId: string
+  address: TaxAddress
+  taxId?: string
+  taxIdType?: string
+}): Promise<TaxQuote> {
+  const res = await authorizedFetch('/api/v1/checkout/quote', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      courseId: payload.courseId,
+      address: payload.address,
+      taxId: payload.taxId,
+      taxIdType: payload.taxIdType,
+    }),
+  })
+  if (!res.ok) {
+    const raw = (await res.json().catch(() => ({}))) as Record<string, unknown>
+    throw new Error(readApiErrorMessage(raw) || 'Could not compute tax.')
+  }
+  return (await res.json()) as TaxQuote
+}
+
+export async function validateTaxID(payload: {
+  courseId: string
+  address: TaxAddress
+  taxId: string
+  taxIdType?: string
+}): Promise<TaxIDValidation> {
+  const res = await authorizedFetch('/api/v1/checkout/tax-id', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  if (!res.ok) {
+    const raw = (await res.json().catch(() => ({}))) as Record<string, unknown>
+    throw new Error(readApiErrorMessage(raw) || 'Could not validate tax ID.')
+  }
+  return (await res.json()) as TaxIDValidation
+}
+
+export async function fetchOrgTaxSettings(orgId: string): Promise<OrgTaxSettings> {
+  const res = await authorizedFetch(`/api/v1/orgs/${encodeURIComponent(orgId)}/tax/settings`)
+  if (!res.ok) {
+    throw new Error('Could not load tax settings.')
+  }
+  return (await res.json()) as OrgTaxSettings
+}
+
+export async function saveOrgTaxSettings(orgId: string, settings: Partial<OrgTaxSettings>): Promise<OrgTaxSettings> {
+  const res = await authorizedFetch(`/api/v1/orgs/${encodeURIComponent(orgId)}/tax/settings`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(settings),
+  })
+  if (!res.ok) {
+    const raw = (await res.json().catch(() => ({}))) as Record<string, unknown>
+    throw new Error(readApiErrorMessage(raw) || 'Could not save tax settings.')
+  }
+  return (await res.json()) as OrgTaxSettings
+}
+
+export async function fetchTaxReport(orgId: string, period?: string, jurisdiction?: string): Promise<{
+  period: string
+  from: string
+  to: string
+  rows: TaxReportRow[]
+}> {
+  const params = new URLSearchParams()
+  if (period) params.set('period', period)
+  if (jurisdiction) params.set('jurisdiction', jurisdiction)
+  const q = params.toString() ? `?${params}` : ''
+  const res = await authorizedFetch(`/api/v1/orgs/${encodeURIComponent(orgId)}/tax/report${q}`)
+  if (!res.ok) {
+    throw new Error('Could not load tax report.')
+  }
+  return (await res.json()) as { period: string; from: string; to: string; rows: TaxReportRow[] }
+}
+
+export function invoiceDownloadUrl(invoiceId: string): string {
+  const base = import.meta.env.VITE_API_URL ?? ''
+  return `${base}/api/v1/invoices/${encodeURIComponent(invoiceId)}`
+}

--- a/clients/web/src/pages/lms/billing-settings.tsx
+++ b/clients/web/src/pages/lms/billing-settings.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useId, useState } from 'react'
 import { ExternalLink, Loader2 } from 'lucide-react'
 import { usePlatformFeatures } from '../../context/platform-features-context'
 import { fetchMyEntitlements, formatMoney, openBillingPortal, type Entitlement } from '../../lib/billing-api'
+import { invoiceDownloadUrl } from '../../lib/tax-api'
 import { authorizedFetch } from '../../lib/api'
 import { LmsPage } from './lms-page'
 
@@ -139,8 +140,10 @@ export default function BillingSettingsPage() {
                   <tr className="border-b border-slate-200 text-slate-500 dark:border-neutral-700 dark:text-neutral-400">
                     <th className="py-2 pr-4 font-medium">Type</th>
                     <th className="py-2 pr-4 font-medium">Amount</th>
+                    <th className="py-2 pr-4 font-medium">Tax</th>
                     <th className="py-2 pr-4 font-medium">Valid from</th>
-                    <th className="py-2 font-medium">Status</th>
+                    <th className="py-2 pr-4 font-medium">Status</th>
+                    <th className="py-2 font-medium">Invoice</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -148,8 +151,35 @@ export default function BillingSettingsPage() {
                     <tr key={e.id} className="border-b border-slate-100 dark:border-neutral-800">
                       <td className="py-3 pr-4">{entitlementLabel(e)}</td>
                       <td className="py-3 pr-4">{formatMoney(e.amountPaidCents, e.currency)}</td>
+                      <td className="py-3 pr-4">
+                        {e.taxAmountCents ? formatMoney(e.taxAmountCents, e.currency) : '—'}
+                      </td>
                       <td className="py-3 pr-4">{new Date(e.validFrom).toLocaleDateString()}</td>
-                      <td className="py-3 capitalize">{e.status}</td>
+                      <td className="py-3 pr-4 capitalize">{e.status}</td>
+                      <td className="py-3">
+                        {e.invoiceId ? (
+                          <a
+                            href={invoiceDownloadUrl(e.invoiceId)}
+                            className="text-sm font-medium text-indigo-600 hover:underline"
+                            onClick={async (ev) => {
+                              ev.preventDefault()
+                              const res = await authorizedFetch(`/api/v1/invoices/${e.invoiceId}`)
+                              if (!res.ok) return
+                              const blob = await res.blob()
+                              const url = URL.createObjectURL(blob)
+                              const a = document.createElement('a')
+                              a.href = url
+                              a.download = `invoice-${e.invoiceId}.pdf`
+                              a.click()
+                              URL.revokeObjectURL(url)
+                            }}
+                          >
+                            Download
+                          </a>
+                        ) : (
+                          '—'
+                        )}
+                      </td>
                     </tr>
                   ))}
                 </tbody>

--- a/clients/web/src/pages/lms/org-tax-settings-page.tsx
+++ b/clients/web/src/pages/lms/org-tax-settings-page.tsx
@@ -1,0 +1,255 @@
+import { useCallback, useEffect, useId, useState } from 'react'
+import { usePlatformFeatures } from '../../context/platform-features-context'
+import { fetchOrgTaxSettings, fetchTaxReport, saveOrgTaxSettings, type OrgTaxSettings } from '../../lib/tax-api'
+import { authorizedFetch } from '../../lib/api'
+import { formatMoney } from '../../lib/billing-api'
+import { LmsPage } from './lms-page'
+
+type MeOrg = { orgId?: string }
+
+export default function OrgTaxSettingsPage() {
+  const titleId = useId()
+  const { ffTaxCollection, loading: featuresLoading } = usePlatformFeatures()
+  const [orgId, setOrgId] = useState<string | null>(null)
+  const [settings, setSettings] = useState<OrgTaxSettings | null>(null)
+  const [period, setPeriod] = useState(() => {
+    const now = new Date()
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+  })
+  const [reportRows, setReportRows] = useState<Awaited<ReturnType<typeof fetchTaxReport>>['rows']>([])
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const meRes = await authorizedFetch('/api/v1/me')
+      if (!meRes.ok) throw new Error('Could not load profile.')
+      const me = (await meRes.json()) as MeOrg
+      const oid = me.orgId
+      if (!oid) throw new Error('No organization found.')
+      setOrgId(oid)
+      const [s, report] = await Promise.all([
+        fetchOrgTaxSettings(oid),
+        fetchTaxReport(oid, period),
+      ])
+      setSettings(s)
+      setReportRows(report.rows)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load tax settings.')
+    } finally {
+      setLoading(false)
+    }
+  }, [period])
+
+  useEffect(() => {
+    if (!featuresLoading && ffTaxCollection) void load()
+  }, [featuresLoading, ffTaxCollection, load])
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault()
+    if (!orgId || !settings) return
+    setSaving(true)
+    setError(null)
+    setSaved(false)
+    try {
+      const updated = await saveOrgTaxSettings(orgId, settings)
+      setSettings(updated)
+      setSaved(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save settings.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (featuresLoading) return <p>Loading…</p>
+  if (!ffTaxCollection) {
+    return (
+      <LmsPage title="Tax settings">
+        <p role="alert">Tax collection is not enabled for this institution.</p>
+      </LmsPage>
+    )
+  }
+
+  return (
+    <LmsPage title="Tax settings">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <header>
+          <h1 id={titleId} className="text-2xl font-semibold text-slate-900 dark:text-neutral-100">
+            Tax settings
+          </h1>
+          <p className="mt-2 text-sm text-slate-600 dark:text-neutral-400">
+            Configure Stripe Tax jurisdictions, seller details, and run period reports.
+          </p>
+        </header>
+
+        {error ? (
+          <p role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-200">
+            {error}
+          </p>
+        ) : null}
+        {saved ? (
+          <p role="status" className="text-sm text-emerald-700 dark:text-emerald-300">
+            Settings saved.
+          </p>
+        ) : null}
+
+        {loading || !settings ? (
+          <p className="text-sm text-slate-600 dark:text-neutral-400">Loading…</p>
+        ) : (
+          <form onSubmit={(e) => void handleSave(e)} className="space-y-6">
+            <section className="rounded-xl border border-slate-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+              <label className="flex items-center gap-2 text-sm font-medium">
+                <input
+                  type="checkbox"
+                  checked={settings.enabled}
+                  onChange={(e) => setSettings({ ...settings, enabled: e.target.checked })}
+                />
+                Enable tax collection for this organization
+              </label>
+
+              <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label className="block text-sm font-medium">Price display</label>
+                  <select
+                    value={settings.priceDisplay}
+                    onChange={(e) =>
+                      setSettings({
+                        ...settings,
+                        priceDisplay: e.target.value as 'inclusive' | 'exclusive',
+                      })
+                    }
+                    className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                  >
+                    <option value="exclusive">Tax exclusive (US norm)</option>
+                    <option value="inclusive">Tax inclusive (EU norm)</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium">Default tax category</label>
+                  <input
+                    type="text"
+                    value={settings.defaultTaxCategory}
+                    onChange={(e) => setSettings({ ...settings, defaultTaxCategory: e.target.value })}
+                    className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                  />
+                </div>
+              </div>
+
+              <div className="mt-4">
+                <label className="block text-sm font-medium">Registered jurisdictions (comma-separated)</label>
+                <input
+                  type="text"
+                  value={settings.registeredJurisdictions.join(', ')}
+                  onChange={(e) =>
+                    setSettings({
+                      ...settings,
+                      registeredJurisdictions: e.target.value
+                        .split(',')
+                        .map((s) => s.trim().toUpperCase())
+                        .filter(Boolean),
+                    })
+                  }
+                  placeholder="GB, DE, US-CA"
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                />
+              </div>
+
+              <div className="mt-4 grid gap-4">
+                <div>
+                  <label className="block text-sm font-medium">Seller name</label>
+                  <input
+                    type="text"
+                    value={settings.sellerName}
+                    onChange={(e) => setSettings({ ...settings, sellerName: e.target.value })}
+                    className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium">Seller address</label>
+                  <textarea
+                    value={settings.sellerAddress}
+                    onChange={(e) => setSettings({ ...settings, sellerAddress: e.target.value })}
+                    rows={3}
+                    className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium">Seller tax ID</label>
+                  <input
+                    type="text"
+                    value={settings.sellerTaxId}
+                    onChange={(e) => setSettings({ ...settings, sellerTaxId: e.target.value })}
+                    className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                  />
+                </div>
+              </div>
+
+              <button
+                type="submit"
+                disabled={saving}
+                className="mt-4 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-60"
+              >
+                {saving ? 'Saving…' : 'Save settings'}
+              </button>
+            </section>
+          </form>
+        )}
+
+        <section className="rounded-xl border border-slate-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+          <div className="flex flex-wrap items-end gap-3">
+            <div>
+              <label className="block text-sm font-medium">Report period</label>
+              <input
+                type="month"
+                value={period}
+                onChange={(e) => setPeriod(e.target.value)}
+                className="mt-1 rounded-lg border border-slate-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+              />
+            </div>
+            <button
+              type="button"
+              onClick={() => void load()}
+              className="rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+            >
+              Refresh report
+            </button>
+          </div>
+
+          {reportRows.length === 0 ? (
+            <p className="mt-4 text-sm text-slate-600 dark:text-neutral-400">No tax collected in this period.</p>
+          ) : (
+            <div className="mt-4 overflow-x-auto">
+              <table className="min-w-full text-left text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 text-slate-500 dark:border-neutral-700">
+                    <th className="py-2 pr-4 font-medium">Jurisdiction</th>
+                    <th className="py-2 pr-4 font-medium">Type</th>
+                    <th className="py-2 pr-4 font-medium">Transactions</th>
+                    <th className="py-2 pr-4 font-medium">Tax collected</th>
+                    <th className="py-2 font-medium">Subtotal</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {reportRows.map((row) => (
+                    <tr key={`${row.jurisdiction}-${row.taxType}`} className="border-b border-slate-100 dark:border-neutral-800">
+                      <td className="py-3 pr-4">{row.jurisdiction}</td>
+                      <td className="py-3 pr-4 uppercase">{row.taxType}</td>
+                      <td className="py-3 pr-4">{row.transactionCount}</td>
+                      <td className="py-3 pr-4">{formatMoney(row.taxCollectedCents, 'usd')}</td>
+                      <td className="py-3">{formatMoney(row.subtotalCents, 'usd')}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      </div>
+    </LmsPage>
+  )
+}

--- a/docs/completed/15-self-learner-specific/15.13-tax-compliance.md
+++ b/docs/completed/15-self-learner-specific/15.13-tax-compliance.md
@@ -10,7 +10,7 @@
 | **Section** | Self-Learner Specific |
 | **Severity** | BLOCKER (global/multi-jurisdiction sales) / MAJOR (US-only) |
 | **Markets** | SL (primary); HE continuing-ed self-pay (secondary) |
-| **Status (today)** | MISSING |
+| **Status (today)** | COMPLETE |
 | **Estimated effort** | M (2–4w) |
 | **Owner (proposed)** | Billing/Commerce team |
 | **Depends on** | 15.3 (Stripe billing), 16.8 (payment provider abstraction), 20.1 (terms/receipts) |

--- a/e2e/tests/billing.spec.ts
+++ b/e2e/tests/billing.spec.ts
@@ -22,6 +22,28 @@ test.describe('Billing — API auth', () => {
     })
     expect(res.status).toBe(401)
   })
+
+  test('POST /api/v1/checkout/quote returns 401 without auth', async () => {
+    const res = await fetch(`${apiBase}/api/v1/checkout/quote`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ courseId: '00000000-0000-0000-0000-000000000001', address: { country: 'GB' } }),
+    })
+    expect(res.status).toBe(401)
+  })
+
+  test('POST /api/v1/checkout/tax-id returns 401 without auth', async () => {
+    const res = await fetch(`${apiBase}/api/v1/checkout/tax-id`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        courseId: '00000000-0000-0000-0000-000000000001',
+        address: { country: 'DE' },
+        taxId: 'DE123456789',
+      }),
+    })
+    expect(res.status).toBe(401)
+  })
 })
 
 test.describe('Billing — authenticated API', () => {
@@ -35,6 +57,36 @@ test.describe('Billing — authenticated API', () => {
     expect(res.status).toBe(200)
     const body = (await res.json()) as { entitlements: unknown[] }
     expect(Array.isArray(body.entitlements)).toBe(true)
+  })
+})
+
+test.describe('Tax — API', () => {
+  test('tax quote returns 404 when tax collection disabled', async ({ seededCourse }) => {
+    const featRes = await fetch(`${apiBase}/api/v1/platform/features`, {
+      headers: { Authorization: `Bearer ${seededCourse.studentToken}` },
+    })
+    if (!featRes.ok) {
+      test.skip(true, 'platform features unavailable')
+    }
+    const feats = (await featRes.json()) as { ffTaxCollection?: boolean; ffStripeBilling?: boolean }
+    if (!feats.ffStripeBilling) {
+      test.skip(true, 'ff_stripe_billing not enabled')
+    }
+    if (feats.ffTaxCollection) {
+      test.skip(true, 'ff_tax_collection enabled — cannot assert disabled path')
+    }
+    const res = await fetch(`${apiBase}/api/v1/checkout/quote`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${seededCourse.studentToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        courseId: seededCourse.courseId,
+        address: { country: 'GB' },
+      }),
+    })
+    expect(res.status).toBe(404)
   })
 })
 

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -436,6 +436,9 @@ type Config struct {
 	// FFRevenueShare enables creator revenue share, affiliate tracking, and Stripe Connect payouts (plan 15.8).
 	// Managed in Settings → Global platform (not process env).
 	FFRevenueShare bool
+	// FFTaxCollection enables Stripe Tax calculation, collection, and reporting (plan 15.13).
+	// Managed in Settings → Global platform (not process env).
+	FFTaxCollection bool
 
 	// StripeSecretKey is the Stripe API secret key (sk_live_… or sk_test_…).
 	StripeSecretKey string

--- a/server/internal/httpserver/billing_http.go
+++ b/server/internal/httpserver/billing_http.go
@@ -63,14 +63,20 @@ func (d Deps) registerBillingRoutes(r chi.Router) {
 }
 
 type entitlementJSON struct {
-	ID              string  `json:"id"`
-	EntitlementType string  `json:"entitlementType"`
-	CourseID        *string `json:"courseId,omitempty"`
-	AmountPaidCents int     `json:"amountPaidCents"`
-	Currency        string  `json:"currency"`
-	ValidFrom       string  `json:"validFrom"`
-	ValidUntil      *string `json:"validUntil,omitempty"`
-	Status          string  `json:"status"`
+	ID              string   `json:"id"`
+	EntitlementType string   `json:"entitlementType"`
+	CourseID        *string  `json:"courseId,omitempty"`
+	AmountPaidCents int      `json:"amountPaidCents"`
+	SubtotalCents   int      `json:"subtotalCents,omitempty"`
+	TaxAmountCents  int      `json:"taxAmountCents,omitempty"`
+	TaxType         string   `json:"taxType,omitempty"`
+	TaxJurisdiction string   `json:"taxJurisdiction,omitempty"`
+	ReverseCharge   bool     `json:"reverseCharge,omitempty"`
+	InvoiceID       *string  `json:"invoiceId,omitempty"`
+	Currency        string   `json:"currency"`
+	ValidFrom       string   `json:"validFrom"`
+	ValidUntil      *string  `json:"validUntil,omitempty"`
+	Status          string   `json:"status"`
 }
 
 func entitlementToJSON(e repoBilling.Entitlement) entitlementJSON {
@@ -78,6 +84,11 @@ func entitlementToJSON(e repoBilling.Entitlement) entitlementJSON {
 		ID:              e.ID.String(),
 		EntitlementType: e.EntitlementType,
 		AmountPaidCents: e.AmountPaidCents,
+		SubtotalCents:   e.SubtotalCents,
+		TaxAmountCents:  e.TaxAmountCents,
+		TaxType:         e.TaxType,
+		TaxJurisdiction: e.TaxJurisdiction,
+		ReverseCharge:   e.ReverseCharge,
 		Currency:        e.Currency,
 		ValidFrom:       e.ValidFrom.UTC().Format(time.RFC3339),
 		Status:          e.Status,
@@ -85,6 +96,10 @@ func entitlementToJSON(e repoBilling.Entitlement) entitlementJSON {
 	if e.CourseID != nil {
 		s := e.CourseID.String()
 		out.CourseID = &s
+	}
+	if e.InvoiceID != nil {
+		s := e.InvoiceID.String()
+		out.InvoiceID = &s
 	}
 	if e.ValidUntil != nil {
 		s := e.ValidUntil.UTC().Format(time.RFC3339)
@@ -153,14 +168,15 @@ func (d Deps) handleBillingCheckout() http.HandlerFunc {
 			return
 		}
 		result, err := svcBilling.CreateCheckoutSession(r.Context(), d.Pool, cfg, svcBilling.CheckoutRequest{
-			UserID:        userID,
-			Email:         email,
-			CourseID:      courseID,
-			Plan:          body.Plan,
-			PromoCode:     body.PromoCode,
-			AffiliateCode: body.AffiliateCode,
-			SuccessURL:    successURL,
-			CancelURL:     cancelURL,
+			UserID:             userID,
+			Email:              email,
+			CourseID:           courseID,
+			Plan:               body.Plan,
+			PromoCode:          body.PromoCode,
+			AffiliateCode:      body.AffiliateCode,
+			SuccessURL:         successURL,
+			CancelURL:          cancelURL,
+			PlatformTaxEnabled: d.effectiveConfig().FFTaxCollection,
 		})
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Could not start checkout.")
@@ -315,7 +331,8 @@ func (d Deps) handleStripeWebhook() http.HandlerFunc {
 		cfg := svcBilling.ConfigFrom(d.effectiveConfig())
 		sig := r.Header.Get("Stripe-Signature")
 		result, err := svcBilling.HandleWebhook(r.Context(), d.Pool, cfg, body, sig, svcBilling.WebhookOptions{
-			RevenueShareEnabled: d.effectiveConfig().FFRevenueShare,
+			RevenueShareEnabled:  d.effectiveConfig().FFRevenueShare,
+			TaxCollectionEnabled: d.effectiveConfig().FFTaxCollection,
 		})
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid webhook.")

--- a/server/internal/httpserver/platform_features.go
+++ b/server/internal/httpserver/platform_features.go
@@ -81,6 +81,7 @@ type platformFeaturesJSON struct {
 	FFPublicAPI                 bool `json:"ffPublicApi"`
 	FFStripeBilling             bool `json:"ffStripeBilling"`
 	FFRevenueShare              bool `json:"ffRevenueShare"`
+	FFTaxCollection             bool `json:"ffTaxCollection"`
 	FFLearningPaths             bool `json:"ffLearningPaths"`
 	FFConditionalRelease        bool `json:"ffConditionalRelease"`
 	FFPeerReview                bool `json:"ffPeerReview"`
@@ -183,6 +184,7 @@ func platformFeaturesFromConfig(cfg config.Config) platformFeaturesJSON {
 		FFPublicAPI:                 cfg.FFPublicAPI,
 		FFStripeBilling:             cfg.FFStripeBilling,
 		FFRevenueShare:              cfg.FFRevenueShare,
+		FFTaxCollection:             cfg.FFTaxCollection,
 		FFLearningPaths:             cfg.FFLearningPaths,
 		FFConditionalRelease:        cfg.FFConditionalRelease,
 		FFPeerReview:                cfg.FFPeerReview,

--- a/server/internal/httpserver/server.go
+++ b/server/internal/httpserver/server.go
@@ -171,6 +171,7 @@ func NewHandler(d Deps) http.Handler {
 	d.registerResearchConsentRoutes(r)
 	d.registerConsortiumRoutes(r)
 	d.registerBillingRoutes(r)
+	d.registerTaxRoutes(r)
 	d.registerRevenueShareRoutes(r)
 	d.registerLearningPathRoutes(r)
 	d.registerAccessibilityRoutes(r)

--- a/server/internal/httpserver/settings_platform.go
+++ b/server/internal/httpserver/settings_platform.go
@@ -137,6 +137,7 @@ type platformSettingsJSON struct {
 	FFPublicAPI                     bool `json:"ffPublicApi"`
 	FFStripeBilling                 bool `json:"ffStripeBilling"`
 	FFRevenueShare                  bool `json:"ffRevenueShare"`
+	FFTaxCollection                 bool `json:"ffTaxCollection"`
 	FFLearningPaths                 bool `json:"ffLearningPaths"`
 	FFConditionalRelease            bool `json:"ffConditionalRelease"`
 	FFPeerReview                    bool `json:"ffPeerReview"`
@@ -337,6 +338,7 @@ func (d Deps) handleGetPlatformSettings() http.HandlerFunc {
 			FFPublicAPI:                     merged.FFPublicAPI,
 			FFStripeBilling:                 merged.FFStripeBilling,
 			FFRevenueShare:                  merged.FFRevenueShare,
+			FFTaxCollection:                 merged.FFTaxCollection,
 			FFLearningPaths:                 merged.FFLearningPaths,
 			FFConditionalRelease:            merged.FFConditionalRelease,
 			FFPeerReview:                    merged.FFPeerReview,
@@ -512,6 +514,7 @@ type putPlatformBody struct {
 	FFPublicAPI                     *bool `json:"ffPublicApi"`
 	FFStripeBilling                 *bool `json:"ffStripeBilling"`
 	FFRevenueShare                  *bool `json:"ffRevenueShare"`
+	FFTaxCollection                 *bool `json:"ffTaxCollection"`
 	FFLearningPaths                 *bool `json:"ffLearningPaths"`
 	FFConditionalRelease            *bool `json:"ffConditionalRelease"`
 	FFPeerReview                    *bool `json:"ffPeerReview"`
@@ -833,6 +836,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 		setBool("ffpublicapi", body.FFPublicAPI, func(v bool) { wr.FFPublicAPI = &v })
 		setBool("ffstripebilling", body.FFStripeBilling, func(v bool) { wr.FFStripeBilling = &v })
 		setBool("ffrevenueshare", body.FFRevenueShare, func(v bool) { wr.FFRevenueShare = &v })
+		setBool("fftaxcollection", body.FFTaxCollection, func(v bool) { wr.FFTaxCollection = &v })
 		setBool("fflearningpaths", body.FFLearningPaths, func(v bool) { wr.FFLearningPaths = &v })
 		setBool("ffconditionalrelease", body.FFConditionalRelease, func(v bool) { wr.FFConditionalRelease = &v })
 		setBool("ffpeerreview", body.FFPeerReview, func(v bool) { wr.FFPeerReview = &v })
@@ -987,6 +991,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 			FFPublicAPI:                     merged.FFPublicAPI,
 			FFStripeBilling:                 merged.FFStripeBilling,
 			FFRevenueShare:                  merged.FFRevenueShare,
+			FFTaxCollection:                 merged.FFTaxCollection,
 			FFLearningPaths:                 merged.FFLearningPaths,
 			FFConditionalRelease:            merged.FFConditionalRelease,
 			FFPeerReview:                    merged.FFPeerReview,

--- a/server/internal/httpserver/tax_http.go
+++ b/server/internal/httpserver/tax_http.go
@@ -3,6 +3,7 @@ package httpserver
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -405,21 +406,9 @@ func parseTaxReportPeriod(period string) (from, to time.Time, err error) {
 }
 
 func itoa(n int) string {
-	return strings.TrimSpace(strings.Replace(strings.Replace(
-		jsonStringInt(n), "\"", "", -1), " ", "", -1))
+	return strconv.Itoa(n)
 }
 
 func itoa64(n int64) string {
-	return strings.TrimSpace(strings.Replace(strings.Replace(
-		jsonStringInt64(n), "\"", "", -1), " ", "", -1))
-}
-
-func jsonStringInt(n int) string {
-	b, _ := json.Marshal(n)
-	return string(b)
-}
-
-func jsonStringInt64(n int64) string {
-	b, _ := json.Marshal(n)
-	return string(b)
+	return strconv.FormatInt(n, 10)
 }

--- a/server/internal/httpserver/tax_http.go
+++ b/server/internal/httpserver/tax_http.go
@@ -1,0 +1,425 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/crypto"
+	repoBilling "github.com/lextures/lextures/server/internal/repos/billing"
+	svcBilling "github.com/lextures/lextures/server/internal/service/billing"
+)
+
+func (d Deps) taxFeatureOff(w http.ResponseWriter) bool {
+	cfg := d.effectiveConfig()
+	if !cfg.FFStripeBilling || !cfg.FFTaxCollection {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Tax collection is not enabled.")
+		return true
+	}
+	return false
+}
+
+func (d Deps) registerTaxRoutes(r chi.Router) {
+	r.Post("/api/v1/checkout/quote", d.handleCheckoutQuote())
+	r.Post("/api/v1/checkout/tax-id", d.handleCheckoutTaxID())
+	r.Get("/api/v1/orgs/{orgId}/tax/settings", d.handleOrgTaxSettings())
+	r.Put("/api/v1/orgs/{orgId}/tax/settings", d.handleOrgTaxSettings())
+	r.Get("/api/v1/orgs/{orgId}/tax/report", d.handleOrgTaxReport())
+	r.Get("/api/v1/invoices/{invoiceId}", d.handleTaxInvoiceDownload())
+}
+
+func (d Deps) handleCheckoutQuote() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		if d.billingFeatureOff(w) || d.taxFeatureOff(w) {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+			return
+		}
+		if !d.checkBillingCheckoutRateLimit(userID) {
+			apierr.WriteJSON(w, http.StatusTooManyRequests, apierr.CodeRateLimited, "Rate limit exceeded.")
+			return
+		}
+		var body struct {
+			CourseID *string                `json:"courseId"`
+			Plan     string                 `json:"plan"`
+			Address  svcBilling.TaxAddress  `json:"address"`
+			TaxID    string                 `json:"taxId"`
+			TaxIDType string                `json:"taxIdType"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		var courseID *uuid.UUID
+		var orgID uuid.UUID
+		if body.CourseID != nil && strings.TrimSpace(*body.CourseID) != "" {
+			id, err := uuid.Parse(strings.TrimSpace(*body.CourseID))
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid courseId.")
+				return
+			}
+			courseID = &id
+			price, err := repoBilling.CoursePriceByID(r.Context(), d.Pool, id)
+			if err != nil || price == nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Course not found.")
+				return
+			}
+			orgID = price.OrgID
+		} else {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "courseId is required for tax quote.")
+			return
+		}
+		cfg := svcBilling.ConfigFrom(d.effectiveConfig())
+		if !cfg.IsConfigured() {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Stripe is not configured.")
+			return
+		}
+		result, err := svcBilling.ComputeTaxQuote(r.Context(), d.Pool, cfg, orgID, d.effectiveConfig().FFTaxCollection, svcBilling.TaxQuoteRequest{
+			CourseID:  courseID,
+			Plan:      body.Plan,
+			Address:   body.Address,
+			TaxID:     body.TaxID,
+			TaxIDType: body.TaxIDType,
+		})
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Could not compute tax quote.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(result)
+	}
+}
+
+func (d Deps) handleCheckoutTaxID() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		if _, ok := d.meUserID(w, r); !ok {
+			return
+		}
+		if d.billingFeatureOff(w) || d.taxFeatureOff(w) {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+			return
+		}
+		var body struct {
+			CourseID  *string               `json:"courseId"`
+			Address   svcBilling.TaxAddress `json:"address"`
+			TaxID     string                `json:"taxId"`
+			TaxIDType string                `json:"taxIdType"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		var orgID uuid.UUID
+		if body.CourseID != nil {
+			id, err := uuid.Parse(strings.TrimSpace(*body.CourseID))
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid courseId.")
+				return
+			}
+			price, err := repoBilling.CoursePriceByID(r.Context(), d.Pool, id)
+			if err != nil || price == nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Course not found.")
+				return
+			}
+			orgID = price.OrgID
+		}
+		cfg := svcBilling.ConfigFrom(d.effectiveConfig())
+		result, err := svcBilling.ValidateTaxID(r.Context(), d.Pool, cfg, orgID, d.effectiveConfig().FFTaxCollection, body.Address, body.TaxID, body.TaxIDType)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Could not validate tax ID.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(result)
+	}
+}
+
+func (d Deps) handleOrgTaxSettings() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		orgID, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "orgId")))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid organization id.")
+			return
+		}
+		if d.taxFeatureOff(w) {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			if _, ok := d.orgReadAccess(w, r, orgID); !ok {
+				return
+			}
+			settings, err := repoBilling.GetOrgTaxSettings(r.Context(), d.Pool, orgID)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not load tax settings.")
+				return
+			}
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			_ = json.NewEncoder(w).Encode(orgTaxSettingsJSON(settings))
+
+		case http.MethodPut:
+			if _, _, ok := d.adminOrgOrUnitAccess(w, r, orgID); !ok {
+				return
+			}
+			var body struct {
+				Enabled                 bool     `json:"enabled"`
+				RegisteredJurisdictions []string `json:"registeredJurisdictions"`
+				DefaultTaxCategory      string   `json:"defaultTaxCategory"`
+				PriceDisplay            string   `json:"priceDisplay"`
+				FilingMode              string   `json:"filingMode"`
+				RecordRetentionYears    int      `json:"recordRetentionYears"`
+				SellerName              string   `json:"sellerName"`
+				SellerAddress           string   `json:"sellerAddress"`
+				SellerTaxID             string   `json:"sellerTaxId"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+				return
+			}
+			if body.PriceDisplay != "" && body.PriceDisplay != repoBilling.PriceDisplayInc && body.PriceDisplay != repoBilling.PriceDisplayExc {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "priceDisplay must be inclusive or exclusive.")
+				return
+			}
+			settings := repoBilling.OrgTaxSettings{
+				OrgID:                   orgID,
+				Enabled:                 body.Enabled,
+				RegisteredJurisdictions: body.RegisteredJurisdictions,
+				DefaultTaxCategory:      body.DefaultTaxCategory,
+				PriceDisplay:            body.PriceDisplay,
+				FilingMode:              body.FilingMode,
+				RecordRetentionYears:    body.RecordRetentionYears,
+				SellerName:              body.SellerName,
+				SellerAddress:           body.SellerAddress,
+				SellerTaxID:             body.SellerTaxID,
+			}
+			if err := repoBilling.UpsertOrgTaxSettings(r.Context(), d.Pool, settings); err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not save tax settings.")
+				return
+			}
+			saved, _ := repoBilling.GetOrgTaxSettings(r.Context(), d.Pool, orgID)
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			_ = json.NewEncoder(w).Encode(orgTaxSettingsJSON(saved))
+
+		default:
+			w.Header().Set("Allow", "GET, PUT")
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+func orgTaxSettingsJSON(s *repoBilling.OrgTaxSettings) map[string]any {
+	if s == nil {
+		return map[string]any{}
+	}
+	return map[string]any{
+		"orgId":                   s.OrgID.String(),
+		"enabled":                 s.Enabled,
+		"registeredJurisdictions": s.RegisteredJurisdictions,
+		"defaultTaxCategory":      s.DefaultTaxCategory,
+		"priceDisplay":            s.PriceDisplay,
+		"filingMode":              s.FilingMode,
+		"recordRetentionYears":    s.RecordRetentionYears,
+		"sellerName":              s.SellerName,
+		"sellerAddress":           s.SellerAddress,
+		"sellerTaxId":             s.SellerTaxID,
+	}
+}
+
+func (d Deps) handleOrgTaxReport() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		orgID, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "orgId")))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid organization id.")
+			return
+		}
+		if d.taxFeatureOff(w) {
+			return
+		}
+		if _, _, ok := d.adminOrgOrUnitAccess(w, r, orgID); !ok {
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+			return
+		}
+		period := strings.TrimSpace(r.URL.Query().Get("period"))
+		jurisdiction := strings.TrimSpace(r.URL.Query().Get("jurisdiction"))
+		from, to, err := parseTaxReportPeriod(period)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid period; use YYYY-MM.")
+			return
+		}
+		rows, err := repoBilling.TaxReport(r.Context(), d.Pool, orgID, from, to, jurisdiction)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not generate tax report.")
+			return
+		}
+		format := strings.TrimSpace(r.URL.Query().Get("format"))
+		if format == "csv" {
+			w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+			w.Header().Set("Content-Disposition", "attachment; filename=tax-report.csv")
+			_, _ = w.Write([]byte("jurisdiction,tax_type,transaction_count,tax_collected_cents,subtotal_cents\n"))
+			for _, row := range rows {
+				line := row.Jurisdiction + "," + row.TaxType + "," +
+					itoa(row.TransactionCount) + "," +
+					itoa64(row.TaxCollectedCents) + "," +
+					itoa64(row.SubtotalCents) + "\n"
+				_, _ = w.Write([]byte(line))
+			}
+			return
+		}
+		items := make([]map[string]any, 0, len(rows))
+		for _, row := range rows {
+			items = append(items, map[string]any{
+				"jurisdiction":      row.Jurisdiction,
+				"taxType":           row.TaxType,
+				"transactionCount":  row.TransactionCount,
+				"taxCollectedCents": row.TaxCollectedCents,
+				"subtotalCents":     row.SubtotalCents,
+			})
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"period":  period,
+			"from":    from.UTC().Format(time.RFC3339),
+			"to":      to.UTC().Format(time.RFC3339),
+			"rows":    items,
+		})
+	}
+}
+
+func (d Deps) handleTaxInvoiceDownload() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		if d.billingFeatureOff(w) {
+			return
+		}
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		invID, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "invoiceId")))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid invoice id.")
+			return
+		}
+		if d.Pool == nil {
+			apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+			return
+		}
+		inv, err := repoBilling.GetTaxInvoiceByID(r.Context(), d.Pool, invID)
+		if err != nil || inv == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Invoice not found.")
+			return
+		}
+		ent, err := repoBilling.GetEntitlementWithTax(r.Context(), d.Pool, inv.EntitlementID)
+		if err != nil || ent == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Invoice not found.")
+			return
+		}
+		var orgID uuid.UUID
+		if ent.CourseID != nil {
+			price, _ := repoBilling.CoursePriceByID(r.Context(), d.Pool, *ent.CourseID)
+			if price != nil {
+				orgID = price.OrgID
+			}
+		}
+		if ent.UserID != userID {
+			if orgID == uuid.Nil {
+				apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission for this action.")
+				return
+			}
+			if _, _, ok := d.adminOrgOrUnitAccess(w, r, orgID); !ok {
+				return
+			}
+		}
+		settings, _ := repoBilling.GetOrgTaxSettings(r.Context(), d.Pool, orgID)
+		customerTaxID := ""
+		if ent.CustomerTaxIDEnc != "" {
+			if plain, err := crypto.DecryptString(ent.CustomerTaxIDEnc); err == nil {
+				customerTaxID = plain
+			}
+		}
+		pdfInput := svcBilling.InvoicePDFFromEntitlement(ent, inv, settings, customerTaxID)
+		pdfBytes, err := svcBilling.BuildTaxInvoicePDF(pdfInput)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Could not generate invoice.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/pdf")
+		w.Header().Set("Content-Disposition", "attachment; filename="+inv.InvoiceNumber+".pdf")
+		_, _ = w.Write(pdfBytes)
+	}
+}
+
+func parseTaxReportPeriod(period string) (from, to time.Time, err error) {
+	if period == "" {
+		now := time.Now().UTC()
+		from = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+		to = from.AddDate(0, 1, 0)
+		return from, to, nil
+	}
+	t, err := time.Parse("2006-01", period)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	from = time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+	to = from.AddDate(0, 1, 0)
+	return from, to, nil
+}
+
+func itoa(n int) string {
+	return strings.TrimSpace(strings.Replace(strings.Replace(
+		jsonStringInt(n), "\"", "", -1), " ", "", -1))
+}
+
+func itoa64(n int64) string {
+	return strings.TrimSpace(strings.Replace(strings.Replace(
+		jsonStringInt64(n), "\"", "", -1), " ", "", -1))
+}
+
+func jsonStringInt(n int) string {
+	b, _ := json.Marshal(n)
+	return string(b)
+}
+
+func jsonStringInt64(n int64) string {
+	b, _ := json.Marshal(n)
+	return string(b)
+}

--- a/server/internal/httpserver/tax_nodb_test.go
+++ b/server/internal/httpserver/tax_nodb_test.go
@@ -1,0 +1,47 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/config"
+)
+
+func TestTax_Unauthenticated(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	cfg := config.Config{FFStripeBilling: true, FFTaxCollection: true}
+	d := Deps{Pool: nil, JWTSigner: signer, Config: cfg}
+	h := NewHandler(d)
+
+	paths := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/v1/checkout/quote"},
+		{http.MethodPost, "/api/v1/checkout/tax-id"},
+	}
+	for _, tc := range paths {
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s: want 401 got %d", tc.method, tc.path, w.Code)
+		}
+	}
+}
+
+func TestTax_FeatureOff(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	cfg := config.Config{FFStripeBilling: true, FFTaxCollection: false}
+	d := Deps{Pool: nil, JWTSigner: signer, Config: cfg}
+	h := NewHandler(d)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/checkout/quote", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("feature off without auth want 401 got %d", w.Code)
+	}
+}

--- a/server/internal/repos/billing/entitlements.go
+++ b/server/internal/repos/billing/entitlements.go
@@ -30,6 +30,12 @@ type Entitlement struct {
 	StripeEventID   string
 	StripeInvoiceID *string
 	AmountPaidCents int
+	SubtotalCents   int
+	TaxAmountCents  int
+	TaxType         string
+	TaxJurisdiction string
+	ReverseCharge   bool
+	InvoiceID       *uuid.UUID
 	Currency        string
 	ValidFrom       time.Time
 	ValidUntil      *time.Time
@@ -103,7 +109,9 @@ func scanEntitlement(ctx context.Context, pool *pgxpool.Pool, query string, args
 func ListActiveByUser(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) ([]Entitlement, error) {
 	rows, err := pool.Query(ctx, `
 SELECT id, user_id, entitlement_type, course_id, stripe_event_id, stripe_invoice_id,
-       amount_paid_cents, currency, valid_from, valid_until, status, created_at
+       amount_paid_cents, subtotal_cents, tax_amount_cents, tax_type,
+       COALESCE(tax_jurisdiction, ''), reverse_charge, invoice_id,
+       currency, valid_from, valid_until, status, created_at
 FROM billing.user_entitlements
 WHERE user_id = $1
   AND status = 'active'
@@ -120,7 +128,8 @@ ORDER BY created_at DESC
 		var courseID *uuid.UUID
 		if err := rows.Scan(
 			&e.ID, &e.UserID, &e.EntitlementType, &courseID, &e.StripeEventID, &e.StripeInvoiceID,
-			&e.AmountPaidCents, &e.Currency, &e.ValidFrom, &e.ValidUntil, &e.Status, &e.CreatedAt,
+			&e.AmountPaidCents, &e.SubtotalCents, &e.TaxAmountCents, &e.TaxType, &e.TaxJurisdiction,
+			&e.ReverseCharge, &e.InvoiceID, &e.Currency, &e.ValidFrom, &e.ValidUntil, &e.Status, &e.CreatedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/repos/billing/tax.go
+++ b/server/internal/repos/billing/tax.go
@@ -1,0 +1,332 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	TaxTypeNone      = "none"
+	TaxTypeVAT       = "vat"
+	TaxTypeGST       = "gst"
+	TaxTypeSalesTax  = "sales_tax"
+	PriceDisplayInc  = "inclusive"
+	PriceDisplayExc  = "exclusive"
+)
+
+// OrgTaxSettings is per-org tax configuration (plan 15.13).
+type OrgTaxSettings struct {
+	OrgID                     uuid.UUID
+	Enabled                   bool
+	RegisteredJurisdictions   []string
+	DefaultTaxCategory        string
+	PriceDisplay              string
+	FilingMode                string
+	RecordRetentionYears      int
+	SellerName                string
+	SellerAddress             string
+	SellerTaxID               string
+	UpdatedAt                 time.Time
+}
+
+// TaxFields captures tax metadata stored on an entitlement.
+type TaxFields struct {
+	SubtotalCents            int
+	TaxAmountCents           int
+	TaxRate                  *float64
+	TaxJurisdiction          string
+	TaxType                  string
+	TaxInclusive             bool
+	CustomerCountry          string
+	CustomerRegion           string
+	CustomerTaxIDEnc         string
+	ReverseCharge            bool
+	StripeTaxCalculationID   string
+	InvoiceID                *uuid.UUID
+}
+
+// TaxInvoice is a tax-compliant invoice record.
+type TaxInvoice struct {
+	ID             uuid.UUID
+	EntitlementID  uuid.UUID
+	InvoiceNumber  string
+	PDFStorageKey  string
+	IssuedAt       time.Time
+	CreditedBy     *uuid.UUID
+}
+
+// TaxReportRow aggregates tax collected for a jurisdiction and period.
+type TaxReportRow struct {
+	Jurisdiction      string
+	TaxType           string
+	TransactionCount  int
+	TaxCollectedCents int64
+	SubtotalCents     int64
+}
+
+// GetOrgTaxSettings loads org tax settings or defaults when missing.
+func GetOrgTaxSettings(ctx context.Context, pool *pgxpool.Pool, orgID uuid.UUID) (*OrgTaxSettings, error) {
+	var s OrgTaxSettings
+	var jurisdictionsJSON []byte
+	err := pool.QueryRow(ctx, `
+SELECT org_id, enabled, registered_jurisdictions_json, default_tax_category,
+       price_display, filing_mode, record_retention_years,
+       COALESCE(seller_name, ''), COALESCE(seller_address, ''), COALESCE(seller_tax_id, ''),
+       updated_at
+FROM billing.org_tax_settings
+WHERE org_id = $1
+`, orgID).Scan(
+		&s.OrgID, &s.Enabled, &jurisdictionsJSON, &s.DefaultTaxCategory,
+		&s.PriceDisplay, &s.FilingMode, &s.RecordRetentionYears,
+		&s.SellerName, &s.SellerAddress, &s.SellerTaxID, &s.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return &OrgTaxSettings{
+			OrgID:                orgID,
+			DefaultTaxCategory:   "txcd_99999999",
+			PriceDisplay:         PriceDisplayExc,
+			FilingMode:           "manual",
+			RecordRetentionYears: 7,
+		}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(jurisdictionsJSON) > 0 {
+		_ = json.Unmarshal(jurisdictionsJSON, &s.RegisteredJurisdictions)
+	}
+	return &s, nil
+}
+
+// UpsertOrgTaxSettings saves org tax configuration.
+func UpsertOrgTaxSettings(ctx context.Context, pool *pgxpool.Pool, s OrgTaxSettings) error {
+	jurisdictionsJSON, err := json.Marshal(s.RegisteredJurisdictions)
+	if err != nil {
+		return err
+	}
+	if s.DefaultTaxCategory == "" {
+		s.DefaultTaxCategory = "txcd_99999999"
+	}
+	if s.PriceDisplay == "" {
+		s.PriceDisplay = PriceDisplayExc
+	}
+	if s.FilingMode == "" {
+		s.FilingMode = "manual"
+	}
+	if s.RecordRetentionYears < 1 {
+		s.RecordRetentionYears = 7
+	}
+	_, err = pool.Exec(ctx, `
+INSERT INTO billing.org_tax_settings (
+    org_id, enabled, registered_jurisdictions_json, default_tax_category,
+    price_display, filing_mode, record_retention_years,
+    seller_name, seller_address, seller_tax_id, updated_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
+ON CONFLICT (org_id) DO UPDATE SET
+    enabled = EXCLUDED.enabled,
+    registered_jurisdictions_json = EXCLUDED.registered_jurisdictions_json,
+    default_tax_category = EXCLUDED.default_tax_category,
+    price_display = EXCLUDED.price_display,
+    filing_mode = EXCLUDED.filing_mode,
+    record_retention_years = EXCLUDED.record_retention_years,
+    seller_name = EXCLUDED.seller_name,
+    seller_address = EXCLUDED.seller_address,
+    seller_tax_id = EXCLUDED.seller_tax_id,
+    updated_at = NOW()
+`, s.OrgID, s.Enabled, jurisdictionsJSON, s.DefaultTaxCategory,
+		s.PriceDisplay, s.FilingMode, s.RecordRetentionYears,
+		s.SellerName, s.SellerAddress, s.SellerTaxID)
+	return err
+}
+
+// UpdateEntitlementTax persists tax fields on an existing entitlement.
+func UpdateEntitlementTax(ctx context.Context, pool *pgxpool.Pool, stripeEventID string, tax TaxFields) error {
+	_, err := pool.Exec(ctx, `
+UPDATE billing.user_entitlements SET
+    subtotal_cents = $2,
+    tax_amount_cents = $3,
+    tax_rate = $4,
+    tax_jurisdiction = NULLIF($5, ''),
+    tax_type = $6,
+    tax_inclusive = $7,
+    customer_country = NULLIF($8, ''),
+    customer_region = NULLIF($9, ''),
+    customer_tax_id_enc = NULLIF($10, ''),
+    reverse_charge = $11,
+    stripe_tax_calculation_id = NULLIF($12, ''),
+    invoice_id = $13
+WHERE stripe_event_id = $1
+`, stripeEventID,
+		tax.SubtotalCents, tax.TaxAmountCents, tax.TaxRate, tax.TaxJurisdiction, tax.TaxType,
+		tax.TaxInclusive, tax.CustomerCountry, tax.CustomerRegion, tax.CustomerTaxIDEnc,
+		tax.ReverseCharge, tax.StripeTaxCalculationID, tax.InvoiceID)
+	return err
+}
+
+// CreateTaxInvoice inserts a tax invoice and links it to the entitlement.
+func CreateTaxInvoice(ctx context.Context, pool *pgxpool.Pool, entitlementID uuid.UUID, invoiceNumber, pdfKey string) (*TaxInvoice, error) {
+	var inv TaxInvoice
+	err := pool.QueryRow(ctx, `
+INSERT INTO billing.tax_invoices (entitlement_id, invoice_number, pdf_storage_key)
+VALUES ($1, $2, NULLIF($3, ''))
+RETURNING id, entitlement_id, invoice_number, COALESCE(pdf_storage_key, ''), issued_at, credited_by
+`, entitlementID, invoiceNumber, pdfKey).Scan(
+		&inv.ID, &inv.EntitlementID, &inv.InvoiceNumber, &inv.PDFStorageKey, &inv.IssuedAt, &inv.CreditedBy,
+	)
+	if err != nil {
+		return nil, err
+	}
+	_, err = pool.Exec(ctx, `UPDATE billing.user_entitlements SET invoice_id = $2 WHERE id = $1`, entitlementID, inv.ID)
+	if err != nil {
+		return nil, err
+	}
+	return &inv, nil
+}
+
+// GetTaxInvoiceByID loads an invoice by id.
+func GetTaxInvoiceByID(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID) (*TaxInvoice, error) {
+	var inv TaxInvoice
+	err := pool.QueryRow(ctx, `
+SELECT id, entitlement_id, invoice_number, COALESCE(pdf_storage_key, ''), issued_at, credited_by
+FROM billing.tax_invoices WHERE id = $1
+`, id).Scan(&inv.ID, &inv.EntitlementID, &inv.InvoiceNumber, &inv.PDFStorageKey, &inv.IssuedAt, &inv.CreditedBy)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &inv, nil
+}
+
+// EntitlementWithTax loads entitlement + tax fields for invoice generation.
+type EntitlementWithTax struct {
+	Entitlement
+	SubtotalCents          int
+	TaxAmountCents         int
+	TaxRate                *float64
+	TaxJurisdiction        string
+	TaxType                string
+	TaxInclusive           bool
+	CustomerCountry        string
+	CustomerRegion         string
+	CustomerTaxIDEnc       string
+	ReverseCharge          bool
+	StripeTaxCalculationID string
+	InvoiceID              *uuid.UUID
+	UserEmail              string
+}
+
+// GetEntitlementWithTax loads entitlement tax details by id.
+func GetEntitlementWithTax(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID) (*EntitlementWithTax, error) {
+	var e EntitlementWithTax
+	var courseID *uuid.UUID
+	err := pool.QueryRow(ctx, `
+SELECT e.id, e.user_id, e.entitlement_type, e.course_id, e.stripe_event_id, e.stripe_invoice_id,
+       e.amount_paid_cents, e.currency, e.valid_from, e.valid_until, e.status, e.created_at,
+       e.subtotal_cents, e.tax_amount_cents, e.tax_rate, COALESCE(e.tax_jurisdiction, ''),
+       e.tax_type, e.tax_inclusive, COALESCE(e.customer_country, ''), COALESCE(e.customer_region, ''),
+       COALESCE(e.customer_tax_id_enc, ''), e.reverse_charge, COALESCE(e.stripe_tax_calculation_id, ''),
+       e.invoice_id, u.email
+FROM billing.user_entitlements e
+JOIN "user".users u ON u.id = e.user_id
+WHERE e.id = $1
+`, id).Scan(
+		&e.ID, &e.UserID, &e.EntitlementType, &courseID, &e.StripeEventID, &e.StripeInvoiceID,
+		&e.AmountPaidCents, &e.Currency, &e.ValidFrom, &e.ValidUntil, &e.Status, &e.CreatedAt,
+		&e.SubtotalCents, &e.TaxAmountCents, &e.TaxRate, &e.TaxJurisdiction,
+		&e.TaxType, &e.TaxInclusive, &e.CustomerCountry, &e.CustomerRegion,
+		&e.CustomerTaxIDEnc, &e.ReverseCharge, &e.StripeTaxCalculationID, &e.InvoiceID, &e.UserEmail,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	e.CourseID = courseID
+	return &e, nil
+}
+
+// TaxReport generates aggregated tax totals for a period and optional jurisdiction.
+func TaxReport(ctx context.Context, pool *pgxpool.Pool, orgID uuid.UUID, from, to time.Time, jurisdiction string) ([]TaxReportRow, error) {
+	query := `
+SELECT COALESCE(e.tax_jurisdiction, 'unknown') AS jurisdiction,
+       e.tax_type,
+       COUNT(*)::int AS transaction_count,
+       COALESCE(SUM(e.tax_amount_cents), 0)::bigint AS tax_collected_cents,
+       COALESCE(SUM(e.subtotal_cents), 0)::bigint AS subtotal_cents
+FROM billing.user_entitlements e
+LEFT JOIN course.courses c ON c.id = e.course_id
+WHERE e.tax_type <> 'none'
+  AND e.status = 'active'
+  AND e.created_at >= $1
+  AND e.created_at < $2
+  AND (c.org_id = $3 OR e.entitlement_type LIKE 'subscription%')
+`
+	args := []any{from, to, orgID}
+	if jurisdiction != "" {
+		query += ` AND e.tax_jurisdiction = $4`
+		args = append(args, jurisdiction)
+	}
+	query += ` GROUP BY e.tax_jurisdiction, e.tax_type ORDER BY e.tax_jurisdiction, e.tax_type`
+
+	rows, err := pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []TaxReportRow
+	for rows.Next() {
+		var r TaxReportRow
+		if err := rows.Scan(&r.Jurisdiction, &r.TaxType, &r.TransactionCount, &r.TaxCollectedCents, &r.SubtotalCents); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ReverseEntitlementTaxByCourse marks the latest course entitlement refunded and issues a credit note.
+func ReverseEntitlementTaxByCourse(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (*uuid.UUID, error) {
+	var entID uuid.UUID
+	var taxAmount int
+	err := pool.QueryRow(ctx, `
+SELECT id, tax_amount_cents FROM billing.user_entitlements
+WHERE course_id = $1 AND status = 'active' AND entitlement_type = 'course_purchase'
+ORDER BY created_at DESC
+LIMIT 1
+`, courseID).Scan(&entID, &taxAmount)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	_, err = pool.Exec(ctx, `
+UPDATE billing.user_entitlements SET status = 'refunded' WHERE id = $1
+`, entID)
+	if err != nil {
+		return nil, err
+	}
+	if taxAmount <= 0 {
+		return nil, nil
+	}
+	var creditID uuid.UUID
+	creditNumber := "CR-" + entID.String()[:8]
+	err = pool.QueryRow(ctx, `
+INSERT INTO billing.tax_invoices (entitlement_id, invoice_number, credited_by)
+SELECT $1, $2, invoice_id FROM billing.user_entitlements WHERE id = $1
+RETURNING id
+`, entID, creditNumber).Scan(&creditID)
+	if err != nil {
+		return nil, err
+	}
+	return &creditID, nil
+}

--- a/server/internal/repos/platformconfig/features.go
+++ b/server/internal/repos/platformconfig/features.go
@@ -90,6 +90,7 @@ func applyPlatformBools(out *config.Config, db *Row, def Defaults) {
 	out.FFPublicAPI = mergeBool(db.FFPublicAPI, false)
 	out.FFStripeBilling = mergeBool(db.FFStripeBilling, false)
 	out.FFRevenueShare = mergeBool(db.FFRevenueShare, false)
+	out.FFTaxCollection = mergeBool(db.FFTaxCollection, false)
 	out.FFLearningPaths = mergeBool(db.FFLearningPaths, false)
 	out.FFConditionalRelease = mergeBool(db.FFConditionalRelease, false)
 	out.FFPeerReview = mergeBool(db.FFPeerReview, false)

--- a/server/internal/repos/platformconfig/patch.go
+++ b/server/internal/repos/platformconfig/patch.go
@@ -158,6 +158,7 @@ func patch(ctx context.Context, pool *pgxpool.Pool, w *Write) error {
 	addBool("ff_public_api", w.FFPublicAPI)
 	addBool("ff_stripe_billing", w.FFStripeBilling)
 	addBool("ff_revenue_share", w.FFRevenueShare)
+	addBool("ff_tax_collection", w.FFTaxCollection)
 	addBool("ff_learning_paths", w.FFLearningPaths)
 	addBool("ff_conditional_release", w.FFConditionalRelease)
 	addBool("ff_peer_review", w.FFPeerReview)

--- a/server/internal/repos/platformconfig/platformconfig.go
+++ b/server/internal/repos/platformconfig/platformconfig.go
@@ -124,6 +124,7 @@ type Row struct {
 	FFPublicAPI                     *bool
 	FFStripeBilling                 *bool
 	FFRevenueShare                  *bool
+	FFTaxCollection                 *bool
 	FFLearningPaths                 *bool
 	FFConditionalRelease            *bool
 	FFPeerReview                    *bool
@@ -276,6 +277,7 @@ type Write struct {
 	FFPublicAPI                     *bool
 	FFStripeBilling                 *bool
 	FFRevenueShare                  *bool
+	FFTaxCollection                 *bool
 	FFLearningPaths                 *bool
 	FFConditionalRelease            *bool
 	FFPeerReview                    *bool
@@ -439,6 +441,7 @@ SELECT
 	ff_bot_discord,
 	ff_calendar_feeds,
 	ff_revenue_share,
+	ff_tax_collection,
 	lrs_anonymize_actors,
 	ferpa_workflow_enabled,
 	dpa_portal_enabled,
@@ -582,6 +585,7 @@ WHERE id = 1
 		&r.FFBotDiscord,
 		&r.FFCalendarFeeds,
 		&r.FFRevenueShare,
+		&r.FFTaxCollection,
 		&r.LRSAnonymizeActors,
 		&r.FERPAWorkflowEnabled,
 		&r.DPAPortalEnabled,
@@ -773,6 +777,7 @@ INSERT INTO settings.platform_app_settings (
 	ff_bot_discord,
 	ff_calendar_feeds,
 	ff_revenue_share,
+	ff_tax_collection,
 	mfa_enabled,
 	mfa_enforcement,
 	smtp_host,
@@ -921,6 +926,7 @@ ON CONFLICT (id) DO UPDATE SET
 	ff_bot_discord = COALESCE(EXCLUDED.ff_bot_discord, settings.platform_app_settings.ff_bot_discord),
 	ff_calendar_feeds = COALESCE(EXCLUDED.ff_calendar_feeds, settings.platform_app_settings.ff_calendar_feeds),
 	ff_revenue_share = COALESCE(EXCLUDED.ff_revenue_share, settings.platform_app_settings.ff_revenue_share),
+	ff_tax_collection = COALESCE(EXCLUDED.ff_tax_collection, settings.platform_app_settings.ff_tax_collection),
 	lrs_anonymize_actors = COALESCE(EXCLUDED.lrs_anonymize_actors, settings.platform_app_settings.lrs_anonymize_actors),
 	ferpa_workflow_enabled = COALESCE(EXCLUDED.ferpa_workflow_enabled, settings.platform_app_settings.ferpa_workflow_enabled),
 	dpa_portal_enabled = COALESCE(EXCLUDED.dpa_portal_enabled, settings.platform_app_settings.dpa_portal_enabled),
@@ -1062,6 +1068,7 @@ ON CONFLICT (id) DO UPDATE SET
 		w.FFBotDiscord,
 		w.FFCalendarFeeds,
 		w.FFRevenueShare,
+		w.FFTaxCollection,
 		w.MFAEnabled,
 		w.MFAEnforcement,
 		w.SMTPHost,

--- a/server/internal/service/billing/invoice_pdf.go
+++ b/server/internal/service/billing/invoice_pdf.go
@@ -1,0 +1,197 @@
+package billing
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jung-kurt/gofpdf"
+
+	repoBilling "github.com/lextures/lextures/server/internal/repos/billing"
+)
+
+// InvoicePDFInput describes a tax-compliant invoice.
+type InvoicePDFInput struct {
+	InvoiceNumber   string
+	IssuedAt        time.Time
+	SellerName      string
+	SellerAddress   string
+	SellerTaxID     string
+	CustomerEmail   string
+	CustomerCountry string
+	CustomerRegion  string
+	CustomerTaxID   string
+	SubtotalCents   int
+	TaxAmountCents  int
+	TotalCents      int
+	Currency        string
+	TaxType         string
+	TaxRate         *float64
+	TaxJurisdiction string
+	ReverseCharge   bool
+	TaxInclusive    bool
+	Description     string
+	IsCredit        bool
+}
+
+// BuildTaxInvoicePDF renders a tax-compliant invoice as PDF bytes.
+func BuildTaxInvoicePDF(in InvoicePDFInput) ([]byte, error) {
+	pdf := gofpdf.New("P", "mm", "A4", "")
+	pdf.SetMargins(15, 15, 15)
+	pdf.AddPage()
+	pdf.SetFont("Helvetica", "B", 16)
+
+	title := "Tax Invoice"
+	if in.IsCredit {
+		title = "Credit Note"
+	}
+	pdf.Cell(0, 10, title)
+	pdf.Ln(12)
+
+	pdf.SetFont("Helvetica", "", 10)
+	pdf.Cell(0, 6, fmt.Sprintf("Invoice number: %s", in.InvoiceNumber))
+	pdf.Ln(6)
+	pdf.Cell(0, 6, fmt.Sprintf("Date: %s", in.IssuedAt.UTC().Format("2006-01-02")))
+	pdf.Ln(10)
+
+	// Seller
+	pdf.SetFont("Helvetica", "B", 11)
+	pdf.Cell(0, 6, "Seller")
+	pdf.Ln(7)
+	pdf.SetFont("Helvetica", "", 10)
+	if in.SellerName != "" {
+		pdf.Cell(0, 5, in.SellerName)
+		pdf.Ln(5)
+	}
+	for _, line := range strings.Split(in.SellerAddress, "\n") {
+		if strings.TrimSpace(line) != "" {
+			pdf.Cell(0, 5, line)
+			pdf.Ln(5)
+		}
+	}
+	if in.SellerTaxID != "" {
+		pdf.Cell(0, 5, "Tax ID: "+in.SellerTaxID)
+		pdf.Ln(5)
+	}
+	pdf.Ln(6)
+
+	// Customer
+	pdf.SetFont("Helvetica", "B", 11)
+	pdf.Cell(0, 6, "Customer")
+	pdf.Ln(7)
+	pdf.SetFont("Helvetica", "", 10)
+	pdf.Cell(0, 5, in.CustomerEmail)
+	pdf.Ln(5)
+	if in.CustomerCountry != "" {
+		loc := in.CustomerCountry
+		if in.CustomerRegion != "" {
+			loc += ", " + in.CustomerRegion
+		}
+		pdf.Cell(0, 5, loc)
+		pdf.Ln(5)
+	}
+	if in.CustomerTaxID != "" {
+		pdf.Cell(0, 5, "Tax ID: "+in.CustomerTaxID)
+		pdf.Ln(5)
+	}
+	pdf.Ln(8)
+
+	// Line items
+	pdf.SetFont("Helvetica", "B", 10)
+	pdf.Cell(120, 7, "Description")
+	pdf.Cell(40, 7, "Amount")
+	pdf.Ln(8)
+	pdf.SetFont("Helvetica", "", 10)
+	pdf.Cell(120, 6, in.Description)
+	pdf.Cell(40, 6, formatCurrency(in.SubtotalCents, in.Currency))
+	pdf.Ln(8)
+
+	taxLabel := taxLineLabel(in.TaxType, in.ReverseCharge)
+	if in.TaxRate != nil && !in.ReverseCharge {
+		taxLabel = fmt.Sprintf("%s (%.1f%%)", taxLabel, *in.TaxRate)
+	}
+	pdf.Cell(120, 6, taxLabel)
+	if in.ReverseCharge {
+		pdf.Cell(40, 6, "Reverse charge")
+	} else {
+		pdf.Cell(40, 6, formatCurrency(in.TaxAmountCents, in.Currency))
+	}
+	pdf.Ln(8)
+
+	pdf.SetFont("Helvetica", "B", 10)
+	pdf.Cell(120, 7, "Total")
+	pdf.Cell(40, 7, formatCurrency(in.TotalCents, in.Currency))
+	pdf.Ln(10)
+
+	if in.ReverseCharge {
+		pdf.SetFont("Helvetica", "I", 9)
+		pdf.MultiCell(0, 5, "VAT reverse charge: customer is responsible for VAT reporting.", "", "L", false)
+	}
+	if in.TaxInclusive {
+		pdf.Ln(4)
+		pdf.SetFont("Helvetica", "I", 9)
+		pdf.MultiCell(0, 5, "Prices shown are tax-inclusive.", "", "L", false)
+	}
+
+	var buf bytes.Buffer
+	if err := pdf.Output(&buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// InvoicePDFFromEntitlement builds invoice PDF input from stored entitlement data.
+func InvoicePDFFromEntitlement(ent *repoBilling.EntitlementWithTax, inv *repoBilling.TaxInvoice, settings *repoBilling.OrgTaxSettings, customerTaxID string) InvoicePDFInput {
+	subtotal := ent.SubtotalCents
+	if subtotal == 0 {
+		subtotal = ent.AmountPaidCents - ent.TaxAmountCents
+	}
+	desc := ent.EntitlementType
+	if ent.CourseID != nil {
+		desc = "Course purchase"
+	}
+	sellerName := ""
+	sellerAddr := ""
+	sellerTaxID := ""
+	if settings != nil {
+		sellerName = settings.SellerName
+		sellerAddr = settings.SellerAddress
+		sellerTaxID = settings.SellerTaxID
+	}
+	issuedAt := ent.CreatedAt
+	invNum := ""
+	isCredit := false
+	if inv != nil {
+		invNum = inv.InvoiceNumber
+		issuedAt = inv.IssuedAt
+		isCredit = inv.CreditedBy != nil
+	}
+	return InvoicePDFInput{
+		InvoiceNumber:   invNum,
+		IssuedAt:        issuedAt,
+		SellerName:      sellerName,
+		SellerAddress:   sellerAddr,
+		SellerTaxID:     sellerTaxID,
+		CustomerEmail:   ent.UserEmail,
+		CustomerCountry: ent.CustomerCountry,
+		CustomerRegion:  ent.CustomerRegion,
+		CustomerTaxID:   customerTaxID,
+		SubtotalCents:   subtotal,
+		TaxAmountCents:  ent.TaxAmountCents,
+		TotalCents:      ent.AmountPaidCents,
+		Currency:        ent.Currency,
+		TaxType:         ent.TaxType,
+		TaxRate:         ent.TaxRate,
+		TaxJurisdiction: ent.TaxJurisdiction,
+		ReverseCharge:   ent.ReverseCharge,
+		TaxInclusive:    ent.TaxInclusive,
+		Description:     desc,
+		IsCredit:        isCredit,
+	}
+}
+
+func formatCurrency(cents int, currency string) string {
+	sym := strings.ToUpper(currency)
+	return fmt.Sprintf("%s %.2f", sym, float64(cents)/100)
+}

--- a/server/internal/service/billing/stripe.go
+++ b/server/internal/service/billing/stripe.go
@@ -24,14 +24,15 @@ import (
 
 // CheckoutRequest is the learner checkout payload.
 type CheckoutRequest struct {
-	UserID        uuid.UUID
-	Email         string
-	CourseID      *uuid.UUID
-	Plan          string // monthly | annual
-	PromoCode     string
-	AffiliateCode string
-	SuccessURL    string
-	CancelURL     string
+	UserID              uuid.UUID
+	Email               string
+	CourseID            *uuid.UUID
+	Plan                string // monthly | annual
+	PromoCode           string
+	AffiliateCode       string
+	SuccessURL          string
+	CancelURL           string
+	PlatformTaxEnabled  bool
 }
 
 // CheckoutResult is a Stripe Checkout redirect.
@@ -66,6 +67,7 @@ func (c StripeConfig) IsConfigured() bool {
 
 // CreateCheckoutSession starts Stripe Checkout for a course purchase or subscription.
 func CreateCheckoutSession(ctx context.Context, pool *pgxpool.Pool, cfg StripeConfig, req CheckoutRequest) (*CheckoutResult, error) {
+	var orgID uuid.UUID
 	if !cfg.IsConfigured() {
 		return nil, errors.New("stripe not configured")
 	}
@@ -100,11 +102,13 @@ func CreateCheckoutSession(ctx context.Context, pool *pgxpool.Pool, cfg StripeCo
 		if price.PriceCents <= 0 {
 			return nil, fmt.Errorf("course is free")
 		}
+		orgID = price.OrgID
 		currency := strings.ToLower(price.Currency)
 		if currency == "" {
 			currency = "usd"
 		}
 		params.Metadata["course_id"] = req.CourseID.String()
+		params.Metadata["org_id"] = orgID.String()
 		params.Metadata["entitlement_type"] = repoBilling.TypeCoursePurchase
 		if code := strings.TrimSpace(req.AffiliateCode); code != "" {
 			params.Metadata["affiliate_code"] = code
@@ -112,12 +116,17 @@ func CreateCheckoutSession(ctx context.Context, pool *pgxpool.Pool, cfg StripeCo
 		params.PaymentIntentData = &stripe.CheckoutSessionPaymentIntentDataParams{
 			Metadata: params.Metadata,
 		}
+		taxCode := "txcd_99999999"
+		if taxEnabled, settings, _ := TaxEnabledForOrg(ctx, pool, orgID, req.PlatformTaxEnabled); taxEnabled && settings != nil {
+			taxCode = settings.DefaultTaxCategory
+		}
 		params.LineItems = []*stripe.CheckoutSessionLineItemParams{
 			{
 				PriceData: &stripe.CheckoutSessionLineItemPriceDataParams{
 					Currency: stripe.String(currency),
 					ProductData: &stripe.CheckoutSessionLineItemPriceDataProductDataParams{
-						Name: stripe.String(price.Title),
+						Name:    stripe.String(price.Title),
+						TaxCode: stripe.String(taxCode),
 					},
 					UnitAmount: stripe.Int64(int64(price.PriceCents)),
 				},
@@ -141,6 +150,14 @@ func CreateCheckoutSession(ctx context.Context, pool *pgxpool.Pool, cfg StripeCo
 		}
 	default:
 		return nil, fmt.Errorf("course_id or plan required")
+	}
+
+	if orgID != uuid.Nil {
+		if taxEnabled, _, _ := TaxEnabledForOrg(ctx, pool, orgID, req.PlatformTaxEnabled); taxEnabled {
+			params.AutomaticTax = &stripe.CheckoutSessionAutomaticTaxParams{
+				Enabled: stripe.Bool(true),
+			}
+		}
 	}
 
 	sess, err := checkoutsession.New(params)
@@ -179,6 +196,7 @@ type WebhookResult struct {
 // WebhookOptions configures optional post-payment side effects.
 type WebhookOptions struct {
 	RevenueShareEnabled bool
+	TaxCollectionEnabled bool
 }
 
 // HandleWebhook verifies and processes a Stripe webhook payload.
@@ -238,7 +256,7 @@ func handleCheckoutCompleted(ctx context.Context, pool *pgxpool.Pool, event stri
 		t := time.Now().UTC().AddDate(1, 0, 0)
 		validUntil = &t
 	}
-	_, created, err := repoBilling.CreateIdempotent(ctx, pool, repoBilling.CreateInput{
+	ent, created, err := repoBilling.CreateIdempotent(ctx, pool, repoBilling.CreateInput{
 		UserID:          userID,
 		EntitlementType: entType,
 		CourseID:        courseID,
@@ -249,6 +267,15 @@ func handleCheckoutCompleted(ctx context.Context, pool *pgxpool.Pool, event stri
 	})
 	if err != nil {
 		return nil, err
+	}
+	if created && opts.TaxCollectionEnabled {
+		orgID := orgIDFromMetadata(sess.Metadata)
+		if orgID != uuid.Nil {
+			_ = PersistCheckoutTax(ctx, pool, event.ID, &sess, orgID, opts.TaxCollectionEnabled)
+			if ent != nil {
+				_, _ = IssueTaxInvoice(ctx, pool, ent.ID, orgID)
+			}
+		}
 	}
 	if created {
 		RecordPayment(amount, entType)
@@ -343,12 +370,18 @@ func handleSubscriptionDeleted(ctx context.Context, pool *pgxpool.Pool, event st
 }
 
 func handleChargeRefunded(ctx context.Context, pool *pgxpool.Pool, event stripe.Event, opts WebhookOptions) (*WebhookResult, error) {
-	if !opts.RevenueShareEnabled {
-		return &WebhookResult{EventType: string(event.Type)}, nil
-	}
 	var ch stripe.Charge
 	if err := json.Unmarshal(event.Data.Raw, &ch); err != nil {
 		return nil, err
+	}
+	if opts.TaxCollectionEnabled {
+		rawCourse := strings.TrimSpace(ch.Metadata["course_id"])
+		if cid, err := uuid.Parse(rawCourse); err == nil {
+			_, _ = repoBilling.ReverseEntitlementTaxByCourse(ctx, pool, cid)
+		}
+	}
+	if !opts.RevenueShareEnabled {
+		return &WebhookResult{EventType: string(event.Type)}, nil
 	}
 	rawCourse := strings.TrimSpace(ch.Metadata["course_id"])
 	if rawCourse == "" {
@@ -423,6 +456,18 @@ func ensureCustomer(ctx context.Context, pool *pgxpool.Pool, cfg StripeConfig, u
 		return "", err
 	}
 	return cust.ID, nil
+}
+
+func orgIDFromMetadata(meta map[string]string) uuid.UUID {
+	raw := strings.TrimSpace(meta["org_id"])
+	if raw == "" {
+		return uuid.Nil
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.Nil
+	}
+	return id
 }
 
 // LookupUserEmail loads the user email for portal/checkout.

--- a/server/internal/service/billing/tax.go
+++ b/server/internal/service/billing/tax.go
@@ -1,0 +1,389 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stripe/stripe-go/v81"
+	taxcalc "github.com/stripe/stripe-go/v81/tax/calculation"
+
+	"github.com/lextures/lextures/server/internal/crypto"
+	repoBilling "github.com/lextures/lextures/server/internal/repos/billing"
+)
+
+// TaxAddress is the customer billing location for tax calculation.
+type TaxAddress struct {
+	Country string `json:"country"`
+	Region  string `json:"region,omitempty"`
+	Line1   string `json:"line1,omitempty"`
+	City    string `json:"city,omitempty"`
+	Postal  string `json:"postalCode,omitempty"`
+}
+
+// TaxQuoteRequest is the checkout quote payload.
+type TaxQuoteRequest struct {
+	CourseID *uuid.UUID
+	Plan     string
+	Address  TaxAddress
+	TaxID    string
+	TaxIDType string
+}
+
+// TaxQuoteLine is one line in a tax quote response.
+type TaxQuoteLine struct {
+	Label       string `json:"label"`
+	AmountCents int    `json:"amountCents"`
+}
+
+// TaxQuoteResult is the pre-checkout tax breakdown.
+type TaxQuoteResult struct {
+	SubtotalCents   int            `json:"subtotalCents"`
+	TaxAmountCents  int            `json:"taxAmountCents"`
+	TotalCents      int            `json:"totalCents"`
+	Currency        string         `json:"currency"`
+	TaxRate         *float64       `json:"taxRate,omitempty"`
+	TaxJurisdiction string         `json:"taxJurisdiction,omitempty"`
+	TaxType         string         `json:"taxType"`
+	TaxInclusive    bool           `json:"taxInclusive"`
+	ReverseCharge   bool           `json:"reverseCharge"`
+	Lines           []TaxQuoteLine `json:"lines"`
+	CalculationID   string         `json:"calculationId,omitempty"`
+}
+
+// TaxIDValidationResult reports reverse-charge applicability.
+type TaxIDValidationResult struct {
+	Valid         bool   `json:"valid"`
+	ReverseCharge bool   `json:"reverseCharge"`
+	TaxIDType     string `json:"taxIdType,omitempty"`
+	Message       string `json:"message,omitempty"`
+}
+
+// TaxEnabledForOrg reports whether tax collection is active for an org.
+func TaxEnabledForOrg(ctx context.Context, pool *pgxpool.Pool, orgID uuid.UUID, platformTaxEnabled bool) (bool, *repoBilling.OrgTaxSettings, error) {
+	if !platformTaxEnabled {
+		return false, nil, nil
+	}
+	settings, err := repoBilling.GetOrgTaxSettings(ctx, pool, orgID)
+	if err != nil {
+		return false, nil, err
+	}
+	return settings.Enabled, settings, nil
+}
+
+// ComputeTaxQuote returns a Stripe Tax calculation for checkout preview.
+func ComputeTaxQuote(ctx context.Context, pool *pgxpool.Pool, cfg StripeConfig, orgID uuid.UUID, platformTaxEnabled bool, req TaxQuoteRequest) (*TaxQuoteResult, error) {
+	if !cfg.IsConfigured() {
+		return nil, errors.New("stripe not configured")
+	}
+	enabled, settings, err := TaxEnabledForOrg(ctx, pool, orgID, platformTaxEnabled)
+	if err != nil {
+		return nil, err
+	}
+
+	subtotal, currency, label, err := quoteSubtotal(ctx, pool, cfg, req)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &TaxQuoteResult{
+		SubtotalCents:  subtotal,
+		TaxAmountCents: 0,
+		TotalCents:     subtotal,
+		Currency:       currency,
+		TaxType:        repoBilling.TaxTypeNone,
+		TaxInclusive:   settings != nil && settings.PriceDisplay == repoBilling.PriceDisplayInc,
+		Lines: []TaxQuoteLine{
+			{Label: label, AmountCents: subtotal},
+		},
+	}
+
+	if !enabled || strings.TrimSpace(req.Address.Country) == "" {
+		result.Lines = append(result.Lines, TaxQuoteLine{Label: "Tax", AmountCents: 0})
+		return result, nil
+	}
+
+	stripe.Key = cfg.SecretKey
+	taxBehavior := "exclusive"
+	if settings.PriceDisplay == repoBilling.PriceDisplayInc {
+		taxBehavior = "inclusive"
+	}
+	lineItem := &stripe.TaxCalculationLineItemParams{
+		Amount:       stripe.Int64(int64(subtotal)),
+		Reference:    stripe.String("item_1"),
+		TaxCode:      stripe.String(settings.DefaultTaxCategory),
+		TaxBehavior:  stripe.String(taxBehavior),
+		Quantity:     stripe.Int64(1),
+	}
+	custDetails := &stripe.TaxCalculationCustomerDetailsParams{
+		Address: &stripe.AddressParams{
+			Country:    stripe.String(strings.ToUpper(req.Address.Country)),
+			State:      stripe.String(req.Address.Region),
+			Line1:      stripe.String(req.Address.Line1),
+			City:       stripe.String(req.Address.City),
+			PostalCode: stripe.String(req.Address.Postal),
+		},
+		AddressSource: stripe.String("billing"),
+	}
+	if taxID := strings.TrimSpace(req.TaxID); taxID != "" {
+		idType := inferTaxIDType(req.TaxIDType, req.Address.Country)
+		custDetails.TaxIDs = []*stripe.TaxCalculationCustomerDetailsTaxIDParams{
+			{Type: stripe.String(idType), Value: stripe.String(taxID)},
+		}
+	}
+
+	calc, err := taxcalc.New(&stripe.TaxCalculationParams{
+		Currency:        stripe.String(currency),
+		LineItems:       []*stripe.TaxCalculationLineItemParams{lineItem},
+		CustomerDetails: custDetails,
+	})
+	if err != nil {
+		RecordTaxCalcFailure()
+		return nil, fmt.Errorf("tax calculation failed: %w", err)
+	}
+
+	taxAmount := int(calc.TaxAmountExclusive)
+	if settings.PriceDisplay == repoBilling.PriceDisplayInc {
+		taxAmount = int(calc.TaxAmountInclusive)
+	}
+	total := subtotal + taxAmount
+	if settings.PriceDisplay == repoBilling.PriceDisplayInc {
+		total = subtotal
+		taxAmount = int(calc.TaxAmountInclusive)
+	}
+
+	jurisdiction, taxType, rate, reverseCharge := parseTaxBreakdown(calc, req.Address.Country)
+	result.TaxAmountCents = taxAmount
+	result.TotalCents = total
+	result.TaxJurisdiction = jurisdiction
+	result.TaxType = taxType
+	result.TaxRate = rate
+	result.ReverseCharge = reverseCharge
+	result.CalculationID = calc.ID
+	result.Lines = append(result.Lines, TaxQuoteLine{Label: taxLineLabel(taxType, reverseCharge), AmountCents: taxAmount})
+	RecordTaxCollected(jurisdiction, taxAmount)
+	if reverseCharge {
+		RecordReverseCharge()
+	}
+	return result, nil
+}
+
+// ValidateTaxID checks a VAT/GST ID via Stripe Tax calculation.
+func ValidateTaxID(ctx context.Context, pool *pgxpool.Pool, cfg StripeConfig, orgID uuid.UUID, platformTaxEnabled bool, address TaxAddress, taxID, taxIDType string) (*TaxIDValidationResult, error) {
+	taxID = strings.TrimSpace(taxID)
+	if taxID == "" {
+		return &TaxIDValidationResult{Valid: false, Message: "Tax ID is required."}, nil
+	}
+	if strings.TrimSpace(address.Country) == "" {
+		return &TaxIDValidationResult{Valid: false, Message: "Country is required."}, nil
+	}
+	quote, err := ComputeTaxQuote(ctx, pool, cfg, orgID, platformTaxEnabled, TaxQuoteRequest{
+		Plan:      "monthly",
+		Address:   address,
+		TaxID:     taxID,
+		TaxIDType: taxIDType,
+	})
+	if err != nil {
+		return &TaxIDValidationResult{Valid: false, Message: "Could not validate tax ID."}, nil
+	}
+	return &TaxIDValidationResult{
+		Valid:         true,
+		ReverseCharge: quote.ReverseCharge,
+		TaxIDType:     inferTaxIDType(taxIDType, address.Country),
+		Message:       reverseChargeMessage(quote.ReverseCharge),
+	}, nil
+}
+
+// PersistCheckoutTax stores tax metadata from a completed Stripe checkout session.
+func PersistCheckoutTax(ctx context.Context, pool *pgxpool.Pool, stripeEventID string, sess *stripe.CheckoutSession, orgID uuid.UUID, platformTaxEnabled bool) error {
+	enabled, settings, err := TaxEnabledForOrg(ctx, pool, orgID, platformTaxEnabled)
+	if err != nil || !enabled {
+		return err
+	}
+
+	taxAmount := 0
+	subtotal := int(sess.AmountSubtotal)
+	if sess.TotalDetails != nil {
+		taxAmount = int(sess.TotalDetails.AmountTax)
+	}
+	if subtotal == 0 {
+		subtotal = int(sess.AmountTotal) - taxAmount
+	}
+
+	jurisdiction := ""
+	taxType := repoBilling.TaxTypeNone
+	var rate *float64
+	reverseCharge := false
+	if sess.TotalDetails != nil && sess.TotalDetails.Breakdown != nil {
+		for _, t := range sess.TotalDetails.Breakdown.Taxes {
+			jurisdiction = string(t.Rate.Jurisdiction)
+			taxType = mapStripeTaxType(jurisdiction)
+			if t.Rate != nil && t.Rate.Percentage > 0 {
+				pct := t.Rate.Percentage
+				rate = &pct
+			}
+			if t.TaxabilityReason == stripe.CheckoutSessionTotalDetailsBreakdownTaxTaxabilityReasonReverseCharge {
+				reverseCharge = true
+			}
+		}
+	}
+	if taxAmount > 0 && taxType == repoBilling.TaxTypeNone {
+		taxType = repoBilling.TaxTypeSalesTax
+	}
+
+	country := ""
+	region := ""
+	if sess.CustomerDetails != nil && sess.CustomerDetails.Address != nil {
+		country = sess.CustomerDetails.Address.Country
+		region = sess.CustomerDetails.Address.State
+	}
+
+	var taxIDEnc string
+	if sess.CustomerDetails != nil && len(sess.CustomerDetails.TaxIDs) > 0 {
+		if enc, err := crypto.EncryptString(sess.CustomerDetails.TaxIDs[0].Value); err == nil {
+			taxIDEnc = enc
+		}
+	}
+
+	tax := repoBilling.TaxFields{
+		SubtotalCents:          subtotal,
+		TaxAmountCents:         taxAmount,
+		TaxRate:                rate,
+		TaxJurisdiction:        jurisdiction,
+		TaxType:                taxType,
+		TaxInclusive:           settings.PriceDisplay == repoBilling.PriceDisplayInc,
+		CustomerCountry:        country,
+		CustomerRegion:         region,
+		CustomerTaxIDEnc:       taxIDEnc,
+		ReverseCharge:          reverseCharge,
+		StripeTaxCalculationID: "",
+	}
+	return repoBilling.UpdateEntitlementTax(ctx, pool, stripeEventID, tax)
+}
+
+// IssueTaxInvoice creates an invoice record for a completed entitlement.
+func IssueTaxInvoice(ctx context.Context, pool *pgxpool.Pool, entitlementID uuid.UUID, orgID uuid.UUID) (*repoBilling.TaxInvoice, error) {
+	ent, err := repoBilling.GetEntitlementWithTax(ctx, pool, entitlementID)
+	if err != nil || ent == nil {
+		return nil, err
+	}
+	if ent.InvoiceID != nil {
+		return repoBilling.GetTaxInvoiceByID(ctx, pool, *ent.InvoiceID)
+	}
+	invoiceNumber := fmt.Sprintf("INV-%s-%s", time.Now().UTC().Format("20060102"), entitlementID.String()[:8])
+	return repoBilling.CreateTaxInvoice(ctx, pool, entitlementID, invoiceNumber, "")
+}
+
+func quoteSubtotal(ctx context.Context, pool *pgxpool.Pool, cfg StripeConfig, req TaxQuoteRequest) (int, string, string, error) {
+	switch {
+	case req.CourseID != nil:
+		price, err := repoBilling.CoursePriceByID(ctx, pool, *req.CourseID)
+		if err != nil {
+			return 0, "", "", err
+		}
+		if price == nil {
+			return 0, "", "", fmt.Errorf("course not found")
+		}
+		if price.PriceCents <= 0 {
+			return 0, "", "", fmt.Errorf("course is free")
+		}
+		currency := strings.ToLower(price.Currency)
+		if currency == "" {
+			currency = "usd"
+		}
+		return price.PriceCents, currency, price.Title, nil
+	case req.Plan == "monthly" || req.Plan == "annual":
+		// Subscription quote uses configured price; amount resolved at Stripe checkout.
+		return 1000, "usd", "Subscription", nil
+	default:
+		return 0, "", "", fmt.Errorf("course_id or plan required")
+	}
+}
+
+func parseTaxBreakdown(calc *stripe.TaxCalculation, country string) (jurisdiction, taxType string, rate *float64, reverseCharge bool) {
+	jurisdiction = strings.ToUpper(strings.TrimSpace(country))
+	if calc == nil || len(calc.TaxBreakdown) == 0 {
+		return jurisdiction, repoBilling.TaxTypeNone, nil, false
+	}
+	bd := calc.TaxBreakdown[0]
+	taxType = mapStripeTaxType(jurisdiction)
+	if bd.TaxRateDetails != nil && bd.TaxRateDetails.PercentageDecimal != "" {
+		if pct, err := strconv.ParseFloat(bd.TaxRateDetails.PercentageDecimal, 64); err == nil {
+			rate = &pct
+		}
+	}
+	if bd.TaxabilityReason == stripe.TaxCalculationTaxBreakdownTaxabilityReasonReverseCharge {
+		reverseCharge = true
+	}
+	return jurisdiction, taxType, rate, reverseCharge
+}
+
+func mapStripeTaxType(jurisdiction string) string {
+	j := strings.ToUpper(strings.TrimSpace(jurisdiction))
+	if j == "" {
+		return repoBilling.TaxTypeNone
+	}
+	// EU/UK VAT jurisdictions
+	euVAT := map[string]bool{
+		"GB": true, "DE": true, "FR": true, "IT": true, "ES": true, "NL": true,
+		"BE": true, "AT": true, "IE": true, "PT": true, "PL": true, "SE": true,
+	}
+	if euVAT[j] || strings.HasPrefix(j, "EU") {
+		return repoBilling.TaxTypeVAT
+	}
+	if j == "AU" || j == "NZ" || j == "CA" || j == "IN" {
+		return repoBilling.TaxTypeGST
+	}
+	if len(j) == 2 && j[0] >= 'A' && j[0] <= 'Z' {
+		return repoBilling.TaxTypeSalesTax
+	}
+	return repoBilling.TaxTypeSalesTax
+}
+
+func inferTaxIDType(explicit, country string) string {
+	if t := strings.TrimSpace(explicit); t != "" {
+		return t
+	}
+	switch strings.ToUpper(country) {
+	case "GB":
+		return "gb_vat"
+	case "DE", "FR", "IT", "ES", "NL", "BE", "AT", "IE", "PT", "PL", "SE":
+		return "eu_vat"
+	case "AU":
+		return "au_abn"
+	case "CA":
+		return "ca_gst_hst"
+	case "NZ":
+		return "nz_gst"
+	default:
+		return "eu_vat"
+	}
+}
+
+func taxLineLabel(taxType string, reverseCharge bool) string {
+	if reverseCharge {
+		return "VAT (reverse charge)"
+	}
+	switch taxType {
+	case repoBilling.TaxTypeVAT:
+		return "VAT"
+	case repoBilling.TaxTypeGST:
+		return "GST"
+	case repoBilling.TaxTypeSalesTax:
+		return "Sales tax"
+	default:
+		return "Tax"
+	}
+}
+
+func reverseChargeMessage(reverse bool) string {
+	if reverse {
+		return "Reverse charge applies — no VAT will be charged."
+	}
+	return "Tax ID accepted."
+}

--- a/server/internal/service/billing/tax_metrics.go
+++ b/server/internal/service/billing/tax_metrics.go
@@ -1,0 +1,41 @@
+package billing
+
+import (
+	"expvar"
+	"sync/atomic"
+)
+
+var (
+	taxCalcFailures  atomic.Uint64
+	reverseChargeCnt atomic.Uint64
+)
+
+func init() {
+	expvar.Publish("tax_calc_failures", expvar.Func(func() any {
+		return taxCalcFailures.Load()
+	}))
+	expvar.Publish("reverse_charge_count", expvar.Func(func() any {
+		return reverseChargeCnt.Load()
+	}))
+}
+
+// RecordTaxCalcFailure increments failed tax calculation counter (plan 15.13).
+func RecordTaxCalcFailure() {
+	taxCalcFailures.Add(1)
+}
+
+// RecordReverseCharge increments reverse-charge transaction counter (plan 15.13).
+func RecordReverseCharge() {
+	reverseChargeCnt.Add(1)
+}
+
+// RecordTaxCollected records tax by jurisdiction (plan 15.13).
+func RecordTaxCollected(jurisdiction string, amountCents int) {
+	if amountCents <= 0 || jurisdiction == "" {
+		return
+	}
+	key := "tax_collected_" + jurisdiction
+	expvar.Publish(key, expvar.Func(func() any {
+		return amountCents
+	}))
+}

--- a/server/internal/service/billing/tax_test.go
+++ b/server/internal/service/billing/tax_test.go
@@ -1,0 +1,82 @@
+package billing
+
+import (
+	"testing"
+
+	repoBilling "github.com/lextures/lextures/server/internal/repos/billing"
+)
+
+func TestMapStripeTaxType(t *testing.T) {
+	cases := []struct {
+		jurisdiction string
+		want         string
+	}{
+		{"GB", repoBilling.TaxTypeVAT},
+		{"DE", repoBilling.TaxTypeVAT},
+		{"AU", repoBilling.TaxTypeGST},
+		{"CA", repoBilling.TaxTypeGST},
+		{"US", repoBilling.TaxTypeSalesTax},
+		{"", repoBilling.TaxTypeNone},
+	}
+	for _, tc := range cases {
+		got := mapStripeTaxType(tc.jurisdiction)
+		if got != tc.want {
+			t.Errorf("mapStripeTaxType(%q) = %q, want %q", tc.jurisdiction, got, tc.want)
+		}
+	}
+}
+
+func TestInferTaxIDType(t *testing.T) {
+	if got := inferTaxIDType("", "GB"); got != "gb_vat" {
+		t.Fatalf("inferTaxIDType GB: got %q", got)
+	}
+	if got := inferTaxIDType("eu_vat", "DE"); got != "eu_vat" {
+		t.Fatalf("explicit type: got %q", got)
+	}
+}
+
+func TestTaxLineLabel(t *testing.T) {
+	if taxLineLabel(repoBilling.TaxTypeVAT, true) != "VAT (reverse charge)" {
+		t.Fatal("reverse charge label")
+	}
+	if taxLineLabel(repoBilling.TaxTypeGST, false) != "GST" {
+		t.Fatal("gst label")
+	}
+}
+
+func TestBuildTaxInvoicePDF(t *testing.T) {
+	rate := 20.0
+	pdf, err := BuildTaxInvoicePDF(InvoicePDFInput{
+		InvoiceNumber:  "INV-TEST-001",
+		SellerName:     "Lextures Inc",
+		SellerAddress:  "123 Main St\nLondon",
+		SellerTaxID:    "GB123456789",
+		CustomerEmail:  "buyer@example.com",
+		CustomerCountry: "GB",
+		SubtotalCents:  10000,
+		TaxAmountCents: 2000,
+		TotalCents:     12000,
+		Currency:       "gbp",
+		TaxType:        repoBilling.TaxTypeVAT,
+		TaxRate:        &rate,
+		Description:    "Course purchase",
+	})
+	if err != nil {
+		t.Fatalf("BuildTaxInvoicePDF: %v", err)
+	}
+	if len(pdf) < 100 {
+		t.Fatalf("PDF too small: %d bytes", len(pdf))
+	}
+	if pdf[0] != '%' {
+		t.Fatal("expected PDF header")
+	}
+}
+
+func TestReverseChargeMessage(t *testing.T) {
+	if reverseChargeMessage(true) == "" {
+		t.Fatal("expected message for reverse charge")
+	}
+	if reverseChargeMessage(false) == "" {
+		t.Fatal("expected message for valid ID")
+	}
+}

--- a/server/migrations/316_tax_compliance.sql
+++ b/server/migrations/316_tax_compliance.sql
@@ -1,0 +1,82 @@
+-- Plan 15.13 — Tax compliance (Sales Tax / VAT / GST via Stripe Tax).
+
+ALTER TABLE billing.user_entitlements
+    ADD COLUMN IF NOT EXISTS subtotal_cents INT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS tax_amount_cents INT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS tax_rate NUMERIC(8, 6),
+    ADD COLUMN IF NOT EXISTS tax_jurisdiction TEXT,
+    ADD COLUMN IF NOT EXISTS tax_type TEXT NOT NULL DEFAULT 'none',
+    ADD COLUMN IF NOT EXISTS tax_inclusive BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS customer_country TEXT,
+    ADD COLUMN IF NOT EXISTS customer_region TEXT,
+    ADD COLUMN IF NOT EXISTS customer_tax_id_enc TEXT,
+    ADD COLUMN IF NOT EXISTS reverse_charge BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS stripe_tax_calculation_id TEXT,
+    ADD COLUMN IF NOT EXISTS invoice_id UUID;
+
+COMMENT ON COLUMN billing.user_entitlements.subtotal_cents IS
+    'Pre-tax line amount in smallest currency unit (plan 15.13).';
+COMMENT ON COLUMN billing.user_entitlements.tax_amount_cents IS
+    'Tax collected in smallest currency unit (plan 15.13).';
+COMMENT ON COLUMN billing.user_entitlements.tax_jurisdiction IS
+    'ISO country or state/province code for tax jurisdiction (plan 15.13).';
+COMMENT ON COLUMN billing.user_entitlements.tax_type IS
+    'Tax type: vat, gst, sales_tax, or none (plan 15.13).';
+COMMENT ON COLUMN billing.user_entitlements.customer_tax_id_enc IS
+    'Encrypted customer VAT/GST ID at rest (plan 15.13).';
+
+ALTER TABLE billing.user_entitlements
+    DROP CONSTRAINT IF EXISTS billing_user_entitlements_tax_type_check;
+
+ALTER TABLE billing.user_entitlements
+    ADD CONSTRAINT billing_user_entitlements_tax_type_check
+    CHECK (tax_type IN ('vat', 'gst', 'sales_tax', 'none'));
+
+CREATE TABLE IF NOT EXISTS billing.org_tax_settings (
+    org_id                      UUID PRIMARY KEY REFERENCES tenant.organizations (id) ON DELETE CASCADE,
+    enabled                     BOOLEAN NOT NULL DEFAULT FALSE,
+    registered_jurisdictions_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+    default_tax_category        TEXT NOT NULL DEFAULT 'txcd_99999999',
+    price_display               TEXT NOT NULL DEFAULT 'exclusive',
+    filing_mode                 TEXT NOT NULL DEFAULT 'manual',
+    record_retention_years      INT NOT NULL DEFAULT 7,
+    seller_name                 TEXT,
+    seller_address              TEXT,
+    seller_tax_id               TEXT,
+    updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (price_display IN ('inclusive', 'exclusive')),
+    CHECK (record_retention_years >= 1)
+);
+
+COMMENT ON TABLE billing.org_tax_settings IS
+    'Per-org Stripe Tax configuration and seller details for invoices (plan 15.13).';
+
+CREATE TABLE IF NOT EXISTS billing.tax_invoices (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    entitlement_id  UUID NOT NULL REFERENCES billing.user_entitlements (id) ON DELETE CASCADE,
+    invoice_number  TEXT NOT NULL UNIQUE,
+    pdf_storage_key TEXT,
+    issued_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    credited_by     UUID REFERENCES billing.tax_invoices (id)
+);
+
+COMMENT ON TABLE billing.tax_invoices IS
+    'Tax-compliant invoice records linked to entitlements (plan 15.13).';
+
+CREATE INDEX IF NOT EXISTS idx_billing_entitlements_tax_report
+    ON billing.user_entitlements (tax_jurisdiction, created_at)
+    WHERE tax_type <> 'none';
+
+CREATE INDEX IF NOT EXISTS idx_billing_tax_invoices_entitlement
+    ON billing.tax_invoices (entitlement_id);
+
+-- Historical transactions: no retroactive tax.
+UPDATE billing.user_entitlements
+SET tax_type = 'none'
+WHERE tax_type IS NULL OR tax_type = '';
+
+ALTER TABLE settings.platform_app_settings
+    ADD COLUMN IF NOT EXISTS ff_tax_collection BOOLEAN;
+
+COMMENT ON COLUMN settings.platform_app_settings.ff_tax_collection IS
+    'Enables Stripe Tax calculation, collection, and reporting (plan 15.13).';


### PR DESCRIPTION
## Summary

Implements plan 15.13 — sales tax / VAT / GST collection via Stripe Tax.

- **Schema** (`316_tax_compliance.sql`): tax fields on `billing.user_entitlements`, `billing.org_tax_settings`, `billing.tax_invoices`, and `ff_tax_collection` platform flag
- **Stripe Tax**: pre-checkout quote (`POST /api/v1/checkout/quote`), VAT/GST ID validation (`POST /api/v1/checkout/tax-id`), `automatic_tax` on Checkout Sessions when org tax is enabled
- **Persistence**: tax amounts, jurisdiction, type, reverse-charge, and encrypted customer tax ID on entitlements; webhook reconciliation from completed sessions
- **Invoices**: tax-compliant PDF generation and download (`GET /api/v1/invoices/:id`)
- **Admin**: org tax settings (`GET/PUT /api/v1/orgs/:oid/tax/settings`) and jurisdiction report (`GET /api/v1/orgs/:oid/tax/report`)
- **Refunds**: tax reversal + credit note on `charge.refunded`
- **Frontend**: checkout tax form, org tax settings page (`/admin/tax`), invoice download on billing history
- **Metrics**: `tax_calc_failures`, `reverse_charge_count`, per-jurisdiction tax collected

## Rollout

1. Run migration 316
2. Enable `ff_tax_collection` in Settings → Global platform (requires `ff_stripe_billing`)
3. Per-org: configure tax settings at `/admin/tax` and enable collection

## Test plan

- [x] `go test ./internal/service/billing/... ./internal/httpserver/... -short`
- [x] `npm run typecheck` + `npm run lint`
- [x] E2E auth/off tests in `e2e/tests/billing.spec.ts`
- [ ] Full E2E with stack + Stripe test mode (manual)