### PR TITLE
refactor(grading-agent): unify queue consumer grade-write paths (GA-S1)

### DIFF
--- a/clients/web/src/pages/__tests__/login.test.tsx
+++ b/clients/web/src/pages/__tests__/login.test.tsx
@@ -31,9 +31,9 @@ describe('Login', () => {
     await user.type(screen.getByLabelText(/^password$/i), 'hunter2correct')
     await user.click(screen.getByRole('button', { name: /^sign in$/i }))
 
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /^dashboard$/i })).toBeInTheDocument()
-    })
+    expect(
+      await screen.findByRole('heading', { name: /^dashboard$/i }, { timeout: 10_000 }),
+    ).toBeInTheDocument()
   })
 
   it('shows the API error message when credentials are rejected', async () => {

--- a/docs/completed/grading-agent/simplify-1-unify-grade-write-paths.md
+++ b/docs/completed/grading-agent/simplify-1-unify-grade-write-paths.md
@@ -1,6 +1,6 @@
 # GA-S1 — Unify the three duplicated grade-write paths in the consumer
 
-> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](../../plan/grading-agent/README.md).
 
 ## Metadata
 
@@ -10,11 +10,19 @@
 | **Section** | Grading Agent — Over-complexity / Simplification |
 | **Severity** | MAJOR |
 | **Markets** | HE / K12 / SL (internal maintainability) |
-| **Status (today)** | THIN |
+| **Status (today)** | COMPLETE |
 | **Estimated effort** | M (2–4w) |
 | **Owner (proposed)** | Assessment / Grading squad |
 | **Depends on** | — |
-| **Unblocks** | [GA-M3](missing-3-suggest-only-batch-and-bulk-review.md), [GA-M4](missing-4-confidence-auto-hold-threshold.md), [GA-M6](missing-6-cancel-running-batch.md), [GA-B2](bug-2-requeue-double-grading.md) |
+| **Unblocks** | [GA-M6](missing-6-cancel-running-batch.md) (suggest-only/confidence floor/idempotency now single-path) |
+
+## Implementation summary (2026-06-25)
+
+- **Queue handler** — `HandleGradingAgentQueueMessage` reduced to setup + one `executeGradingAgentPreview` call + `persistGradingAgentPreview` (~120 lines).
+- **Execute** — `grading_agent_execute.go`: compiled graphs always run through `ExecuteWorkflowDryRun`; legacy configs with no compilable graph fall back to `Service.Score` / `ScoreWithVision`. Model resolution and AI-gateway checks live once per branch.
+- **Persist** — `persistGradingAgentPreview` in `grading_agent_apply.go`: flagged, gate-held, agent-floor-held, suggest-only, and applied outcomes share one path (closes Path B's missing held/flagged handling).
+- **Tests** — `grading_agent_execute_test.go`, `grading_agent_apply_test.go` cover routing helpers, preview mapping, and hold composition.
+- **Docs** — agent-grader README execution layer updated to reference the unified consumer path.
 
 ## 1. Problem Statement
 

--- a/docs/plan/agent-grader/README.md
+++ b/docs/plan/agent-grader/README.md
@@ -43,8 +43,10 @@ A node is wired into **five** layers; every plan in this folder specifies all fi
 4. **Execution** — the topological walker
    [`workflow_execute.go`](../../../server/internal/service/gradingagent/workflow_execute.go)
    (`ExecuteWorkflowDryRun`) produces a `slotValue{ text, grade, rubric, score }` per `nodeID:handle`. Live
-   batch/auto runs reuse the same compiler via
-   [`grading_agent_consumer.go`](../../../server/internal/background/grading_agent_consumer.go).
+   batch runs use the same engine via
+   [`grading_agent_queue.go`](../../../server/internal/httpserver/grading_agent_queue.go)
+   (`executeGradingAgentPreview` → `persistGradingAgentPreview`; see
+   [GA-S1](../../completed/grading-agent/simplify-1-unify-grade-write-paths.md)).
 5. **Inspector & i18n** — the right-hand editor
    [`inspector-panel.tsx`](../../../clients/web/src/components/annotation/grader-agent/inspector-panel.tsx)
    renders per-node settings; all strings live under `gradingAgent.canvas.*` in

--- a/docs/plan/grading-agent/README.md
+++ b/docs/plan/grading-agent/README.md
@@ -39,7 +39,7 @@
 
 | ID | Plan | One-liner |
 |---|---|---|
-| GA-S1 | [Unify the three duplicated grade-write paths in the consumer](simplify-1-unify-grade-write-paths.md) | `HandleGradingAgentQueueMessage` has three overlapping branches that all end in "execute + write grade". |
+| GA-S1 | [Unify the three duplicated grade-write paths in the consumer](../../completed/grading-agent/simplify-1-unify-grade-write-paths.md) | **Done** — single execute + persist path in the queue consumer. |
 | GA-S2 | [Remove the dead HTTP dry-run path; rename the execution engine](simplify-2-remove-dead-dry-run-and-rename-engine.md) | `POST /dry-run` + `Service.Score` legacy path is unused by the client and mis-handles complex graphs. |
 | GA-S3 | [Collapse the duplicated per-node update callbacks](simplify-3-generic-node-data-updater.md) | ~12 near-identical `updateXNode` callbacks in the hook can be one generic updater. |
 | GA-S4 | [Retire legacy node-type aliases & palette ternaries](simplify-4-legacy-node-type-aliases.md) | `submission`/`assignmentContext`/`grader` legacy types and giant nested ternaries add accidental complexity. |

--- a/server/internal/httpserver/grading_agent_apply.go
+++ b/server/internal/httpserver/grading_agent_apply.go
@@ -2,6 +2,7 @@ package httpserver
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -125,4 +126,46 @@ func (d Deps) finishGradingAgentSuccess(
 		return err
 	}
 	return gradingagentrepo.IncrementRunProgress(ctx, d.Pool, msg.RunID, false)
+}
+
+func (d Deps) persistGradingAgentPreview(
+	ctx context.Context,
+	msg gradingagentqueue.QueueMessage,
+	cfg *gradingagentrepo.ConfigRow,
+	assignRow *coursemoduleassignments.CourseItemAssignmentRow,
+	subRow *moduleassignmentsubmissions.SubmissionRow,
+	run *gradingagentrepo.RunRow,
+	preview gradingAgentPreviewResult,
+) error {
+	if preview.Flagged != nil {
+		reason := preview.Flagged.Reason
+		priority := preview.Flagged.Priority
+		_, _ = gradingagentrepo.InsertResult(ctx, d.Pool, gradingagentrepo.InsertResultInput{
+			RunID: &msg.RunID, ConfigID: cfg.ID, SubmissionID: msg.SubmissionID,
+			Status: gradingagentrepo.ItemFlagged, FlagReason: &reason,
+			FlagPriority: &priority,
+		})
+		return gradingagentrepo.IncrementRunProgress(ctx, d.Pool, msg.RunID, false)
+	}
+
+	var rubricJSON []byte
+	if len(preview.RubricScores) > 0 {
+		rubricJSON, _ = json.Marshal(preview.RubricScores)
+	}
+	successIn := gradingAgentSuccessInput{
+		Points: preview.Points, Comment: preview.Comment, Confidence: preview.Confidence,
+		RubricJSON: rubricJSON, ModelID: preview.ModelID, PromptTokens: preview.PromptTokens,
+		CompletionTokens: preview.CompletionTokens, CostUSD: preview.CostUSD, GradedByAI: preview.GradedByAI,
+	}
+
+	gateHold := &gradingAgentGateHoldInput{}
+	if preview.Held != nil {
+		gateHold.WouldHold = preview.Held.WouldHold
+		gateHold.Reason = preview.Held.Reason
+		gateHold.Queue = preview.Held.Queue
+	}
+	if hold, heldReason, queue := gradingAgentHoldDecision(cfg, preview.Confidence, gateHold); hold {
+		return d.insertHeldGradingAgentResult(ctx, msg, cfg, successIn, heldReason, queue)
+	}
+	return d.finishGradingAgentSuccess(ctx, msg, cfg, assignRow, subRow, run, successIn)
 }

--- a/server/internal/httpserver/grading_agent_apply_test.go
+++ b/server/internal/httpserver/grading_agent_apply_test.go
@@ -1,0 +1,54 @@
+package httpserver
+
+import (
+	"testing"
+
+	gradingagentrepo "github.com/lextures/lextures/server/internal/repos/gradingagent"
+	gradingagentsvc "github.com/lextures/lextures/server/internal/service/gradingagent"
+)
+
+func TestGradingAgentHoldDecision_composesGateAndFloor(t *testing.T) {
+	floor := 0.8
+	cfg := &gradingagentrepo.ConfigRow{ConfidenceFloor: &floor}
+	gate := &gradingAgentGateHoldInput{WouldHold: true, Reason: "Human review gate (always)", Queue: "instructor"}
+
+	hold, reason, queue := gradingAgentHoldDecision(cfg, 0.95, gate)
+	if !hold || queue != "instructor" {
+		t.Fatalf("gate hold: hold=%v queue=%q", hold, queue)
+	}
+	if reason == "" {
+		t.Fatal("expected hold reason")
+	}
+
+	hold, reason, _ = gradingAgentHoldDecision(cfg, 0.62, &gradingAgentGateHoldInput{})
+	if !hold || reason == "" {
+		t.Fatalf("floor hold: hold=%v reason=%q", hold, reason)
+	}
+
+	hold, _, _ = gradingAgentHoldDecision(cfg, 0.95, &gradingAgentGateHoldInput{})
+	if hold {
+		t.Fatal("expected no hold above floor without gate")
+	}
+}
+
+func TestGradingAgentPreviewResult_routesToPersistInputs(t *testing.T) {
+	preview := gradingAgentPreviewResult{
+		Points: 9, Comment: "Nice", Confidence: 0.88, GradedByAI: true,
+		RubricScores: map[string]float64{"c1": 4},
+		Held: &gradingagentsvc.DryRunHeldPreview{
+			WouldHold: true,
+			Reason:    "Human review gate (below confidence)",
+			Queue:     "default",
+		},
+	}
+	gateHold := &gradingAgentGateHoldInput{}
+	if preview.Held != nil {
+		gateHold.WouldHold = preview.Held.WouldHold
+		gateHold.Reason = preview.Held.Reason
+		gateHold.Queue = preview.Held.Queue
+	}
+	hold, _, _ := gradingAgentHoldDecision(&gradingagentrepo.ConfigRow{}, preview.Confidence, gateHold)
+	if !hold {
+		t.Fatal("expected persist path to honor gate hold from preview")
+	}
+}

--- a/server/internal/httpserver/grading_agent_execute.go
+++ b/server/internal/httpserver/grading_agent_execute.go
@@ -1,0 +1,224 @@
+package httpserver
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/lextures/lextures/server/internal/models/assignmentrubric"
+	gradingagentsvc "github.com/lextures/lextures/server/internal/service/gradingagent"
+	aigateway "github.com/lextures/lextures/server/internal/service/aigateway"
+	"github.com/lextures/lextures/server/internal/service/codeexecution"
+)
+
+type gradingAgentPreviewResult struct {
+	Points           float64
+	Comment          string
+	Confidence       float64
+	RubricScores     map[string]float64
+	Flagged          *gradingagentsvc.DryRunFlagPreview
+	Held             *gradingagentsvc.DryRunHeldPreview
+	ModelID          *string
+	PromptTokens     *int
+	CompletionTokens *int
+	CostUSD          *float64
+	GradedByAI       bool
+}
+
+type gradingAgentExecuteInput struct {
+	ModelUser       uuid.UUID
+	Submissions     []string
+	SubmissionText  string
+	UseVision       bool
+	VisionImages    []string
+	WorkflowGraph   *gradingagentsvc.WorkflowGraph
+	GradeSourceID   string
+	Compiled        gradingagentsvc.CompiledWorkflow
+	ContentModality gradingagentsvc.InputModality
+	ContentMarkdown string
+	Rubric          *assignmentrubric.RubricDefinition
+	MaxPoints       float64
+	CourseCode      string
+	SubmissionID    uuid.UUID
+	InstructorPrompt string
+	IncludeAssignmentContent bool
+	IncludeRubric   bool
+	ConfigModelID   *string
+}
+
+// gradingAgentVisionComplexGraphBlocked reports vision submissions on router/flag/gate/aggregator graphs.
+func gradingAgentVisionComplexGraphBlocked(useVision bool, g *gradingagentsvc.WorkflowGraph) bool {
+	return useVision && g != nil && gradingagentsvc.WorkflowRequiresGraphExecution(g)
+}
+
+// gradingAgentUsesWorkflowEngine reports whether a compiled workflow graph should be executed via the engine.
+func gradingAgentUsesWorkflowEngine(g *gradingagentsvc.WorkflowGraph) bool {
+	return g != nil
+}
+
+func (d Deps) executeGradingAgentPreview(
+	ctx context.Context,
+	svc *gradingagentsvc.Service,
+	in gradingAgentExecuteInput,
+) (gradingAgentPreviewResult, error) {
+	if gradingAgentUsesWorkflowEngine(in.WorkflowGraph) {
+		return d.executeGradingAgentWorkflowPreview(ctx, svc, in)
+	}
+	return d.executeGradingAgentLegacyScore(ctx, svc, in)
+}
+
+func (d Deps) executeGradingAgentWorkflowPreview(
+	ctx context.Context,
+	svc *gradingagentsvc.Service,
+	in gradingAgentExecuteInput,
+) (gradingAgentPreviewResult, error) {
+	modelID := in.Compiled.ScoreRequest.ModelID
+	if gradingagentsvc.WorkflowUsesLLM(in.WorkflowGraph) {
+		var modelErr error
+		modelID, modelErr = d.resolveGraderAgentModelID(ctx, in.ModelUser, modelID, in.ConfigModelID)
+		if modelErr != nil {
+			return gradingAgentPreviewResult{}, modelErr
+		}
+		dec, _ := aigateway.Evaluate(
+			ctx, d.Pool, d.aiGatewayConfig(), in.ModelUser, nil,
+			aigateway.FeatureGraderAgent, modelID,
+			aigateway.ContentHash(gradingagentsvc.ContentHashInput(in.Compiled.ScoreRequest.InstructorPrompt, in.SubmissionText)),
+		)
+		if !dec.Allowed {
+			return gradingAgentPreviewResult{}, errGradingAgentAIGatewayBlocked
+		}
+		if svc.Client == nil {
+			return gradingAgentPreviewResult{}, errGradingAgentProviderNotConfigured
+		}
+	}
+
+	preview, execErr := gradingagentsvc.ExecuteWorkflowDryRun(ctx, gradingagentsvc.DryRunExecutionInput{
+		Graph:           in.WorkflowGraph,
+		Submissions:     in.Submissions,
+		InputModality:   in.ContentModality,
+		SubmissionID:    in.SubmissionID,
+		CourseCode:      in.CourseCode,
+		DefaultMarkdown: in.ContentMarkdown,
+		DefaultRubric:   in.Rubric,
+		MaxPoints:       in.MaxPoints,
+		ModelID:         modelID,
+		LoadOriginalityReports: d.loadOriginalityReportsForGraderAgent,
+		LoadReferenceFile: func(ctx context.Context, courseCode string, fileID uuid.UUID) (string, error) {
+			return svc.LoadReferenceFileMarkdown(ctx, courseCode, fileID)
+		},
+		Runner:     svc,
+		CodeRunner: codeexecution.New(),
+	})
+	if execErr != nil {
+		return gradingAgentPreviewResult{}, execErr
+	}
+
+	return gradingAgentPreviewFromDryRun(preview, gradingagentsvc.WorkflowUsesLLM(in.WorkflowGraph)), nil
+}
+
+func (d Deps) executeGradingAgentLegacyScore(
+	ctx context.Context,
+	svc *gradingagentsvc.Service,
+	in gradingAgentExecuteInput,
+) (gradingAgentPreviewResult, error) {
+	modelID, modelErr := d.resolveGraderAgentModelID(ctx, in.ModelUser, "", in.ConfigModelID)
+	if modelErr != nil {
+		return gradingAgentPreviewResult{}, modelErr
+	}
+	prompt := in.InstructorPrompt
+	dec, _ := aigateway.Evaluate(
+		ctx, d.Pool, d.aiGatewayConfig(), in.ModelUser, nil,
+		aigateway.FeatureGraderAgent, modelID,
+		aigateway.ContentHash(gradingagentsvc.ContentHashInput(prompt, in.SubmissionText)),
+	)
+	if !dec.Allowed {
+		return gradingAgentPreviewResult{}, errGradingAgentAIGatewayBlocked
+	}
+	if svc.Client == nil {
+		return gradingAgentPreviewResult{}, errGradingAgentProviderNotConfigured
+	}
+
+	scoreReq := d.buildLegacyGradingAgentScoreRequest(in, modelID)
+	var result gradingagentsvc.ScoreResult
+	var err error
+	if in.UseVision {
+		result, err = svc.ScoreWithVision(ctx, scoreReq, in.VisionImages)
+	} else {
+		result, err = svc.Score(ctx, scoreReq)
+	}
+	if err != nil {
+		return gradingAgentPreviewResult{}, err
+	}
+	return gradingAgentPreviewFromScore(result), nil
+}
+
+func (d Deps) buildLegacyGradingAgentScoreRequest(in gradingAgentExecuteInput, modelID string) gradingagentsvc.ScoreRequest {
+	scoreReq := gradingagentsvc.ScoreRequest{
+		InstructorPrompt:         in.InstructorPrompt,
+		IncludeAssignmentContent: in.IncludeAssignmentContent,
+		IncludeRubric:            in.IncludeRubric,
+		ModelID:                  modelID,
+		SubmissionText:           in.SubmissionText,
+	}
+	if in.Compiled.GradeSource != "" {
+		scoreReq = in.Compiled.ScoreRequest
+		scoreReq.ModelID = modelID
+	}
+	scoreReq.AssignmentMarkdown = in.ContentMarkdown
+	scoreReq.Rubric = in.Rubric
+	scoreReq.MaxPoints = in.MaxPoints
+	if in.WorkflowGraph != nil && strings.TrimSpace(in.GradeSourceID) != "" {
+		scoreReq.InstructorPrompt = gradingagentsvc.SubstituteWorkflowPromptVariables(
+			in.WorkflowGraph,
+			in.GradeSourceID,
+			scoreReq.InstructorPrompt,
+			gradingagentsvc.PromptVariableContext{
+				Submissions:     in.Submissions,
+				ContentMarkdown: in.ContentMarkdown,
+				Rubric:          in.Rubric,
+			},
+		)
+	}
+	return scoreReq
+}
+
+func gradingAgentPreviewFromDryRun(preview gradingagentsvc.DryRunPreview, gradedByAI bool) gradingAgentPreviewResult {
+	return gradingAgentPreviewResult{
+		Points:       preview.SuggestedPoints,
+		Comment:      preview.Comment,
+		Confidence:   preview.Confidence,
+		RubricScores: preview.RubricScores,
+		Flagged:      preview.Flagged,
+		Held:         preview.Held,
+		GradedByAI:   gradedByAI,
+	}
+}
+
+func gradingAgentPreviewFromScore(result gradingagentsvc.ScoreResult) gradingAgentPreviewResult {
+	pt := result.PromptTokens
+	ct := result.CompletionTokens
+	cost := result.CostUSD
+	model := result.ModelID
+	return gradingAgentPreviewResult{
+		Points:           result.Output.TotalPoints,
+		Comment:          result.Output.Comment,
+		Confidence:       result.Output.Confidence,
+		RubricScores:     result.Output.RubricScores,
+		ModelID:          &model,
+		PromptTokens:     &pt,
+		CompletionTokens: &ct,
+		CostUSD:          &cost,
+		GradedByAI:       true,
+	}
+}
+
+// Sentinel errors mapped to user-facing failure reasons in the queue handler.
+var (
+	errGradingAgentAIGatewayBlocked      = gradingAgentExecuteError{"AI processing blocked"}
+	errGradingAgentProviderNotConfigured = gradingAgentExecuteError{"AI provider not configured"}
+)
+
+type gradingAgentExecuteError struct{ msg string }
+
+func (e gradingAgentExecuteError) Error() string { return e.msg }

