### PR TITLE
Complete calendar feeds (16.5): tests, cache invalidation, observability

### DIFF
--- a/docs/completed/16-integrations-extensibility/16.5-calendar-feeds.md
+++ b/docs/completed/16-integrations-extensibility/16.5-calendar-feeds.md
@@ -10,7 +10,7 @@
 | **Section** | Integrations & Extensibility |
 | **Severity** | MAJOR |
 | **Markets** | K12, HE, SL |
-| **Status (today)** | MISSING |
+| **Status (today)** | COMPLETE |
 | **Estimated effort** | S (1–2 w) |
 | **Owner (proposed)** | Platform / API team |
 | **Depends on** | 16.2 (API tokens for authenticated feed URLs) |

--- a/e2e/tests/calendar-feeds.spec.ts
+++ b/e2e/tests/calendar-feeds.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from '@playwright/test'
+import {
+  apiSignup,
+  apiCreateCourse,
+  apiCreateModule,
+  apiCreateAssignment,
+  apiEnroll,
+} from '../fixtures/api.js'
+
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:8080'
+const PASSWORD = 'E2eTestPass1!'
+
+function uniqueEmail(prefix = 'calendar-feed') {
+  return `e2e-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}@test.invalid`
+}
+
+function authHeaders(token: string) {
+  return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+}
+
+test.describe('Calendar feeds (16.5)', () => {
+  test('unauthenticated management routes return 401', async ({ request }) => {
+    for (const method of ['GET', 'POST'] as const) {
+      const res = await request.fetch(`${API_BASE}/api/v1/me/calendar-token`, { method })
+      expect(res.status(), method).toBe(401)
+    }
+    const feedRes = await request.get(`${API_BASE}/api/v1/me/calendar.ics?token=lcf_invalid`)
+    expect(feedRes.status()).toBe(401)
+  })
+
+  test('feature on: generate token, fetch iCal feed, rotate invalidates old URL', async ({
+    request,
+  }) => {
+    const email = uniqueEmail()
+    const { access_token } = await apiSignup({
+      email,
+      password: PASSWORD,
+      displayName: 'Calendar Feed User',
+      accountType: 'parent',
+    })
+
+    const platformRes = await request.get(`${API_BASE}/api/v1/platform/features`, {
+      headers: { Authorization: `Bearer ${access_token}` },
+    })
+    expect(platformRes.ok()).toBeTruthy()
+    const features = (await platformRes.json()) as { ffCalendarFeeds?: boolean }
+    if (!features.ffCalendarFeeds) {
+      test.skip(true, 'ffCalendarFeeds is false on the API')
+    }
+
+    const createRes = await request.post(`${API_BASE}/api/v1/me/calendar-token`, {
+      headers: authHeaders(access_token),
+    })
+    expect(createRes.ok()).toBeTruthy()
+    const created = (await createRes.json()) as { token?: string; feedUrl?: string }
+    expect(created.token).toMatch(/^lcf_/)
+    expect(created.feedUrl).toContain('/api/v1/me/calendar.ics?token=')
+
+    const feedRes = await request.get(
+      `${API_BASE}/api/v1/me/calendar.ics?token=${encodeURIComponent(created.token ?? '')}`,
+    )
+    expect(feedRes.ok()).toBeTruthy()
+    expect(feedRes.headers()['content-type'] ?? '').toContain('text/calendar')
+    const body = await feedRes.text()
+    expect(body).toContain('BEGIN:VCALENDAR')
+
+    const oldToken = created.token ?? ''
+    const rotateRes = await request.post(`${API_BASE}/api/v1/me/calendar-token`, {
+      headers: authHeaders(access_token),
+    })
+    expect(rotateRes.ok()).toBeTruthy()
+    const rotated = (await rotateRes.json()) as { token?: string }
+    expect(rotated.token).toMatch(/^lcf_/)
+    expect(rotated.token).not.toBe(oldToken)
+
+    const staleRes = await request.get(
+      `${API_BASE}/api/v1/me/calendar.ics?token=${encodeURIComponent(oldToken)}`,
+    )
+    expect(staleRes.status()).toBe(401)
+  })
+
+  test('enrolled assignment due date appears in personal feed', async ({ request }) => {
+    const instructorEmail = uniqueEmail('cal-inst')
+    const { access_token: instructorToken } = await apiSignup({
+      email: instructorEmail,
+      password: PASSWORD,
+      displayName: 'Calendar Instructor',
+    })
+
+    const studentEmail = uniqueEmail('cal-stu')
+    const { access_token: studentToken } = await apiSignup({
+      email: studentEmail,
+      password: PASSWORD,
+      displayName: 'Calendar Student',
+      accountType: 'parent',
+    })
+
+    const platformRes = await request.get(`${API_BASE}/api/v1/platform/features`, {
+      headers: { Authorization: `Bearer ${studentToken}` },
+    })
+    const features = (await platformRes.json()) as { ffCalendarFeeds?: boolean }
+    if (!features.ffCalendarFeeds) {
+      test.skip(true, 'ffCalendarFeeds is false on the API')
+    }
+
+    const course = await apiCreateCourse(instructorToken, { title: 'Calendar Feed Course' })
+    await apiEnroll(instructorToken, course.courseCode, instructorEmail, 'teacher')
+    await apiEnroll(instructorToken, course.courseCode, studentEmail, 'student', studentToken)
+
+    const mod = await apiCreateModule(instructorToken, course.courseCode, 'Unit 1')
+    const assignment = await apiCreateAssignment(
+      instructorToken,
+      course.courseCode,
+      mod.id,
+      'Feed Assignment',
+    )
+
+    const dueAt = new Date(Date.UTC(2026, 8, 15, 23, 59, 0)).toISOString()
+    const dueRes = await request.patch(
+      `${API_BASE}/api/v1/courses/${encodeURIComponent(course.courseCode)}/structure/items/${encodeURIComponent(assignment.id)}/due-at`,
+      {
+        headers: authHeaders(instructorToken),
+        data: { dueAt },
+      },
+    )
+    expect(dueRes.ok()).toBeTruthy()
+
+    const tokenRes = await request.post(`${API_BASE}/api/v1/me/calendar-token`, {
+      headers: authHeaders(studentToken),
+    })
+    expect(tokenRes.ok()).toBeTruthy()
+    const { token } = (await tokenRes.json()) as { token?: string }
+    expect(token).toMatch(/^lcf_/)
+
+    const feedRes = await request.get(
+      `${API_BASE}/api/v1/me/calendar.ics?token=${encodeURIComponent(token ?? '')}`,
+    )
+    expect(feedRes.ok()).toBeTruthy()
+    const body = await feedRes.text()
+    expect(body).toContain('Feed Assignment')
+    expect(body).toContain(assignment.id)
+    expect(body).toContain('BEGIN:VEVENT')
+  })
+})

