### PR TITLE
docs(grading-agent): audit — missing features, simplifications, and bugs

### DIFF
--- a/docs/plan/grading-agent/README.md
+++ b/docs/plan/grading-agent/README.md
@@ -1,0 +1,67 @@
+# Grading Agent — Audit & Remediation Plans
+
+> Findings from a full review of the **grading (grader) agent**: the workflow-canvas auto-grader
+> that scores assignment submissions with an instructor-authored node graph. Each finding below is a
+> standalone plan that follows [`_TEMPLATE.md`](../_TEMPLATE.md).
+>
+> Companion folder [`../agent-grader/`](../agent-grader/) plans *new canvas nodes*. This folder is
+> scoped to **usability gaps, simplifications, and bugs** in the agent as it exists today.
+
+## What the agent is (as built)
+
+- **Authoring** — a React Flow DAG in SpeedGrader (`clients/web/src/components/annotation/grader-agent/`)
+  with a typed palette (Student Submission, Activity, Rubric, Reference, AI, Criterion Grader,
+  Code Test Runner, Conditional Router, Score Aggregator, Originality, Human Review Gate,
+  Flag for Review, Student Grade output).
+- **Validation/compile** — client `validation.ts` + server `workflow.go` (`ValidateWorkflowGraph`,
+  `CompileWorkflowGraph`).
+- **Execution** — `workflow_execute.go::ExecuteWorkflowDryRun` topologically walks the graph. The
+  **same engine runs both dry runs (WebSocket) and live batch/auto grading**
+  (`background/grading_agent_consumer.go` → `HandleGradingAgentQueueMessage`).
+- **Persistence** — `assessment.grading_agent_configs / _runs / _results` via
+  `repos/gradingagent/repo.go`. Batch jobs flow through `gradingagentqueue` (RabbitMQ or in-memory).
+
+## Findings index
+
+### Missing features (HE instructor / TA / grader usability)
+
+| ID | Plan | Severity | One-liner |
+|---|---|---|---|
+| GA-M1 | [Persistent, actionable review queue & run history](missing-1-persistent-review-queue.md) | BLOCKER | Held/flagged items vanish when the modal closes; flagged queue has no actions; no run history. |
+| GA-M2 | [Grade non-file (online text-entry) & image/scanned submissions](missing-2-non-file-submission-grading.md) | BLOCKER | Only file attachments with extractable text are gradable; text-box and scanned work are silently skipped. |
+| GA-M3 | [Suggest-only batch + bulk review/apply + posting control](missing-3-suggest-only-batch-and-bulk-review.md) | MAJOR | Batch runs auto-write grades; no "AI suggests, human approves in bulk" mode. |
+| GA-M4 | [Agent-level confidence auto-hold threshold](missing-4-confidence-auto-hold-threshold.md) | MAJOR | "Hold anything below X% confidence" requires hand-building a gate graph; the `confidence_floor` column is unused. |
+| GA-M5 | [Section / group / student-scoped runs](missing-5-section-scoped-runs.md) | MAJOR | Scope is only current/ungraded/all — a TA cannot grade just their section. |
+| GA-M6 | [Cancel / stop a running batch](missing-6-cancel-running-batch.md) | MAJOR | Once a batch starts it cannot be stopped; a mistake burns the whole class of AI calls. |
+| GA-M7 | [Pre-run cost & scope estimate + run cost summary](missing-7-cost-estimate-and-budget.md) | MAJOR | No cost/size preview before running and no aggregate cost after; instructors fear runaway spend. |
+
+### Over-complexities to simplify
+
+| ID | Plan | One-liner |
+|---|---|---|
+| GA-S1 | [Unify the three duplicated grade-write paths in the consumer](simplify-1-unify-grade-write-paths.md) | `HandleGradingAgentQueueMessage` has three overlapping branches that all end in "execute + write grade". |
+| GA-S2 | [Remove the dead HTTP dry-run path; rename the execution engine](simplify-2-remove-dead-dry-run-and-rename-engine.md) | `POST /dry-run` + `Service.Score` legacy path is unused by the client and mis-handles complex graphs. |
+| GA-S3 | [Collapse the duplicated per-node update callbacks](simplify-3-generic-node-data-updater.md) | ~12 near-identical `updateXNode` callbacks in the hook can be one generic updater. |
+| GA-S4 | [Retire legacy node-type aliases & palette ternaries](simplify-4-legacy-node-type-aliases.md) | `submission`/`assignmentContext`/`grader` legacy types and giant nested ternaries add accidental complexity. |
+
+### Bugs
+
+| ID | Plan | Size | One-liner |
+|---|---|---|---|
+| GA-B1 | [In-memory queue overflow & stuck runs](bug-1-queue-overflow-and-stuck-runs.md) | Large | A class > 128 submissions (or a slow consumer) overflows the in-memory queue and leaves the run stuck in `running`. |
+| GA-B2 | [Requeue causes double grading & duplicate results](bug-2-requeue-double-grading.md) | Medium | A transient DB error after the grade is written requeues the message → second LLM call, duplicate result, inflated counts. |
+| GA-B3 | [Auto-post / confidence_floor dead code](bug-3-auto-post-dead-code.md) | Medium | `post_policy` is never writable, so AI grades never auto-post even when the assignment posts automatically. |
+| GA-B4 | [HTTP dry-run mis-previews complex graphs](bug-4-post-dry-run-mispreviews-graphs.md) | Medium | The non-WS dry-run endpoint ignores routers/gates/aggregators/flags and returns a wrong (or failing) preview. |
+| GA-B5 | [Run-status polling robustness](bug-5-run-polling-robustness.md) | Small | Polling can over-fire `onApplied` and keep ticking one cycle after a run is already done. |
+
+## Severity legend
+
+- **BLOCKER** — most HE classes cannot adopt the agent without it.
+- **MAJOR** — adoption-limiting / RFP-losing gap.
+- **MINOR** — parity / nice-to-have.
+
+## Conventions
+
+- File naming: `{category}-{n}-{kebab-slug}.md`; Feature IDs `GA-M*`, `GA-S*`, `GA-B*`.
+- Each plan fills every `_TEMPLATE.md` section and names the concrete files it touches.
+- Cross-references between plans use relative links.

--- a/docs/plan/grading-agent/bug-1-queue-overflow-and-stuck-runs.md
+++ b/docs/plan/grading-agent/bug-1-queue-overflow-and-stuck-runs.md
@@ -1,0 +1,146 @@
+# GA-B1 — In-memory queue overflow & stuck runs
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-B1 |
+| **Section** | Grading Agent — Bugs |
+| **Severity** | BLOCKER |
+| **Bug size** | Large |
+| **Markets** | HE / K12 (single-node & large-class deployments) |
+| **Status (today)** | BUG |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Platform / Grading squad |
+| **Depends on** | — |
+| **Unblocks** | [GA-M6](missing-6-cancel-running-batch.md), reliable large runs |
+
+## 1. Problem Statement
+
+Two coupled defects make large batch runs unreliable, especially on deployments without RabbitMQ:
+
+1. **Overflow.** The in-memory bus is `make(chan QueueMessage, 128)` and `Publish` is **non-blocking**:
+   if the buffer is full it returns `"memory queue full"`. `handlePostGraderAgentRun` publishes one
+   message **per submission** in a loop. A class with > 128 submissions (or a consumer slower than the
+   publish loop) hits a full channel; `Publish` errors mid-loop.
+2. **Stuck run.** On that error the handler returns `500 "Failed to enqueue run"` — but the run was
+   already created, `MarkRunRunning` was already called, and some messages were already enqueued and
+   will grade. There is no rollback and **no terminal failure state for the run**:
+   `IncrementRunProgress` only flips status to `done` when `completed_count >= total_count`, which can
+   never happen because the un-enqueued items never complete. The run is stuck in `running` forever, the
+   client polls it indefinitely, and the gradebook is left partially graded with no signal.
+
+## 2. Goals
+
+- No silent message loss when enqueuing a batch (back-pressure or durable enqueue).
+- Atomic-ish enqueue: either the whole run is queued or it fails cleanly with the run marked failed.
+- A terminal `failed` (or `cancelled`, see [GA-M6](missing-6-cancel-running-batch.md)) run state and a stuck-run reconciler so no run polls forever.
+
+## 3. Non-Goals
+
+- Replacing the queue technology; fix the in-memory path and the enqueue/lifecycle logic.
+- Cancel UX (separate plan [GA-M6](missing-6-cancel-running-batch.md), but shares terminal-state plumbing).
+
+## 4. Personas & User Stories
+
+- **As an instructor on a single-node install**, I want a 200-student run to fully enqueue, so that everyone gets graded.
+- **As an instructor**, I want a run that fails to enqueue to say so, so that I am not stuck watching a frozen progress bar.
+- **As an operator**, I want stuck runs auto-reconciled, so that they do not accumulate in `running`.
+
+## 5. Functional Requirements
+
+- **FR-1.** In-memory `Publish` MUST NOT drop messages: use a blocking send with context cancellation (and/or a larger/unbounded-with-backpressure buffer), so enqueuing N > 128 items succeeds.
+- **FR-2.** Enqueue MUST be all-or-nothing from the user's perspective: if any publish fails, the run MUST be marked terminally failed and the response MUST report how many items were/weren't queued.
+- **FR-3.** A run MUST reach a terminal state even when fewer than `total_count` items complete (reconciler marks runs `failed` after a timeout with no progress, or enqueue accounts for the true queued count).
+- **FR-4.** `total_count` MUST reflect the number actually enqueued (set/adjust after enqueue), so `done` is reachable.
+- **FR-5.** The client MUST stop polling and show a clear error when a run is terminally failed.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — blocking publish bounded by consumer throughput; publish loop SHOULD run off the request goroutine for large batches (enqueue asynchronously) to avoid long-held HTTP requests.
+- **Reliability** — no message loss; terminal state guaranteed; reconciler idempotent.
+- **Scalability** — validate against a 500-submission run on the in-memory bus and on RabbitMQ.
+- **Observability** — metrics: enqueue failures, stuck-run reconciliations, run terminal states.
+- **Security** — unchanged RBAC.
+- **Backward compatibility** — RabbitMQ path already blocks on publish; align in-memory semantics.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a 300-submission run on the in-memory bus, *when* started, *then* all 300 enqueue and the run reaches `done`.
+- **AC-2.** *Given* an induced publish failure, *when* it occurs, *then* the run is marked `failed`, the response states the partial count, and the client stops polling with an error.
+- **AC-3.** *Given* a run that loses some workers, *when* the reconciler runs, *then* the run is marked `failed` after the no-progress timeout (not stuck in `running`).
+- **AC-4.** *Given* `total_count` adjusted to the enqueued count, *when* all enqueued items finish, *then* `status = done`.
+
+## 8. Data Model
+
+- `grading_agent_runs`: ensure a `failed` terminal status is recognized; add `last_progress_at TIMESTAMPTZ` to support the reconciler.
+- Migration: `server/migrations/NNN_grading_agent_run_terminal_states.sql`.
+- Backfill: set `last_progress_at = created_at` for existing rows; optionally mark long-stale `running` runs `failed`.
+
+## 9. API Surface
+
+- `POST …/grader-agent/runs` response gains `queuedCount` (and `failed` indication when partial).
+- `GET …/runs/{run_id}` returns terminal `failed` with a reason.
+
+## 10. UI / UX
+
+- Run popover/dock shows a terminal error state for failed runs and stops the 1.5 s poll loop.
+- Run history ([GA-M1](missing-1-persistent-review-queue.md)) shows failed runs distinctly.
+- Copy/i18n under `gradingAgent.run.failed*`.
+
+## 11. AI / ML Considerations
+
+- None directly; preventing stuck/partial runs avoids paying for half-graded classes.
+
+## 12. Integration Points
+
+- `server/internal/gradingagentqueue/queue.go` (`memoryBus.Publish` blocking semantics, buffer).
+- `server/internal/httpserver/grading_agent_http.go` (`handlePostGraderAgentRun` enqueue loop + lifecycle).
+- `server/internal/repos/gradingagent/repo.go` (`CreateRun`/`MarkRun*`/terminal states, reconciler query).
+- A background reconciler (new) near `server/internal/background/`.
+- `clients/web/src/components/annotation/grader-agent/use-grader-agent-workflow.ts` (poll stop on terminal).
+
+## 13. Dependencies & Sequencing
+
+- Shares terminal-state plumbing with [GA-M6](missing-6-cancel-running-batch.md); land together or B1 first.
+- Benefits from [GA-S1](simplify-1-unify-grade-write-paths.md) (single apply path) for the idempotency in [GA-B2](bug-2-requeue-double-grading.md).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Blocking publish stalls the HTTP request for big runs | M | M | Enqueue asynchronously; return `202` immediately with `queuedCount` pending, or chunk enqueue in a goroutine |
+| Reconciler races a slow-but-live run | M | M | Use `last_progress_at` with a generous timeout; only fail runs with no progress |
+| Backfill mislabels legitimately-running runs | L | M | Only auto-fail runs stale beyond the timeout at migration time |
+
+## 15. Rollout Plan
+
+- Flag: none (correctness fix); stage the reconciler behind config to tune the timeout.
+- Sequence: blocking publish + enqueue lifecycle → terminal states + reconciler → client poll-stop.
+- Rollback: revert publish change (note: reverting reintroduces overflow — prefer forward fix).
+
+## 16. Test Plan
+
+- **Unit** — `memoryBus.Publish` blocks and never drops; enqueue failure marks run failed.
+- **Integration** — 500-item run completes on memory bus; induced failure → terminal failed; reconciler fails a stalled run.
+- **Load** — publish/consume throughput under concurrency.
+- **E2E** — large run completes; failed run surfaces error and stops polling.
+
+## 17. Documentation & Training
+
+- Runbook: in-memory vs RabbitMQ queue behavior, run lifecycle, reconciler timeout.
+
+## 18. Open Questions
+
+1. Make the in-memory buffer unbounded-with-backpressure, or just enqueue asynchronously and keep 128?
+2. Should the enqueue loop move fully off the request goroutine (return `202` with a pending count)?
+3. What no-progress timeout balances responsiveness vs slow models?
+
+## 19. References
+
+- `server/internal/gradingagentqueue/queue.go` (`newMemoryBus`, `memoryBus.Publish` — 128 cap, non-blocking).
+- `server/internal/httpserver/grading_agent_http.go` (`handlePostGraderAgentRun`).
+- `server/internal/repos/gradingagent/repo.go` (`IncrementRunProgress`, `MarkRunRunning`).
+- Related: [GA-M6](missing-6-cancel-running-batch.md), [GA-B2](bug-2-requeue-double-grading.md).

