### PR TITLE
feat(integrations): Slack/Teams/Discord classroom bots (16.6)

### DIFF
--- a/clients/web/src/components/bot-channel-mappings-panel.tsx
+++ b/clients/web/src/components/bot-channel-mappings-panel.tsx
@@ -1,0 +1,174 @@
+import { useId, useState } from 'react'
+import {
+  deleteBotMapping,
+  upsertBotMapping,
+  type BotChannelMapping,
+  type BotConnection,
+} from '../lib/bots-api'
+
+const BOT_EVENT_TYPES = [
+  'assignment.created',
+  'assignment.due_soon',
+  'grade.released',
+  'announcement.created',
+] as const
+
+const EVENT_LABEL: Record<(typeof BOT_EVENT_TYPES)[number], string> = {
+  'assignment.created': 'New assignments',
+  'assignment.due_soon': 'Due-date reminders',
+  'grade.released': 'Grade releases',
+  'announcement.created': 'Announcements',
+}
+
+type Props = {
+  connection: BotConnection
+  onUpdated: () => void
+}
+
+/** Admin panel for mapping course events to platform channels (plan 16.6). */
+export function BotChannelMappingsPanel({ connection, onUpdated }: Props) {
+  const channelId = useId()
+  const courseId = useId()
+  const [channel, setChannel] = useState('')
+  const [course, setCourse] = useState('')
+  const [events, setEvents] = useState<string[]>(['assignment.created', 'announcement.created'])
+  const [busy, setBusy] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const mappings = connection.mappings ?? []
+
+  function toggleEvent(eventType: string) {
+    setEvents((prev) =>
+      prev.includes(eventType) ? prev.filter((e) => e !== eventType) : [...prev, eventType],
+    )
+  }
+
+  async function saveMapping() {
+    if (!channel.trim()) {
+      setError('Channel ID is required.')
+      return
+    }
+    if (events.length === 0) {
+      setError('Select at least one event type.')
+      return
+    }
+    setBusy('save')
+    setError(null)
+    try {
+      await upsertBotMapping(connection.id, {
+        channelId: channel.trim(),
+        courseId: course.trim() || undefined,
+        eventTypes: events,
+      })
+      setChannel('')
+      setCourse('')
+      onUpdated()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save mapping.')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function removeMapping(mapping: BotChannelMapping) {
+    setBusy(`delete-${mapping.id}`)
+    setError(null)
+    try {
+      await deleteBotMapping(connection.id, mapping.id)
+      onUpdated()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to delete mapping.')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <div className="mt-4 border-t border-slate-200 pt-4 dark:border-neutral-600" data-testid="bot-mappings">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-400">
+        Channel mappings
+      </h4>
+      {mappings.length > 0 ? (
+        <ul className="mt-2 space-y-1 text-xs text-slate-600 dark:text-neutral-400">
+          {mappings.map((m) => (
+            <li key={m.id} className="flex items-center justify-between gap-2">
+              <span>
+                <code className="rounded bg-slate-100 px-1 dark:bg-neutral-800">{m.channelId}</code>
+                {m.courseId ? ` · course ${m.courseId.slice(0, 8)}…` : ' · all courses'}
+                {' · '}
+                {m.eventTypes.join(', ')}
+              </span>
+              <button
+                type="button"
+                className="text-rose-600 hover:text-rose-500"
+                disabled={busy === `delete-${m.id}`}
+                onClick={() => void removeMapping(m)}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-2 text-xs text-slate-500 dark:text-neutral-500">
+          No channel mappings yet. Add one below to start receiving notifications.
+        </p>
+      )}
+
+      <div className="mt-3 space-y-2">
+        <label htmlFor={channelId} className="block text-xs font-medium text-slate-700 dark:text-neutral-300">
+          Channel ID
+        </label>
+        <input
+          id={channelId}
+          type="text"
+          value={channel}
+          onChange={(e) => setChannel(e.target.value)}
+          placeholder="C01234567 or #general channel id"
+          className="w-full rounded border border-slate-300 px-2 py-1 text-sm dark:border-neutral-600 dark:bg-neutral-900"
+        />
+        <label htmlFor={courseId} className="block text-xs font-medium text-slate-700 dark:text-neutral-300">
+          Course ID (optional)
+        </label>
+        <input
+          id={courseId}
+          type="text"
+          value={course}
+          onChange={(e) => setCourse(e.target.value)}
+          placeholder="Leave blank for org-wide notifications"
+          className="w-full rounded border border-slate-300 px-2 py-1 text-sm dark:border-neutral-600 dark:bg-neutral-900"
+        />
+        <fieldset>
+          <legend className="text-xs font-medium text-slate-700 dark:text-neutral-300">Events</legend>
+          <ul className="mt-1 space-y-1">
+            {BOT_EVENT_TYPES.map((eventType) => (
+              <li key={eventType}>
+                <label className="flex items-center gap-2 text-xs text-slate-600 dark:text-neutral-400">
+                  <input
+                    type="checkbox"
+                    checked={events.includes(eventType)}
+                    onChange={() => toggleEvent(eventType)}
+                  />
+                  {EVENT_LABEL[eventType]}
+                </label>
+              </li>
+            ))}
+          </ul>
+        </fieldset>
+        {error ? (
+          <p className="text-xs text-rose-600" role="alert">
+            {error}
+          </p>
+        ) : null}
+        <button
+          type="button"
+          disabled={busy === 'save'}
+          onClick={() => void saveMapping()}
+          className="rounded bg-slate-800 px-3 py-1 text-xs font-medium text-white hover:bg-slate-900 disabled:opacity-50 dark:bg-neutral-200 dark:text-neutral-900"
+        >
+          {busy === 'save' ? 'Saving…' : 'Add mapping'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/clients/web/src/lib/bots-api.ts
+++ b/clients/web/src/lib/bots-api.ts
@@ -66,6 +66,15 @@ export async function disconnectBot(id: string): Promise<void> {
   }
 }
 
+export async function deleteBotMapping(connectionId: string, mappingId: string): Promise<void> {
+  const res = await authorizedFetch(`/api/v1/bots/${connectionId}/mappings/${mappingId}`, {
+    method: 'DELETE',
+  })
+  if (!res.ok) {
+    throw new Error(await readError(res, 'Failed to delete channel mapping.'))
+  }
+}
+
 export async function upsertBotMapping(
   connectionId: string,
   payload: {

--- a/clients/web/src/pages/admin/integrations.tsx
+++ b/clients/web/src/pages/admin/integrations.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useId, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
+import { BotChannelMappingsPanel } from '../../components/bot-channel-mappings-panel'
 import {
   disconnectBot,
   fetchBotConnections,
@@ -275,10 +276,13 @@ export default function IntegrationsAdminPage() {
               </div>
               <p className="mt-2 text-xs text-slate-600 dark:text-neutral-400">{BOT_BLURB[platform]}</p>
               {connected && conn ? (
-                <p className="mt-2 text-xs text-slate-500 dark:text-neutral-500">
-                  Workspace: {conn.workspaceName || conn.workspaceId}
-                  {conn.mappings?.length ? ` · ${conn.mappings.length} channel mapping(s)` : null}
-                </p>
+                <>
+                  <p className="mt-2 text-xs text-slate-500 dark:text-neutral-500">
+                    Workspace: {conn.workspaceName || conn.workspaceId}
+                    {conn.mappings?.length ? ` · ${conn.mappings.length} channel mapping(s)` : null}
+                  </p>
+                  <BotChannelMappingsPanel connection={conn} onUpdated={() => void load()} />
+                </>
               ) : null}
               <div className="mt-4">
                 {connected && conn ? (

--- a/docs/completed/16-integrations-extensibility/16.6-slack-teams-discord-bots.md
+++ b/docs/completed/16-integrations-extensibility/16.6-slack-teams-discord-bots.md
@@ -10,7 +10,7 @@
 | **Section** | Integrations & Extensibility |
 | **Severity** | MINOR |
 | **Markets** | HE, SL |
-| **Status (today)** | MISSING |
+| **Status (today)** | COMPLETE |
 | **Estimated effort** | M (3–4 w) |
 | **Owner (proposed)** | Integrations team |
 | **Depends on** | 16.3 (outbound webhooks as event source), 16.2 (API tokens), 17.3 (background jobs) |

--- a/e2e/fixtures/platform-features.ts
+++ b/e2e/fixtures/platform-features.ts
@@ -89,6 +89,10 @@ export async function seedE2EPlatformFeatures(): Promise<void> {
       originalityDetectionEnabled: true,
       originalityStubExternal: true,
       ffAiStudyBuddy: true,
+      ffWebhooks: true,
+      ffBotSlack: true,
+      ffBotDiscord: true,
+      ffBotTeams: true,
       updateMask: [
         'h5pEnabled',
         'scormIngestionEnabled',
@@ -141,6 +145,10 @@ export async function seedE2EPlatformFeatures(): Promise<void> {
         'originalityDetectionEnabled',
         'originalityStubExternal',
         'ffAiStudyBuddy',
+        'ffWebhooks',
+        'ffBotSlack',
+        'ffBotDiscord',
+        'ffBotTeams',
       ],
     }),
   })

--- a/e2e/tests/bots.spec.ts
+++ b/e2e/tests/bots.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Classroom bots (plan 16.6)
+ *
+ *   [x] GET /api/v1/bots unauthenticated returns 401
+ *   [x] Non-admin listing bots returns 403
+ *   [x] POST /integrations/slack/events with invalid signature returns 401
+ *   [x] POST /integrations/discord/interactions with invalid signature returns 401
+ *   [x] GET /api/v1/me/bot-links unauthenticated returns 401
+ *   [x] Admin Integrations page renders classroom bot cards
+ *   [x] Settings account page shows messaging app link panel
+ */
+import { test, expect, injectToken } from '../fixtures/test.js'
+import { apiSignup } from '../fixtures/api.js'
+
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:8080'
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL ?? 'admin@e2e.test'
+const ADMIN_PASSWORD = process.env.E2E_ADMIN_PASSWORD ?? 'E2eTestPass1!'
+
+async function adminToken(): Promise<string> {
+  const { access_token } = await apiSignup({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD })
+  return access_token
+}
+
+function uniqueEmail(prefix = 'bots') {
+  return `e2e-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}@test.invalid`
+}
+
+function expectUnauthenticatedOrDisabled(status: number) {
+  expect([401, 501]).toContain(status)
+}
+
+// ──────────────────────────────────────────────────────────
+// Auth contract
+// ──────────────────────────────────────────────────────────
+
+test('Bots: GET /api/v1/bots unauthenticated returns 401', async () => {
+  const res = await fetch(`${API_BASE}/api/v1/bots`)
+  expectUnauthenticatedOrDisabled(res.status)
+})
+
+test('Bots: non-admin listing returns 403', async () => {
+  const { access_token } = await apiSignup({ email: uniqueEmail('nonadmin'), password: ADMIN_PASSWORD })
+  const res = await fetch(`${API_BASE}/api/v1/bots`, {
+    headers: { Authorization: `Bearer ${access_token}` },
+  })
+  if (res.status === 501) {
+    test.skip(true, 'classroom bots not enabled in this environment')
+  }
+  expect(res.status).toBe(403)
+})
+
+test('Bots: GET /api/v1/me/bot-links unauthenticated returns 401', async () => {
+  const res = await fetch(`${API_BASE}/api/v1/me/bot-links`)
+  expectUnauthenticatedOrDisabled(res.status)
+})
+
+// ──────────────────────────────────────────────────────────
+// Inbound signing verification
+// ──────────────────────────────────────────────────────────
+
+test('Bots: Slack events with invalid signature returns 401', async () => {
+  const res = await fetch(`${API_BASE}/integrations/slack/events`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Slack-Request-Timestamp': '1',
+      'X-Slack-Signature': 'v0=invalid',
+    },
+    body: JSON.stringify({ command: '/lextures', text: 'upcoming' }),
+  })
+  if (res.status === 501) {
+    test.skip(true, 'Slack bot not enabled in this environment')
+  }
+  expect(res.status).toBe(401)
+})
+
+test('Bots: Discord interactions with invalid signature returns 401', async () => {
+  const res = await fetch(`${API_BASE}/integrations/discord/interactions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Signature-Timestamp': '1',
+      'X-Signature-Ed25519': 'deadbeef',
+    },
+    body: JSON.stringify({ type: 2, data: { name: 'lextures' } }),
+  })
+  if (res.status === 501) {
+    test.skip(true, 'Discord bot not enabled in this environment')
+  }
+  expect(res.status).toBe(401)
+})
+
+// ──────────────────────────────────────────────────────────
+// Admin API happy path
+// ──────────────────────────────────────────────────────────
+
+test('Bots: admin can list bot connections', async () => {
+  const token = await adminToken()
+  const res = await fetch(`${API_BASE}/api/v1/bots`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (res.status === 501) {
+    test.skip(true, 'classroom bots not enabled in this environment')
+  }
+  if (res.status === 400) {
+    test.skip(true, 'admin account has no organization in this environment')
+  }
+  expect(res.status).toBe(200)
+  const body = (await res.json()) as { connections: unknown[] }
+  expect(Array.isArray(body.connections)).toBe(true)
+})
+
+// ──────────────────────────────────────────────────────────
+// UI smoke
+// ──────────────────────────────────────────────────────────
+
+test('Bots: admin integrations page renders classroom bot grid', async ({ page }) => {
+  const token = await adminToken()
+  await injectToken(page, token)
+  await page.goto('/admin/integrations')
+  await expect(page.getByRole('heading', { name: 'Integrations' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Classroom bots' })).toBeVisible()
+  await expect(page.getByTestId('bot-grid')).toBeVisible()
+  await expect(page.getByTestId('bot-card-slack')).toBeVisible()
+  await expect(page.getByTestId('bot-card-discord')).toBeVisible()
+  await expect(page.getByTestId('bot-card-teams')).toBeVisible()
+})
+
+test('Bots: account settings shows messaging apps panel', async ({ authedPage: page }) => {
+  await page.goto('/settings/account')
+  await expect(page.getByText('Messaging apps')).toBeVisible({ timeout: 8000 })
+  await expect(page.getByText(/lextures upcoming/i)).toBeVisible()
+})

--- a/server/internal/service/bots/delivery.go
+++ b/server/internal/service/bots/delivery.go
@@ -42,7 +42,7 @@ func DeliverWebhookJob(ctx context.Context, pool *pgxpool.Pool, cfg config.Confi
 	}
 
 	// grade.released must not post to channels unless explicitly enabled (FERPA).
-	channelBlocked := ep.EventType == string(webhooks.EventGradeReleased) && !conn.Settings.GradeChannelEnabled
+	channelBlocked := gradeChannelBlocked(ep.EventType, conn.Settings.GradeChannelEnabled)
 
 	var courseID *uuid.UUID
 	if ep.CourseID != "" {
@@ -177,6 +177,10 @@ func strField(m map[string]any, key string) string {
 		return v
 	}
 	return ""
+}
+
+func gradeChannelBlocked(eventType string, gradeChannelEnabled bool) bool {
+	return eventType == string(webhooks.EventGradeReleased) && !gradeChannelEnabled
 }
 
 func recordMetric(platform botsrepo.Platform, eventType, status string) {

--- a/server/internal/service/bots/delivery_test.go
+++ b/server/internal/service/bots/delivery_test.go
@@ -1,0 +1,87 @@
+package bots
+
+import (
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/webhooks"
+)
+
+func TestParseEnvelope_AssignmentCreated(t *testing.T) {
+	payload := []byte(`{
+		"event_type": "assignment.created",
+		"data": {
+			"courseId": "550e8400-e29b-41d4-a716-446655440000",
+			"courseCode": "ENG-101",
+			"title": "Essay 1",
+			"dueAt": "2026-06-01T17:00:00Z",
+			"url": "https://app.example/courses/550e8400-e29b-41d4-a716-446655440000"
+		}
+	}`)
+	ep, err := parseEnvelope("assignment.created", payload, "http://localhost:5173")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ep.EventType != string(webhooks.EventAssignmentCreated) {
+		t.Fatalf("event_type=%q", ep.EventType)
+	}
+	if ep.Title != "Essay 1" || ep.CourseCode != "ENG-101" {
+		t.Fatalf("parsed fields: %+v", ep)
+	}
+	if ep.URL == "" {
+		t.Fatal("expected url")
+	}
+}
+
+func TestParseEnvelope_FillsCourseURLFromOrigin(t *testing.T) {
+	payload := []byte(`{
+		"event_type": "announcement.created",
+		"data": {
+			"courseId": "550e8400-e29b-41d4-a716-446655440000",
+			"title": "Office hours moved"
+		}
+	}`)
+	ep, err := parseEnvelope("announcement.created", payload, "https://lextures.test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://lextures.test/courses/550e8400-e29b-41d4-a716-446655440000"
+	if ep.URL != want {
+		t.Fatalf("url=%q want %q", ep.URL, want)
+	}
+}
+
+func TestParseEnvelope_GradeReleasedIncludesStudent(t *testing.T) {
+	payload := []byte(`{
+		"event_type": "grade.released",
+		"data": {
+			"studentUserId": "660e8400-e29b-41d4-a716-446655440001",
+			"title": "Quiz 2",
+			"pointsEarned": 18.5
+		}
+	}`)
+	ep, err := parseEnvelope("grade.released", payload, "http://localhost:5173")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ep.StudentUserID != "660e8400-e29b-41d4-a716-446655440001" {
+		t.Fatalf("studentUserId=%q", ep.StudentUserID)
+	}
+	if ep.PointsEarned != 18.5 {
+		t.Fatalf("pointsEarned=%v", ep.PointsEarned)
+	}
+}
+
+func TestGradeChannelBlocked_DefaultSettings(t *testing.T) {
+	if !gradeChannelBlocked(string(webhooks.EventGradeReleased), false) {
+		t.Fatal("grade.released must be channel-blocked by default")
+	}
+	if gradeChannelBlocked(string(webhooks.EventAssignmentCreated), false) {
+		t.Fatal("assignment.created should not be blocked")
+	}
+}
+
+func TestGradeChannelBlocked_ExplicitOptIn(t *testing.T) {
+	if gradeChannelBlocked(string(webhooks.EventGradeReleased), true) {
+		t.Fatal("grade.released should post to channel when explicitly enabled")
+	}
+}


### PR DESCRIPTION
## Summary

Completes plan 16.6 — first-party Slack, Teams, and Discord classroom bots wired through the outbound webhook pipeline.

- **Backend** (already on main): OAuth install flows, webhook-subscriber delivery worker, slash commands (`/lextures upcoming`), user account linking, FERPA-safe grade DM routing, due-soon reminder sweep, feature flags (`ff_bot_slack`, `ff_bot_teams`, `ff_bot_discord`).
- **This PR adds:**
  - Admin channel-mapping UI on Integrations → Classroom bots
  - E2E auth/UI smoke tests (`e2e/tests/bots.spec.ts`)
  - Delivery unit tests for envelope parsing and grade channel blocking
  - E2E platform seed enables webhooks + bot flags
  - Moves plan doc to `docs/completed/`

## Test plan

- [x] `go test ./internal/service/bots/...`
- [x] `go test ./internal/httpserver/... -run Bots`
- [x] `npm run lint` + `tsc -b` (clients/web)
- [ ] CI e2e suite (`bots.spec.ts`)