### PR TITLE
Redesign Canvas import modal UX

### DIFF
--- a/clients/web/src/components/canvas/canvas-read-only-notice.tsx
+++ b/clients/web/src/components/canvas/canvas-read-only-notice.tsx
@@ -1,9 +1,38 @@
+import { ShieldCheck } from 'lucide-react'
+
 type Props = {
   className?: string
+  variant?: 'default' | 'compact'
 }
 
 /** Explains that Canvas import only uses read API access and does not mutate Canvas. */
-export function CanvasReadOnlyNotice({ className = '' }: Props) {
+export function CanvasReadOnlyNotice({ className = '', variant = 'default' }: Props) {
+  if (variant === 'compact') {
+    return (
+      <div
+        role="note"
+        className={[
+          'flex h-full gap-2.5 rounded-lg bg-sky-50/80 px-3 py-2.5 shadow-[inset_0_0_0_1px_rgba(14,165,233,0.18)] dark:bg-sky-950/30 dark:shadow-[inset_0_0_0_1px_rgba(56,189,248,0.16)]',
+          className,
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        <ShieldCheck
+          className="mt-0.5 h-4 w-4 shrink-0 text-sky-600 dark:text-sky-400"
+          aria-hidden
+        />
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-sky-950 dark:text-sky-100">Read-only on Canvas</p>
+          <p className="mt-0.5 text-pretty text-xs leading-relaxed text-sky-900/85 dark:text-sky-100/85">
+            Lextures only reads from Canvas. Nothing in your account or courses is created, changed,
+            or deleted.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div
       role="note"
@@ -14,8 +43,8 @@ export function CanvasReadOnlyNotice({ className = '' }: Props) {
         .filter(Boolean)
         .join(' ')}
     >
-      <p className="font-medium">Read-only on Canvas</p>
-      <p className="mt-0.5 text-sky-900/90 dark:text-sky-100/90">
+      <p className="text-balance font-medium">Read-only on Canvas</p>
+      <p className="mt-0.5 text-pretty text-sky-900/90 dark:text-sky-100/90">
         Lextures only reads from Canvas (view courses, modules, assignments, and related data). Nothing
         in your Canvas account or courses is created, changed, or deleted. Import creates and updates
         content in Lextures only.

--- a/clients/web/src/context/canvas-import-context.tsx
+++ b/clients/web/src/context/canvas-import-context.tsx
@@ -578,6 +578,7 @@ function CanvasImportOverlay({
   importComplete: boolean
 }) {
   const canDismissBackdrop = !busy || importComplete
+  const modalExpanded = panelProps.step !== 'credentials'
 
   if (presentation === 'fullscreen') {
     return (
@@ -596,7 +597,10 @@ function CanvasImportOverlay({
           ref={panelRef}
           role="dialog"
           aria-modal="true"
-          className="relative flex w-full max-w-lg flex-col"
+          className={[
+            'relative flex w-full flex-col motion-safe:transition-[max-width] motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.2,0,0,1)]',
+            modalExpanded ? 'max-w-4xl' : 'max-w-md',
+          ].join(' ')}
         >
           <CanvasImportCoursesPanel {...panelProps} />
         </div>
@@ -717,7 +721,7 @@ export function CanvasImportHeaderWidget() {
           aria-modal="true"
           aria-label="Canvas import"
           data-testid="canvas-import-popover"
-          className="absolute end-0 top-full z-50 mt-1 flex w-[min(32rem,calc(100vw-2rem))] max-h-[min(85vh,720px)] flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-lg shadow-slate-900/10 dark:border-neutral-600 dark:bg-neutral-900 dark:shadow-black/40"
+          className="absolute end-0 top-full z-50 mt-1 flex w-[min(36rem,calc(100vw-2rem))] max-h-[min(85vh,720px)] flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-lg shadow-slate-900/10 dark:border-neutral-600 dark:bg-neutral-900 dark:shadow-black/40"
         >
           <CanvasImportCoursesPanel {...panelProps} compact className="max-h-[min(85vh,720px)]" />
         </div>

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -234,6 +234,25 @@ html.dark {
   animation: canvas-import-status-in 0.12s ease-out forwards;
 }
 
+@keyframes canvas-import-select-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+    filter: blur(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  html:not(.reduced-motion) .canvas-import-select-in {
+    animation: canvas-import-select-in 0.3s cubic-bezier(0.2, 0, 0, 1) forwards;
+  }
+}
+
 .sidenav-course-items > * {
   animation: sidenav-item-in 0.28s cubic-bezier(0.33, 1, 0.68, 1) backwards;
 }

--- a/clients/web/src/pages/lms/canvas-import-courses-panel.tsx
+++ b/clients/web/src/pages/lms/canvas-import-courses-panel.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react'
+import { useId, useLayoutEffect, useRef, type RefObject } from 'react'
 import { Search, X } from 'lucide-react'
 import { CanvasImportProgressLog } from '../../components/canvas/canvas-import-progress-log'
 import { CanvasReadOnlyNotice } from '../../components/canvas/canvas-read-only-notice'
@@ -44,8 +44,72 @@ export type CanvasImportCoursesPanelProps = {
   className?: string
 }
 
+const pressableButtonClassName =
+  'motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:active:scale-[0.96]'
+
+const PANEL_RESIZE_MS = 300
+const PANEL_RESIZE_EASING = 'cubic-bezier(0.2, 0, 0, 1)'
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined') return false
+  return (
+    document.documentElement.classList.contains('reduced-motion') ||
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}
+
+function useAnimatedPanelResize(
+  panelRef: RefObject<HTMLDivElement | null>,
+  step: CanvasImportCoursesStep,
+  enabled: boolean,
+) {
+  const prevStepRef = useRef(step)
+
+  useLayoutEffect(() => {
+    if (!enabled) return
+    const node = panelRef.current
+    if (!node) return
+    if (prevStepRef.current === step) return
+    prevStepRef.current = step
+    if (prefersReducedMotion()) return
+
+    const startHeight = node.getBoundingClientRect().height
+    node.style.height = `${startHeight}px`
+    node.style.overflow = 'hidden'
+
+    const endHeight = node.scrollHeight
+    node.style.transition = `height ${PANEL_RESIZE_MS}ms ${PANEL_RESIZE_EASING}`
+
+    const raf = requestAnimationFrame(() => {
+      node.style.height = `${endHeight}px`
+    })
+
+    const finish = () => {
+      node.style.height = ''
+      node.style.overflow = ''
+      node.style.transition = ''
+    }
+
+    node.addEventListener('transitionend', finish, { once: true })
+    const timeout = window.setTimeout(finish, PANEL_RESIZE_MS + 50)
+
+    return () => {
+      cancelAnimationFrame(raf)
+      clearTimeout(timeout)
+      node.removeEventListener('transitionend', finish)
+    }
+  }, [enabled, panelRef, step])
+}
+
 function isCanvasCourseUnpublished(workflowState: string | undefined): boolean {
   return workflowState?.trim().toLowerCase() === 'unpublished'
+}
+
+function courseCountLabel(filtered: number, total: number): string {
+  if (filtered === total) {
+    return `${total} course${total === 1 ? '' : 's'}`
+  }
+  return `${filtered} of ${total} courses`
 }
 
 export function CanvasImportCoursesPanel({
@@ -84,26 +148,34 @@ export function CanvasImportCoursesPanel({
   className,
 }: CanvasImportCoursesPanelProps) {
   const titleId = useId()
+  const panelRef = useRef<HTMLDivElement>(null)
   const canDismiss = !busy || importComplete
+  const isExpandedStep = step !== 'credentials'
+
+  useAnimatedPanelResize(panelRef, step, !compact)
 
   return (
     <div
+      ref={panelRef}
       className={[
         'flex flex-col overflow-hidden',
         compact ? '' : 'rounded-2xl border border-slate-200 bg-white shadow-xl dark:border-neutral-700 dark:bg-neutral-900',
-        step === 'importing' && !compact ? 'min-h-[32rem] max-h-[min(92vh,880px)]' : '',
-        !compact ? 'max-h-[min(90vh,720px)]' : '',
+        !compact && isExpandedStep ? 'max-h-[min(92vh,880px)]' : '',
+        step === 'importing' && !compact ? 'min-h-[32rem]' : '',
         className,
       ]
         .filter(Boolean)
         .join(' ')}
     >
-      <div className="flex items-start justify-between gap-3 border-b border-slate-200 px-5 py-4 dark:border-neutral-700">
-        <div>
-          <h2 id={titleId} className="text-lg font-semibold text-slate-900 dark:text-neutral-100">
+      <div className="flex shrink-0 items-start justify-between gap-3 border-b border-slate-200 px-5 py-4 dark:border-neutral-700">
+        <div className="min-w-0">
+          <h2
+            id={titleId}
+            className="text-balance text-lg font-semibold text-slate-900 dark:text-neutral-100"
+          >
             Import from Canvas
           </h2>
-          <p className="mt-0.5 text-sm text-slate-500 dark:text-neutral-400">
+          <p className="mt-0.5 text-pretty text-sm text-slate-500 dark:text-neutral-400">
             {importComplete
               ? 'Import finished. Review the log below.'
               : step === 'credentials'
@@ -118,7 +190,10 @@ export function CanvasImportCoursesPanel({
             type="button"
             disabled={!canDismiss}
             onClick={onDismiss}
-            className="rounded-lg p-1.5 text-slate-500 hover:bg-slate-100 disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-800"
+            className={[
+              'relative -me-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-800',
+              pressableButtonClassName,
+            ].join(' ')}
             aria-label="Close"
           >
             <X className="h-5 w-5" aria-hidden />
@@ -129,19 +204,20 @@ export function CanvasImportCoursesPanel({
       <div
         className={[
           'min-h-0 flex-1 px-5 py-4',
-          step === 'importing' ? 'overflow-visible' : 'overflow-y-auto',
+          step === 'select' && courses ? 'flex flex-col overflow-hidden' : '',
+          step === 'importing' ? 'overflow-visible' : step === 'select' && courses ? '' : 'overflow-y-auto',
         ].join(' ')}
       >
         {error ? (
-          <p className="mb-4 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-800 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-200">
+          <p className="mb-4 shrink-0 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-800 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-200">
             {error}
           </p>
         ) : null}
 
         {step === 'credentials' ? (
-          <div className="space-y-4">
-            <CanvasReadOnlyNotice />
-            <p className="text-sm text-slate-600 dark:text-neutral-400">
+          <div className="space-y-3">
+            <CanvasReadOnlyNotice variant="compact" />
+            <p className="text-pretty text-sm text-slate-600 dark:text-neutral-400">
               Create a token in Canvas under Account → Settings → New Access Token (read-only
               scopes are sufficient). The token is sent to our server only for this session and is
               not stored on the server.
@@ -157,7 +233,7 @@ export function CanvasImportCoursesPanel({
                 placeholder="https://yourschool.instructure.com"
                 autoComplete="off"
                 disabled={busy}
-                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/30 disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+                className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/30 disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
               />
             </label>
             <label className="block">
@@ -171,10 +247,10 @@ export function CanvasImportCoursesPanel({
                 placeholder="Canvas API token"
                 autoComplete="off"
                 disabled={busy}
-                className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/30 disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+                className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/30 disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
               />
             </label>
-            <label className="flex cursor-pointer items-start gap-2 rounded-xl border border-slate-200 p-3 dark:border-neutral-600">
+            <label className="flex cursor-pointer items-start gap-2 rounded-lg p-3 shadow-[inset_0_0_0_1px_rgba(15,23,42,0.08)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]">
               <input
                 type="checkbox"
                 className="mt-0.5"
@@ -190,14 +266,10 @@ export function CanvasImportCoursesPanel({
         ) : null}
 
         {step === 'select' && courses ? (
-          <div className="space-y-3">
-            <CanvasReadOnlyNotice />
-            <div className="space-y-3 rounded-xl border border-slate-200 bg-slate-50/80 p-3 dark:border-neutral-600 dark:bg-neutral-800/40">
-              <label className="block">
-                <span className="text-xs font-medium text-slate-600 dark:text-neutral-400">
-                  Search by name
-                </span>
-                <span className="relative mt-1 flex">
+          <div className="canvas-import-select-in flex min-h-[min(68vh,620px)] flex-1 flex-col gap-3">
+            <div className="shrink-0 space-y-2">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <span className="relative flex min-w-0 flex-1">
                   <Search
                     className="pointer-events-none absolute start-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400 dark:text-neutral-500"
                     aria-hidden
@@ -207,88 +279,81 @@ export function CanvasImportCoursesPanel({
                     value={nameFilter}
                     onChange={(e) => onNameFilterChange(e.target.value)}
                     placeholder="Filter courses…"
+                    aria-label="Filter courses by name"
                     autoComplete="off"
-                    className="w-full rounded-xl border border-slate-200 bg-white py-2 ps-9 pe-3 text-sm text-slate-900 shadow-inner outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/30 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100"
+                    className="w-full rounded-lg border border-slate-200 bg-white py-2 ps-9 pe-3 text-sm text-slate-900 shadow-inner outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/30 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100"
                   />
                 </span>
-              </label>
-              <label className="flex cursor-pointer items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={hideUnpublished}
-                  onChange={(e) => onHideUnpublishedChange(e.target.checked)}
-                />
-                <span className="text-sm text-slate-700 dark:text-neutral-300">
-                  Hide unpublished courses
-                </span>
-              </label>
-              <label className="flex cursor-pointer items-start gap-2 rounded-xl border border-sky-200 bg-sky-50/80 p-3 dark:border-sky-900/50 dark:bg-sky-950/30">
-                <input
-                  type="checkbox"
-                  className="mt-0.5"
-                  checked={enableCanvasGradeSync}
-                  onChange={(e) => onEnableCanvasGradeSyncChange(e.target.checked)}
-                />
-                <span>
-                  <span className="block text-sm font-medium text-slate-900 dark:text-neutral-100">
-                    Sync grades back to Canvas when grading
+                <label className="flex min-h-10 shrink-0 cursor-pointer items-center gap-2 px-1 sm:px-2">
+                  <input
+                    type="checkbox"
+                    checked={hideUnpublished}
+                    onChange={(e) => onHideUnpublishedChange(e.target.checked)}
+                  />
+                  <span className="text-sm whitespace-nowrap text-slate-700 dark:text-neutral-300">
+                    Hide unpublished
                   </span>
-                  <span className="mt-0.5 block text-xs text-slate-600 dark:text-neutral-400">
-                    When enabled, saving a grade in Lextures automatically pushes it to Canvas.
-                    Requires a Canvas token with grade-update permission (saved in this browser if
-                    you chose Remember).
+                </label>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-sm text-slate-600 dark:text-neutral-400">
+                  <span className="tabular-nums">
+                    {courseCountLabel(filteredCourses.length, courses.length)}
                   </span>
-                </span>
-              </label>
+                  {coursesToImport.length > 0 ? (
+                    <>
+                      {' '}
+                      ·{' '}
+                      <span className="tabular-nums">
+                        {coursesToImport.length} selected
+                      </span>
+                    </>
+                  ) : null}
+                </p>
+                <div className="flex gap-1 text-sm">
+                  <button
+                    type="button"
+                    disabled={filteredCourses.length === 0}
+                    className={[
+                      'min-h-10 rounded-lg px-2 font-medium text-indigo-600 hover:bg-indigo-50 hover:text-indigo-500 disabled:opacity-50 dark:text-indigo-400 dark:hover:bg-indigo-950/40',
+                      pressableButtonClassName,
+                    ].join(' ')}
+                    onClick={onSelectAllVisible}
+                  >
+                    Select all shown
+                  </button>
+                  <button
+                    type="button"
+                    disabled={coursesToImport.length === 0}
+                    className={[
+                      'min-h-10 rounded-lg px-2 font-medium text-indigo-600 hover:bg-indigo-50 hover:text-indigo-500 disabled:opacity-50 dark:text-indigo-400 dark:hover:bg-indigo-950/40',
+                      pressableButtonClassName,
+                    ].join(' ')}
+                    onClick={onClearSelection}
+                  >
+                    Clear all
+                  </button>
+                </div>
+              </div>
+              {selectedHiddenCount > 0 ? (
+                <p className="text-xs text-amber-800 dark:text-amber-200">
+                  <span className="tabular-nums">{selectedHiddenCount}</span> selected course
+                  {selectedHiddenCount === 1 ? '' : 's'}{' '}
+                  {selectedHiddenCount === 1 ? 'is' : 'are'} hidden by your filters and will still
+                  be imported unless you clear selection.
+                </p>
+              ) : null}
             </div>
 
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <p className="text-sm text-slate-600 dark:text-neutral-400">
-                {filteredCourses.length === courses.length
-                  ? `${courses.length} course${courses.length === 1 ? '' : 's'}`
-                  : `${filteredCourses.length} of ${courses.length} courses`}
-                {coursesToImport.length > 0
-                  ? ` · ${coursesToImport.length} selected for import`
-                  : ''}
-              </p>
-              <div className="flex gap-2 text-sm">
-                <button
-                  type="button"
-                  disabled={filteredCourses.length === 0}
-                  className="font-medium text-indigo-600 hover:text-indigo-500 disabled:opacity-50 dark:text-indigo-400"
-                  onClick={onSelectAllVisible}
-                >
-                  Select all shown
-                </button>
-                <span className="text-slate-300 dark:text-neutral-600" aria-hidden>
-                  |
-                </span>
-                <button
-                  type="button"
-                  disabled={coursesToImport.length === 0}
-                  className="font-medium text-indigo-600 hover:text-indigo-500 disabled:opacity-50 dark:text-indigo-400"
-                  onClick={onClearSelection}
-                >
-                  Clear all
-                </button>
-              </div>
-            </div>
-            {selectedHiddenCount > 0 ? (
-              <p className="text-xs text-amber-800 dark:text-amber-200">
-                {selectedHiddenCount} selected course{selectedHiddenCount === 1 ? '' : 's'}{' '}
-                {selectedHiddenCount === 1 ? 'is' : 'are'} hidden by your filters and will still be
-                imported unless you clear selection.
-              </p>
-            ) : null}
-            <ul className="max-h-64 space-y-1 overflow-y-auto rounded-xl border border-slate-200 p-2 dark:border-neutral-600">
+            <ul className="min-h-0 flex-1 space-y-0.5 overflow-y-auto rounded-lg bg-slate-50/70 p-1.5 shadow-[inset_0_0_0_1px_rgba(15,23,42,0.08)] dark:bg-neutral-800/40 dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]">
               {filteredCourses.length === 0 ? (
-                <li className="px-2 py-6 text-center text-sm text-slate-500 dark:text-neutral-400">
+                <li className="px-2 py-10 text-center text-sm text-slate-500 dark:text-neutral-400">
                   No courses match your filters.
                 </li>
               ) : (
                 filteredCourses.map((c) => (
                   <li key={c.id}>
-                    <label className="flex cursor-pointer items-start gap-3 rounded-lg px-2 py-2 hover:bg-slate-50 dark:hover:bg-neutral-800/80">
+                    <label className="flex min-h-10 cursor-pointer items-start gap-3 rounded-md px-2 py-2 hover:bg-white/80 dark:hover:bg-neutral-900/70">
                       <input
                         type="checkbox"
                         className="mt-1"
@@ -301,13 +366,13 @@ export function CanvasImportCoursesPanel({
                             {c.name}
                           </span>
                           {isCanvasCourseUnpublished(c.workflowState) ? (
-                            <span className="rounded-md bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-900 dark:bg-amber-950/60 dark:text-amber-200">
+                            <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-900 dark:bg-amber-950/60 dark:text-amber-200">
                               Unpublished
                             </span>
                           ) : null}
                         </span>
                         <span className="mt-0.5 block text-xs text-slate-500 dark:text-neutral-500">
-                          ID {c.id}
+                          <span className="tabular-nums">ID {c.id}</span>
                           {c.courseCode ? ` · ${c.courseCode}` : ''}
                           {c.termName ? ` · ${c.termName}` : ''}
                           {c.workflowState && !isCanvasCourseUnpublished(c.workflowState)
@@ -320,12 +385,27 @@ export function CanvasImportCoursesPanel({
                 ))
               )}
             </ul>
-            <p className="text-xs text-slate-500 dark:text-neutral-500">
-              Check the courses you want, then import. Each one is created in Lextures and filled from
-              Canvas (modules, assignments, quizzes, roster enrollments, grades, and settings).
-              Learners with an email in Canvas get Lextures accounts when needed. Canvas is not
-              modified.
-            </p>
+
+            <div className="mt-auto grid shrink-0 gap-3 lg:grid-cols-2 lg:gap-4">
+              <CanvasReadOnlyNotice variant="compact" />
+              <label className="flex h-full cursor-pointer items-start gap-2 rounded-lg bg-slate-50/80 px-3 py-2.5 shadow-[inset_0_0_0_1px_rgba(15,23,42,0.08)] dark:bg-neutral-800/40 dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]">
+                <input
+                  type="checkbox"
+                  className="mt-0.5"
+                  checked={enableCanvasGradeSync}
+                  onChange={(e) => onEnableCanvasGradeSyncChange(e.target.checked)}
+                />
+                <span className="min-w-0">
+                  <span className="block text-sm font-medium text-slate-900 dark:text-neutral-100">
+                    Sync grades back to Canvas
+                  </span>
+                  <span className="mt-0.5 block text-pretty text-xs leading-relaxed text-slate-600 dark:text-neutral-400">
+                    Push grades to Canvas when you save in Lextures. Requires a token with
+                    grade-update permission.
+                  </span>
+                </span>
+              </label>
+            </div>
           </div>
         ) : null}
 
@@ -341,7 +421,7 @@ export function CanvasImportCoursesPanel({
         ) : null}
       </div>
 
-      <div className="flex flex-wrap justify-end gap-2 border-t border-slate-200 px-5 py-4 dark:border-neutral-700">
+      <div className="flex shrink-0 flex-wrap justify-end gap-2 border-t border-slate-200 px-5 py-4 dark:border-neutral-700">
         {step === 'credentials' ? (
           <>
             {onDismiss ? (
@@ -349,7 +429,10 @@ export function CanvasImportCoursesPanel({
                 type="button"
                 disabled={busy}
                 onClick={onDismiss}
-                className="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                className={[
+                  'rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800',
+                  pressableButtonClassName,
+                ].join(' ')}
               >
                 Cancel
               </button>
@@ -358,7 +441,10 @@ export function CanvasImportCoursesPanel({
               type="button"
               disabled={busy}
               onClick={onConnect}
-              className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:opacity-60"
+              className={[
+                'inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:opacity-60',
+                pressableButtonClassName,
+              ].join(' ')}
             >
               {busy ? 'Connecting…' : 'Load courses'}
             </button>
@@ -370,7 +456,10 @@ export function CanvasImportCoursesPanel({
               type="button"
               disabled={busy}
               onClick={onBackToCredentials}
-              className="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
+              className={[
+                'rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800',
+                pressableButtonClassName,
+              ].join(' ')}
             >
               Back
             </button>
@@ -378,9 +467,13 @@ export function CanvasImportCoursesPanel({
               type="button"
               disabled={busy || coursesToImport.length === 0}
               onClick={onImport}
-              className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:opacity-60"
+              className={[
+                'rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:opacity-60',
+                pressableButtonClassName,
+              ].join(' ')}
             >
-              Import {coursesToImport.length} course{coursesToImport.length === 1 ? '' : 's'}
+              Import <span className="tabular-nums">{coursesToImport.length}</span> course
+              {coursesToImport.length === 1 ? '' : 's'}
             </button>
           </>
         ) : null}
@@ -388,7 +481,10 @@ export function CanvasImportCoursesPanel({
           <button
             type="button"
             onClick={onCancelImport}
-            className="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800"
+            className={[
+              'rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-neutral-600 dark:text-neutral-200 dark:hover:bg-neutral-800',
+              pressableButtonClassName,
+            ].join(' ')}
           >
             Cancel import
           </button>
@@ -397,7 +493,10 @@ export function CanvasImportCoursesPanel({
           <button
             type="button"
             onClick={onDismiss}
-            className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500"
+            className={[
+              'rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500',
+              pressableButtonClassName,
+            ].join(' ')}
           >
             Done
           </button>


### PR DESCRIPTION
## Summary
- Redesigns the Canvas import modal with a full-width course picker, inline filter toolbar, and balanced read-only/grade-sync footer strip
- Starts the connect step in a compact `max-w-md` dialog that animates to the larger course-selection layout after Load courses succeeds
- Adds compact read-only notice variant, press feedback on actions, tabular counts, and reduced-motion-safe resize/enter animations

## Test plan
- [ ] Open Import from Canvas and confirm credentials step uses a compact modal
- [ ] Click Load courses and verify width/height expand smoothly into the course list
- [ ] Filter courses, toggle Hide unpublished, select courses, and import
- [ ] Click Back and confirm modal shrinks back to compact credentials layout
- [ ] Verify reduced-motion preference skips resize/enter animations
- [ ] Run `npm run typecheck` in `clients/web/`


Made with [Cursor](https://cursor.com)