--- a/server/internal/httpserver/grading_agent_execute_test.go
+++ b/server/internal/httpserver/grading_agent_execute_test.go
@@ -1,0 +1,120 @@
+package httpserver
+
+import (
+	"testing"
+
+	gradingagentsvc "github.com/lextures/lextures/server/internal/service/gradingagent"
+)
+
+func TestGradingAgentUsesWorkflowEngine(t *testing.T) {
+	if !gradingAgentUsesWorkflowEngine(&gradingagentsvc.WorkflowGraph{}) {
+		t.Fatal("expected compiled graph to use engine")
+	}
+	if gradingAgentUsesWorkflowEngine(nil) {
+		t.Fatal("expected nil graph to use legacy score")
+	}
+}
+
+func TestGradingAgentVisionComplexGraphBlocked(t *testing.T) {
+	simple := sampleGraphWithGraderForQueueTest("Grade", false, false)
+	if gradingAgentVisionComplexGraphBlocked(true, &simple) {
+		t.Fatal("simple AI graph should not block vision")
+	}
+
+	flagGraph := gradingagentsvc.WorkflowGraph{
+		Version: gradingagentsvc.WorkflowVersion,
+		Nodes: []gradingagentsvc.WorkflowNode{
+			{ID: "output", Type: gradingagentsvc.NodeTypeOutput, Data: map[string]any{}},
+			{ID: "flag", Type: gradingagentsvc.NodeTypeFlagForReview, Data: map[string]any{}},
+		},
+		Edges: []gradingagentsvc.WorkflowEdge{
+			{ID: "e1", Source: "flag", SourceHandle: gradingagentsvc.HandleReason, Target: "output", TargetHandle: gradingagentsvc.HandleComments},
+		},
+	}
+	if !gradingAgentVisionComplexGraphBlocked(true, &flagGraph) {
+		t.Fatal("vision on flag graph should be blocked")
+	}
+	if gradingAgentVisionComplexGraphBlocked(false, &flagGraph) {
+		t.Fatal("file modality should not block flag graph")
+	}
+}
+
+func TestGradingAgentPreviewFromDryRun_preservesHeldAndFlagged(t *testing.T) {
+	preview := gradingAgentPreviewFromDryRun(gradingagentsvc.DryRunPreview{
+		SuggestedPoints: 8,
+		Comment:         "Good work",
+		Confidence:      0.72,
+		Held: &gradingagentsvc.DryRunHeldPreview{
+			WouldHold: true,
+			Reason:    "Human review gate (below confidence)",
+			Queue:     "instructor",
+		},
+	}, true)
+	if preview.Held == nil || !preview.Held.WouldHold {
+		t.Fatal("expected held preview")
+	}
+	if !preview.GradedByAI {
+		t.Fatal("expected gradedByAI")
+	}
+
+	flagged := gradingAgentPreviewFromDryRun(gradingagentsvc.DryRunPreview{
+		Flagged: &gradingagentsvc.DryRunFlagPreview{Reason: "Blank submission", Priority: "high"},
+	}, false)
+	if flagged.Flagged == nil || flagged.Flagged.Reason != "Blank submission" {
+		t.Fatal("expected flagged preview")
+	}
+	if flagged.GradedByAI {
+		t.Fatal("code-test-only graph should not set gradedByAI")
+	}
+}
+
+func TestBuildLegacyGradingAgentScoreRequest_substitutesPromptVariables(t *testing.T) {
+	g := sampleGraphWithGraderForQueueTest("Grade $Submission.Text", true, false)
+	compiled, err := gradingagentsvc.CompileWorkflowGraph(&g, "hello world")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := Deps{}
+	req := d.buildLegacyGradingAgentScoreRequest(gradingAgentExecuteInput{
+		InstructorPrompt:         "fallback",
+		IncludeAssignmentContent: true,
+		IncludeRubric:            true,
+		SubmissionText:           "hello world",
+		Submissions:              []string{"hello world"},
+		WorkflowGraph:            &g,
+		GradeSourceID:            compiled.GradeSource,
+		Compiled:                 compiled,
+		ContentMarkdown:          "assignment body",
+	}, "model-x")
+	if req.ModelID != "model-x" {
+		t.Fatalf("model = %q", req.ModelID)
+	}
+	if req.InstructorPrompt == "fallback" {
+		t.Fatal("expected prompt substitution from workflow graph")
+	}
+}
+
+func sampleGraphWithGraderForQueueTest(prompt string, includeContent, includeRubric bool) gradingagentsvc.WorkflowGraph {
+	nodes := []gradingagentsvc.WorkflowNode{
+		{ID: "output", Type: gradingagentsvc.NodeTypeOutput, Data: map[string]any{}},
+		{ID: "g1", Type: gradingagentsvc.NodeTypeGrader, Data: map[string]any{"prompt": prompt}},
+		{ID: "sub1", Type: gradingagentsvc.NodeTypeStudentSubmission, Data: map[string]any{}},
+	}
+	edges := []gradingagentsvc.WorkflowEdge{
+		{ID: "e1", Source: "g1", SourceHandle: gradingagentsvc.HandleGrade, Target: "output", TargetHandle: gradingagentsvc.HandleGrade},
+		{ID: "e2", Source: "g1", SourceHandle: gradingagentsvc.HandleComments, Target: "output", TargetHandle: gradingagentsvc.HandleComments},
+		{ID: "e3", Source: "sub1", SourceHandle: gradingagentsvc.HandleSubmission, Target: "g1", TargetHandle: gradingagentsvc.HandleSubmission},
+	}
+	if includeContent || includeRubric {
+		nodes = append(nodes, gradingagentsvc.WorkflowNode{
+			ID: "act", Type: gradingagentsvc.NodeTypeActivity, Data: map[string]any{},
+		})
+		if includeContent {
+			edges = append(edges, gradingagentsvc.WorkflowEdge{ID: "e4", Source: "act", SourceHandle: gradingagentsvc.HandleContent, Target: "g1", TargetHandle: gradingagentsvc.HandleContent})
+		}
+		if includeRubric {
+			edges = append(edges, gradingagentsvc.WorkflowEdge{ID: "e5", Source: "act", SourceHandle: gradingagentsvc.HandleRubric, Target: "g1", TargetHandle: gradingagentsvc.HandleRubric})
+		}
+	}
+	return gradingagentsvc.WorkflowGraph{Version: gradingagentsvc.WorkflowVersion, Nodes: nodes, Edges: edges}
+}

