### PR TITLE
fix(api): log 5xx errors and repair submissions list query

### DIFF
--- a/server/internal/apierr/apierr.go
+++ b/server/internal/apierr/apierr.go
@@ -51,6 +51,19 @@ func WriteJSON(w http.ResponseWriter, status int, code, message string) {
 	_ = json.NewEncoder(w).Encode(body(code, message))
 }
 
+// WriteJSONWithErr writes a JSON error body and records server-side failures for access logging.
+func WriteJSONWithErr(w http.ResponseWriter, r *http.Request, status int, code, message string, err error) {
+	if status >= http.StatusInternalServerError && r != nil {
+		RecordServerError(r, message, err)
+	}
+	WriteJSON(w, status, code, message)
+}
+
+// WriteInternal writes a 500 INTERNAL response and records err for access logging.
+func WriteInternal(w http.ResponseWriter, r *http.Request, message string, err error) {
+	WriteJSONWithErr(w, r, http.StatusInternalServerError, CodeInternal, message, err)
+}
+
 func body(code, message string) Body {
 	var b Body
 	b.Error.Code = code

--- a/server/internal/apierr/apierr_internal_test.go
+++ b/server/internal/apierr/apierr_internal_test.go
@@ -1,0 +1,40 @@
+package apierr
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+)
+
+func TestWriteInternal_RecordsServerError(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req = WithServerErrorTracking(req)
+	rr := httptest.NewRecorder()
+
+	err := errors.New("query failed")
+	WriteInternal(rr, req, "Failed to load submissions.", err)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d want %d", rr.Code, http.StatusInternalServerError)
+	}
+	msg, got := ServerErrorFromRequest(req)
+	if msg != "Failed to load submissions." {
+		t.Fatalf("message: got %q want %q", msg, "Failed to load submissions.")
+	}
+	if got != err {
+		t.Fatalf("err: got %v want %v", got, err)
+	}
+
+	var b Body
+	if err := json.NewDecoder(rr.Body).Decode(&b); err != nil {
+		t.Fatal(err)
+	}
+	if b.Error.Code != CodeInternal || b.Error.Message != "Failed to load submissions." {
+		t.Fatalf("body: %#v", b)
+	}
+}

--- a/server/internal/apierr/request_error.go
+++ b/server/internal/apierr/request_error.go
@@ -1,0 +1,49 @@
+package apierr
+
+import (
+	"context"
+	"net/http"
+)
+
+type serverErrorKey struct{}
+
+type serverErrorState struct {
+	message string
+	err     error
+}
+
+// WithServerErrorTracking attaches a per-request slot for the underlying error behind 5xx responses.
+func WithServerErrorTracking(r *http.Request) *http.Request {
+	if r == nil {
+		return r
+	}
+	if _, ok := r.Context().Value(serverErrorKey{}).(*serverErrorState); ok {
+		return r
+	}
+	return r.WithContext(context.WithValue(r.Context(), serverErrorKey{}, &serverErrorState{}))
+}
+
+// RecordServerError stores the server-side failure for inclusion in the access log.
+func RecordServerError(r *http.Request, message string, err error) {
+	if r == nil {
+		return
+	}
+	state, ok := r.Context().Value(serverErrorKey{}).(*serverErrorState)
+	if !ok || state == nil {
+		return
+	}
+	state.message = message
+	state.err = err
+}
+
+// ServerErrorFromRequest returns the recorded 5xx message and error, if any.
+func ServerErrorFromRequest(r *http.Request) (message string, err error) {
+	if r == nil {
+		return "", nil
+	}
+	state, ok := r.Context().Value(serverErrorKey{}).(*serverErrorState)
+	if !ok || state == nil {
+		return "", nil
+	}
+	return state.message, state.err
+}