--- a/docs/plan/grading-agent/bug-2-requeue-double-grading.md
+++ b/docs/plan/grading-agent/bug-2-requeue-double-grading.md
@@ -1,0 +1,133 @@
+# GA-B2 — Requeue causes double grading & duplicate results
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-B2 |
+| **Section** | Grading Agent — Bugs |
+| **Severity** | MAJOR |
+| **Bug size** | Medium |
+| **Markets** | HE / K12 / SL |
+| **Status (today)** | BUG |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Platform / Grading squad |
+| **Depends on** | — |
+| **Unblocks** | trustworthy counts & cost |
+
+## 1. Problem Statement
+
+The RabbitMQ consumer requeues on handler error: `if err := handler(msg); err != nil { d.Nack(false, true) }`.
+`HandleGradingAgentQueueMessage` swallows most errors (it calls `failGradingAgentItem`, which returns
+`nil`), but it **returns the error from the final `IncrementRunProgress`** — which runs *after* the grade
+has already been written via `UpsertCellWithFlags` and a result row inserted. So a transient DB blip on
+that last call requeues a message whose grade is already applied. On redelivery the submission is graded
+**again**: a second LLM call (extra cost), a **duplicate** `grading_agent_results` row, a second
+gradebook write, and a second progress increment — which can push `completed_count` past `total_count`
+and skew applied/failed tallies. There is no idempotency key on `(run_id, submission_id)`.
+
+## 2. Goals
+
+- Make per-submission grading idempotent: a redelivered message must not double-grade, double-insert, or double-count.
+- Ensure progress accounting cannot exceed `total_count`.
+- Avoid a wasted second LLM call on redelivery.
+
+## 3. Non-Goals
+
+- Removing requeue entirely (it is still useful for genuinely un-started messages).
+- Changing the queue technology.
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I want each submission graded once, so that cost and counts are accurate.
+- **As an operator**, I want redeliveries to be safe, so that transient DB errors do not corrupt run state.
+
+## 5. Functional Requirements
+
+- **FR-1.** Grading MUST be idempotent per `(run_id, submission_id)`: if a non-dry-run result already exists for that pair, the handler MUST short-circuit (no LLM call, no duplicate insert, no extra increment) and ack.
+- **FR-2.** `grading_agent_results` MUST enforce uniqueness on `(run_id, submission_id)` for non-dry-run rows (partial unique index), so duplicate inserts fail fast.
+- **FR-3.** Progress increment MUST be coupled to the *first* successful processing only (e.g., increment within the same transaction that inserts the result, guarded by the unique constraint).
+- **FR-4.** `completed_count` MUST never exceed `total_count`.
+- **FR-5.** The final progress update failing MUST NOT cause re-grading; either make insert+increment atomic, or detect the existing result on redelivery and only retry the increment.
+
+## 6. Non-Functional Requirements
+
+- **Reliability** — exactly-once *effect* (at-least-once delivery tolerated).
+- **Performance** — idempotency check is one indexed lookup.
+- **Observability** — metric: redeliveries detected/short-circuited.
+- **Security** — unchanged.
+- **Backward compatibility** — existing single result-per-pair runs are already compliant; add the index `NOT VALID`-style/concurrently if needed to handle any historical dupes.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a message redelivered after its grade was applied, *when* processed again, *then* no second LLM call, no duplicate result row, and counts are unchanged.
+- **AC-2.** *Given* the unique index, *when* a duplicate insert is attempted, *then* it is rejected and handled as "already processed".
+- **AC-3.** *Given* an `IncrementRunProgress` failure, *when* the message is redelivered, *then* only the increment is retried (idempotently), not the whole grading.
+- **AC-4.** *Given* any run, *when* it completes, *then* `completed_count == total_count` exactly and never exceeds it.
+
+## 8. Data Model
+
+- `CREATE UNIQUE INDEX … ON assessment.grading_agent_results (run_id, submission_id) WHERE run_id IS NOT NULL AND is_dry_run = false;`
+- Consider a `processed` semantics or rely on result existence as the idempotency marker.
+- Migration: `server/migrations/NNN_grading_agent_results_unique_run_submission.sql` (de-dupe any existing duplicates first).
+- Backfill: collapse pre-existing duplicate result rows (keep the latest), then create the index.
+
+## 9. API Surface
+
+- None public. Internal handler + repo changes.
+
+## 10. UI / UX
+
+- None directly; counts become trustworthy (benefits [GA-M7](missing-7-cost-estimate-and-budget.md) and progress display).
+
+## 11. AI / ML Considerations
+
+- Skipping the second LLM call on redelivery is an explicit cost-correctness win.
+
+## 12. Integration Points
+
+- `server/internal/httpserver/grading_agent_queue.go` (idempotency guard at top; atomic insert+increment).
+- `server/internal/repos/gradingagent/repo.go` (`InsertResult` conflict handling; combined insert+progress in a tx; or `ResultExists(runID, submissionID)`).
+- `server/internal/gradingagentqueue/queue.go` (ack/nack semantics; consider nack-without-requeue for already-applied).
+
+## 13. Dependencies & Sequencing
+
+- Cleanest after [GA-S1](simplify-1-unify-grade-write-paths.md) (one apply path to make idempotent), but can land independently.
+- Complements [GA-B1](bug-1-queue-overflow-and-stuck-runs.md) (accurate counts → reachable `done`).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Existing duplicate rows block the unique index | M | M | De-dupe migration before index creation; create concurrently |
+| Atomic insert+increment requires a tx refactor | M | M | Wrap both repo calls in one `pgx.Tx`; or use the unique index to gate the increment |
+| Auto-grade (`run_id` per single submission) edge cases | L | L | Auto runs have one item; unique index still holds |
+
+## 15. Rollout Plan
+
+- Sequence: de-dupe + unique index → idempotency guard + atomic progress → ack tuning.
+- Rollback: drop the guard (index is harmless to keep).
+
+## 16. Test Plan
+
+- **Unit** — idempotency guard short-circuits on existing result; counts capped at total.
+- **Integration** — simulate redelivery after apply → no double effects; insert conflict handled.
+- **Concurrency** — two workers same message → exactly one effect.
+
+## 17. Documentation & Training
+
+- Runbook: "How redeliveries are handled; results are unique per (run, submission)."
+
+## 18. Open Questions
+
+1. Prefer `ack` (drop) vs `nack(requeue=false)` for an already-applied redelivery?
+2. Should the increment live in the same tx as the result insert, or be a separate idempotent step keyed off result existence?
+
+## 19. References
+
+- `server/internal/gradingagentqueue/queue.go` (`rabbitBus.Consume` — `Nack(false, true)` on handler error).
+- `server/internal/httpserver/grading_agent_queue.go` (`HandleGradingAgentQueueMessage` returns `IncrementRunProgress` error after writing the grade).
+- `server/internal/repos/gradingagent/repo.go` (`InsertResult`, `IncrementRunProgress`).
+- Related: [GA-S1](simplify-1-unify-grade-write-paths.md), [GA-B1](bug-1-queue-overflow-and-stuck-runs.md).