--- a/server/internal/httpserver/grading_agent_queue.go
+++ b/server/internal/httpserver/grading_agent_queue.go
@@ -2,19 +2,13 @@ package httpserver
 
 import (
 	"context"
-	"encoding/json"
-	"strings"
-
-	"github.com/google/uuid"
 
 	gradingagentrepo "github.com/lextures/lextures/server/internal/repos/gradingagent"
 	"github.com/lextures/lextures/server/internal/repos/coursegrades"
 	"github.com/lextures/lextures/server/internal/repos/coursemoduleassignments"
 	"github.com/lextures/lextures/server/internal/repos/moduleassignmentsubmissions"
 	"github.com/lextures/lextures/server/internal/gradingagentqueue"
-	"github.com/lextures/lextures/server/internal/service/codeexecution"
 	gradingagentsvc "github.com/lextures/lextures/server/internal/service/gradingagent"
-	aigateway "github.com/lextures/lextures/server/internal/service/aigateway"
 )
 
 // HandleGradingAgentQueueMessage grades one submission and writes a provisional grade.
@@ -65,10 +59,7 @@ func (d Deps) HandleGradingAgentQueueMessage(ctx context.Context, msg gradingage
 		modality := string(content.Modality)
 		return d.failGradingAgentItem(ctx, msg, content.FailureReason, &modality)
 	}