--- a/server/internal/httpserver/assignment_submissions_http.go
+++ b/server/internal/httpserver/assignment_submissions_http.go
@@ -64,12 +64,12 @@ func (d Deps) loadAssignmentForSubmissions(
 	itemID uuid.UUID,
 ) (*uuid.UUID, *coursemoduleassignments.CourseItemAssignmentRow, bool) {
 	if d.Pool == nil {
-		apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.")
+		apierr.WriteJSONWithErr(w, r, http.StatusServiceUnavailable, apierr.CodeInternal, "Database unavailable.", nil)
 		return nil, nil, false
 	}
 	cid, err := course.GetIDByCourseCode(r.Context(), d.Pool, courseCode)
 	if err != nil {
-		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course.")
+		apierr.WriteInternal(w, r, "Failed to load course.", err)
 		return nil, nil, false
 	}
 	if cid == nil {
@@ -78,7 +78,7 @@ func (d Deps) loadAssignmentForSubmissions(
 	}
 	row, err := coursemoduleassignments.GetForCourseItem(r.Context(), d.Pool, *cid, itemID)
 	if err != nil {
-		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load assignment.")
+		apierr.WriteInternal(w, r, "Failed to load assignment.", err)
 		return nil, nil, false
 	}
 	if row == nil {
@@ -280,7 +280,7 @@ func (d Deps) handleListAssignmentSubmissions() http.HandlerFunc {
 		}
 		has, err := courseroles.UserHasPermission(r.Context(), d.Pool, viewer, "course:"+courseCode+":gradebook:view")
 		if err != nil {
-			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify permissions.")
+			apierr.WriteInternal(w, r, "Failed to verify permissions.", err)
 			return
 		}
 		if !has {
@@ -299,14 +299,14 @@ func (d Deps) handleListAssignmentSubmissions() http.HandlerFunc {
 		filter := parseSubmissionGradedFilter(r.URL.Query().Get("graded"))
 		students, err := enrollment.ListStudentUsersForCourseCode(r.Context(), d.Pool, courseCode, nil)
 		if err != nil {
-			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load course roster.")
+			apierr.WriteInternal(w, r, "Failed to load course roster.", err)
 			return
 		}
 		rows, err := moduleassignmentsubmissions.ListForAssignment(
 			r.Context(), d.Pool, *cid, itemID, moduleassignmentsubmissions.GradedFilterAll,
 		)
 		if err != nil {
-			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load submissions.")
+			apierr.WriteInternal(w, r, "Failed to load submissions.", err)
 			return
 		}
 		roster := buildAssignmentRosterEntries(students, rows)
@@ -325,7 +325,7 @@ func (d Deps) handleListAssignmentSubmissions() http.HandlerFunc {
 			}
 			displayNames, err = user.DisplayLabelsByIDs(r.Context(), d.Pool, userIDs)
 			if err != nil {
-				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load submitter names.")
+				apierr.WriteInternal(w, r, "Failed to load submitter names.", err)
 				return
 			}
 			for _, entry := range roster {
@@ -343,14 +343,14 @@ func (d Deps) handleListAssignmentSubmissions() http.HandlerFunc {
 			WHERE course_id = $1 AND module_item_id = $2
 		`, *cid, itemID)
 		if err != nil {
-			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load grades.")
+			apierr.WriteInternal(w, r, "Failed to load grades.", err)
 			return
 		}
 		defer gradeRows.Close()
 		for gradeRows.Next() {
 			var sID uuid.UUID
 			if err := gradeRows.Scan(&sID); err != nil {
-				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to scan grades.")
+				apierr.WriteInternal(w, r, "Failed to scan grades.", err)
 				return
 			}
 			gradedMap[sID] = true
@@ -419,7 +419,7 @@ func (d Deps) handleGetMyAssignmentSubmission() http.HandlerFunc {
 		}
 		row, err := moduleassignmentsubmissions.GetForCourseItemUser(r.Context(), d.Pool, *cid, itemID, viewer)
 		if err != nil {
-			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load submission.")
+			apierr.WriteInternal(w, r, "Failed to load submission.", err)
 			return
 		}
 		if row == nil {
@@ -440,7 +440,7 @@ func (d Deps) handleGetMyAssignmentSubmission() http.HandlerFunc {
 			)
 		`, *cid, viewer, itemID).Scan(&exists)
 		if err != nil {
-			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to check grading status.")
+			apierr.WriteInternal(w, r, "Failed to check grading status.", err)
 			return
 		}
 		payload["isGraded"] = exists

--- a/server/internal/logging/middleware.go
+++ b/server/internal/logging/middleware.go
@@ -6,21 +6,36 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/lextures/lextures/server/internal/apierr"
 )
 
 // AccessLog logs HTTP requests with redacted paths (plan 10.14 FR-5).
 func AccessLog(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
+		r = apierr.WithServerErrorTracking(r)
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		next.ServeHTTP(ww, r)
-		slog.Info("http request",
+		status := ww.Status()
+		attrs := []any{
 			"method", r.Method,
 			"path", RedactRequestPath(r.URL.Path),
-			"status", ww.Status(),
+			"status", status,
 			"bytes", ww.BytesWritten(),
 			"duration_ms", time.Since(start).Milliseconds(),
 			"request_id", middleware.GetReqID(r.Context()),
-		)
+		}
+		if status >= http.StatusInternalServerError {
+			msg, serverErr := apierr.ServerErrorFromRequest(r)
+			if msg != "" {
+				attrs = append(attrs, "error_message", msg)
+			}
+			if serverErr != nil {
+				attrs = append(attrs, "err", serverErr)
+			}
+			slog.Error("http request", attrs...)
+			return
+		}
+		slog.Info("http request", attrs...)
 	})
 }

--- a/server/internal/logging/middleware_test.go
+++ b/server/internal/logging/middleware_test.go
@@ -1,0 +1,49 @@
+package logging
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/apierr"
+)
+
+func TestAccessLog_LogsServerErrorOn500(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	handler := AccessLog(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apierr.WriteInternal(w, r, "Failed to load submissions.", errTestFailure)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/courses/C-TEST/assignments/item/submissions", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d want %d", rr.Code, http.StatusInternalServerError)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"level":"ERROR"`) {
+		t.Fatalf("expected ERROR log, got: %s", out)
+	}
+	if !strings.Contains(out, `"error_message":"Failed to load submissions."`) {
+		t.Fatalf("expected error_message in log, got: %s", out)
+	}
+	if !strings.Contains(out, `"err":"database unavailable"`) {
+		t.Fatalf("expected err in log, got: %s", out)
+	}
+}
+
+var errTestFailure = errString("database unavailable")
+
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/server/internal/repos/moduleassignmentsubmissions/repo.go
+++ b/server/internal/repos/moduleassignmentsubmissions/repo.go
@@ -158,7 +158,7 @@ func ListForAssignment(ctx context.Context, pool *pgxpool.Pool, courseID, module
 		gradedClause = "AND g.student_user_id IS NULL"
 	}
 	rows, err := pool.Query(ctx, `
-SELECT s.id, s.course_id, s.module_item_id, s.submitted_by, s.attachment_file_id, s.submitted_at, s.updated_at,
+SELECT s.id, s.course_id, s.module_item_id, s.submitted_by, s.attachment_file_id, s.body_text, s.submitted_at, s.updated_at,
        s.resubmission_requested, s.revision_due_at, s.revision_feedback, s.version_number
 FROM course.module_assignment_submissions s
 LEFT JOIN course.course_grades g ON g.module_item_id = s.module_item_id AND g.student_user_id = s.submitted_by


### PR DESCRIPTION
## Summary

- Log underlying errors on 5xx responses: access logs now emit at `ERROR` level with `error_message` and `err` fields when handlers use `apierr.WriteInternal` / `apierr.WriteJSONWithErr`
- Fix grading agent submissions 500: `ListForAssignment` was missing `body_text` in its SELECT, causing an 11-vs-12 column scan mismatch

## Context

Loading the grading agent hit repeated 500s on `GET /api/v1/courses/{course}/assignments/{item}/submissions`. The access log only showed status codes with no root cause. After adding error recording, the real failure was:

```
number of field descriptions must equal number of destinations, got 11 and 12
```

## Changes

- Add request-scoped server error tracking (`apierr/request_error.go`)
- Add `WriteInternal` and `WriteJSONWithErr` helpers
- Upgrade access log middleware to log 5xx at ERROR with attached error details
- Update assignment submissions handler to use the new helpers
- Add missing `s.body_text` to `ListForAssignment` query

## Test plan

- [x] `go test ./internal/logging/... ./internal/apierr/...`
- [x] `go test ./internal/httpserver/... -run Submission`
- [ ] Reload grading agent and confirm submissions list loads without 500
- [ ] Confirm server logs show `error_message` + `err` on any future 5xx from updated handlers