--- a/server/internal/httpserver/calendar_feed_db_test.go
+++ b/server/internal/httpserver/calendar_feed_db_test.go
@@ -1,0 +1,130 @@
+package httpserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	serverdata "github.com/lextures/lextures/server"
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/config"
+	"github.com/lextures/lextures/server/internal/db"
+	"github.com/lextures/lextures/server/internal/migrate"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+	"github.com/lextures/lextures/server/internal/repos/user"
+)
+
+func TestCalendarFeed_TokenRotateAndFetch_Pg(t *testing.T) {
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	dsn := os.Getenv("DATABASE_URL")
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	jwtSecret := "01234567890123456789012345678901"
+	ph, err := auth.HashPassword("longpassword0")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	em := "cf-" + time.Now().Format("20060102150405") + "@e.com"
+	row, err := user.InsertUser(ctx, pool, em, ph, nil)
+	if err != nil {
+		t.Fatalf("user: %v", err)
+	}
+	if err := rbac.AssignUserRoleByName(ctx, pool, uuid.MustParse(row.ID), "Student"); err != nil {
+		t.Fatalf("role: %v", err)
+	}
+
+	signer := auth.NewJWTSignerWithPool(jwtSecret, pool)
+	tok, err := signer.Sign(ctx, row.ID, em, "", "", nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	h := NewHandler(Deps{
+		Pool:      pool,
+		JWTSigner: signer,
+		Config:    config.Config{FFCalendarFeeds: true, JWTSecret: jwtSecret, PublicWebOrigin: "https://app.lextures.io"},
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/me/calendar-token", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create token: %d %s", rr.Code, rr.Body.String())
+	}
+	var created struct {
+		Token   string `json:"token"`
+		FeedURL string `json:"feedUrl"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(created.Token, "lcf_") {
+		t.Fatalf("expected lcf_ token, got %q", created.Token)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/me/calendar.ics?token="+created.Token, nil)
+	req = req.WithContext(ctx)
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("fetch feed: %d %s", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.Contains(ct, "text/calendar") {
+		t.Fatalf("expected text/calendar, got %q", ct)
+	}
+	if !strings.Contains(rr.Body.String(), "BEGIN:VCALENDAR") {
+		t.Fatalf("expected VCALENDAR body, got: %s", rr.Body.String())
+	}
+
+	oldToken := created.Token
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/me/calendar-token", bytes.NewReader([]byte("{}")))
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("rotate token: %d %s", rr.Code, rr.Body.String())
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+	if created.Token == oldToken {
+		t.Fatal("expected new token after rotation")
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/me/calendar.ics?token="+oldToken, nil)
+	req = req.WithContext(ctx)
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("old token should be 401, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/me/calendar.ics?token="+created.Token, nil)
+	req = req.WithContext(ctx)
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("new token feed: %d %s", rr.Code, rr.Body.String())
+	}
+}

--- a/server/internal/httpserver/calendar_feed_nodb_test.go
+++ b/server/internal/httpserver/calendar_feed_nodb_test.go
@@ -1,0 +1,77 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/config"
+)
+
+func TestCalendarFeedRoutes_NoDB_Unauthenticated(t *testing.T) {
+	t.Parallel()
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	cfg := config.Config{FFCalendarFeeds: true}
+	h := NewHandler(Deps{JWTSigner: signer, Config: cfg})
+
+	routes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/me/calendar.ics"},
+		{http.MethodGet, "/api/v1/me/calendar-token"},
+		{http.MethodPost, "/api/v1/me/calendar-token"},
+	}
+	for _, rt := range routes {
+		req := httptest.NewRequest(rt.method, rt.path, nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("%s %s: expected 401, got %d: %s", rt.method, rt.path, rr.Code, rr.Body.String())
+		}
+	}
+}
+
+func TestCalendarFeedRoutes_NoDB_FeatureDisabled(t *testing.T) {
+	t.Parallel()
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	cfg := config.Config{FFCalendarFeeds: false}
+	h := NewHandler(Deps{JWTSigner: signer, Config: cfg})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/calendar.ics?token=lcf_test", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 when feature disabled, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCalDAVWellKnown_NoDB_MissingToken(t *testing.T) {
+	t.Parallel()
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	cfg := config.Config{FFCalendarFeeds: true}
+	h := NewHandler(Deps{JWTSigner: signer, Config: cfg})
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/caldav", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing token, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCalDAVCollection_NoDB_InvalidUser(t *testing.T) {
+	t.Parallel()
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	cfg := config.Config{FFCalendarFeeds: true}
+	h := NewHandler(Deps{JWTSigner: signer, Config: cfg})
+
+	req := httptest.NewRequest(http.MethodGet, "/caldav/users/not-a-uuid/?token=lcf_test", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid user id, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+

--- a/server/internal/httpserver/calendar_http.go
+++ b/server/internal/httpserver/calendar_http.go
@@ -139,7 +139,7 @@ func (d Deps) serveUserCalendarFeed(w http.ResponseWriter, r *http.Request, user
 		cacheKey = "user:" + userID.String()
 		courses, err := courserepo.ListForEnrolledUser(ctx, d.Pool, userID, nil)
 		if err != nil {
-			d.serveCalendarWithCacheFallback(w, cacheKey, "Failed to load courses.")
+			d.serveCalendarWithCacheFallback(w, cacheKey, "Failed to load courses.", courseID)
 			return
 		}
 		courseIDs = make([]uuid.UUID, 0, len(courses))
@@ -155,13 +155,14 @@ func (d Deps) serveUserCalendarFeed(w http.ResponseWriter, r *http.Request, user
 	if body, ok := calendarsvc.DefaultFeedCache.Get(cacheKey, now); ok {
 		w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
 		w.Header().Set("X-Cache", "hit")
+		calendarsvc.RecordFeedRequest(calendarFeedType(courseID), "hit")
 		_, _ = w.Write(body)
 		return
 	}
 
 	events, err := calendarsvc.LoadEventsForCourses(ctx, d.Pool, courseIDs, userID, rangeStart, rangeEnd)
 	if err != nil {
-		d.serveCalendarWithCacheFallback(w, cacheKey, "Failed to generate calendar feed.")
+		d.serveCalendarWithCacheFallback(w, cacheKey, "Failed to generate calendar feed.", courseID)
 		return
 	}
 
@@ -171,13 +172,22 @@ func (d Deps) serveUserCalendarFeed(w http.ResponseWriter, r *http.Request, user
 
 	w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
 	w.Header().Set("X-Cache", "miss")
+	calendarsvc.RecordFeedRequest(calendarFeedType(courseID), "miss")
 	_, _ = w.Write(body)
 }
 
-func (d Deps) serveCalendarWithCacheFallback(w http.ResponseWriter, cacheKey, errMsg string) {
+func calendarFeedType(courseID *uuid.UUID) string {
+	if courseID != nil {
+		return "course"
+	}
+	return "user"
+}
+
+func (d Deps) serveCalendarWithCacheFallback(w http.ResponseWriter, cacheKey, errMsg string, courseID *uuid.UUID) {
 	if body, ok := calendarsvc.DefaultFeedCache.GetStale(cacheKey); ok {
 		w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
 		w.Header().Set("X-Cache", "stale")
+		calendarsvc.RecordFeedRequest(calendarFeedType(courseID), "stale")
 		_, _ = w.Write(body)
 		return
 	}

--- a/server/internal/httpserver/structure_item.go
+++ b/server/internal/httpserver/structure_item.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lextures/lextures/server/internal/repos/course"
 	"github.com/lextures/lextures/server/internal/repos/coursestructure"
 	"github.com/lextures/lextures/server/internal/courseroles"
+	calendarsvc "github.com/lextures/lextures/server/internal/service/calendar"
 )
 
 // handlePatchCourseStructureItem is PATCH /api/v1/courses/{course_code}/structure/items/{item_id}
@@ -170,6 +171,9 @@ func (d Deps) handlePatchCourseStructureItemDueAt() http.HandlerFunc {
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to update due date.")
 			return
+		}
+		if d.calendarFeedsEnabled() {
+			calendarsvc.DefaultFeedCache.InvalidateCourse(cid.String())
 		}
 		w.WriteHeader(http.StatusNoContent)
 	}

--- a/server/internal/service/calendar/cache_test.go
+++ b/server/internal/service/calendar/cache_test.go
@@ -1,0 +1,48 @@
+package calendar_test
+
+import (
+	"testing"
+	"time"
+
+	calendarsvc "github.com/lextures/lextures/server/internal/service/calendar"
+)
+
+func TestFeedCache_InvalidateUser(t *testing.T) {
+	c := calendarsvc.NewFeedCache()
+	now := time.Now()
+	c.Set("user:abc", []byte("personal"), now)
+	c.Set("course:def:abc", []byte("course"), now)
+	c.Set("user:xyz", []byte("other"), now)
+
+	c.InvalidateUser("abc")
+
+	if _, ok := c.Get("user:abc", now); ok {
+		t.Fatal("expected user:abc invalidated")
+	}
+	if _, ok := c.Get("course:def:abc", now); ok {
+		t.Fatal("expected course:def:abc invalidated")
+	}
+	if _, ok := c.Get("user:xyz", now); !ok {
+		t.Fatal("expected user:xyz to remain cached")
+	}
+}
+
+func TestFeedCache_InvalidateCourse(t *testing.T) {
+	c := calendarsvc.NewFeedCache()
+	now := time.Now()
+	c.Set("course:def:abc", []byte("course-a"), now)
+	c.Set("course:def:xyz", []byte("course-b"), now)
+	c.Set("user:abc", []byte("personal"), now)
+
+	c.InvalidateCourse("def")
+
+	if _, ok := c.Get("course:def:abc", now); ok {
+		t.Fatal("expected course:def:abc invalidated")
+	}
+	if _, ok := c.Get("course:def:xyz", now); ok {
+		t.Fatal("expected course:def:xyz invalidated")
+	}
+	if _, ok := c.Get("user:abc", now); !ok {
+		t.Fatal("expected user:abc to remain cached")
+	}
+}

--- a/server/internal/service/calendar/metrics.go
+++ b/server/internal/service/calendar/metrics.go
@@ -1,0 +1,8 @@
+package calendar
+
+import "log/slog"
+
+// RecordFeedRequest logs a calendar feed request for observability (plan 16.5).
+func RecordFeedRequest(feedType, cacheStatus string) {
+	slog.Info("calendar_feed_requests_total", "type", feedType, "cache", cacheStatus)
+}


### PR DESCRIPTION
## Summary

Completes plan 16.5 (Calendar Feeds). The core iCal/CalDAV implementation shipped in #318 and #322; this PR adds the remaining plan items:

- **Cache invalidation** — calendar feed cache is cleared when assignment/quiz due dates are patched
- **Observability** — `calendar_feed_requests_total` structured log counter with `type` (user|course) and `cache` (hit|miss|stale)
- **Tests** — HTTP nodb/db integration tests, cache unit tests, and Playwright e2e for token rotation and assignment events in feeds
- **Docs** — moves `16.5-calendar-feeds.md` to `docs/completed` with status COMPLETE

## Test plan

- [x] `go test ./internal/service/calendar/... ./internal/httpserver/ -run 'Calendar|FeedCache|BuildICalendar'`
- [x] `go test ./internal/... -short`
- [ ] `e2e/tests/calendar-feeds.spec.ts` (CI)