-	submissions := content.Markdowns
-	submissionText := content.Text
 	useVision := content.Modality == gradingagentsvc.ModalityVision
-	visionImages := content.ImageDataURLs
 	modelUser := cfg.CreatedBy
 	if run.InitiatedBy != nil {
 		modelUser = *run.InitiatedBy
@@ -80,7 +71,7 @@ func (d Deps) HandleGradingAgentQueueMessage(ctx context.Context, msg gradingage
 	var gradeSourceID string
 	var compiled gradingagentsvc.CompiledWorkflow
 	if wg, wgErr := gradingagentsvc.EffectiveWorkflowGraph(cfg.WorkflowGraph, cfg.Prompt, cfg.IncludeAssignmentContent, cfg.IncludeRubric); wgErr == nil && wg != nil {
-		if c, compileErr := gradingagentsvc.CompileWorkflowGraph(wg, submissionText); compileErr == nil {
+		if c, compileErr := gradingagentsvc.CompileWorkflowGraph(wg, content.Text); compileErr == nil {
 			compiled = c
 			contentItemID = c.ContentItemID
 			rubricItemID = c.RubricItemID
@@ -99,209 +90,36 @@ func (d Deps) HandleGradingAgentQueueMessage(ctx context.Context, msg gradingage
 	rubric, _ := gradingagentsvc.ParseAssignmentRubric(rubricRow)
 	maxPoints := gradingagentsvc.MaxPointsFromAssignment(assignRow)
 
-	if useVision && workflowGraph != nil && gradingagentsvc.WorkflowRequiresGraphExecution(workflowGraph) {
+	if gradingAgentVisionComplexGraphBlocked(useVision, workflowGraph) {
 		reason := gradingagentsvc.FailureVisionWorkflowUnsupported
 		modality := string(gradingagentsvc.ModalityUnreadable)
 		return d.failGradingAgentItem(ctx, msg, reason, &modality)
 	}
-	if workflowGraph != nil && gradingagentsvc.WorkflowRequiresGraphExecution(workflowGraph) {
-		dryRunModelID, modelErr := d.resolveGraderAgentModelID(ctx, modelUser, compiled.ScoreRequest.ModelID, cfg.ModelID)
-		if modelErr != nil {
-			return d.failGradingAgentItem(ctx, msg, modelErr.Error(), nil)
-		}
-		if gradingagentsvc.WorkflowUsesLLM(workflowGraph) {
-			dec, _ := aigateway.Evaluate(ctx, d.Pool, d.aiGatewayConfig(), modelUser, nil, aigateway.FeatureGraderAgent, dryRunModelID, aigateway.ContentHash(gradingagentsvc.ContentHashInput(compiled.ScoreRequest.InstructorPrompt, submissionText)))
-			if !dec.Allowed {
-				return d.failGradingAgentItem(ctx, msg, "AI processing blocked", nil)
-			}
-			if svc.Client == nil {
-				return d.failGradingAgentItem(ctx, msg, "AI provider not configured", nil)
-			}
-		}
-		preview, execErr := gradingagentsvc.ExecuteWorkflowDryRun(ctx, gradingagentsvc.DryRunExecutionInput{
-			Graph:           workflowGraph,
-			Submissions:     submissions,
-			InputModality:   content.Modality,
-			SubmissionID:    msg.SubmissionID,
-			CourseCode:      msg.CourseCode,
-			DefaultMarkdown: contentRow.Markdown,
-			DefaultRubric:   rubric,
-			MaxPoints:       maxPoints,
-			ModelID:         dryRunModelID,
-			LoadOriginalityReports: d.loadOriginalityReportsForGraderAgent,
-			LoadReferenceFile: func(ctx context.Context, courseCode string, fileID uuid.UUID) (string, error) {
-				return svc.LoadReferenceFileMarkdown(ctx, courseCode, fileID)
-			},
-			Runner:     svc,
-			CodeRunner: codeexecution.New(),
-		})
-		if execErr != nil {
-			return d.failGradingAgentItem(ctx, msg, execErr.Error(), nil)
-		}
-		if preview.Flagged != nil {
-			reason := preview.Flagged.Reason
-			priority := preview.Flagged.Priority
-			_, _ = gradingagentrepo.InsertResult(ctx, d.Pool, gradingagentrepo.InsertResultInput{
-				RunID: &msg.RunID, ConfigID: cfg.ID, SubmissionID: msg.SubmissionID,
-				Status: gradingagentrepo.ItemFlagged, FlagReason: &reason,
-				FlagPriority: &priority,
-			})
-			return gradingagentrepo.IncrementRunProgress(ctx, d.Pool, msg.RunID, false)
-		}
-		comment := preview.Comment
-		conf := preview.Confidence
-		pts := preview.SuggestedPoints
-		gateHold := &gradingAgentGateHoldInput{}
-		if preview.Held != nil {
-			gateHold.WouldHold = preview.Held.WouldHold
-			gateHold.Reason = preview.Held.Reason
-			gateHold.Queue = preview.Held.Queue
-		}
-		if hold, heldReason, queue := gradingAgentHoldDecision(cfg, conf, gateHold); hold {
-			if err := d.insertHeldGradingAgentResult(ctx, msg, cfg, gradingAgentSuccessInput{
-				Points: pts, Comment: comment, Confidence: conf,
-			}, heldReason, queue); err != nil {
-				return d.failGradingAgentItem(ctx, msg, "failed to record held grade", nil)
-			}
-			return nil
-		}
-		var rubricJSON []byte
-		if len(preview.RubricScores) > 0 {
-			rubricJSON, _ = json.Marshal(preview.RubricScores)
-		}
-		if err := d.finishGradingAgentSuccess(ctx, msg, cfg, assignRow, subRow, run, gradingAgentSuccessInput{
-			Points: pts, Comment: comment, Confidence: conf, RubricJSON: rubricJSON, GradedByAI: true,
-		}); err != nil {
-			return d.failGradingAgentItem(ctx, msg, "failed to write grade", nil)
-		}
-		return nil
-	}
 
-	if workflowGraph != nil && gradeSourceID != "" {
-		var gradeSource *gradingagentsvc.WorkflowNode
-		for i := range workflowGraph.Nodes {
-			if workflowGraph.Nodes[i].ID == gradeSourceID {
-				gradeSource = &workflowGraph.Nodes[i]
-				break
-			}
-		}
-		if gradeSource != nil {
-			switch gradeSource.Type {
-			case gradingagentsvc.NodeTypeCodeTestRunner, gradingagentsvc.NodeTypeCriterionGrader, gradingagentsvc.NodeTypeAI:
-				dryRunModelID := compiled.ScoreRequest.ModelID
-				if gradeSource.Type != gradingagentsvc.NodeTypeCodeTestRunner {
-					var modelErr error
-					dryRunModelID, modelErr = d.resolveGraderAgentModelID(ctx, modelUser, dryRunModelID, cfg.ModelID)
-					if modelErr != nil {
-						return d.failGradingAgentItem(ctx, msg, modelErr.Error(), nil)
-					}
-					dec, _ := aigateway.Evaluate(ctx, d.Pool, d.aiGatewayConfig(), modelUser, nil, aigateway.FeatureGraderAgent, dryRunModelID, aigateway.ContentHash(gradingagentsvc.ContentHashInput(compiled.ScoreRequest.InstructorPrompt, submissionText)))
-					if !dec.Allowed {
-						return d.failGradingAgentItem(ctx, msg, "AI processing blocked", nil)
-					}
-					if svc.Client == nil {
-						return d.failGradingAgentItem(ctx, msg, "AI provider not configured", nil)
-					}
-				}
-				preview, execErr := gradingagentsvc.ExecuteWorkflowDryRun(ctx, gradingagentsvc.DryRunExecutionInput{
-					Graph:           workflowGraph,
-					Submissions:     submissions,
-					InputModality:   content.Modality,
-					SubmissionID:    msg.SubmissionID,
-					CourseCode:      msg.CourseCode,
-					DefaultMarkdown: contentRow.Markdown,
-					DefaultRubric:   rubric,
-					MaxPoints:       maxPoints,
-					ModelID:         dryRunModelID,
-					LoadOriginalityReports: d.loadOriginalityReportsForGraderAgent,
-					LoadReferenceFile: func(ctx context.Context, courseCode string, fileID uuid.UUID) (string, error) {
-						return svc.LoadReferenceFileMarkdown(ctx, courseCode, fileID)
-					},
-					Runner:     svc,
-					CodeRunner: codeexecution.New(),
-				})
-				if execErr != nil {
-					return d.failGradingAgentItem(ctx, msg, execErr.Error(), nil)
-				}
-				comment := preview.Comment
-				conf := preview.Confidence
-				pts := preview.SuggestedPoints
-				var rubricJSON []byte
-				if len(preview.RubricScores) > 0 {
-					rubricJSON, _ = json.Marshal(preview.RubricScores)
-				}
-				gradedByAI := gradeSource.Type != gradingagentsvc.NodeTypeCodeTestRunner
-				if err := d.finishGradingAgentSuccess(ctx, msg, cfg, assignRow, subRow, run, gradingAgentSuccessInput{
-					Points: pts, Comment: comment, Confidence: conf, RubricJSON: rubricJSON, GradedByAI: gradedByAI,
-				}); err != nil {
-					return d.failGradingAgentItem(ctx, msg, "failed to write grade", nil)
-				}
-				return nil
-			}
-		}
-	}
-
-	modelID, modelErr := d.resolveGraderAgentModelID(ctx, modelUser, "", cfg.ModelID)
-	if modelErr != nil {
-		return d.failGradingAgentItem(ctx, msg, modelErr.Error(), nil)
-	}
-	dec, _ := aigateway.Evaluate(ctx, d.Pool, d.aiGatewayConfig(), modelUser, nil, aigateway.FeatureGraderAgent, modelID, aigateway.ContentHash(gradingagentsvc.ContentHashInput(cfg.Prompt, submissionText)))
-	if !dec.Allowed {
-		return d.failGradingAgentItem(ctx, msg, "AI processing blocked", nil)
-	}
-	if svc.Client == nil {
-		return d.failGradingAgentItem(ctx, msg, "AI provider not configured", nil)
-	}
-	scoreReq := gradingagentsvc.ScoreRequest{
+	preview, execErr := d.executeGradingAgentPreview(ctx, svc, gradingAgentExecuteInput{
+		ModelUser:                modelUser,
+		Submissions:              content.Markdowns,
+		SubmissionText:           content.Text,
+		UseVision:                useVision,
+		VisionImages:             content.ImageDataURLs,
+		WorkflowGraph:            workflowGraph,
+		GradeSourceID:            gradeSourceID,
+		Compiled:                 compiled,
+		ContentModality:          content.Modality,
+		ContentMarkdown:          contentRow.Markdown,
+		Rubric:                     rubric,
+		MaxPoints:                  maxPoints,
+		CourseCode:               msg.CourseCode,
+		SubmissionID:             msg.SubmissionID,
 		InstructorPrompt:         cfg.Prompt,
 		IncludeAssignmentContent: cfg.IncludeAssignmentContent,
 		IncludeRubric:            cfg.IncludeRubric,
-		ModelID:                  modelID,
-		SubmissionText:           submissionText,
+		ConfigModelID:            cfg.ModelID,
+	})
+	if execErr != nil {
+		return d.failGradingAgentItem(ctx, msg, execErr.Error(), nil)
 	}
-	if compiled.GradeSource != "" {
-		scoreReq = compiled.ScoreRequest
-		scoreReq.ModelID = modelID
-	}
-	scoreReq.AssignmentMarkdown = contentRow.Markdown
-	scoreReq.Rubric = rubric
-	scoreReq.MaxPoints = maxPoints
-	if workflowGraph != nil && strings.TrimSpace(gradeSourceID) != "" {
-		scoreReq.InstructorPrompt = gradingagentsvc.SubstituteWorkflowPromptVariables(
-			workflowGraph,
-			gradeSourceID,
-			scoreReq.InstructorPrompt,
-			gradingagentsvc.PromptVariableContext{
-				Submissions:     submissions,
-				ContentMarkdown: contentRow.Markdown,
-				Rubric:          rubric,
-			},
-		)
-	}
-	var result gradingagentsvc.ScoreResult
-	if useVision {
-		result, err = svc.ScoreWithVision(ctx, scoreReq, visionImages)
-	} else {
-		result, err = svc.Score(ctx, scoreReq)
-	}
-	if err != nil {
-		return d.failGradingAgentItem(ctx, msg, err.Error(), nil)
-	}
-	comment := result.Output.Comment
-	conf := result.Output.Confidence
-	pt := result.PromptTokens
-	ct := result.CompletionTokens
-	cost := result.CostUSD
-	model := result.ModelID
-	pts := result.Output.TotalPoints
-	var rubricJSON []byte
-	if len(result.Output.RubricScores) > 0 {
-		rubricJSON, _ = json.Marshal(result.Output.RubricScores)
-	}
-	if err := d.finishGradingAgentSuccess(ctx, msg, cfg, assignRow, subRow, run, gradingAgentSuccessInput{
-		Points: pts, Comment: comment, Confidence: conf, RubricJSON: rubricJSON,
-		ModelID: &model, PromptTokens: &pt, CompletionTokens: &ct, CostUSD: &cost, GradedByAI: true,
-	}); err != nil {
+	if err := d.persistGradingAgentPreview(ctx, msg, cfg, assignRow, subRow, run, preview); err != nil {
 		return d.failGradingAgentItem(ctx, msg, "failed to write grade", nil)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Collapse the three duplicated branches in `HandleGradingAgentQueueMessage` into `executeGradingAgentPreview` and `persistGradingAgentPreview`.
- Compiled workflow graphs always run through `ExecuteWorkflowDryRun`; legacy configs without a compilable graph still use `Service.Score` / `ScoreWithVision`.
- Held, flagged, suggest-only, and applied outcomes now share one persist path (fixes Path B silently skipping gate holds and flags on simple graphs).

## Test plan
- [x] `go test ./internal/httpserver/... -short -run 'GradingAgent|GraderAgent'`
- [x] `go test ./... -short`
- [ ] CI green on PR checks


Made with [Cursor](https://cursor.com)