--- a/docs/plan/grading-agent/bug-3-auto-post-dead-code.md
+++ b/docs/plan/grading-agent/bug-3-auto-post-dead-code.md
@@ -1,0 +1,139 @@
+# GA-B3 — Auto-post / confidence_floor dead code
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-B3 |
+| **Section** | Grading Agent — Bugs |
+| **Severity** | MAJOR |
+| **Bug size** | Medium |
+| **Markets** | HE / K12 |
+| **Status (today)** | BUG |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Assessment / Grading squad |
+| **Depends on** | — |
+| **Unblocks** | [GA-M3](missing-3-suggest-only-batch-and-bulk-review.md), [GA-M4](missing-4-confidence-auto-hold-threshold.md) |
+
+## 1. Problem Statement
+
+Two config columns are read but **never written**, leaving intended behavior unreachable:
+
+- **`post_policy`** — the consumer gates auto-posting with
+  `strings.TrimSpace(assignRow.PostingPolicy) == "automatic" && cfg.PostPolicy == "auto_post"`
+  in three places. But `UpsertConfig` never sets `post_policy` (it is omitted from the INSERT column
+  list), so it is always its DB default `'unposted'`. Therefore `cfg.PostPolicy == "auto_post"` is
+  **always false** and AI grades are **always written with `posting = "manual"`** (unposted), even for
+  assignments configured to post automatically. There is no UI/API to change it. Instructors who expect
+  automatic-posting assignments to show AI grades to students will find grades silently withheld.
+- **`confidence_floor`** — read into `ConfigRow.ConfidenceFloor` but used nowhere and never written;
+  fully dead (the live confidence-hold lives only on the gate node). See [GA-M4](missing-4-confidence-auto-hold-threshold.md).
+
+This is both a latent bug (a whole code branch is unreachable) and a feature gap (no posting control).
+
+## 2. Goals
+
+- Decide and implement the intended posting behavior: either make `post_policy` settable end-to-end, or remove the dead branch and document "AI grades are always unposted until reviewed."
+- Remove or wire `confidence_floor` (wiring is [GA-M4](missing-4-confidence-auto-hold-threshold.md); this plan at minimum removes the dead read or connects it).
+- Eliminate misleading unreachable code so behavior matches intent.
+
+## 3. Non-Goals
+
+- Building the full suggest-only/bulk experience ([GA-M3](missing-3-suggest-only-batch-and-bulk-review.md)) — this plan fixes the posting plumbing it depends on.
+- Changing the gradebook posting model itself.
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I want to choose whether AI grades post to students automatically, so that the behavior matches my assignment's posting policy.
+- **As a maintainer**, I want no unreachable branches, so that the code reflects real behavior.
+
+## 5. Functional Requirements
+
+- **FR-1.** `post_policy` MUST be persisted by `UpsertConfig` (add to INSERT/UPDATE) and exposed via the config GET/PUT API, **or** the three `cfg.PostPolicy == "auto_post"` branches MUST be removed and the behavior documented as always-manual.
+- **FR-2.** If retained, the agent MUST default to `draft`/`unposted` (safe), with `auto_post` opt-in; the effective posting still respects the assignment's own posting policy.
+- **FR-3.** `confidence_floor` MUST either be wired ([GA-M4](missing-4-confidence-auto-hold-threshold.md)) or removed from `ConfigRow`/queries to avoid a dead field.
+- **FR-4.** No grade's posting state changes silently for existing agents (existing default behavior preserved unless the instructor opts in).
+
+## 6. Non-Functional Requirements
+
+- **Privacy & Compliance** — default remains "do not auto-show AI grades to students" (FERPA-safe); auto-post is explicit and logged.
+- **Reliability** — posting decision covered by tests for both policies.
+- **Observability** — log the effective posting decision per applied grade.
+- **Backward compatibility** — existing agents keep `unposted` default; no behavior change without opt-in.
+- **Maintainability** — no unreachable branches remain.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* an agent set to `auto_post` and an assignment that posts automatically, *when* a grade is applied, *then* it is posted (visible to the student per posting rules).
+- **AC-2.** *Given* an agent left at default, *when* a grade is applied, *then* it is unposted (today's behavior).
+- **AC-3.** *Given* the config API, *when* I set and reload posting policy, *then* it persists.
+- **AC-4.** *Given* the codebase, *when* searched, *then* there is no `cfg.PostPolicy == "auto_post"` branch that can never be true (it is either reachable or removed).
+- **AC-5.** *Given* `confidence_floor`, *when* searched, *then* it is either used or fully removed.
+
+## 8. Data Model
+
+- `grading_agent_configs.post_policy` already exists (default `'unposted'`); add to `UpsertConfigInput` and the upsert SQL.
+- `confidence_floor` exists; wire ([GA-M4](missing-4-confidence-auto-hold-threshold.md)) or drop from `ConfigRow` and queries.
+- Migration: none required for `post_policy` (column exists); a migration only if dropping `confidence_floor`.
+
+## 9. API Surface
+
+- `GET …/grader-agent` config gains `postPolicy`; `PUT …/grader-agent` accepts `postPolicy` (`draft`|`auto_post`).
+- `graderAgentConfigToJSON` includes `postPolicy` (and `confidenceFloor` if wired).
+
+## 10. UI / UX
+
+- Posting control in the agent settings (pairs with [GA-M3](missing-3-suggest-only-batch-and-bulk-review.md)'s posting note): "Post AI grades to students automatically" vs "Keep as draft until I post."
+- Copy/i18n under `gradingAgent.settings.posting.*`.
+
+## 11. AI / ML Considerations
+
+- None; posting is a downstream gradebook concern.
+
+## 12. Integration Points
+
+- `server/internal/repos/gradingagent/repo.go` (`UpsertConfigInput.PostPolicy`, upsert SQL; `ConfidenceFloor`).
+- `server/internal/httpserver/grading_agent_http.go` (config body + `graderAgentConfigToJSON`).
+- `server/internal/httpserver/grading_agent_queue.go` (the three posting-derivation sites → centralize once via [GA-S1](simplify-1-unify-grade-write-paths.md)).
+
+## 13. Dependencies & Sequencing
+
+- Foundational for [GA-M3](missing-3-suggest-only-batch-and-bulk-review.md) (posting) and [GA-M4](missing-4-confidence-auto-hold-threshold.md) (confidence_floor).
+- Cleanest after [GA-S1](simplify-1-unify-grade-write-paths.md) so posting is decided in one place.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Enabling auto-post surprises students with unreviewed grades | M | H | Default stays draft; auto-post is explicit opt-in + recommend suggest-only first |
+| Removing the branch loses a planned feature | M | M | Prefer wiring over deletion; if removed, document and keep the column |
+
+## 15. Rollout Plan
+
+- Flag: `graderAgentPostingPolicy` if wiring; otherwise a straight cleanup PR.
+- Sequence: persist + expose `post_policy` → centralize posting decision → UI control.
+- Rollback: revert to always-`unposted`.
+
+## 16. Test Plan
+
+- **Unit** — posting decision matrix (config × assignment posting policy).
+- **Integration** — auto_post posts; default does not; config persists.
+- **Static** — no unreachable `auto_post` branch; `confidence_floor` used or gone.
+
+## 17. Documentation & Training
+
+- Help-center: "When do AI grades become visible to students?"
+
+## 18. Open Questions
+
+1. Wire `post_policy` (recommended, enables [GA-M3]) or remove the branch and document always-manual?
+2. Remove `confidence_floor` now or implement [GA-M4](missing-4-confidence-auto-hold-threshold.md) in the same change?
+
+## 19. References
+
+- `server/internal/httpserver/grading_agent_queue.go` (3× `cfg.PostPolicy == "auto_post"`).
+- `server/internal/repos/gradingagent/repo.go` (`UpsertConfig` omits `post_policy`/`confidence_floor`; `ConfigRow.PostPolicy/ConfidenceFloor`).
+- `server/migrations/290_grading_agent.sql` (`post_policy` default `'unposted'`, `confidence_floor`).
+- Related: [GA-M3](missing-3-suggest-only-batch-and-bulk-review.md), [GA-M4](missing-4-confidence-auto-hold-threshold.md), [GA-S1](simplify-1-unify-grade-write-paths.md).

--- a/docs/plan/grading-agent/bug-4-post-dry-run-mispreviews-graphs.md
+++ b/docs/plan/grading-agent/bug-4-post-dry-run-mispreviews-graphs.md
@@ -1,0 +1,130 @@
+# GA-B4 — HTTP dry-run mis-previews complex graphs
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-B4 |
+| **Section** | Grading Agent — Bugs |
+| **Severity** | MINOR |
+| **Bug size** | Medium |
+| **Markets** | internal correctness |
+| **Status (today)** | BUG (latent — endpoint currently unused by the client) |
+| **Estimated effort** | XS (≤1d) |
+| **Owner (proposed)** | Assessment / Grading squad |
+| **Depends on** | — |
+| **Unblocks** | — |
+
+## 1. Problem Statement
+
+`handlePostGraderAgentDryRun` (`POST …/grader-agent/dry-run`) compiles the graph with
+`CompileWorkflowGraph` and then calls `svc.Score(scoreReq)` — a **single** LLM scoring call. It does not
+use the graph engine (`ExecuteWorkflowDryRun`). For any graph beyond "submission → AI/grader → output",
+this is wrong:
+
+- Routers, Human Review Gates, Flag-for-Review sinks, Score Aggregators, Originality, Reference, and
+  multi-criterion fan-out are **ignored** — the preview reflects only the single compiled grade source.
+- For a Code Test Runner or Score Aggregator grade source, `CompileWorkflowGraph` returns an **empty**
+  `ScoreRequest` (no submission text/prompt), so `svc.Score` fails with "submission text is empty" or
+  produces a meaningless preview.
+
+The client currently dodges this by only using the WebSocket dry run (`handleGraderAgentDryRunWS`, which
+*does* run the engine), so the POST handler is effectively dead (`postGraderAgentDryRun` is unused in
+`courses-api.ts`). But the divergence is a live trap: any future caller, test, or integration that hits
+the POST endpoint gets a silently incorrect preview that disagrees with how the submission is actually
+graded.
+
+## 2. Goals
+
+- Eliminate the divergence so there is a single source of truth for previews and live grading.
+- Either delete the POST endpoint ([GA-S2](simplify-2-remove-dead-dry-run-and-rename-engine.md)) or make it delegate to the same engine as the WS path and the consumer.
+
+## 3. Non-Goals
+
+- Changing the WebSocket dry-run protocol or behavior (it is correct).
+- Adding new preview features.
+
+## 4. Personas & User Stories
+
+- **As an engineer**, I want one preview engine, so that a dry run can never disagree with live grading.
+- **As an integrator**, I want the POST endpoint (if it exists) to return the true preview, so that I am not misled.
+
+## 5. Functional Requirements
+
+- **FR-1.** The POST dry-run endpoint MUST either be removed, or reimplemented to call `ExecuteWorkflowDryRun` (the engine) and return the same preview shape as the WS path for the same graph + submission.
+- **FR-2.** If retained, a graph whose grade source is a Code Test Runner or Score Aggregator MUST produce a correct preview (not an empty-`ScoreRequest` error).
+- **FR-3.** A graph with routers/gates/flags/aggregators MUST preview those effects (held/flagged/branch) identically to the WS path.
+- **FR-4.** Removal MUST also drop the unused client `postGraderAgentDryRun`.
+
+## 6. Non-Functional Requirements
+
+- **Reliability** — preview parity between POST (if kept), WS, and live grading, asserted by a shared test.
+- **Security** — reduce surface if removed.
+- **Backward compatibility** — no client impact (endpoint unused today).
+- **Maintainability** — single engine path.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a complex graph (router + gate + aggregator), *when* previewed via POST (if kept) and WS, *then* the previews match.
+- **AC-2.** *Given* a Code-Test-Runner grade source, *when* previewed via POST (if kept), *then* it returns a correct preview, not "submission text is empty".
+- **AC-3.** *Given* removal, *when* grepping, *then* `handlePostGraderAgentDryRun` and `postGraderAgentDryRun` are gone and the route is unregistered.
+
+## 8. Data Model
+
+- None.
+
+## 9. API Surface
+
+- Remove `POST …/grader-agent/dry-run` (preferred), or change its implementation to delegate to the engine. Update OpenAPI either way.
+
+## 10. UI / UX
+
+- None (endpoint not surfaced).
+
+## 11. AI / ML Considerations
+
+- Ensures previews and live grading use one engine, so token/cost and outputs are consistent.
+
+## 12. Integration Points
+
+- `server/internal/httpserver/grading_agent_http.go` (`handlePostGraderAgentDryRun`, `dryRunGraderAgentBody`).
+- `server/internal/httpserver/grading_agent_dry_run_ws.go` (the correct engine call to mirror).
+- `server/internal/httpserver/courses_routes.go` (route).
+- `clients/web/src/lib/courses-api.ts` (`postGraderAgentDryRun`).
+
+## 13. Dependencies & Sequencing
+
+- This is the bug; [GA-S2](simplify-2-remove-dead-dry-run-and-rename-engine.md) is the matching cleanup. Resolve together (removal satisfies both).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| A hidden caller relies on the POST endpoint | L | M | API analytics + grep before removal; otherwise delegate to engine instead of deleting |
+
+## 15. Rollout Plan
+
+- Sequence: confirm no callers → remove (or delegate) → ship.
+- Rollback: revert (pure code change).
+
+## 16. Test Plan
+
+- **Integration** — if kept, POST and WS previews match for representative graphs; if removed, route 404s and build is green.
+- **Static** — no dangling references.
+
+## 17. Documentation & Training
+
+- OpenAPI updated; note that dry run is WS-only (or engine-backed POST).
+
+## 18. Open Questions
+
+1. Keep a non-WS preview endpoint (engine-backed) for non-WebSocket clients, or remove outright?
+
+## 19. References
+
+- `server/internal/httpserver/grading_agent_http.go` (`handlePostGraderAgentDryRun` → `svc.Score`).
+- `server/internal/service/gradingagent/workflow.go` (`CompileWorkflowGraph` returns empty `ScoreRequest` for code-test/aggregator sources).
+- `server/internal/httpserver/grading_agent_dry_run_ws.go` (`ExecuteWorkflowDryRun`).
+- Related: [GA-S2](simplify-2-remove-dead-dry-run-and-rename-engine.md).

--- a/docs/plan/grading-agent/bug-5-run-polling-robustness.md
+++ b/docs/plan/grading-agent/bug-5-run-polling-robustness.md
@@ -1,0 +1,124 @@
+# GA-B5 — Run-status polling robustness
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-B5 |
+| **Section** | Grading Agent — Bugs |
+| **Severity** | MINOR |
+| **Bug size** | Small |
+| **Markets** | HE / K12 / SL |
+| **Status (today)** | BUG |
+| **Estimated effort** | XS (≤1d) |
+| **Owner (proposed)** | Web / Grading squad |
+| **Depends on** | — |
+| **Unblocks** | — |
+
+## 1. Problem Statement
+
+The batch-run poller in `use-grader-agent-workflow.ts` has two minor robustness issues:
+
+1. **Late interval clear.** `poll()` is invoked immediately (`void poll()`) **before** `timer` is
+   assigned, and the "finished" branch only clears the interval when `timer !== undefined`. If a run is
+   already `done` on the very first poll, that first invocation cannot clear the (not-yet-created)
+   interval, so the interval is still created and fires at least one extra time before the next branch
+   clears it. Harmless but sloppy, and it makes the "done" path do one redundant network round trip.
+2. **Repeated `onApplied`.** `processRunStatus` calls `onApplied?.()` on every terminal poll, and
+   `syncAppliedResultToCanvas` is invoked for every `applied` result on every poll (guarded by a ref
+   set, so mostly idempotent). `onApplied` (which typically refreshes the gradebook) can fire more than
+   necessary, causing extra refetches.
+
+Neither corrupts data, but both add avoidable network chatter and make the polling logic harder to reason about — and they sit right next to the more serious lifecycle gaps in [GA-B1](bug-1-queue-overflow-and-stuck-runs.md).
+
+## 2. Goals
+
+- Stop polling promptly and exactly once when a run is terminal (including terminal-on-first-poll).
+- Fire `onApplied` once on terminal, not repeatedly.
+- Make the poller resilient to terminal `failed`/`cancelled` states (ties to [GA-B1](bug-1-queue-overflow-and-stuck-runs.md), [GA-M6](missing-6-cancel-running-batch.md)).
+
+## 3. Non-Goals
+
+- Switching from polling to WebSocket/SSE for batch progress (possible future, not here).
+- Changing the 1.5 s cadence.
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I want progress to settle immediately when a run finishes, so that the UI does not flicker or refetch needlessly.
+- **As a web engineer**, I want clear poll lifecycle, so that terminal states are handled in one place.
+
+## 5. Functional Requirements
+
+- **FR-1.** When a run is terminal on the first poll, the poller MUST NOT start (or MUST immediately stop) the interval — no extra request.
+- **FR-2.** The interval MUST be cleared exactly once on terminal, regardless of which poll observed it.
+- **FR-3.** `onApplied` MUST fire once per run completion, not on every terminal poll.
+- **FR-4.** The poller MUST treat `failed` and `cancelled` as terminal and stop (forward-compatible with [GA-B1](bug-1-queue-overflow-and-stuck-runs.md)/[GA-M6](missing-6-cancel-running-batch.md)).
+- **FR-5.** Use a ref/flag to guard against double-finalization across overlapping polls.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — fewer redundant requests and gradebook refetches.
+- **Reliability** — deterministic single finalization.
+- **Accessibility** — `statusMessage`/`aria-live` settles to one final value.
+- **Backward compatibility** — internal behavior only.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a run that is `done` on first poll, *when* polling starts, *then* at most one status request is made and no interval lingers.
+- **AC-2.** *Given* a run that completes after several polls, *when* it finishes, *then* `onApplied` fires once and polling stops.
+- **AC-3.** *Given* a `failed`/`cancelled` run, *when* observed, *then* polling stops and the terminal state is shown.
+
+## 8. Data Model
+
+- None.
+
+## 9. API Surface
+
+- None.
+
+## 10. UI / UX
+
+- No visible change beyond fewer flickers/refetches; terminal status settles cleanly.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- `clients/web/src/components/annotation/grader-agent/use-grader-agent-workflow.ts` (the poll `useEffect`, `processRunStatus`, `finished` handling, `onApplied`).
+
+## 13. Dependencies & Sequencing
+
+- Small; best landed with [GA-B1](bug-1-queue-overflow-and-stuck-runs.md) so terminal `failed`/`cancelled` are handled together.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Over-eager finalization stops a still-running poll | L | M | Finalize only on explicit terminal statuses; guard with a `finishedRef` |
+
+## 15. Rollout Plan
+
+- Single PR; no flag. Covered by hook/component tests.
+- Rollback: revert PR.
+
+## 16. Test Plan
+
+- **Unit/Component** — terminal-on-first-poll stops cleanly; `onApplied` fires once; failed/cancelled stop polling.
+- **Manual** — observe network panel: no polling after terminal.
+
+## 17. Documentation & Training
+
+- None beyond PR notes.
+
+## 18. Open Questions
+
+1. Move batch progress to the existing WS channel instead of polling (larger change, separate plan)?
+
+## 19. References
+
+- `clients/web/src/components/annotation/grader-agent/use-grader-agent-workflow.ts` (poll `useEffect` ~L379–407; `processRunStatus` ~L327–377).
+- Related: [GA-B1](bug-1-queue-overflow-and-stuck-runs.md), [GA-M6](missing-6-cancel-running-batch.md).

--- a/docs/plan/grading-agent/missing-1-persistent-review-queue.md
+++ b/docs/plan/grading-agent/missing-1-persistent-review-queue.md
@@ -1,0 +1,168 @@
+# GA-M1 — Persistent, actionable review queue & run history
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-M1 |
+| **Section** | Grading Agent — Missing Features |
+| **Severity** | BLOCKER |
+| **Markets** | HE / K12 / SL |
+| **Status (today)** | PARTIAL |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Assessment / Grading squad |
+| **Depends on** | — |
+| **Unblocks** | [GA-M3](missing-3-suggest-only-batch-and-bulk-review.md), [GA-M6](missing-6-cancel-running-batch.md), [GA-M7](missing-7-cost-estimate-and-budget.md) |
+
+---
+
+## 1. Problem Statement
+
+Held items (Human Review Gate) and flagged items (Flag for Review) only exist in the UI while the
+grading-agent modal is open and a `runId` is held in React state (`use-grader-agent-workflow.ts`).
+The moment the instructor closes the modal, the in-memory `runId` is lost and there is **no endpoint
+to list an assignment's runs or re-open the latest run** — only `GET …/runs/{run_id}` by id. The
+flagged queue (`review-queue-panel.tsx`) is also **read-only**: it lists a reason and priority with
+no approve/grade/dismiss action. The result is that a TA who batch-grades 120 essays, sees "18 held
+for review," and closes the tab cannot get back to those 18 items. This makes the human-in-the-loop
+story — the main reason an instructor trusts the agent — effectively unusable across sessions.
+
+## 2. Goals
+
+- A durable, re-openable review queue scoped to an assignment (and to the course) that survives modal close.
+- Make **flagged** items actionable (open submission, grade, dismiss/resolve, re-run) — parity with the held queue.
+- Run history per agent: who ran it, when, scope, model, counts, cost, status.
+- A single "needs my attention" count surfaced where graders already work (assignment page, gradebook, course agents list).
+
+## 3. Non-Goals
+
+- Cross-tenant or admin-wide review dashboards (course scope is enough for v1).
+- Changing how held/flagged decisions are *made* (that is the gate/flag node config; see [GA-M4](missing-4-confidence-auto-hold-threshold.md)).
+- A new notification channel beyond the existing inbox.
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I want to reopen the list of held/flagged submissions after closing the grader, so that review is not a single-session task.
+- **As a TA**, I want one place that shows "N submissions awaiting your review" across runs, so that I can clear the queue between classes.
+- **As an instructor**, I want to act on a flagged item (open it, grade it, or dismiss the flag), so that flagging is not a dead end.
+- **As an instructor**, I want a run history with model + counts + cost, so that I can audit what the agent did.
+- **As an admin**, I want runs and review actions retained for FERPA audit, so that AI grading is accountable.
+
+## 5. Functional Requirements
+
+- **FR-1.** The system MUST expose `GET …/assignments/{item_id}/grader-agent/runs` returning runs ordered by `created_at desc` with status, scope, counts, initiated_by, model, and cost.
+- **FR-2.** The system MUST expose a review queue read model: held (`status = suggested` with `held_at`) and flagged (`status = flagged`) results for an assignment across all non-dry-run runs, with submission/student labels.
+- **FR-3.** The UI MUST render the review queue from that read model independent of any live `runId`, and on modal open MUST hydrate it for the current assignment.
+- **FR-4.** Flagged items MUST support actions: **open submission**, **grade now** (write a grade + mark `applied`/`overridden`), and **dismiss** (mark `skipped` with a reason). These reuse the held-queue handlers in `held-review-queue-panel.tsx`.
+- **FR-5.** The review queue count MUST be surfaced on the assignment page action menu and on the course "Grading agents" list row.
+- **FR-6.** A held/flagged item MUST be **deduplicated by submission** in the read model (latest non-terminal result per submission wins) so re-runs do not stack duplicates.
+- **FR-7.** Review actions MUST be permission-gated identically to existing grading (`course:{code}:item:create`).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — review-queue read model p95 < 300 ms for an assignment with 1k submissions; paginate at 100.
+- **Security** — same RBAC as `requireGraderAgentAccess`; no cross-course leakage of labels.
+- **Privacy & Compliance** — respect blind/anonymous grading: labels MUST use `blindLabel` when the assignment is anonymized; retain run/result rows per the existing audit retention policy (FERPA).
+- **Accessibility** — queue is a list with actionable buttons; `aria-live` count; full keyboard operation; focus returns to the triggering row after an action.
+- **Scalability** — indexed reads (see §8); no N+1 per item for labels.
+- **Reliability** — actions are idempotent (grading an already-graded item is a safe upsert).
+- **Observability** — emit metrics for queue size, time-to-review, and action outcomes.
+- **Internationalization** — all new strings under `gradingAgent.review.*`.
+- **Backward compatibility** — additive; existing per-run polling continues to work.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a completed batch run with held items, *when* I close and reopen the grader for that assignment, *then* the held items still appear and are actionable.
+- **AC-2.** *Given* a flagged item, *when* I click "Grade now" and submit a score, *then* the result becomes `applied`/`overridden` and the grade is written to the gradebook.
+- **AC-3.** *Given* a flagged item, *when* I click "Dismiss" with a reason, *then* it becomes `skipped` and leaves the queue.
+- **AC-4.** *Given* two runs that both touched submission X, *when* I open the queue, *then* X appears at most once.
+- **AC-5.** *Given* an anonymized assignment, *when* the queue renders, *then* no student name is shown.
+- **AC-6.** *Given* an assignment with 3 items needing review, *when* I view the assignment page, *then* a "3 to review" affordance is shown.
+
+## 8. Data Model
+
+- No new tables required; `grading_agent_runs` and `grading_agent_results` already store everything.
+- Add indexes:
+  - `CREATE INDEX ON assessment.grading_agent_runs (config_id, created_at DESC);`
+  - `CREATE INDEX ON assessment.grading_agent_results (config_id, status) WHERE is_dry_run = false;`
+- Optional column on results: `resolved_at TIMESTAMPTZ`, `resolved_by UUID` to record who cleared a held/flagged item (else infer from status transition).
+- Migration: `server/migrations/NNN_grading_agent_review_indexes.sql` (next free number).
+- Backfill: none (indexes only); resolved_* nullable.
+
+## 9. API Surface
+
+- `GET …/assignments/{item_id}/grader-agent/runs` → `{ runs: [{ id, scope, status, totalCount, completedCount, failedCount, model, costUsd, initiatedBy, createdAt, finishedAt }] }`.
+- `GET …/assignments/{item_id}/grader-agent/review-queue` → `{ held: [...], flagged: [...] }` (dedup per submission, includes labels).
+- Reuse existing `PATCH …/results/{result_id}` for dismiss/apply; extend `handlePatchGraderAgentResult` to accept `flagged → applied/overridden/skipped` transitions (today only suggested→applied/overridden/skipped is the implicit expectation).
+- Rate-limit identical to other grading endpoints; document in OpenAPI.
+
+## 10. UI / UX
+
+- New `ReviewInbox` surface reachable from (a) the grader modal (hydrated independent of live run) and (b) the course "Grading agents" section as a per-agent "Review (N)" link.
+- Upgrade `review-queue-panel.tsx` (flagged) to the same action set as `held-review-queue-panel.tsx`.
+- States: empty ("Nothing to review"), loading skeleton, error, and per-item busy.
+- Mobile: single-column cards; actions wrap.
+- Accessibility: `aria-live="polite"` on counts; focus management after each action.
+- Copy/i18n: `gradingAgent.review.*`.
+
+## 11. AI / ML Considerations
+
+- None new. Re-grading from the queue may re-invoke the agent (see [GA-M3](missing-3-suggest-only-batch-and-bulk-review.md)); cost is attributed to the re-run.
+
+## 12. Integration Points
+
+- `server/internal/httpserver/grading_agent_http.go` (new handlers), `courses_routes.go` (routes).
+- `server/internal/repos/gradingagent/repo.go` (`ListRunsByConfig`, `ListReviewQueueByConfig`).
+- `clients/web/src/components/annotation/grader-agent/{review-queue-panel,held-review-queue-panel,use-grader-agent-workflow}.tsx/ts`.
+- `clients/web/src/pages/lms/course-grading-agents-section.tsx`, assignment page action menu.
+
+## 13. Dependencies & Sequencing
+
+- Must ship before [GA-M6](missing-6-cancel-running-batch.md) and [GA-M7](missing-7-cost-estimate-and-budget.md) so cancel/cost have a run-history home.
+- Shared infra: none beyond Postgres.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Dedup logic hides a genuinely re-run item | M | M | Dedup by (submission, latest createdAt); show run timestamp on each card |
+| Label lookups N+1 | M | M | Batch-resolve labels in one query keyed by submission ids |
+| Blind-grading identity leak | L | H | Centralize label resolution; cover with a test on anonymized assignments |
+
+## 15. Rollout Plan
+
+- Flag: `graderAgentReviewInbox` (default off → dogfood → on).
+- Sequence: migration (indexes) → repo reads → API → UI → flip flag.
+- Pilot: a TA-heavy course; GA when queue actions and counts verified.
+- Rollback: hide UI via flag; endpoints are read-only/idempotent.
+
+## 16. Test Plan
+
+- **Unit** — dedup + label resolution; PATCH transition matrix (flagged→applied/overridden/skipped).
+- **Integration** — list runs / review queue across multiple runs; RBAC denial.
+- **E2E** — batch run → close modal → reopen → act on held + flagged items → gradebook reflects change.
+- **Security** — cross-course access denied; anonymized labels.
+- **Accessibility** — axe + keyboard-only walkthrough.
+- **Performance** — 1k-result assignment read p95.
+
+## 17. Documentation & Training
+
+- Help-center: "Reviewing AI-suggested and flagged grades."
+- Instructor doc: where the review inbox lives and how counts work.
+- API reference + runbook for the new endpoints.
+
+## 18. Open Questions
+
+1. Should the inbox aggregate across *all* assignments in a course (a true grader inbox) in v1, or per-assignment only?
+2. Do we keep dry-run results out of the queue entirely (current assumption) or show the latest dry run as a preview?
+3. Should "dismiss" on a flagged item leave the submission ungraded or require a grade?
+
+## 19. References
+
+- `clients/web/src/components/annotation/grader-agent/use-grader-agent-workflow.ts` (`runId`, `processRunStatus`, `refreshRunResults`).
+- `clients/web/src/components/annotation/grader-agent/{review-queue-panel,held-review-queue-panel}.tsx`.
+- `server/internal/httpserver/grading_agent_http.go` (`handleGetGraderAgentRun`, `handlePatchGraderAgentResult`).
+- `server/internal/repos/gradingagent/repo.go`.
+- Related: [GA-M3](missing-3-suggest-only-batch-and-bulk-review.md), [GA-M4](missing-4-confidence-auto-hold-threshold.md).

--- a/docs/plan/grading-agent/missing-2-non-file-submission-grading.md
+++ b/docs/plan/grading-agent/missing-2-non-file-submission-grading.md
@@ -1,0 +1,154 @@
+# GA-M2 — Grade non-file (online text-entry) & image/scanned submissions
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-M2 |
+| **Section** | Grading Agent — Missing Features |
+| **Severity** | BLOCKER |
+| **Markets** | HE / K12 |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Assessment / Grading squad |
+| **Depends on** | — |
+| **Unblocks** | broad agent adoption |
+
+## 1. Problem Statement
+
+The agent can only grade a submission that has a **file attachment** whose bytes convert to non-empty
+text. `gradableSubmissionsForAgent` drops every submission where `AttachmentFileID == nil`, and
+`LoadSubmissionMarkdownsForSubmission` errors with "no submission text available" when there are no
+file refs. Two extremely common Higher-Ed submission types are therefore ungradable:
+
+1. **Online text-entry** submissions (student types an essay/short answer directly into the box) — no file at all.
+2. **Image-only or scanned PDF** submissions (handwritten math, lab sketches, scanned problem sets) — a file exists but markitdown yields no extractable text.
+
+For these, a batch run reports "No submissions with readable file attachments matched this scope," and
+the instructor reasonably concludes the agent is broken. Any class that uses text-entry or handwritten
+work cannot adopt the agent.
+
+## 2. Goals
+
+- Grade online text-entry submissions (body text stored on the submission, no file).
+- Grade image/scanned submissions via a vision-capable model path (or explicit OCR), behind config.
+- Give a clear, per-submission reason when something truly cannot be read, instead of silently excluding it.
+
+## 3. Non-Goals
+
+- Grading binary artifacts that are out of scope for text/vision (e.g., raw video) — those route to manual.
+- Building a bespoke OCR engine; prefer a vision model or an existing OCR dependency.
+- Changing the rubric/scoring contract.
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I want the agent to read text typed into the submission box, so that essay/short-answer classes can use it.
+- **As a math/physics TA**, I want the agent to read a scanned/handwritten PDF or photo, so that problem sets are gradable.
+- **As an instructor**, I want a clear per-student note when a submission can't be read, so that I know exactly what to grade by hand.
+
+## 5. Functional Requirements
+
+- **FR-1.** The agent MUST grade submissions whose content is online text-entry (no file) by sourcing the submission body text.
+- **FR-2.** `gradableSubmissionsForAgent` MUST include text-entry submissions, not only `AttachmentFileID != nil`.
+- **FR-3.** When a file yields empty text and the platform has a vision-capable grader model configured, the system SHOULD send the image/PDF pages to the vision path instead of failing.
+- **FR-4.** When neither text nor vision can read a submission, the system MUST record a per-submission `failed` result with a human-readable reason (surfaced in the review queue, [GA-M1](missing-1-persistent-review-queue.md)) rather than excluding it from the run.
+- **FR-5.** The Student Submission node MUST advertise which input modalities a given submission provides (text / file / image) in the dry-run log.
+- **FR-6.** Vision usage MUST pass through the same AI-gateway opt-in / PII / cost accounting as text grading.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — text-entry path adds no LLM cost beyond existing; vision path capped by page count (configurable, default ≤ 10 pages).
+- **Security** — image bytes handled with the same storage auth as files; signed reads only.
+- **Privacy & Compliance** — PII redaction applies to extracted/typed text; vision requests honor tenant BYOK and opt-in; FERPA-safe logging (no raw content in logs).
+- **Accessibility** — n/a (backend); failure reasons localized.
+- **Scalability** — vision requests are heavier; respect per-run concurrency and budget ([GA-M7](missing-7-cost-estimate-and-budget.md)).
+- **Reliability** — a single unreadable submission never fails the whole run.
+- **Observability** — metric: submissions by modality (text/file/vision/unreadable) per run.
+- **Internationalization** — failure reasons under `gradingAgent.*`.
+- **Backward compatibility** — file-text path unchanged.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a text-entry submission, *when* the agent runs, *then* it grades the typed body and writes a grade.
+- **AC-2.** *Given* a scanned PDF and a configured vision model, *when* the agent runs, *then* it grades from the rendered pages.
+- **AC-3.** *Given* an unreadable submission, *when* the agent runs, *then* a `failed` result with reason appears in the review queue and the run still completes.
+- **AC-4.** *Given* no vision model configured, *when* an image-only submission is encountered, *then* the reason explicitly says vision grading is not enabled.
+- **AC-5.** *Given* a mixed scope (text-entry + file + image), *when* the batch runs, *then* every submission is attempted and accounted for.
+
+## 8. Data Model
+
+- No new tables. Confirm the submission row exposes body text for online text-entry (`moduleassignmentsubmissions`); add a read accessor if missing.
+- Optionally record per-result `input_modality TEXT` on `grading_agent_results` for analytics.
+- Migration only if `input_modality` is added: `server/migrations/NNN_grading_agent_input_modality.sql`.
+
+## 9. API Surface
+
+- No new public routes. Internal `Service` gains a submission-content resolver that returns `{text, images[]}` from text-entry body and/or files.
+- Dry-run WS log gains modality lines (existing `DryRunEvent` log type).
+
+## 10. UI / UX
+
+- Run scope copy updated: remove the implication that only file submissions count.
+- Per-submission failure reasons render in the review queue and dry-run console.
+- Settings: surface whether a vision-capable grader model is configured (links to AI settings).
+
+## 11. AI / ML Considerations
+
+- Vision path uses a vision-capable model id (per-tenant BYOK respected). Prompt mirrors text grading but with image parts.
+- Page/image cap and downscaling to bound cost; PII redaction on any extracted text.
+- Fallback order: text-entry body → file text → vision (if enabled) → `failed` with reason.
+
+## 12. Integration Points
+
+- `server/internal/service/gradingagent/submission_markdown.go` (content resolver), `service.go` (vision call path).
+- `server/internal/httpserver/grading_agent_http.go` + `grading_agent_queue.go` (scope selection, per-submission failure recording).
+- `moduleassignmentsubmissions` repo (body text accessor).
+- AI gateway + openrouter client for vision.
+
+## 13. Dependencies & Sequencing
+
+- Best sequenced with [GA-M1](missing-1-persistent-review-queue.md) so per-submission failures are reviewable.
+- Vision requires a configured vision model (ties to existing AI provider settings).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Vision cost surprises instructors | M | H | Gate behind config + budget/estimate ([GA-M7](missing-7-cost-estimate-and-budget.md)) |
+| OCR/vision accuracy on messy handwriting | M | M | Always route low-confidence to review ([GA-M4](missing-4-confidence-auto-hold-threshold.md)); never silently auto-apply |
+| Large scanned PDFs blow token limits | M | M | Page cap + downscale; clear failure reason |
+
+## 15. Rollout Plan
+
+- Flags: `graderAgentTextEntryGrading` (low-risk, default on after dogfood), `graderAgentVisionGrading` (default off).
+- Sequence: text-entry path → ship; vision path → dogfood → opt-in.
+- Pilot: an essay course (text-entry) and a STEM course (scanned).
+- Rollback: disable vision flag; text-entry path is additive and safe.
+
+## 16. Test Plan
+
+- **Unit** — content resolver fallback order; failure-reason mapping.
+- **Integration** — text-entry submission graded end-to-end; unreadable submission produces reviewable failure.
+- **E2E** — mixed-modality batch; counts reconcile.
+- **Security** — signed image reads; PII redaction on typed text.
+- **Performance** — vision page cap honored.
+
+## 17. Documentation & Training
+
+- Help-center: "Which submission types the grading agent can read."
+- Admin doc: enabling vision grading and its cost profile.
+
+## 18. Open Questions
+
+1. Do we render scanned PDFs to images server-side, or rely on the model's native PDF support?
+2. Should text-entry + attachments be concatenated, or graded as the student's "primary" content only?
+3. Is there a per-assignment switch to force manual grading for image submissions regardless of vision availability?
+
+## 19. References
+
+- `server/internal/service/gradingagent/submission_markdown.go` (`LoadSubmissionMarkdownsForSubmission`).
+- `server/internal/httpserver/grading_agent_http.go` (`gradableSubmissionsForAgent`, `resolveGraderAgentSubmissions`).
+- `server/internal/service/gradingagent/service.go` (`Score`, PII redaction).
+- Related: [GA-M1](missing-1-persistent-review-queue.md), [GA-M4](missing-4-confidence-auto-hold-threshold.md), [GA-M7](missing-7-cost-estimate-and-budget.md).

--- a/docs/plan/grading-agent/missing-3-suggest-only-batch-and-bulk-review.md
+++ b/docs/plan/grading-agent/missing-3-suggest-only-batch-and-bulk-review.md
@@ -1,0 +1,148 @@
+# GA-M3 — Suggest-only batch + bulk review/apply + posting control
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-M3 |
+| **Section** | Grading Agent — Missing Features |
+| **Severity** | MAJOR |
+| **Markets** | HE / K12 |
+| **Status (today)** | PARTIAL |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Assessment / Grading squad |
+| **Depends on** | [GA-M1](missing-1-persistent-review-queue.md) |
+| **Unblocks** | trust-driven adoption |
+
+## 1. Problem Statement
+
+A batch run **writes grades immediately**. In `HandleGradingAgentQueueMessage`, every non-held,
+non-flagged item calls `coursegrades.UpsertCellWithFlags(...)` as it is processed. The only way to get
+"AI suggests, human approves" is to hand-build a graph with a Human Review Gate on every path. There
+is no first-class **suggest-only** batch mode and no **bulk review/apply** of suggestions. New adopters
+almost universally want to start in suggest-only mode (AI drafts, instructor spot-checks and approves
+in bulk) before trusting auto-apply. Additionally, applied grades are always written with
+`posting = "manual"` because the auto-post branch is unreachable (see [GA-B3](bug-3-auto-post-dead-code.md)),
+so there is no coherent control over whether students see AI grades.
+
+## 2. Goals
+
+- A run mode toggle: **Suggest only** (nothing is written to the gradebook; all items land in the review queue) vs **Auto-apply**.
+- Bulk actions over suggestions: approve all, approve above a confidence threshold, approve selected, edit-then-approve, reject selected.
+- One clear posting control: keep AI grades as draft (unposted) or post on apply, per agent.
+
+## 3. Non-Goals
+
+- Replacing the Human Review Gate node (it remains for per-path control); this is the simple, whole-run switch.
+- Changing the gradebook's own posting/hide mechanics — only choosing which posting state the agent writes.
+
+## 4. Personas & User Stories
+
+- **As a cautious instructor**, I want a suggest-only run so I can review every AI grade before any student sees it.
+- **As a TA with 200 submissions**, I want "approve all above 85% confidence" so I only hand-check the uncertain ones.
+- **As an instructor**, I want to keep AI grades unposted until I post them, so students never see an unreviewed grade.
+
+## 5. Functional Requirements
+
+- **FR-1.** The run request MUST accept a `mode` of `suggest` or `apply` (default `suggest` for a newly accepted agent).
+- **FR-2.** In `suggest` mode the consumer MUST record results as `suggested` (held) and MUST NOT call `UpsertCellWithFlags`.
+- **FR-3.** The review queue ([GA-M1](missing-1-persistent-review-queue.md)) MUST support bulk **approve all**, **approve ≥ confidence X**, **approve selected**, **reject selected**, and **edit + approve** for a single item.
+- **FR-4.** Approving a suggestion MUST write the grade and mark the result `applied` (or `overridden` if edited).
+- **FR-5.** The agent config MUST carry a posting choice (`draft` vs `auto_post`) that is **persisted and read** at write time — fixing the dead `post_policy` path ([GA-B3](bug-3-auto-post-dead-code.md)).
+- **FR-6.** Bulk apply MUST be transactional per batch chunk and idempotent (re-approving an applied item is a no-op).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — bulk approve of 500 items completes < 10 s; chunked writes.
+- **Security** — same RBAC as grading; posting choice respects course posting policy.
+- **Privacy & Compliance** — suggest-only guarantees no student visibility until approval (FERPA-friendly default).
+- **Accessibility** — bulk controls keyboard-operable; selection has clear focus + `aria-selected`.
+- **Reliability** — partial bulk failures report per-item outcomes; no half-written state.
+- **Observability** — metrics: suggest vs apply runs, bulk-approve sizes, edit rate.
+- **Internationalization** — `gradingAgent.run.mode.*`, `gradingAgent.review.bulk.*`.
+- **Backward compatibility** — existing runs default to today's behavior under a flag until GA.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a suggest-only run, *when* it completes, *then* no gradebook cells changed and all items are in the review queue.
+- **AC-2.** *Given* 50 suggestions, *when* I "approve all ≥ 80%", *then* only those write grades and the rest remain.
+- **AC-3.** *Given* a suggestion, *when* I edit the score and approve, *then* the result is `overridden` with my values.
+- **AC-4.** *Given* an agent set to `draft`, *when* grades are applied, *then* they are written unposted.
+- **AC-5.** *Given* an agent set to `auto_post` and an assignment that posts automatically, *when* grades are applied, *then* they are posted.
+
+## 8. Data Model
+
+- `grading_agent_runs`: add `mode TEXT NOT NULL DEFAULT 'suggest'` (`suggest`|`apply`).
+- `grading_agent_configs`: make `post_policy` writable (already exists; `'unposted'` default → allow `'auto_post'`).
+- Migration: `server/migrations/NNN_grading_agent_run_mode.sql`.
+- Backfill: existing runs are historical; default `apply` for backfilled rows to preserve meaning, `suggest` for new.
+
+## 9. API Surface
+
+- `POST …/grader-agent/runs` body gains `mode`.
+- `PUT …/grader-agent` config body gains `postPolicy` (`draft`|`auto_post`); persisted by `UpsertConfig` (extend `UpsertConfigInput`).
+- New bulk endpoint `POST …/grader-agent/review/bulk` `{ action, resultIds?|filter }` → per-item outcomes. (Or extend PATCH with batch semantics.)
+
+## 10. UI / UX
+
+- Run popover (`run-agent-popover.tsx`) gains a **Suggest only / Auto-apply** segmented control and a posting note.
+- Review queue gains a bulk toolbar: select-all, "approve ≥ [confidence]", approve/reject selected.
+- Empty/loading/error states; confirmation on "approve all".
+- Copy/i18n under `gradingAgent.run.mode.*` and `gradingAgent.review.bulk.*`.
+
+## 11. AI / ML Considerations
+
+- None new; suggest-only still runs the model once per submission. Confidence threshold for bulk approve reuses model confidence already returned.
+
+## 12. Integration Points
+
+- `server/internal/httpserver/grading_agent_queue.go` (mode-aware write), `grading_agent_http.go` (run body, config body, bulk endpoint).
+- `server/internal/repos/gradingagent/repo.go` (`UpsertConfigInput.PostPolicy`, run `mode`).
+- `clients/web/src/components/annotation/grader-agent/{run-agent-popover,review-queue-panel,held-review-queue-panel}.tsx`, `use-grader-agent-workflow.ts`.
+
+## 13. Dependencies & Sequencing
+
+- Requires [GA-M1](missing-1-persistent-review-queue.md) (the durable queue) to host suggestions and bulk actions.
+- Pairs with [GA-B3](bug-3-auto-post-dead-code.md) (posting) and [GA-M4](missing-4-confidence-auto-hold-threshold.md) (confidence).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Suggest-only confuses users expecting grades written | M | M | Clear mode copy + post-run summary "0 written, N to review" |
+| Bulk approve writes wrong grades at scale | L | H | Dry-run-style confirmation count + per-item outcome report + idempotency |
+| `mode` backfill changes historical meaning | L | M | Backfill historical runs to `apply` |
+
+## 15. Rollout Plan
+
+- Flag: `graderAgentSuggestMode`.
+- Sequence: migration → consumer mode branch + posting write → run/config API → review bulk UI → flip flag (default suggest for new agents).
+- Pilot: a course onboarding the agent for the first time.
+- Rollback: flag off → revert to immediate apply.
+
+## 16. Test Plan
+
+- **Unit** — consumer write/no-write by mode; posting decision matrix; bulk filter selection.
+- **Integration** — suggest run writes nothing; approve writes grade; auto_post posts.
+- **E2E** — suggest run → bulk approve ≥ threshold → gradebook reflects only approved.
+- **Security** — bulk action RBAC; idempotent re-approve.
+
+## 17. Documentation & Training
+
+- Help-center: "Suggest-only vs auto-apply, and approving AI grades in bulk."
+- Instructor onboarding checklist recommends suggest-only first.
+
+## 18. Open Questions
+
+1. Should the default for a brand-new accepted agent be `suggest` (recommended) and switch to `apply` only after the instructor opts in?
+2. Should "approve ≥ confidence" use model confidence or also factor originality/flag signals?
+3. Do we expose posting choice at run time as well as config time?
+
+## 19. References
+
+- `server/internal/httpserver/grading_agent_queue.go` (`UpsertCellWithFlags`, `posting` derivation).
+- `server/internal/repos/gradingagent/repo.go` (`UpsertConfig`, `CreateRun`).
+- `clients/web/src/components/annotation/grader-agent/run-agent-popover.tsx`, `held-review-queue-panel.tsx`.
+- Related: [GA-M1](missing-1-persistent-review-queue.md), [GA-M4](missing-4-confidence-auto-hold-threshold.md), [GA-B3](bug-3-auto-post-dead-code.md).

--- a/docs/plan/grading-agent/missing-4-confidence-auto-hold-threshold.md
+++ b/docs/plan/grading-agent/missing-4-confidence-auto-hold-threshold.md
@@ -1,0 +1,140 @@
+# GA-M4 — Agent-level confidence auto-hold threshold
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-M4 |
+| **Section** | Grading Agent — Missing Features |
+| **Severity** | MAJOR |
+| **Markets** | HE / K12 / SL |
+| **Status (today)** | THIN |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Assessment / Grading squad |
+| **Depends on** | [GA-M1](missing-1-persistent-review-queue.md) |
+| **Unblocks** | confident auto-apply |
+
+## 1. Problem Statement
+
+To hold low-confidence grades for human review, an instructor must drop a **Human Review Gate** node
+onto the canvas and wire it on every grade path. The data model already anticipated a simpler control —
+`grading_agent_configs.confidence_floor NUMERIC` exists and is read into `ConfigRow.ConfidenceFloor` —
+but it is **never written and never used** anywhere in the codebase. The common ask ("auto-apply grades
+the model is confident about; send everything below 80% to me") therefore requires graph surgery that
+most instructors will not do. This both under-delivers the obvious feature and leaves a dead column.
+
+## 2. Goals
+
+- A single per-agent setting: "Hold for review when confidence is below X%."
+- Wire the existing `confidence_floor` column end-to-end (config API → consumer → review queue).
+- Make it composable with suggest-only mode and the Human Review Gate (gate still wins when stricter).
+
+## 3. Non-Goals
+
+- Replacing the Human Review Gate node (it stays for per-branch logic).
+- Inventing a new confidence metric — reuse the model confidence already returned in `GradeOutput.Confidence`.
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I want to auto-apply confident grades and review the rest, so that I save time without losing oversight.
+- **As a TA**, I want a course-wide default floor, so that every agent behaves consistently.
+
+## 5. Functional Requirements
+
+- **FR-1.** The agent config MUST expose `confidenceFloor` (0–1, nullable) via GET/PUT, persisted by `UpsertConfig`.
+- **FR-2.** At write time, the consumer MUST hold (record `suggested` + `held_reason`) any item whose `Confidence < confidenceFloor` instead of applying it.
+- **FR-3.** The floor MUST apply in both apply-mode batch runs and auto-grade-on-submission.
+- **FR-4.** When a Human Review Gate also holds, the stricter outcome wins (gate hold OR floor hold ⇒ held); reasons are combined.
+- **FR-5.** A null/zero floor MUST preserve today's behavior (no extra holding).
+- **FR-6.** The held reason MUST state the threshold and the observed confidence (e.g., "Confidence 0.62 < floor 0.80").
+
+## 6. Non-Functional Requirements
+
+- **Performance** — pure comparison; negligible.
+- **Security** — same RBAC as config edits.
+- **Privacy & Compliance** — held items are not written to the gradebook, so low-confidence AI grades never reach students unreviewed.
+- **Accessibility** — slider/number input with label, min/max, and step; value echoed as %.
+- **Reliability** — deterministic; covered by unit tests on the boundary.
+- **Observability** — metric: % of items auto-held by floor per run.
+- **Internationalization** — `gradingAgent.settings.confidenceFloor.*`.
+- **Backward compatibility** — additive; default null.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* floor 0.8 and an item at 0.62, *when* the agent runs, *then* the item is held with a threshold reason and no grade is written.
+- **AC-2.** *Given* floor 0.8 and an item at 0.91, *when* the agent runs, *then* the grade is applied.
+- **AC-3.** *Given* floor null, *when* the agent runs, *then* behavior is unchanged from today.
+- **AC-4.** *Given* a gate that holds at 0.9 and a floor at 0.8, *when* an item is at 0.85, *then* it is held (gate stricter).
+- **AC-5.** *Given* I set the floor in the UI and reload, *then* the value persists.
+
+## 8. Data Model
+
+- Reuse `grading_agent_configs.confidence_floor` (exists; `CHECK (confidence_floor BETWEEN 0 AND 1)`).
+- Add `confidence_floor` to `UpsertConfig` INSERT/UPDATE column list (today it is omitted, so it stays default/null).
+- No migration needed unless a course-wide default is added (`courses` or course settings).
+
+## 9. API Surface
+
+- `GET …/grader-agent` config response gains `confidenceFloor`.
+- `PUT …/grader-agent` body gains `confidenceFloor` (nullable number); validated 0–1.
+- `graderAgentConfigToJSON` includes `confidenceFloor` (currently omitted).
+
+## 10. UI / UX
+
+- Inspector / agent settings: a "Hold for review below __%" control with helper text and a "never hold" (off) state.
+- Surfaced near the run popover so the instructor sees the active floor before running.
+- Copy/i18n under `gradingAgent.settings.confidenceFloor.*`.
+
+## 11. AI / ML Considerations
+
+- Confidence comes from `ParseAndClampModelOutput` / `GradeOutput.Confidence`. Document that confidence is model-reported and should be treated as a heuristic, not a calibrated probability.
+
+## 12. Integration Points
+
+- `server/internal/repos/gradingagent/repo.go` (`UpsertConfigInput.ConfidenceFloor`, INSERT/UPDATE).
+- `server/internal/httpserver/grading_agent_http.go` (`putGraderAgentConfigBody`, `graderAgentConfigToJSON`).
+- `server/internal/httpserver/grading_agent_queue.go` (hold decision before `UpsertCellWithFlags`).
+- `server/internal/service/gradingagent/gate_hold.go` (compose with gate hold).
+- `clients/web/src/components/annotation/grader-agent/inspector-panel.tsx` (or a config panel).
+
+## 13. Dependencies & Sequencing
+
+- Needs [GA-M1](missing-1-persistent-review-queue.md) so auto-held items are reviewable.
+- Complements [GA-M3](missing-3-suggest-only-batch-and-bulk-review.md) (suggest-only is the floor=1 extreme).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Users over-trust model confidence | M | M | Helper text framing it as a heuristic; recommend conservative defaults |
+| Floor + gate interaction confusing | L | M | Combine reasons explicitly; document "stricter wins" |
+
+## 15. Rollout Plan
+
+- Flag: none required (additive, default null). Optional `graderAgentConfidenceFloor` for staged exposure.
+- Sequence: repo write → API → consumer hold → UI.
+- Rollback: set floor null.
+
+## 16. Test Plan
+
+- **Unit** — boundary tests at, just below, and just above the floor; compose-with-gate matrix; null floor no-op.
+- **Integration** — config persists; held vs applied write paths.
+- **E2E** — set floor, run, verify split into applied vs review queue.
+
+## 17. Documentation & Training
+
+- Help-center: "Auto-applying confident grades and reviewing the rest."
+
+## 18. Open Questions
+
+1. Add a course-wide default floor (inherited by new agents)?
+2. Should confidence be surfaced per item in the review queue sort (highest-uncertainty first)?
+
+## 19. References
+
+- `server/internal/repos/gradingagent/repo.go` (`ConfigRow.ConfidenceFloor`, `UpsertConfig`).
+- `server/internal/service/gradingagent/gate_hold.go` (`EvaluateHoldDecision`, `gateConfidenceFloorFromNode`).
+- `server/internal/httpserver/grading_agent_queue.go` (apply vs hold).
+- Related: [GA-M1](missing-1-persistent-review-queue.md), [GA-M3](missing-3-suggest-only-batch-and-bulk-review.md).

--- a/docs/plan/grading-agent/missing-5-section-scoped-runs.md
+++ b/docs/plan/grading-agent/missing-5-section-scoped-runs.md
@@ -1,0 +1,139 @@
+# GA-M5 — Section / group / student-scoped runs
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-M5 |
+| **Section** | Grading Agent — Missing Features |
+| **Severity** | MAJOR |
+| **Markets** | HE / K12 |
+| **Status (today)** | MISSING |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Assessment / Grading squad |
+| **Depends on** | — |
+| **Unblocks** | TA workflows |
+
+## 1. Problem Statement
+
+A run scope is exactly one of `current`, `ungraded`, or `all` (`resolveGraderAgentSubmissions`).
+There is no way to grade a **subset** — e.g., "just the submissions in my discussion section," "just
+this student group," or "these 5 selected students." In large Higher-Ed courses, grading is divided
+across TAs by section. Today a section TA must either grade the whole class (stepping on other TAs) or
+grade one submission at a time via "current." This makes the agent impractical for the exact teams
+that most need batch grading.
+
+## 2. Goals
+
+- Scope a run to a section, a group set/group, or an explicit selection of submissions.
+- Keep the existing scopes; add the subset as an orthogonal filter.
+- Respect section/role visibility so a TA only acts on their own students.
+
+## 3. Non-Goals
+
+- Inventing new section/group data — reuse existing sections ([5.4]) and group spaces ([6.6]).
+- Per-TA assignment of the agent itself (the agent config stays per-assignment).
+
+## 4. Personas & User Stories
+
+- **As a section TA**, I want to run the agent on just my section, so that I grade only my students.
+- **As an instructor**, I want to grade one project group at a time, so that group work is handled coherently.
+- **As an instructor**, I want to multi-select submissions and run on those, so that I can re-grade a specific set.
+
+## 5. Functional Requirements
+
+- **FR-1.** The run request MUST accept an optional `filter` of `{ sectionId? , groupId?, submissionIds?[] }` combined with the existing `scope` (ungraded/all act *within* the filter).
+- **FR-2.** `resolveGraderAgentSubmissions` MUST intersect the chosen scope with the filter and the caller's visibility.
+- **FR-3.** A section TA MUST only be able to target sections/students they can see; the server MUST enforce this, not just the UI.
+- **FR-4.** The run summary MUST state the effective target ("Ungraded in Section B: 24 submissions").
+- **FR-5.** Selecting zero matching submissions MUST return the existing clear "no submissions matched" error.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — filter pushed into the submission query (no client-side filtering of large sets).
+- **Security** — server-side visibility enforcement; section/group membership checked.
+- **Privacy & Compliance** — respects blind grading labels in the picker.
+- **Accessibility** — scope + filter controls fully keyboard operable; clear current-target summary.
+- **Reliability** — deterministic target resolution; idempotent with [GA-B2](bug-2-requeue-double-grading.md) fixes.
+- **Observability** — record `filter` on the run for audit.
+- **Internationalization** — `gradingAgent.run.filter.*`.
+- **Backward compatibility** — no filter ⇒ today's behavior.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* I pick Section B + ungraded, *when* I run, *then* only ungraded Section B submissions are queued.
+- **AC-2.** *Given* I am a TA without access to Section A, *when* I attempt to target Section A, *then* the server rejects it.
+- **AC-3.** *Given* I multi-select 5 submissions, *when* I run, *then* exactly those 5 are graded.
+- **AC-4.** *Given* a group set, *when* I pick one group, *then* only that group's submissions are graded.
+- **AC-5.** *Given* a filter matches nothing, *then* I get the standard no-match message and no run is created.
+
+## 8. Data Model
+
+- No new tables. Reuse sections and group membership repos.
+- Persist the run filter on `grading_agent_runs` as `filter JSONB NULL` for audit/repeatability.
+- Migration: `server/migrations/NNN_grading_agent_run_filter.sql`.
+
+## 9. API Surface
+
+- `POST …/grader-agent/runs` body gains optional `filter`.
+- Submission listing for the picker reuses existing section/group-aware endpoints.
+
+## 10. UI / UX
+
+- Run popover (`run-agent-popover.tsx`) gains a target picker: All / Section ▾ / Group ▾ / Selected.
+- A live "target summary" line shows the resolved count before running.
+- Submission picker supports multi-select for the "Selected" mode.
+- Copy/i18n under `gradingAgent.run.filter.*`.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- `server/internal/httpserver/grading_agent_http.go` (`resolveGraderAgentSubmissions`, run body, visibility checks).
+- `moduleassignmentsubmissions` repo (section/group-filtered listing).
+- Sections ([5.4]) and group spaces ([6.6]) repos.
+- `clients/web/src/components/annotation/grader-agent/run-agent-popover.tsx`.
+
+## 13. Dependencies & Sequencing
+
+- Independent; pairs naturally with [GA-M1](missing-1-persistent-review-queue.md) (review queue can also filter by section).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| TA targets students outside their section | M | H | Server-side visibility enforcement + tests |
+| Filter + scope semantics confuse users | M | M | Explicit target summary string before run |
+
+## 15. Rollout Plan
+
+- Flag: `graderAgentRunFilters`.
+- Sequence: filtered submission query → run API → picker UI → flip flag.
+- Pilot: a multi-TA course.
+- Rollback: hide picker; default unfiltered.
+
+## 16. Test Plan
+
+- **Unit** — scope×filter intersection; visibility enforcement.
+- **Integration** — section/group/explicit targeting queues exactly the right submissions.
+- **Security** — TA cannot target other sections (server-enforced).
+- **E2E** — section TA grades only their section.
+
+## 17. Documentation & Training
+
+- Help-center: "Running the grading agent for your section or a group."
+
+## 18. Open Questions
+
+1. Should "Selected" mode persist the selection for repeat runs?
+2. Do we expose instructor-only "all sections" explicitly vs the existing `all`?
+
+## 19. References
+
+- `server/internal/httpserver/grading_agent_http.go` (`resolveGraderAgentSubmissions`, `gradableSubmissionsForAgent`).
+- `clients/web/src/components/annotation/grader-agent/run-agent-popover.tsx`.
+- Related plans: `../completed/05-multi-tenancy-org-roles/5.4-sections.md`, `../completed/06-communication-collaboration/6.6-group-spaces.md`.

--- a/docs/plan/grading-agent/missing-6-cancel-running-batch.md
+++ b/docs/plan/grading-agent/missing-6-cancel-running-batch.md
@@ -1,0 +1,139 @@
+# GA-M6 — Cancel / stop a running batch
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-M6 |
+| **Section** | Grading Agent — Missing Features |
+| **Severity** | MAJOR |
+| **Markets** | HE / K12 / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Assessment / Grading squad |
+| **Depends on** | [GA-M1](missing-1-persistent-review-queue.md) |
+| **Unblocks** | safe large-class runs |
+
+## 1. Problem Statement
+
+Once a batch run starts, there is no way to stop it. `handlePostGraderAgentRun` publishes one queue
+message per submission and the client only polls progress; there is no cancel endpoint, no run state
+the consumer checks, and no UI control. If an instructor notices a bad prompt, the wrong scope, or
+runaway cost mid-run on a 300-student class, they can only watch it finish — spending real AI dollars
+on grades they will discard. Combined with the lack of a cost estimate ([GA-M7](missing-7-cost-estimate-and-budget.md)),
+this makes large runs feel dangerous.
+
+## 2. Goals
+
+- A "Cancel run" control that stops further grading promptly.
+- The consumer skips queued items for a cancelled run instead of grading them.
+- Clear terminal run state (`cancelled`) and a summary of what was/ wasn't applied.
+
+## 3. Non-Goals
+
+- Rolling back grades already written before cancel (out of scope; surfaced in the summary instead).
+- Pausing/resuming (cancel is terminal for v1).
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I want to cancel a run I started by mistake, so that I stop wasting AI budget.
+- **As a TA**, I want cancel to take effect quickly, so that few extra submissions are graded after I click it.
+- **As an instructor**, I want a clear summary of what was applied before cancel, so that I know the gradebook state.
+
+## 5. Functional Requirements
+
+- **FR-1.** The system MUST expose `POST …/grader-agent/runs/{run_id}/cancel` that sets the run status to `cancelled` (only from `queued`/`running`).
+- **FR-2.** The consumer MUST check run status before grading each message and, if `cancelled`, record the item as `skipped` (reason "run cancelled") without an LLM call, then progress the run.
+- **FR-3.** The run MUST reach a terminal `cancelled` state once all messages are drained (graded, skipped, or failed).
+- **FR-4.** The UI MUST show a Cancel button while `batchRunning`, disable it after click, and surface the final summary.
+- **FR-5.** Cancel MUST be permission-gated like other run actions and only by users who can run the agent in that course.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — status check is a cheap indexed read; cache per-run status briefly to avoid hammering Postgres under high concurrency.
+- **Security** — RBAC identical to run creation.
+- **Privacy & Compliance** — cancelled items leave no partial student-visible state when suggest-only ([GA-M3](missing-3-suggest-only-batch-and-bulk-review.md)).
+- **Reliability** — cancel is idempotent; double-cancel is a no-op; works on both RabbitMQ and in-memory buses.
+- **Observability** — metric: items skipped due to cancel; time from cancel to drain.
+- **Internationalization** — `gradingAgent.run.cancel.*`.
+- **Backward compatibility** — additive; runs without cancel behave as today.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a running batch, *when* I cancel, *then* the run status becomes `cancelled` and remaining items are skipped.
+- **AC-2.** *Given* cancel, *when* the consumer dequeues a remaining message, *then* it records `skipped` without calling the model.
+- **AC-3.** *Given* cancel after 40/300 applied, *when* the run drains, *then* the summary reports 40 applied and the rest skipped.
+- **AC-4.** *Given* a `done` run, *when* I attempt cancel, *then* it is rejected (not cancellable).
+- **AC-5.** *Given* concurrent consumers, *when* I cancel, *then* no item is graded after the cancel is visible.
+
+## 8. Data Model
+
+- `grading_agent_runs.status` already free-text; add `cancelled` as a recognized value (and `finished_at` set on drain).
+- Optional `cancelled_at`, `cancelled_by` columns for audit.
+- Migration: `server/migrations/NNN_grading_agent_run_cancel.sql` (if audit columns added).
+
+## 9. API Surface
+
+- `POST …/grader-agent/runs/{run_id}/cancel` → `{ status: "cancelled" }`.
+- `GET …/runs/{run_id}` already returns status/counts; extend to include cancel metadata.
+
+## 10. UI / UX
+
+- Run popover / dry-run dock: a **Cancel run** button while `batchRunning`; becomes "Cancelling…" then shows the summary.
+- Run history ([GA-M1](missing-1-persistent-review-queue.md)) shows `cancelled` runs distinctly.
+- Copy/i18n under `gradingAgent.run.cancel.*`.
+
+## 11. AI / ML Considerations
+
+- Cancel's value is precisely to stop further model spend; ensure the status check happens *before* the gateway/LLM call in `HandleGradingAgentQueueMessage`.
+
+## 12. Integration Points
+
+- `server/internal/httpserver/grading_agent_http.go` (cancel handler), `courses_routes.go` (route).
+- `server/internal/httpserver/grading_agent_queue.go` (status check at top of `HandleGradingAgentQueueMessage`).
+- `server/internal/repos/gradingagent/repo.go` (`CancelRun`, status read).
+- `clients/web/src/components/annotation/grader-agent/{run-agent-popover,dry-run-dock}.tsx`, `use-grader-agent-workflow.ts`.
+
+## 13. Dependencies & Sequencing
+
+- Pairs with [GA-M1](missing-1-persistent-review-queue.md) (run history) and [GA-B1](bug-1-queue-overflow-and-stuck-runs.md) (terminal states). Should land alongside the stuck-run fix so `cancelled` and stuck-detection share status handling.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Per-message status read adds DB load | M | M | Short-TTL in-process cache of run status keyed by run id |
+| Cancel races with in-flight grading | M | L | Accept that in-flight items finish; only *queued* items are skipped |
+| In-memory bus has no per-message control | L | M | Status check is at handler entry, bus-agnostic |
+
+## 15. Rollout Plan
+
+- Flag: `graderAgentCancelRun`.
+- Sequence: status read + handler guard → cancel endpoint → UI → flip flag.
+- Pilot: a large course.
+- Rollback: hide cancel UI; guard is harmless if unused.
+
+## 16. Test Plan
+
+- **Unit** — `CancelRun` transitions; handler guard skips on cancelled.
+- **Integration** — cancel mid-run skips remaining; run drains to `cancelled`.
+- **E2E** — start large run, cancel, verify summary + gradebook.
+- **Security** — RBAC on cancel.
+
+## 17. Documentation & Training
+
+- Help-center: "Cancelling a grading-agent run."
+
+## 18. Open Questions
+
+1. Do we offer "cancel and discard applied grades" as a separate destructive action, or only forward cancel?
+2. Should auto-grade-on-submission runs (single item) expose cancel at all?
+
+## 19. References
+
+- `server/internal/httpserver/grading_agent_queue.go` (`HandleGradingAgentQueueMessage`).
+- `server/internal/repos/gradingagent/repo.go` (`MarkRunRunning`, `IncrementRunProgress`).
+- `clients/web/src/components/annotation/grader-agent/use-grader-agent-workflow.ts` (`batchRunning`, polling).
+- Related: [GA-M1](missing-1-persistent-review-queue.md), [GA-B1](bug-1-queue-overflow-and-stuck-runs.md).

--- a/docs/plan/grading-agent/missing-7-cost-estimate-and-budget.md
+++ b/docs/plan/grading-agent/missing-7-cost-estimate-and-budget.md
@@ -1,0 +1,141 @@
+# GA-M7 — Pre-run cost & scope estimate + run cost summary
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-M7 |
+| **Section** | Grading Agent — Missing Features |
+| **Severity** | MAJOR |
+| **Markets** | HE / SL |
+| **Status (today)** | THIN |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Assessment / Grading squad |
+| **Depends on** | [GA-M1](missing-1-persistent-review-queue.md) |
+| **Unblocks** | confident large-class runs |
+
+## 1. Problem Statement
+
+The system records `prompt_tokens`, `completion_tokens`, and `cost_usd` per result row, but nowhere does
+the instructor see **how much a run will cost before starting it**, or **the total cost after it finishes**.
+The run popover shows only a scope radio and a progress count. For a department footing the AI bill, an
+unbounded "grade all 300 submissions" button with no estimate and no cap is a hard blocker to approval.
+A single dry run already produces real token counts, so a per-submission estimate is readily available.
+
+## 2. Goals
+
+- Before running: show "≈ N submissions, ≈ $X" derived from a sample dry run and the chosen scope/model.
+- After running: show the run's actual total cost and token usage in the run summary and history.
+- Optional per-run or per-agent budget cap that stops the run (ties to [GA-M6](missing-6-cancel-running-batch.md)).
+
+## 3. Non-Goals
+
+- Department-wide budgeting/quotas (belongs to the AI gateway / billing surfaces).
+- Exact pricing guarantees — estimates are clearly labeled approximate.
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I want a cost estimate before I run, so that I do not surprise my department.
+- **As an admin**, I want a per-run budget cap, so that a misconfigured agent cannot spend without bound.
+- **As an instructor**, I want the actual run cost afterward, so that I can report spend.
+
+## 5. Functional Requirements
+
+- **FR-1.** The run popover MUST display the resolved submission count and an estimated cost range for the selected scope/filter and model before the run is created.
+- **FR-2.** The estimate SHOULD reuse the most recent dry-run token usage for the agent (per-submission tokens × count × model price), and clearly label it approximate.
+- **FR-3.** After a run, the system MUST expose the aggregate `cost_usd`, `prompt_tokens`, `completion_tokens` for the run.
+- **FR-4.** An optional budget cap (per run) MUST stop further grading (skip remaining as `skipped`, reason "budget exceeded") when projected/observed spend exceeds the cap.
+- **FR-5.** Cost numbers MUST reconcile with the AI-gateway usage already recorded (`recordAIUsage`).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — estimate is a cheap computation; the optional sample dry run is one model call, run on demand.
+- **Security** — cost surfaced only to users who can run the agent.
+- **Privacy & Compliance** — no submission content in cost telemetry.
+- **Accessibility** — estimate text is associated with the run control via `aria-describedby`.
+- **Reliability** — budget enforcement uses the same per-message guard as cancel ([GA-M6](missing-6-cancel-running-batch.md)).
+- **Observability** — run-level cost metric; estimate-vs-actual delta metric.
+- **Internationalization** — currency/number formatting via locale; `gradingAgent.run.cost.*`.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a prior dry run and scope "ungraded (24)", *when* I open the run popover, *then* I see "≈ 24 submissions, ≈ $X–$Y".
+- **AC-2.** *Given* no prior dry run, *when* I open the popover, *then* I see the count and a prompt to dry-run for a cost estimate.
+- **AC-3.** *Given* a finished run, *when* I view its summary/history, *then* the actual total cost and tokens are shown.
+- **AC-4.** *Given* a per-run budget cap, *when* observed spend crosses it, *then* remaining items are skipped with reason "budget exceeded" and the run terminates.
+- **AC-5.** *Given* the run cost, *when* compared to AI-gateway usage records, *then* they reconcile.
+
+## 8. Data Model
+
+- Add run-level aggregates (or compute on read): `cost_usd`, `prompt_tokens`, `completion_tokens` summed from results; optional materialized columns on `grading_agent_runs` for fast history.
+- Optional `budget_usd NUMERIC NULL` on `grading_agent_runs`.
+- Migration: `server/migrations/NNN_grading_agent_run_cost.sql` (if materialized).
+
+## 9. API Surface
+
+- `GET …/grader-agent/runs/{run_id}` includes aggregate cost/tokens (sum from results if not materialized).
+- `POST …/grader-agent/runs` body gains optional `budgetUsd`.
+- Optional `GET …/grader-agent/estimate?scope=…&filter=…` returning count + estimated cost (or compute client-side from the last dry run + count endpoint).
+
+## 10. UI / UX
+
+- Run popover: a cost line under the scope picker; "Dry run for an estimate" CTA when none exists.
+- Run summary + history ([GA-M1](missing-1-persistent-review-queue.md)): actual cost and tokens.
+- Optional budget cap input with helper text.
+- Copy/i18n under `gradingAgent.run.cost.*`.
+
+## 11. AI / ML Considerations
+
+- Estimate accuracy depends on token variance across submissions; present a range, not a point.
+- Use the model's price (per the provider/BYOK config) to convert tokens → USD.
+
+## 12. Integration Points
+
+- `server/internal/repos/gradingagent/repo.go` (run cost aggregation; `budget_usd`).
+- `server/internal/httpserver/grading_agent_{http,queue}.go` (estimate endpoint, budget guard, reconcile with `recordAIUsage`).
+- Pricing/model metadata from the AI provider settings (per-tenant BYOK, plan 16.7).
+- `clients/web/src/components/annotation/grader-agent/run-agent-popover.tsx`, `use-grader-agent-workflow.ts`.
+
+## 13. Dependencies & Sequencing
+
+- Needs [GA-M1](missing-1-persistent-review-queue.md) for the run-history home and [GA-M6](missing-6-cancel-running-batch.md) for the budget stop mechanism.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Estimate badly off → eroded trust | M | M | Show a range; label approximate; refine from rolling per-agent averages |
+| Model price data missing for some models | M | M | Fall back to tokens-only display when price unknown |
+
+## 15. Rollout Plan
+
+- Flag: `graderAgentCostEstimate`.
+- Sequence: run cost aggregation → estimate display → budget cap → flip flag.
+- Pilot: a cost-sensitive department.
+- Rollback: hide cost UI; data still recorded.
+
+## 16. Test Plan
+
+- **Unit** — estimate math; budget-stop boundary; reconcile with usage.
+- **Integration** — run aggregates match summed results.
+- **E2E** — dry run → estimate shown → run → actual cost shown; budget cap stops a run.
+
+## 17. Documentation & Training
+
+- Help-center: "Understanding grading-agent costs and budgets."
+- Admin doc: setting per-run budgets.
+
+## 18. Open Questions
+
+1. Per-agent rolling average vs last dry run as the estimate basis?
+2. Should the budget cap live on the agent config (default) as well as per run?
+
+## 19. References
+
+- `server/internal/repos/gradingagent/repo.go` (`ResultRow.CostUSD/PromptTokens/CompletionTokens`).
+- `server/internal/httpserver/grading_agent_http.go` (`recordAIUsage`, `openrouterUsageFromScore`).
+- `clients/web/src/components/annotation/grader-agent/run-agent-popover.tsx`.
+- Related: [GA-M1](missing-1-persistent-review-queue.md), [GA-M6](missing-6-cancel-running-batch.md); per-tenant BYOK (plan 16.7).

--- a/docs/plan/grading-agent/simplify-1-unify-grade-write-paths.md
+++ b/docs/plan/grading-agent/simplify-1-unify-grade-write-paths.md
@@ -1,0 +1,144 @@
+# GA-S1 — Unify the three duplicated grade-write paths in the consumer
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-S1 |
+| **Section** | Grading Agent — Over-complexity / Simplification |
+| **Severity** | MAJOR |
+| **Markets** | HE / K12 / SL (internal maintainability) |
+| **Status (today)** | THIN |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Assessment / Grading squad |
+| **Depends on** | — |
+| **Unblocks** | [GA-M3](missing-3-suggest-only-batch-and-bulk-review.md), [GA-M4](missing-4-confidence-auto-hold-threshold.md), [GA-M6](missing-6-cancel-running-batch.md), [GA-B2](bug-2-requeue-double-grading.md) |
+
+## 1. Problem Statement
+
+`HandleGradingAgentQueueMessage` (≈ 300 lines) grades one submission through **three overlapping
+branches**:
+
+1. **Path A** — `WorkflowRequiresGraphExecution` (router/flag/gate/aggregator present): runs
+   `ExecuteWorkflowDryRun`, handles flagged/held/applied.
+2. **Path B** — single grade source of type AI / Criterion Grader / Code Test Runner: runs
+   `ExecuteWorkflowDryRun` *again* with a near-identical input block and applies — but ignores
+   held/flagged (≈ 70 lines duplicated from Path A).
+3. **Path C** — legacy fallthrough: builds a `ScoreRequest`, calls `Service.Score`, applies.
+
+All three end in the same "resolve model → AI-gateway check → execute → build comment/points/rubric →
+`UpsertCellWithFlags` → `InsertResult` → `IncrementRunProgress`" shape. The model-resolution,
+gateway-evaluation, posting-derivation, and `gradecomment.Append` logic are copy-pasted three times.
+Any new behavior (suggest-only mode, confidence floor, cancel check, idempotency) must be added in
+three places, and Path B silently can't hold/flag because its branch predates that capability. This is
+the single biggest maintainability liability in the agent.
+
+## 2. Goals
+
+- One execution path for live grading: always walk the graph via the shared engine, then apply the resulting preview.
+- Delete Paths B and C as distinct branches; collapse to a single helper sequence.
+- Make held/flagged handling uniform regardless of graph shape.
+- Preserve current outcomes for every existing graph (AI-only, criterion, code-test, router, gate, flag, aggregator, legacy).
+
+## 3. Non-Goals
+
+- Changing scoring semantics or prompt construction.
+- Removing the legacy `Service.Score` API used by other callers (handled in [GA-S2](simplify-2-remove-dead-dry-run-and-rename-engine.md)).
+- Rewriting the queue/bus.
+
+## 4. Personas & User Stories
+
+- **As an engineer**, I want one apply path, so that adding suggest-only/cancel/idempotency is a one-place change.
+- **As a maintainer**, I want held/flagged handled uniformly, so that a "simple" AI-only graph can still hold low-confidence items.
+- **As a QA engineer**, I want one code path to test, so that coverage is tractable.
+
+## 5. Functional Requirements
+
+- **FR-1.** The consumer MUST execute every accepted graph through the single shared engine and obtain a uniform preview (points, comment, rubric, confidence, held, flagged, tokens, cost).
+- **FR-2.** Held, flagged, skipped (already-graded), applied, and failed outcomes MUST be produced by one shared "persist preview" helper.
+- **FR-3.** Model resolution, AI-gateway evaluation, posting derivation, and comment assembly MUST each exist once.
+- **FR-4.** Behavior MUST be byte-for-byte equivalent for existing graphs (verified by golden tests across all node shapes).
+- **FR-5.** The legacy non-graph path (config with no workflow graph) MUST still work via the synthesized default graph (`EffectiveWorkflowGraph`) routed through the same engine.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — no extra model calls vs today (the engine already runs once); avoid the double-execute that Path B/A could imply.
+- **Security** — gateway checks preserved and centralized.
+- **Reliability** — single path makes [GA-B2](bug-2-requeue-double-grading.md) idempotency a one-place fix.
+- **Maintainability** — target ≤ ~120 lines for `HandleGradingAgentQueueMessage` with extracted helpers.
+- **Observability** — one structured "graded" log/metric with outcome label.
+- **Backward compatibility** — outcomes unchanged; covered by golden tests.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* each existing graph shape (AI-only, criterion, code-test, router, gate, flag, aggregator, legacy-no-graph), *when* graded before and after the refactor, *then* points/comment/rubric/status match.
+- **AC-2.** *Given* an AI-only graph with a confidence floor (post-[GA-M4](missing-4-confidence-auto-hold-threshold.md)), *when* a low-confidence item is graded, *then* it is held — proving Path B's gap is closed.
+- **AC-3.** *Given* a flagged graph, *when* graded, *then* the flagged result is recorded exactly as today.
+- **AC-4.** *Given* the refactor, *when* measured, *then* no graph triggers two model executions.
+
+## 8. Data Model
+
+- None. Pure refactor.
+
+## 9. API Surface
+
+- None. Internal only.
+
+## 10. UI / UX
+
+- None.
+
+## 11. AI / ML Considerations
+
+- Ensure exactly one execution per submission; the consolidation removes the risk of Path A/B double execution.
+
+## 12. Integration Points
+
+- `server/internal/httpserver/grading_agent_queue.go` (the consolidation target).
+- `server/internal/service/gradingagent/{workflow_execute,flag_sink,code_test_runner}.go` (engine + capability helpers).
+- `server/internal/repos/gradingagent/repo.go` (`InsertResult`, `IncrementRunProgress`).
+
+## 13. Dependencies & Sequencing
+
+- Best done **before** [GA-M3](missing-3-suggest-only-batch-and-bulk-review.md), [GA-M4](missing-4-confidence-auto-hold-threshold.md), [GA-M6](missing-6-cancel-running-batch.md), and [GA-B2](bug-2-requeue-double-grading.md) so each lands once.
+- Pairs with [GA-S2](simplify-2-remove-dead-dry-run-and-rename-engine.md).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Subtle behavior drift for an edge graph | M | H | Golden tests per node shape captured **before** refactor |
+| Path B "skip model on code-test-only" nuance lost | M | M | Preserve the no-LLM detection (`WorkflowUsesLLM`) in the unified path |
+| Hidden coupling to legacy `Service.Score` outputs | L | M | Keep `Score` for [GA-S2]; route default-graph through engine |
+
+## 15. Rollout Plan
+
+- Flag: `graderAgentUnifiedConsumer` to switch old↔new path during bake.
+- Sequence: capture golden tests → implement unified path behind flag → shadow-compare in staging → flip → delete old branches.
+- Rollback: flag back to legacy branches until deletion.
+
+## 16. Test Plan
+
+- **Unit** — extracted helpers (model resolve, gateway, persist preview, posting).
+- **Golden/Integration** — every node-shape graph graded pre/post produces identical persisted rows.
+- **Regression** — already-graded skip (ungraded scope), failed item, held, flagged.
+- **Performance** — assert single execution per submission.
+
+## 17. Documentation & Training
+
+- Internal runbook: "How a queued submission is graded" updated to one path.
+- Architecture note in `../agent-grader/README.md` cross-link.
+
+## 18. Open Questions
+
+1. Keep a flag long-term or delete legacy branches immediately after bake?
+2. Should the default-graph synthesis be removed in favor of always persisting an explicit graph on accept?
+
+## 19. References
+
+- `server/internal/httpserver/grading_agent_queue.go` (`HandleGradingAgentQueueMessage`, Paths A/B/C).
+- `server/internal/service/gradingagent/flag_sink.go` (`WorkflowRequiresGraphExecution`).
+- `server/internal/service/gradingagent/code_test_runner.go` (`WorkflowUsesLLM`).
+- Related: [GA-S2](simplify-2-remove-dead-dry-run-and-rename-engine.md), [GA-B2](bug-2-requeue-double-grading.md).

--- a/docs/plan/grading-agent/simplify-2-remove-dead-dry-run-and-rename-engine.md
+++ b/docs/plan/grading-agent/simplify-2-remove-dead-dry-run-and-rename-engine.md
@@ -1,0 +1,134 @@
+# GA-S2 — Remove the dead HTTP dry-run path; rename the execution engine
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-S2 |
+| **Section** | Grading Agent — Over-complexity / Simplification |
+| **Severity** | MINOR |
+| **Markets** | internal maintainability |
+| **Status (today)** | THIN |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Assessment / Grading squad |
+| **Depends on** | — |
+| **Unblocks** | clarity for all engine work |
+
+## 1. Problem Statement
+
+There are **two** dry-run code paths that do different things:
+
+- `handlePostGraderAgentDryRun` (`POST …/grader-agent/dry-run`, ≈ 185 lines) compiles the graph to a
+  single `ScoreRequest` and calls `Service.Score` — it cannot execute routers, gates, aggregators,
+  flag sinks, code-test, originality, or reference nodes. The client never calls it
+  (`postGraderAgentDryRun` is dead in `courses-api.ts`).
+- `handleGraderAgentDryRunWS` (WebSocket) calls `ExecuteWorkflowDryRun`, the real engine, and is the
+  only dry run the canvas uses.
+
+So the POST endpoint is **dead and divergent** — it produces wrong previews for any non-trivial graph
+(see [GA-B4](bug-4-post-dry-run-mispreviews-graphs.md)). Separately, the engine is named
+`ExecuteWorkflowDryRun` but is the **live grading engine** too (the consumer calls it for real grades).
+The "DryRun" name actively misleads readers into thinking the consumer only previews.
+
+## 2. Goals
+
+- Delete the dead POST dry-run handler, route, and client function (or make it delegate to the engine if a non-WS path is genuinely needed).
+- Rename `ExecuteWorkflowDryRun` → `ExecuteWorkflow` (and `DryRunExecutionInput` → `ExecutionInput`, `DryRunEvent` → `ExecutionEvent`) to reflect dual use, keeping the dry-run *flag* explicit.
+- Reduce the engine's API surface and the reader's confusion.
+
+## 3. Non-Goals
+
+- Changing what the WS dry run does or its event protocol on the wire (only Go-side type names).
+- Removing `Service.Score` if still used by other features (audit usages first).
+
+## 4. Personas & User Stories
+
+- **As an engineer**, I want one dry-run path, so that I do not accidentally fix a bug in the dead one.
+- **As a new contributor**, I want the engine name to tell me it runs live grading, so that I do not assume it is preview-only.
+
+## 5. Functional Requirements
+
+- **FR-1.** The dead `POST …/grader-agent/dry-run` route and `handlePostGraderAgentDryRun` MUST be removed, **or** reimplemented to call the shared engine (`ExecuteWorkflow`) so its output matches the WS path.
+- **FR-2.** The unused client `postGraderAgentDryRun` MUST be removed from `courses-api.ts`.
+- **FR-3.** The engine and its public types MUST be renamed to drop the misleading "DryRun" prefix where they cover live execution; the dry-run vs live distinction remains an explicit input field.
+- **FR-4.** `Service.Score` usages MUST be audited; if only the dead handler used it, it MAY be removed or retained for the unified consumer ([GA-S1](simplify-1-unify-grade-write-paths.md)).
+- **FR-5.** No behavior change to the WS dry run or live grading.
+
+## 6. Non-Functional Requirements
+
+- **Maintainability** — net code reduction; one dry-run path.
+- **Backward compatibility** — wire protocol for the WS dry run unchanged; only internal Go symbols and a dead HTTP route change.
+- **Observability** — no change.
+- **Security** — removing an unused authenticated route reduces surface.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* the change, *when* the client dry-runs, *then* it still works via WS with identical behavior.
+- **AC-2.** *Given* a grep for `postGraderAgentDryRun` / `handlePostGraderAgentDryRun`, *then* there are no remaining references (or the handler now delegates to the engine).
+- **AC-3.** *Given* the rename, *when* the suite runs, *then* it compiles and passes with the new symbol names.
+- **AC-4.** *Given* live grading, *when* a batch runs, *then* outcomes are unchanged.
+
+## 8. Data Model
+
+- None.
+
+## 9. API Surface
+
+- Remove `POST …/assignments/{item_id}/grader-agent/dry-run` (keep the `…/dry-run/ws` route). Update OpenAPI.
+
+## 10. UI / UX
+
+- None (the dead POST path is not surfaced).
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- `server/internal/httpserver/grading_agent_http.go` (`handlePostGraderAgentDryRun`, `dryRunGraderAgentBody`).
+- `server/internal/httpserver/courses_routes.go` (route).
+- `server/internal/service/gradingagent/workflow_execute.go` (renames).
+- `server/internal/background/grading_agent_consumer.go`, `grading_agent_queue.go`, `grading_agent_dry_run_ws.go` (call sites).
+- `clients/web/src/lib/courses-api.ts` (`postGraderAgentDryRun`).
+
+## 13. Dependencies & Sequencing
+
+- Do alongside or just after [GA-S1](simplify-1-unify-grade-write-paths.md); together they leave one execution engine and one apply path.
+- Fixes the divergence reported in [GA-B4](bug-4-post-dry-run-mispreviews-graphs.md).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| A non-web caller depends on the POST route | L | M | Grep + API analytics before removal; 1 release deprecation if uncertain |
+| Rename churn touches many files | M | L | Mechanical rename in one commit; rely on the compiler |
+
+## 15. Rollout Plan
+
+- Sequence: confirm no callers → remove route + client fn → rename symbols → ship.
+- Rollback: revert; pure code change.
+
+## 16. Test Plan
+
+- **Unit/Integration** — WS dry run unchanged; live grading unchanged.
+- **Static** — grep proves no dangling references; build green.
+
+## 17. Documentation & Training
+
+- OpenAPI updated; internal note that `ExecuteWorkflow` is the single engine (dry-run is a flag).
+
+## 18. Open Questions
+
+1. Keep a non-WS dry-run endpoint (delegating to the engine) for clients that cannot use WebSockets, or drop entirely?
+2. Is `Service.Score` still wanted as the LLM call primitive inside the unified consumer?
+
+## 19. References
+
+- `server/internal/httpserver/grading_agent_http.go` (`handlePostGraderAgentDryRun`).
+- `server/internal/httpserver/grading_agent_dry_run_ws.go` (`ExecuteWorkflowDryRun` call).
+- `server/internal/service/gradingagent/workflow_execute.go` (engine + `DryRun*` types).
+- `clients/web/src/lib/courses-api.ts` (`postGraderAgentDryRun`, `streamGraderAgentDryRun`).
+- Related: [GA-S1](simplify-1-unify-grade-write-paths.md), [GA-B4](bug-4-post-dry-run-mispreviews-graphs.md).

--- a/docs/plan/grading-agent/simplify-3-generic-node-data-updater.md
+++ b/docs/plan/grading-agent/simplify-3-generic-node-data-updater.md
@@ -1,0 +1,124 @@
+# GA-S3 — Collapse the duplicated per-node update callbacks
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-S3 |
+| **Section** | Grading Agent — Over-complexity / Simplification |
+| **Severity** | MINOR |
+| **Markets** | internal maintainability |
+| **Status (today)** | THIN |
+| **Estimated effort** | XS (≤1d) |
+| **Owner (proposed)** | Web / Grading squad |
+| **Depends on** | — |
+| **Unblocks** | faster node-config work |
+
+## 1. Problem Statement
+
+`use-grader-agent-workflow.ts` defines **~12 nearly identical callbacks** — `updateGraderNode`,
+`updateAiNode`, `updateCriterionGraderNode`, `updateCodeTestRunnerNode`, `updateConditionalRouterNode`,
+`updateFlagForReviewNode`, `updateOriginalityNode`, `updateReferenceNode`, `updateRubricNode`,
+`updateHumanReviewGateNode`, `updateScoreAggregatorNode`, `updateActivityNode` — each of which is the
+same body:
+
+```ts
+setGraph({ ...graph, nodes: graph.nodes.map(n => n.id === nodeId ? { ...n, data: { ...n.data, ...patch } } : n) })
+```
+
+Each also closes over `graph` (not the functional `setGraph(prev => …)` form), so they all invalidate
+together on every graph change. Every new node type adds yet another copy. This is ~120 lines of pure
+duplication and a steady tax on adding nodes.
+
+## 2. Goals
+
+- One generic `updateNodeData(nodeId, patch)` (functional-update form) used by every node inspector.
+- Keep per-node **typed** wrappers only where a component wants a narrow `Partial<XNodeData>` signature.
+- Remove the closure-over-`graph` churn.
+
+## 3. Non-Goals
+
+- Changing inspector components' external props beyond the update signature.
+- Reworking the graph state container.
+
+## 4. Personas & User Stories
+
+- **As a web engineer**, I want one updater, so that adding a node type does not mean adding a callback.
+- **As a reviewer**, I want less duplicated code to read, so that diffs are smaller.
+
+## 5. Functional Requirements
+
+- **FR-1.** A single `updateNodeData<T>(nodeId: string, patch: Partial<T>)` MUST exist, implemented with `setGraph(prev => …)`.
+- **FR-2.** All existing `updateXNode` call sites MUST route through it (either directly or via thin typed wrappers).
+- **FR-3.** Behavior MUST be identical (same patches applied, same re-renders or fewer).
+- **FR-4.** `updateNodeLabel`, `removeNode`, `removeEdge` SHOULD also adopt the functional-update form for consistency.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — fewer callback identities recreated per render (stable `useCallback` with empty deps via functional update).
+- **Maintainability** — net deletion of ~100 lines.
+- **Accessibility / i18n** — unaffected.
+- **Backward compatibility** — internal only; no API/UX change.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* each node inspector, *when* a field changes, *then* the node data updates exactly as before.
+- **AC-2.** *Given* the refactor, *when* counting update callbacks, *then* there is one generic updater plus only intentional typed wrappers.
+- **AC-3.** *Given* existing tests, *when* run, *then* they pass unchanged.
+
+## 8. Data Model
+
+- None.
+
+## 9. API Surface
+
+- None.
+
+## 10. UI / UX
+
+- None visible. Inspector components receive a single `onChange`/`updateNodeData` style callback.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- `clients/web/src/components/annotation/grader-agent/use-grader-agent-workflow.ts` (the updaters + return object).
+- Inspector components that consume the per-node updaters: `inspector-panel.tsx`, `*-inspector.tsx`.
+
+## 13. Dependencies & Sequencing
+
+- Independent; low risk. Good warm-up before [GA-S4](simplify-4-legacy-node-type-aliases.md).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| A wrapper had subtly different typing a component relied on | L | L | Keep thin typed wrappers where a component imports a specific `Partial<XNodeData>` |
+| Functional-update changes a memoization assumption | L | L | Verify inspectors with existing component tests |
+
+## 15. Rollout Plan
+
+- Single PR; no flag needed (internal refactor with full test coverage).
+- Rollback: revert PR.
+
+## 16. Test Plan
+
+- **Unit/Component** — existing inspector tests cover each node type's edits.
+- **Manual** — edit one field per node type and confirm persistence on save.
+
+## 17. Documentation & Training
+
+- None beyond a short PR description; optionally a contributor note "use `updateNodeData`".
+
+## 18. Open Questions
+
+1. Keep typed wrappers for every node or only those whose inspectors want a narrowed signature?
+
+## 19. References
+
+- `clients/web/src/components/annotation/grader-agent/use-grader-agent-workflow.ts` (lines defining `updateGraderNode` … `updateScoreAggregatorNode`).
+- Related: [GA-S4](simplify-4-legacy-node-type-aliases.md).

--- a/docs/plan/grading-agent/simplify-4-legacy-node-type-aliases.md
+++ b/docs/plan/grading-agent/simplify-4-legacy-node-type-aliases.md
@@ -1,0 +1,133 @@
+# GA-S4 — Retire legacy node-type aliases & palette ternaries
+
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | GA-S4 |
+| **Section** | Grading Agent — Over-complexity / Simplification |
+| **Severity** | MINOR |
+| **Markets** | internal maintainability |
+| **Status (today)** | THIN |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Assessment / Grading squad |
+| **Depends on** | — |
+| **Unblocks** | cleaner node additions |
+
+## 1. Problem Statement
+
+The graph schema carries **three legacy node types** that the palette no longer offers but every layer
+must still special-case:
+
+- `submission` (alias of `studentSubmission`), `assignmentContext` (alias of `activity`), and `grader`
+  (superseded by `ai` / `criterionGrader`).
+
+Server code threads these through helpers like `isStudentSubmissionNodeType`, `isActivityNodeType`,
+the `HandleContext` legacy handle, and `deriveIncludeFlags`'s `assignmentContext` branch. On the client,
+`addPaletteNode` builds node prefixes, fallback positions, and default data via **three giant nested
+ternaries** spanning ~90 lines that are easy to mis-edit (the ordering of `originality`/`reference`/
+`rubric`/`criterionGrader` branches is already non-obvious). This accidental complexity slows every
+node change and is a frequent source of "why did my node get the wrong default position" confusion.
+
+## 2. Goals
+
+- A one-time migration that rewrites stored graphs from legacy types/handles to current ones, then removes the alias branches.
+- Replace the `addPaletteNode` ternary pyramids with a single declarative node-descriptor table (prefix, default position, default data factory).
+- Shrink the type/handle/validation surface accordingly.
+
+## 3. Non-Goals
+
+- Removing genuinely-current node types.
+- Changing node behavior or default values (defaults preserved exactly).
+
+## 4. Personas & User Stories
+
+- **As an engineer**, I want a node registry, so that adding a node is one table entry, not edits across five ternaries.
+- **As a maintainer**, I want legacy aliases gone, so that validation/compile logic is half as branchy.
+
+## 5. Functional Requirements
+
+- **FR-1.** A migration MUST rewrite persisted `workflow_graph` JSON: `submission→studentSubmission`, `assignmentContext→activity` (preserving its `includeContent`/`includeRubric` semantics by wiring content/rubric handles), `grader→ai` where safe, and `context` handle → `content`/`rubric` edges.
+- **FR-2.** After migration, the alias helpers and `NodeTypeSubmission`/`NodeTypeAssignmentCtx`/legacy `grader` handling MAY be removed (or reduced to a load-time normalizer kept for one release).
+- **FR-3.** The client MUST replace the `addPaletteNode` ternaries with a `NODE_DESCRIPTORS` map keyed by `PaletteNodeType` providing `{ idPrefix, fallbackPosition(index), defaultData() }`.
+- **FR-4.** Defaults (positions, data) MUST match current output for every node type (snapshot-tested).
+- **FR-5.** Validation and compile MUST continue to accept any pre-migration graph during the deprecation window via a normalizer.
+
+## 6. Non-Functional Requirements
+
+- **Reliability** — migration is idempotent and reversible (keep a backup of pre-migration JSON or gate behind a normalizer rather than destructive rewrite initially).
+- **Maintainability** — measurable reduction in branch count in `workflow.go` and `use-grader-agent-workflow.ts`.
+- **Backward compatibility** — old saved graphs still load (normalizer) until the migration runs; templates migrated too.
+- **Observability** — log count of graphs normalized/migrated.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a stored graph using `submission`/`assignmentContext`/`grader`, *when* migrated, *then* it loads, validates, and grades identically to before.
+- **AC-2.** *Given* the node registry, *when* a node is added via the palette, *then* its prefix, position, and defaults match the previous ternary output (snapshot test).
+- **AC-3.** *Given* the removed aliases, *when* the server suite runs, *then* it compiles and passes.
+- **AC-4.** *Given* a saved template with legacy types, *when* cloned to an assignment, *then* it works.
+
+## 8. Data Model
+
+- No schema change; a data migration over `assessment.grading_agent_configs.workflow_graph` and `..._templates.workflow_graph`.
+- Migration: `server/migrations/NNN_grading_agent_normalize_legacy_nodes.sql` (or a Go one-shot if JSON rewriting is easier in code).
+
+## 9. API Surface
+
+- None. Internal.
+
+## 10. UI / UX
+
+- None visible; palette/canvas behavior preserved.
+
+## 11. AI / ML Considerations
+
+- None (prompt/scoring unchanged; `assignmentContext` include-flag semantics preserved via explicit handles).
+
+## 12. Integration Points
+
+- `server/internal/service/gradingagent/workflow.go` (`NodeTypeSubmission`, `NodeTypeAssignmentCtx`, `HandleContext`, `isActivityNodeType`, `isStudentSubmissionNodeType`, `deriveIncludeFlags`).
+- `clients/web/src/components/annotation/grader-agent/use-grader-agent-workflow.ts` (`addPaletteNode`).
+- `clients/web/src/components/annotation/grader-agent/types.ts` (legacy type unions).
+- Migration script + template normalization.
+
+## 13. Dependencies & Sequencing
+
+- Independent; do after [GA-S3](simplify-3-generic-node-data-updater.md) to keep the hook diff small.
+- Coordinate with [GA-S1](simplify-1-unify-grade-write-paths.md) since both touch `workflow.go`/consumer assumptions.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Destructive migration corrupts a graph | L | H | Ship a load-time normalizer first; migrate data only after a release of normalizer soak |
+| `assignmentContext` include-flag semantics lost | M | M | Map to explicit content/rubric edges; golden test the include flags |
+| Hidden consumer reliance on legacy handles | M | M | Keep normalizer for one release; grep all `Handle*`/`NodeType*` legacy refs |
+
+## 15. Rollout Plan
+
+- Flag/phase: (1) add normalizer + node registry (non-destructive), ship; (2) run data migration; (3) delete alias branches.
+- Rollback: keep normalizer until step 3; revert deletion if needed.
+
+## 16. Test Plan
+
+- **Unit** — normalizer maps each legacy type/handle correctly; node-registry defaults snapshot.
+- **Golden** — legacy graphs grade identically pre/post.
+- **Integration** — templates with legacy types clone and run.
+
+## 17. Documentation & Training
+
+- Contributor note: "Add a node by extending `NODE_DESCRIPTORS` + the registry; legacy aliases are gone."
+
+## 18. Open Questions
+
+1. Do `grader` nodes always map cleanly to `ai`, or do some need `criterionGrader`? (Audit stored graphs first.)
+2. Keep the load-time normalizer permanently as a safety net, or remove after migration?
+
+## 19. References
+
+- `server/internal/service/gradingagent/workflow.go` (legacy constants + `isActivityNodeType`/`isStudentSubmissionNodeType`/`deriveIncludeFlags`).
+- `clients/web/src/components/annotation/grader-agent/use-grader-agent-workflow.ts` (`addPaletteNode` ternaries).
+- Related: [GA-S1](simplify-1-unify-grade-write-paths.md), [GA-S3](simplify-3-generic-node-data-updater.md).


### PR DESCRIPTION
## Summary

A full review of the **grading (grader) agent** — the workflow-canvas auto-grader that scores submissions with an instructor-authored node graph. Covers the canvas authoring layer, the typed node graph (`workflow.go`), the execution engine (`workflow_execute.go`), the batch consumer/queue, the HTTP handlers, the repo/data model, and the React UI.

Adds `docs/plan/grading-agent/` with **one plan per finding** (16 findings + a README index), each following `docs/plan/_TEMPLATE.md`. This PR is **docs only** — no code changes.

> Note: there is a pre-existing `docs/plan/agent-grader/` folder that plans *new canvas nodes*. This audit is intentionally kept in a separate `grading-agent/` folder scoped to **usability gaps, simplifications, and bugs**, and cross-references the other folder rather than disturbing it.

## Findings

### Missing features (HE instructor / TA / grader usability)
- **GA-M1** Persistent, actionable review queue & run history `BLOCKER` — held/flagged items vanish on modal close; flagged queue is read-only; no list-runs endpoint.
- **GA-M2** Grade non-file (text-entry) & image/scanned submissions `BLOCKER` — only file attachments with extractable text are gradable.
- **GA-M3** Suggest-only batch + bulk review/apply + posting control `MAJOR`.
- **GA-M4** Agent-level confidence auto-hold threshold `MAJOR` — `confidence_floor` column exists but is unused.
- **GA-M5** Section/group/student-scoped runs `MAJOR` — scope is only current/ungraded/all.
- **GA-M6** Cancel a running batch `MAJOR`.
- **GA-M7** Pre-run cost estimate + run cost summary `MAJOR`.

### Over-complexities to simplify
- **GA-S1** Unify the three duplicated grade-write paths in `HandleGradingAgentQueueMessage`.
- **GA-S2** Remove the dead HTTP `/dry-run` path; rename the "DryRun" engine that runs live grading.
- **GA-S3** Collapse ~12 identical `updateXNode` callbacks into one generic updater.
- **GA-S4** Retire legacy node-type aliases & `addPaletteNode` ternary pyramids.

### Bugs
- **GA-B1** In-memory queue overflow (128 cap, non-blocking publish) & runs stuck in `running` `Large`.
- **GA-B2** Requeue → double grading; no `(run_id, submission_id)` idempotency `Medium`.
- **GA-B3** Auto-post / `confidence_floor` dead code — `post_policy` never writable, so AI grades never auto-post `Medium`.
- **GA-B4** HTTP dry-run mis-previews complex graphs (single `Score` call) `Medium`.
- **GA-B5** Run-status polling robustness `Small`.

## Notes for reviewers
- See [`docs/plan/grading-agent/README.md`](docs/plan/grading-agent/README.md) for the index, severity tables, and a map of the agent as built.
- GA-B3's posting behavior may be an intentional safety default (AI never auto-posts) rather than a pure bug — documented as a latent dead branch + missing control, with the wire-vs-remove decision left as an open question.
- Dependencies are cross-linked (e.g. GA-S1 unblocks M3/M4/M6/B2).

## Test plan
- Docs only; no code paths affected. Each plan includes its own implementation/test plan for when the work is scheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)