### PR TITLE
refactor(grading-agent): rename workflow engine and complete GA-S2

### DIFF
--- a/docs/completed/grading-agent/simplify-2-remove-dead-dry-run-and-rename-engine.md
+++ b/docs/completed/grading-agent/simplify-2-remove-dead-dry-run-and-rename-engine.md
@@ -1,6 +1,6 @@
 # GA-S2 — Remove the dead HTTP dry-run path; rename the execution engine
 
-> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](../../plan/grading-agent/README.md).
 
 ## Metadata
 
@@ -10,7 +10,7 @@
 | **Section** | Grading Agent — Over-complexity / Simplification |
 | **Severity** | MINOR |
 | **Markets** | internal maintainability |
-| **Status (today)** | THIN |
+| **Status (today)** | COMPLETE |
 | **Estimated effort** | S (1w) |
 | **Owner (proposed)** | Assessment / Grading squad |
 | **Depends on** | — |
@@ -128,7 +128,15 @@ The "DryRun" name actively misleads readers into thinking the consumer only prev
 ## 19. References
 
 - `server/internal/httpserver/grading_agent_http.go` (`handlePostGraderAgentDryRun`).
-- `server/internal/httpserver/grading_agent_dry_run_ws.go` (`ExecuteWorkflowDryRun` call).
-- `server/internal/service/gradingagent/workflow_execute.go` (engine + `DryRun*` types).
-- `clients/web/src/lib/courses-api.ts` (`postGraderAgentDryRun`, `streamGraderAgentDryRun`).
+- `server/internal/httpserver/grading_agent_dry_run_ws.go` (`ExecuteWorkflow` call).
+- `server/internal/service/gradingagent/workflow_execute.go` (engine + `Execution*` types).
+- `clients/web/src/lib/courses-api.ts` (`streamGraderAgentDryRun`).
 - Related: [GA-S1](simplify-1-unify-grade-write-paths.md), [GA-B4](bug-4-post-dry-run-mispreviews-graphs.md).
+
+## 20. Implementation notes
+
+- The dead `POST …/grader-agent/dry-run` route, handler, and `postGraderAgentDryRun` client function were already removed prior to this change (via GA-S1 / GA-B4 work). Confirmed by grep: no live code references remain.
+- Renamed the shared workflow engine: `ExecuteWorkflowDryRun` → `ExecuteWorkflow`, `DryRunExecutionInput` → `ExecutionInput`, `DryRunEvent` → `ExecutionEvent` across `workflow_execute.go` and all call sites (WS dry run, queue consumer execute path, node helpers, tests).
+- `Service.Score` is retained for legacy configs without a compilable workflow graph (`executeGradingAgentLegacyScore` in `grading_agent_execute.go`).
+- WS dry-run wire protocol unchanged; only internal Go symbol names updated.
+- OpenAPI never documented the removed POST route; no spec change required.

--- a/docs/plan/grading-agent/README.md
+++ b/docs/plan/grading-agent/README.md
@@ -15,7 +15,7 @@
   Flag for Review, Student Grade output).
 - **Validation/compile** — client `validation.ts` + server `workflow.go` (`ValidateWorkflowGraph`,
   `CompileWorkflowGraph`).
-- **Execution** — `workflow_execute.go::ExecuteWorkflowDryRun` topologically walks the graph. The
+- **Execution** — `workflow_execute.go::ExecuteWorkflow` topologically walks the graph. The
   **same engine runs both dry runs (WebSocket) and live batch/auto grading**
   (`background/grading_agent_consumer.go` → `HandleGradingAgentQueueMessage`).
 - **Persistence** — `assessment.grading_agent_configs / _runs / _results` via
@@ -40,7 +40,7 @@
 | ID | Plan | One-liner |
 |---|---|---|
 | GA-S1 | [Unify the three duplicated grade-write paths in the consumer](../../completed/grading-agent/simplify-1-unify-grade-write-paths.md) | **Done** — single execute + persist path in the queue consumer. |
-| GA-S2 | [Remove the dead HTTP dry-run path; rename the execution engine](simplify-2-remove-dead-dry-run-and-rename-engine.md) | `POST /dry-run` + `Service.Score` legacy path is unused by the client and mis-handles complex graphs. |
+| GA-S2 | [Remove the dead HTTP dry-run path; rename the execution engine](../../completed/grading-agent/simplify-2-remove-dead-dry-run-and-rename-engine.md) | **Done** — POST dry-run removed; engine renamed to `ExecuteWorkflow`. |
 | GA-S3 | [Collapse the duplicated per-node update callbacks](simplify-3-generic-node-data-updater.md) | ~12 near-identical `updateXNode` callbacks in the hook can be one generic updater. |
 | GA-S4 | [Retire legacy node-type aliases & palette ternaries](simplify-4-legacy-node-type-aliases.md) | `submission`/`assignmentContext`/`grader` legacy types and giant nested ternaries add accidental complexity. |
 

--- a/server/internal/httpserver/grading_agent_dry_run_ws.go
+++ b/server/internal/httpserver/grading_agent_dry_run_ws.go
@@ -65,7 +65,7 @@ func (d Deps) handleGraderAgentDryRunWS() http.HandlerFunc {
 
 		var first graderAgentDryRunWSFirstMessage
 		if err := json.Unmarshal(payload, &first); err != nil || strings.TrimSpace(first.AuthToken) == "" {
-			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.DryRunEvent{Type: "error", Message: "Invalid first message. Send authToken, submissionId, and workflowGraph."})
+			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.ExecutionEvent{Type: "error", Message: "Invalid first message. Send authToken, submissionId, and workflowGraph."})
 			return
 		}
 		u, err := d.JWTSigner.Verify(r.Context(), first.AuthToken)
@@ -82,22 +82,22 @@ func (d Deps) handleGraderAgentDryRunWS() http.HandlerFunc {
 
 		submissionID, err := uuid.Parse(strings.TrimSpace(first.SubmissionID))
 		if err != nil {
-			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.DryRunEvent{Type: "error", Message: "Invalid submission id."})
+			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.ExecutionEvent{Type: "error", Message: "Invalid submission id."})
 			return
 		}
 		if first.WorkflowGraph == nil {
-			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.DryRunEvent{Type: "error", Message: "Workflow graph is required."})
+			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.ExecutionEvent{Type: "error", Message: "Workflow graph is required."})
 			return
 		}
 
 		cid, assignRow, loadErr := d.loadAssignmentForSubmissionsByIDs(r.Context(), courseCode, itemID)
 		if loadErr != nil || assignRow == nil || cid == nil {
-			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.DryRunEvent{Type: "error", Message: "Assignment not found."})
+			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.ExecutionEvent{Type: "error", Message: "Assignment not found."})
 			return
 		}
 		subRow, err := moduleassignmentsubmissions.GetByIDForCourse(r.Context(), d.Pool, *cid, submissionID)
 		if err != nil || subRow == nil {
-			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.DryRunEvent{Type: "error", Message: "Submission not found."})
+			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.ExecutionEvent{Type: "error", Message: "Submission not found."})
 			return
 		}
 		svc := d.gradingAgentService()
@@ -106,15 +106,15 @@ func (d Deps) handleGraderAgentDryRunWS() http.HandlerFunc {
 			VisionEnabled:    d.graderAgentVisionGradingEnabled(),
 		})
 		if err != nil {
-			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.DryRunEvent{Type: "error", Message: dryRunSubmissionLoadMessage(err)})
+			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.ExecutionEvent{Type: "error", Message: dryRunSubmissionLoadMessage(err)})
 			return
 		}
 		if content.FailureReason != "" {
-			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.DryRunEvent{Type: "error", Message: content.FailureReason})
+			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.ExecutionEvent{Type: "error", Message: content.FailureReason})
 			return
 		}
 		if content.Modality == gradingagentsvc.ModalityVision {
-			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.DryRunEvent{Type: "error", Message: "Dry run for vision submissions requires a workflow with extractable text or a simplified graph."})
+			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.ExecutionEvent{Type: "error", Message: "Dry run for vision submissions requires a workflow with extractable text or a simplified graph."})
 			return
 		}
 		submissions := content.Markdowns
@@ -126,7 +126,7 @@ func (d Deps) handleGraderAgentDryRunWS() http.HandlerFunc {
 			if ve, ok := compileErr.(gradingagentsvc.ValidationError); ok {
 				msg = ve.Message
 			}
-			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.DryRunEvent{Type: "error", Message: msg})
+			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.ExecutionEvent{Type: "error", Message: msg})
 			return
 		}
 
@@ -138,44 +138,44 @@ func (d Deps) handleGraderAgentDryRunWS() http.HandlerFunc {
 			var modelErr error
 			modelID, modelErr = d.resolveGraderAgentModelID(r.Context(), viewer, explicitModel, nil)
 			if modelErr != nil {
-				_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.DryRunEvent{Type: "error", Message: gradingagentsvc.UserFacingScoreError(modelErr)})
+				_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.ExecutionEvent{Type: "error", Message: gradingagentsvc.UserFacingScoreError(modelErr)})
 				return
 			}
 			governancePrompt = compiled.ScoreRequest.InstructorPrompt
 			if blockMsg, blocked := d.evaluateAIGatewayBlock(r.Context(), viewer, aigateway.FeatureGraderAgent, modelID, gradingagentsvc.ContentHashInput(governancePrompt, submissionText)); blocked {
-				_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.DryRunEvent{Type: "error", Message: blockMsg})
+				_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.ExecutionEvent{Type: "error", Message: blockMsg})
 				return
 			}
 			if d.openRouterClient() == nil || strings.TrimSpace(d.effectiveConfig().OpenRouterAPIKey) == "" {
-				_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.DryRunEvent{Type: "error", Message: "AI provider is not configured."})
+				_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.ExecutionEvent{Type: "error", Message: "AI provider is not configured."})
 				return
 			}
 		}
 
 		contentRow, contentErr := d.assignmentRowForActivitySource(r.Context(), *cid, itemID, assignRow, compiled.ContentItemID)
 		if contentErr != nil {
-			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.DryRunEvent{Type: "error", Message: contentErr.Error()})
+			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.ExecutionEvent{Type: "error", Message: contentErr.Error()})
 			return
 		}
 		rubricRow, rubricErr := d.assignmentRowForActivitySource(r.Context(), *cid, itemID, assignRow, compiled.RubricItemID)
 		if rubricErr != nil {
-			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.DryRunEvent{Type: "error", Message: rubricErr.Error()})
+			_ = wsWriteJSON(r.Context(), conn, gradingagentsvc.ExecutionEvent{Type: "error", Message: rubricErr.Error()})
 			return
 		}
 		rubric, _ := gradingagentsvc.ParseAssignmentRubric(rubricRow)
 		maxPoints := gradingagentsvc.MaxPointsFromAssignment(assignRow)
 
 		runCtx := r.Context()
-		emit := func(ev gradingagentsvc.DryRunEvent) {
+		emit := func(ev gradingagentsvc.ExecutionEvent) {
 			_ = wsWriteJSON(runCtx, conn, ev)
 		}
-		emit(gradingagentsvc.DryRunEvent{Type: "log", Level: "info", Message: "Starting dry run…"})
-		emit(gradingagentsvc.DryRunEvent{
+		emit(gradingagentsvc.ExecutionEvent{Type: "log", Level: "info", Message: "Starting dry run…"})
+		emit(gradingagentsvc.ExecutionEvent{
 			Type: "log", Level: "info",
 			Message: fmt.Sprintf("Submission input modality: %s.", content.Modality.ModalityLogLabel()),
 		})
 
-		preview, execErr := gradingagentsvc.ExecuteWorkflowDryRun(runCtx, gradingagentsvc.DryRunExecutionInput{
+		preview, execErr := gradingagentsvc.ExecuteWorkflow(runCtx, gradingagentsvc.ExecutionInput{
 			Graph:           first.WorkflowGraph,
 			Submissions:     submissions,
 			InputModality:   content.Modality,
@@ -206,7 +206,7 @@ func (d Deps) handleGraderAgentDryRunWS() http.HandlerFunc {
 			if ve, ok := execErr.(gradingagentsvc.ValidationError); ok {
 				msg = ve.Message
 			}
-			emit(gradingagentsvc.DryRunEvent{Type: "error", Message: msg})
+			emit(gradingagentsvc.ExecutionEvent{Type: "error", Message: msg})
 			return
 		}
 
@@ -249,7 +249,7 @@ func (d Deps) handleGraderAgentDryRunWS() http.HandlerFunc {
 			})
 		}
 
-		emit(gradingagentsvc.DryRunEvent{Type: "complete"})
+		emit(gradingagentsvc.ExecutionEvent{Type: "complete"})
 	}
 }
 

--- a/server/internal/httpserver/grading_agent_execute.go
+++ b/server/internal/httpserver/grading_agent_execute.go
@@ -93,7 +93,7 @@ func (d Deps) executeGradingAgentWorkflowPreview(
 		}
 	}
 
-	preview, execErr := gradingagentsvc.ExecuteWorkflowDryRun(ctx, gradingagentsvc.DryRunExecutionInput{
+	preview, execErr := gradingagentsvc.ExecuteWorkflow(ctx, gradingagentsvc.ExecutionInput{
 		Graph:           in.WorkflowGraph,
 		Submissions:     in.Submissions,
 		InputModality:   in.ContentModality,

--- a/server/internal/service/gradingagent/aggregator_node.go
+++ b/server/internal/service/gradingagent/aggregator_node.go
@@ -187,7 +187,7 @@ func executeScoreAggregatorNode(
 	state *executionState,
 	maxPoints float64,
 	rubric *assignmentrubric.RubricDefinition,
-	emit func(DryRunEvent),
+	emit func(ExecutionEvent),
 	label string,
 ) error {
 	inputs, err := gatherAggregatorInputs(g, node, nodeByID, state)
@@ -202,12 +202,12 @@ func executeScoreAggregatorNode(
 	if combineErr != nil {
 		return combineErr
 	}
-	emit(DryRunEvent{
+	emit(ExecutionEvent{
 		Type: "log", Level: "info",
 		Message: fmt.Sprintf("[%s] Aggregating %d input(s) via %s:", label, len(inputs), cfg.Mode),
 	})
 	for _, line := range logs {
-		emit(DryRunEvent{Type: "log", Level: "info", Message: line})
+		emit(ExecutionEvent{Type: "log", Level: "info", Message: line})
 	}
 	state.set(node.ID, HandleGrade, slotValue{grade: &grade})
 	if cfg.MergeComments && strings.TrimSpace(grade.Comment) != "" {

--- a/server/internal/service/gradingagent/code_test_runner.go
+++ b/server/internal/service/gradingagent/code_test_runner.go
@@ -115,7 +115,7 @@ func executeCodeTestRunnerNode(
 	nodeByID map[string]WorkflowNode,
 	state *executionState,
 	runner CodeTestRunner,
-	emit func(DryRunEvent),
+	emit func(ExecutionEvent),
 	label string,
 ) error {
 	if runner == nil {
@@ -134,7 +134,7 @@ func executeCodeTestRunnerNode(
 		return ValidationError{Field: "node:" + node.ID + ".testSuiteId", Message: "Test suite not found. Add inline test cases until suite lookup is available."}
 	}
 
-	emit(DryRunEvent{Type: "log", Level: "info", Message: fmt.Sprintf("[%s] Running %d test(s)…", label, len(tests))})
+	emit(ExecutionEvent{Type: "log", Level: "info", Message: fmt.Sprintf("[%s] Running %d test(s)…", label, len(tests))})
 	resp, runErr := runner.RunTests(ctx, codeexecution.RunRequest{
 		Runtime: cfg.Runtime,
 		Code:    submissionText,
@@ -148,7 +148,7 @@ func executeCodeTestRunnerNode(
 		if r.Passed {
 			statusLabel = "pass"
 		}
-		emit(DryRunEvent{
+		emit(ExecutionEvent{
 			Type: "log", Level: "info",
 			Message: fmt.Sprintf("[%s] Test %d/%d: %s", label, i+1, len(resp.Results), statusLabel),
 		})
@@ -166,7 +166,7 @@ func executeCodeTestRunnerNode(
 	state.set(node.ID, HandleReport, slotValue{text: report})
 	state.set(node.ID, HandleScore, slotValue{text: fmt.Sprintf("%.4f", passRate)})
 
-	emit(DryRunEvent{
+	emit(ExecutionEvent{
 		Type: "log", Level: "info",
 		Message: fmt.Sprintf("[%s] Test score %.2f (pass rate %.0f%%).", label, grade.TotalPoints, passRate*100),
 	})

--- a/server/internal/service/gradingagent/default_templates_test.go
+++ b/server/internal/service/gradingagent/default_templates_test.go
@@ -27,7 +27,7 @@ func TestDefaultTemplates_validate(t *testing.T) {
 
 func TestParticipationWorkflowGraph_emptySubmissionScoresZero(t *testing.T) {
 	g := ParticipationWorkflowGraph()
-	preview, err := ExecuteWorkflowDryRun(t.Context(), DryRunExecutionInput{
+	preview, err := ExecuteWorkflow(t.Context(), ExecutionInput{
 		Graph:       &g,
 		Submissions: []string{""},
 		MaxPoints:   10,
@@ -42,7 +42,7 @@ func TestParticipationWorkflowGraph_emptySubmissionScoresZero(t *testing.T) {
 
 func TestParticipationWorkflowGraph_nonEmptySubmissionScoresMax(t *testing.T) {
 	g := ParticipationWorkflowGraph()
-	preview, err := ExecuteWorkflowDryRun(t.Context(), DryRunExecutionInput{
+	preview, err := ExecuteWorkflow(t.Context(), ExecutionInput{
 		Graph:       &g,
 		Submissions: []string{"I completed the reading."},
 		MaxPoints:   10,

--- a/server/internal/service/gradingagent/flag_sink.go
+++ b/server/internal/service/gradingagent/flag_sink.go
@@ -147,7 +147,7 @@ func assembleFlagForReview(
 	node WorkflowNode,
 	nodeByID map[string]WorkflowNode,
 	state *executionState,
-	in DryRunExecutionInput,
+	in ExecutionInput,
 ) (reason, queue, priority string) {
 	queue = flagQueueFromNode(node)
 	priority = flagPriorityFromNode(node)

--- a/server/internal/service/gradingagent/flag_sink_test.go
+++ b/server/internal/service/gradingagent/flag_sink_test.go
@@ -55,16 +55,16 @@ func TestValidateWorkflowGraph_flagOnlyWithoutGradeSlot(t *testing.T) {
 	}
 }
 
-func TestExecuteWorkflowDryRun_flagBlankSubmission(t *testing.T) {
+func TestExecuteWorkflow_flagBlankSubmission(t *testing.T) {
 	g := sampleGraphRouterFlagElseGrade()
 	var logs []string
-	preview, err := ExecuteWorkflowDryRun(context.Background(), DryRunExecutionInput{
+	preview, err := ExecuteWorkflow(context.Background(), ExecutionInput{
 		Graph:       &g,
 		Submissions: []string{""},
 		MaxPoints:   10,
 		ModelID:     "test/model",
 		Runner:      stubDryRunRunner{},
-		Emit: func(ev DryRunEvent) {
+		Emit: func(ev ExecutionEvent) {
 			if ev.Type == "log" {
 				logs = append(logs, ev.Message)
 			}

--- a/server/internal/service/gradingagent/gate_sink_test.go
+++ b/server/internal/service/gradingagent/gate_sink_test.go
@@ -32,16 +32,16 @@ func TestValidateWorkflowGraph_aiGateOutput(t *testing.T) {
 	}
 }
 
-func TestExecuteWorkflowDryRun_gateHoldsLowConfidence(t *testing.T) {
+func TestExecuteWorkflow_gateHoldsLowConfidence(t *testing.T) {
 	g := sampleGraphAIGateOutput()
 	var logs []string
-	preview, err := ExecuteWorkflowDryRun(context.Background(), DryRunExecutionInput{
+	preview, err := ExecuteWorkflow(context.Background(), ExecutionInput{
 		Graph:       &g,
 		Submissions: []string{"short answer"},
 		MaxPoints:   10,
 		ModelID:     "test/model",
 		Runner: lowConfidenceDryRunRunner{},
-		Emit: func(ev DryRunEvent) {
+		Emit: func(ev ExecutionEvent) {
 			if ev.Type == "log" {
 				logs = append(logs, ev.Message)
 			}

--- a/server/internal/service/gradingagent/originality_node.go
+++ b/server/internal/service/gradingagent/originality_node.go
@@ -173,7 +173,7 @@ func originalityHasSubmissionInput(g *WorkflowGraph, nodeID string) bool {
 	return false
 }
 
-func loadOriginalityRows(ctx context.Context, in DryRunExecutionInput) ([]OriginalityReportRow, error) {
+func loadOriginalityRows(ctx context.Context, in ExecutionInput) ([]OriginalityReportRow, error) {
 	if in.LoadOriginalityReports == nil || in.SubmissionID == uuid.Nil {
 		return nil, nil
 	}
@@ -183,9 +183,9 @@ func loadOriginalityRows(ctx context.Context, in DryRunExecutionInput) ([]Origin
 func executeOriginalityNode(
 	ctx context.Context,
 	node WorkflowNode,
-	in DryRunExecutionInput,
+	in ExecutionInput,
 	state *executionState,
-	emit func(DryRunEvent),
+	emit func(ExecutionEvent),
 	label string,
 ) error {
 	rows, err := loadOriginalityRows(ctx, in)
@@ -210,12 +210,12 @@ func executeOriginalityNode(
 	state.set(node.ID, HandleReport, slotValue{text: signal.Report})
 
 	if signal.Present && signal.Score != nil {
-		emit(DryRunEvent{
+		emit(ExecutionEvent{
 			Type: "log", Level: "info",
 			Message: fmt.Sprintf("[%s] %s %.2f (flag=%v)", label, signal.Metric, *signal.Score, signal.Flag),
 		})
 	} else {
-		emit(DryRunEvent{
+		emit(ExecutionEvent{
 			Type: "log", Level: "info",
 			Message: fmt.Sprintf("[%s] No stored originality report available.", label),
 		})

--- a/server/internal/service/gradingagent/predicate_test.go
+++ b/server/internal/service/gradingagent/predicate_test.go
@@ -129,21 +129,21 @@ func sampleGraphWithRouterEmptyShortCircuit() WorkflowGraph {
 	}
 }
 
-func TestExecuteWorkflowDryRun_routerSkipsAIBranchOnEmpty(t *testing.T) {
+func TestExecuteWorkflow_routerSkipsAIBranchOnEmpty(t *testing.T) {
 	g := sampleGraphWithRouterEmptyShortCircuit()
 	if err := ValidateWorkflowGraph(&g); err != nil {
 		t.Fatalf("graph should validate: %v", err)
 	}
 	var aiComplete string
 	var skipped []string
-	preview, err := ExecuteWorkflowDryRun(t.Context(), DryRunExecutionInput{
+	preview, err := ExecuteWorkflow(t.Context(), ExecutionInput{
 		Graph:       &g,
 		Submissions: []string{""},
 		MaxPoints:   10,
 		ModelID:     "test/model",
 		Runner:      stubDryRunRunner{},
 		CodeRunner:  nil,
-		Emit: func(ev DryRunEvent) {
+		Emit: func(ev ExecutionEvent) {
 			if ev.Type == "node_complete" && ev.NodeID == "ai1" {
 				aiComplete = ev.Status
 			}

--- a/server/internal/service/gradingagent/reference_node.go
+++ b/server/internal/service/gradingagent/reference_node.go
@@ -97,7 +97,7 @@ func truncateReferenceText(text string) (string, bool) {
 }
 
 // LoadReferenceText resolves inline text or extracts text from a course file.
-func (in DryRunExecutionInput) LoadReferenceText(ctx context.Context, node WorkflowNode) (string, bool, error) {
+func (in ExecutionInput) LoadReferenceText(ctx context.Context, node WorkflowNode) (string, bool, error) {
 	if resourceID, ok := referenceResourceID(node); ok {
 		if in.LoadReferenceFile == nil {
 			return "", false, fmt.Errorf("reference file loader not configured")

--- a/server/internal/service/gradingagent/reference_node_test.go
+++ b/server/internal/service/gradingagent/reference_node_test.go
@@ -54,17 +54,17 @@ func TestFormatReferenceTrustedAIBlock_labelsByMode(t *testing.T) {
 	}
 }
 
-func TestExecuteWorkflowDryRun_referenceInAIInput(t *testing.T) {
+func TestExecuteWorkflow_referenceInAIInput(t *testing.T) {
 	g := sampleGraphWithReferenceAI()
 	var compiledInput string
 	var compiledPrompt string
-	_, err := ExecuteWorkflowDryRun(t.Context(), DryRunExecutionInput{
+	_, err := ExecuteWorkflow(t.Context(), ExecutionInput{
 		Graph:       &g,
 		Submissions: []string{"Student essay"},
 		MaxPoints:   100,
 		ModelID:     "test/model",
 		Runner:      stubDryRunRunner{},
-		Emit: func(ev DryRunEvent) {
+		Emit: func(ev ExecutionEvent) {
 			if ev.Type == "node_complete" && ev.NodeID == "ai1" {
 				compiledInput = ev.CompiledInput
 				compiledPrompt = ev.CompiledPrompt

--- a/server/internal/service/gradingagent/rubric_node.go
+++ b/server/internal/service/gradingagent/rubric_node.go
@@ -85,7 +85,7 @@ func parseInlineRubric(n WorkflowNode) (*assignmentrubric.RubricDefinition, erro
 }
 
 // LoadRubricDefinition resolves rubric data for a Rubric node.
-func (in DryRunExecutionInput) LoadRubricDefinition(node WorkflowNode) (*assignmentrubric.RubricDefinition, error) {
+func (in ExecutionInput) LoadRubricDefinition(node WorkflowNode) (*assignmentrubric.RubricDefinition, error) {
 	switch rubricSourceFromNode(node) {
 	case RubricSourceInline:
 		rubric, err := parseInlineRubric(node)

--- a/server/internal/service/gradingagent/rubric_node_test.go
+++ b/server/internal/service/gradingagent/rubric_node_test.go
@@ -54,17 +54,17 @@ func TestValidateWorkflowGraph_requiresInlineRubricCriteria(t *testing.T) {
 	}
 }
 
-func TestExecuteWorkflowDryRun_inlineRubricInAIInput(t *testing.T) {
+func TestExecuteWorkflow_inlineRubricInAIInput(t *testing.T) {
 	g := sampleGraphWithRubricAI()
 	criterionID := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
 	var compiledSystemPrompt string
-	_, err := ExecuteWorkflowDryRun(t.Context(), DryRunExecutionInput{
+	_, err := ExecuteWorkflow(t.Context(), ExecutionInput{
 		Graph:       &g,
 		Submissions: []string{"Student essay"},
 		MaxPoints:   100,
 		ModelID:     "test/model",
 		Runner:      stubDryRunRunner{},
-		Emit: func(ev DryRunEvent) {
+		Emit: func(ev ExecutionEvent) {
 			if ev.Type == "node_complete" && ev.NodeID == "ai1" {
 				compiledSystemPrompt = ev.CompiledSystemPrompt
 			}
@@ -92,7 +92,7 @@ func TestLoadRubricDefinition_inlineMode(t *testing.T) {
 			},
 		},
 	}
-	in := DryRunExecutionInput{}
+	in := ExecutionInput{}
 	rubric, err := in.LoadRubricDefinition(node)
 	if err != nil {
 		t.Fatal(err)
@@ -123,7 +123,7 @@ func TestResolveActivity_libraryRubricMode(t *testing.T) {
 			"rubricAssignmentItemId": libraryID.String(),
 		},
 	}
-	in := DryRunExecutionInput{
+	in := ExecutionInput{
 		ResolveActivity: func(itemID string) (string, *assignmentrubric.RubricDefinition, error) {
 			if itemID != libraryID.String() {
 				t.Fatalf("itemID = %q", itemID)

--- a/server/internal/service/gradingagent/workflow_execute.go
+++ b/server/internal/service/gradingagent/workflow_execute.go
@@ -10,8 +10,8 @@ import (
 	"github.com/lextures/lextures/server/internal/models/assignmentrubric"
 )
 
-// DryRunEvent is streamed to the client while a workflow dry run executes.
-type DryRunEvent struct {
+// ExecutionEvent is streamed while a workflow executes (dry-run WS or live batch grading).
+type ExecutionEvent struct {
 	Type            string         `json:"type"`
 	NodeID          string         `json:"nodeId,omitempty"`
 	NodeType        string         `json:"nodeType,omitempty"`
@@ -63,8 +63,8 @@ type DryRunRunner interface {
 	RunPrompt(ctx context.Context, modelID, systemPrompt, prompt, input string, jsonMode bool) (text string, promptTokens, completionTokens int, err error)
 }
 
-// DryRunExecutionInput configures a step-by-step workflow dry run.
-type DryRunExecutionInput struct {
+// ExecutionInput configures a step-by-step workflow execution (dry-run or live).
+type ExecutionInput struct {
 	Graph                  *WorkflowGraph
 	Submissions            []string
 	InputModality          InputModality
@@ -80,7 +80,7 @@ type DryRunExecutionInput struct {
 	CourseCode             string
 	Runner                 DryRunRunner
 	CodeRunner             CodeTestRunner
-	Emit                   func(DryRunEvent)
+	Emit                   func(ExecutionEvent)
 }
 
 type slotValue struct {
@@ -188,7 +188,7 @@ func gatherRouterInput(g *WorkflowGraph, routerID string, nodeByID map[string]Wo
 	return slotValue{}, false
 }
 
-func buildPredicateContext(in DryRunExecutionInput, input slotValue) PredicateEvalContext {
+func buildPredicateContext(in ExecutionInput, input slotValue) PredicateEvalContext {
 	ctx := PredicateEvalContext{
 		SubmissionText: JoinSubmissions(in.Submissions),
 		IsLate:         in.IsLate,
@@ -254,8 +254,8 @@ func TopologicalNodeOrder(g *WorkflowGraph) ([]string, error) {
 	return order, nil
 }
 
-// ExecuteWorkflowDryRun walks the graph node by node and streams dry-run events.
-func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRunPreview, error) {
+// ExecuteWorkflow walks the graph node by node, streaming execution events when Emit is set.
+func ExecuteWorkflow(ctx context.Context, in ExecutionInput) (DryRunPreview, error) {
 	if err := ValidateWorkflowGraph(in.Graph); err != nil {
 		return DryRunPreview{}, err
 	}
@@ -267,7 +267,7 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 	}
 	emit := in.Emit
 	if emit == nil {
-		emit = func(DryRunEvent) {}
+		emit = func(ExecutionEvent) {}
 	}
 
 	nodeByID := make(map[string]WorkflowNode, len(in.Graph.Nodes))
@@ -291,16 +291,16 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 		label := NodeDisplayLabel(node.Data, node.Type)
 
 		if !nodeHasActiveInput(in.Graph, node.ID, nodeByID, state) {
-			emit(DryRunEvent{Type: "node_start", NodeID: node.ID, NodeType: node.Type, NodeLabel: label})
-			emit(DryRunEvent{
+			emit(ExecutionEvent{Type: "node_start", NodeID: node.ID, NodeType: node.Type, NodeLabel: label})
+			emit(ExecutionEvent{
 				Type: "log", Level: "info",
 				Message: fmt.Sprintf("[%s] Skipped (inactive branch).", label),
 			})
-			emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, NodeType: node.Type, Status: "skipped"})
+			emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, NodeType: node.Type, Status: "skipped"})
 			continue
 		}
 
-		emit(DryRunEvent{Type: "node_start", NodeID: node.ID, NodeType: node.Type, NodeLabel: label})
+		emit(ExecutionEvent{Type: "node_start", NodeID: node.ID, NodeType: node.Type, NodeLabel: label})
 
 		var compiledPrompt, compiledSystemPrompt, compiledInput, compiledOutput string
 		switch node.Type {
@@ -311,7 +311,7 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 			if modality == "unreadable" || modality == "" {
 				modality = "file"
 			}
-			emit(DryRunEvent{
+			emit(ExecutionEvent{
 				Type: "log", Level: "info",
 				Message: fmt.Sprintf("[%s] Input modality: %s; loaded %d part(s) (%d characters).", label, modality, len(in.Submissions), len(text)),
 			})
@@ -319,30 +319,30 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 			itemID := activityAssignmentItemID(node)
 			markdown, rubric, loadErr := in.resolveActivity(itemID)
 			if loadErr != nil {
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, loadErr
 			}
 			state.set(node.ID, HandleContent, slotValue{text: markdown})
 			state.set(node.ID, HandleRubric, slotValue{text: formatRubricVariableText(rubric), rubric: rubric})
-			emit(DryRunEvent{
+			emit(ExecutionEvent{
 				Type: "log", Level: "info",
 				Message: fmt.Sprintf("[%s] Loaded assignment content (%d chars) and rubric.", label, len(markdown)),
 			})
 		case NodeTypeRubric:
 			rubric, loadErr := in.LoadRubricDefinition(node)
 			if loadErr != nil {
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, loadErr
 			}
 			state.set(node.ID, HandleRubric, slotValue{text: formatRubricVariableText(rubric), rubric: rubric})
-			emit(DryRunEvent{
+			emit(ExecutionEvent{
 				Type: "log", Level: "info",
 				Message: fmt.Sprintf("[%s] Loaded %d criteria.", label, len(rubric.Criteria)),
 			})
 		case NodeTypeReference:
 			text, truncated, loadErr := in.LoadReferenceText(ctx, node)
 			if loadErr != nil {
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, loadErr
 			}
 			state.set(node.ID, HandleReference, slotValue{text: text})
@@ -351,7 +351,7 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 			if truncated {
 				logMsg += " (truncated)"
 			}
-			emit(DryRunEvent{Type: "log", Level: "info", Message: logMsg})
+			emit(ExecutionEvent{Type: "log", Level: "info", Message: logMsg})
 		case NodeTypeAI:
 			prompt := graderPrompt(node)
 			inputText := gatherAIInput(in.Graph, node.ID, nodeByID, state)
@@ -361,19 +361,19 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 			rubricForOutput := resolveAIRubric(in.Graph, node.ID, nodeByID, state, in.DefaultRubric)
 			systemPrompt := BuildAISystemPrompt(outputFormat, rubricForOutput, in.MaxPoints)
 			if in.Runner == nil {
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, fmt.Errorf("dry run runner not configured")
 			}
 			out, pt, ct, runErr := in.Runner.RunPrompt(ctx, in.ModelID, systemPrompt, prompt, inputText, true)
 			if runErr != nil {
-				emit(DryRunEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, UserFacingScoreError(runErr))})
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, UserFacingScoreError(runErr))})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, runErr
 			}
 			grade, parseErr := ParseAIOutput(out, outputFormat, rubricForOutput, in.MaxPoints)
 			if parseErr != nil {
-				emit(DryRunEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, UserFacingScoreError(parseErr))})
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, UserFacingScoreError(parseErr))})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, parseErr
 			}
 			totalPromptTokens += pt
@@ -383,24 +383,24 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 			compiledSystemPrompt = systemPrompt
 			compiledInput = inputText
 			compiledOutput = out
-			emit(DryRunEvent{
+			emit(ExecutionEvent{
 				Type: "log", Level: "info",
 				Message: fmt.Sprintf("[%s] AI output: %s", label, truncateLog(out, 240)),
 			})
 		case NodeTypeGrader:
 			req, buildErr := buildGraderScoreRequest(in, node, nodeByID, state)
 			if buildErr != nil {
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, buildErr
 			}
 			if in.Runner == nil {
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, fmt.Errorf("dry run runner not configured")
 			}
 			result, scoreErr := in.Runner.Score(ctx, req)
 			if scoreErr != nil {
-				emit(DryRunEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, UserFacingScoreError(scoreErr))})
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, UserFacingScoreError(scoreErr))})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, scoreErr
 			}
 			totalPromptTokens += result.PromptTokens
@@ -408,29 +408,29 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 			grade := result.Output
 			state.set(node.ID, HandleGrade, slotValue{grade: &grade})
 			state.set(node.ID, HandleComments, slotValue{text: grade.Comment})
-			emit(DryRunEvent{
+			emit(ExecutionEvent{
 				Type: "log", Level: "info",
 				Message: fmt.Sprintf("[%s] Suggested score %.2f (confidence %.0f%%).", label, grade.TotalPoints, grade.Confidence*100),
 			})
 		case NodeTypeCriterionGrader:
 			criterionID, cidErr := criterionIDFromNode(node)
 			if cidErr != nil {
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, cidErr
 			}
 			req, buildErr := buildGraderScoreRequest(in, node, nodeByID, state)
 			if buildErr != nil {
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, buildErr
 			}
 			criterion, critErr := findRubricCriterion(req.Rubric, criterionID)
 			if critErr != nil {
-				emit(DryRunEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, critErr.Error())})
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, critErr.Error())})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, ValidationError{Field: "node:" + node.ID + ".criterionId", Message: critErr.Error()}
 			}
 			if in.Runner == nil {
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, fmt.Errorf("dry run runner not configured")
 			}
 			prompt := req.InstructorPrompt
@@ -446,14 +446,14 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 			)
 			out, pt, ct, runErr := in.Runner.RunPrompt(ctx, req.ModelID, systemPrompt, userMessage, "", true)
 			if runErr != nil {
-				emit(DryRunEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, UserFacingScoreError(runErr))})
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, UserFacingScoreError(runErr))})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, runErr
 			}
 			grade, parseErr := ParseSingleCriterionOutput(out, req.Rubric, criterionID)
 			if parseErr != nil {
-				emit(DryRunEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, UserFacingScoreError(parseErr))})
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, UserFacingScoreError(parseErr))})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, parseErr
 			}
 			totalPromptTokens += pt
@@ -464,32 +464,32 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 			compiledSystemPrompt = systemPrompt
 			compiledInput = userMessage
 			compiledOutput = out
-			emit(DryRunEvent{
+			emit(ExecutionEvent{
 				Type: "log", Level: "info",
 				Message: fmt.Sprintf("[%s] Criterion %q: %.2f (confidence %.0f%%).", label, criterion.Title, grade.TotalPoints, grade.Confidence*100),
 			})
 		case NodeTypeCodeTestRunner:
 			if execErr := executeCodeTestRunnerNode(ctx, node, in.Graph, nodeByID, state, in.CodeRunner, emit, label); execErr != nil {
-				emit(DryRunEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, UserFacingScoreError(execErr))})
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, UserFacingScoreError(execErr))})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, execErr
 			}
 		case NodeTypeConditionalRouter:
 			cond, condErr := routerConditionFromNode(node)
 			if condErr != nil {
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, ValidationError{Field: "node:" + node.ID + ".condition", Message: condErr.Error()}
 			}
 			inputVal, hasInput := gatherRouterInput(in.Graph, node.ID, nodeByID, state)
 			if !hasInput {
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, ValidationError{Field: "node:" + node.ID, Message: "Router input is required."}
 			}
 			predCtx := buildPredicateContext(in, inputVal)
 			result, evalErr := EvaluateRouterCondition(cond, predCtx)
 			if evalErr != nil {
-				emit(DryRunEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, evalErr.Error())})
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, evalErr.Error())})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, evalErr
 			}
 			takenHandle := HandleElse
@@ -502,26 +502,26 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 			}
 			state.set(node.ID, takenHandle, inputVal)
 			state.deactivateRouterBranch(in.Graph, node.ID, untakenHandle)
-			emit(DryRunEvent{
+			emit(ExecutionEvent{
 				Type: "log", Level: "info",
 				Message: fmt.Sprintf("[%s] Condition %s → %s branch.", label, formatRouterConditionSentence(cond), branchLabel),
 			})
 		case NodeTypeOriginality:
 			if execErr := executeOriginalityNode(ctx, node, in, state, emit, label); execErr != nil {
-				emit(DryRunEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, UserFacingScoreError(execErr))})
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, UserFacingScoreError(execErr))})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, execErr
 			}
 		case NodeTypeScoreAggregator:
 			if execErr := executeScoreAggregatorNode(in.Graph, node, nodeByID, state, in.MaxPoints, in.DefaultRubric, emit, label); execErr != nil {
-				emit(DryRunEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, execErr.Error())})
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "log", Level: "error", Message: fmt.Sprintf("[%s] %s", label, execErr.Error())})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, execErr
 			}
 		case NodeTypeHumanReviewGate:
 			gradeVal, gradeErr := gatherGateGrade(in.Graph, node.ID, nodeByID, state)
 			if gradeErr != nil {
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, gradeErr
 			}
 			flagTruthy := gatherGateFlagTruthy(in.Graph, node.ID, nodeByID, state)
@@ -537,53 +537,53 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 				Queue:           queue,
 				ConfidenceFloor: floor,
 			}
-			emit(DryRunEvent{
+			emit(ExecutionEvent{
 				Type: "log", Level: "info",
 				Message: fmt.Sprintf("Would hold for review (mode=%s, would-hold=%v)", mode, wouldHold),
 			})
 			if wouldHold && holdReason != "" {
-				emit(DryRunEvent{Type: "log", Level: "info", Message: holdReason})
+				emit(ExecutionEvent{Type: "log", Level: "info", Message: holdReason})
 			}
 		case NodeTypeFlagForReview:
 			reason, queue, priority := assembleFlagForReview(in.Graph, node, nodeByID, state, in)
 			preview.Flagged = &DryRunFlagPreview{Reason: reason, Queue: queue, Priority: priority}
 			preview.PromptTokens = totalPromptTokens
 			preview.CompletionTokens = totalCompletionTokens
-			emit(DryRunEvent{Type: "log", Level: "info", Message: "── Flag for Review (dry run — not persisted) ──"})
-			emit(DryRunEvent{Type: "log", Level: "info", Message: fmt.Sprintf("Would flag for review: %s", truncateLog(reason, 400))})
-			emit(DryRunEvent{Type: "log", Level: "info", Message: fmt.Sprintf("Queue: %s · Priority: %s", queue, priority)})
-			emit(DryRunEvent{Type: "result", Result: &preview})
+			emit(ExecutionEvent{Type: "log", Level: "info", Message: "── Flag for Review (dry run — not persisted) ──"})
+			emit(ExecutionEvent{Type: "log", Level: "info", Message: fmt.Sprintf("Would flag for review: %s", truncateLog(reason, 400))})
+			emit(ExecutionEvent{Type: "log", Level: "info", Message: fmt.Sprintf("Queue: %s · Priority: %s", queue, priority)})
+			emit(ExecutionEvent{Type: "result", Result: &preview})
 		case NodeTypeOutput:
 			if preview.Flagged != nil {
-				emit(DryRunEvent{Type: "log", Level: "info", Message: fmt.Sprintf("[%s] Skipped (flagged on another branch).", label)})
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, NodeType: node.Type, Status: "skipped"})
+				emit(ExecutionEvent{Type: "log", Level: "info", Message: fmt.Sprintf("[%s] Skipped (flagged on another branch).", label)})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, NodeType: node.Type, Status: "skipped"})
 				continue
 			}
 			held := preview.Held
 			preview, err = assembleOutputPreview(in.Graph, nodeByID, state, in.MaxPoints)
 			if err != nil {
-				emit(DryRunEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
+				emit(ExecutionEvent{Type: "node_complete", NodeID: node.ID, Status: "error"})
 				return DryRunPreview{}, err
 			}
 			preview.Held = held
 			preview.PromptTokens = totalPromptTokens
 			preview.CompletionTokens = totalCompletionTokens
-			emit(DryRunEvent{Type: "log", Level: "info", Message: "── Student Grade (dry run — not persisted) ──"})
-			emit(DryRunEvent{Type: "log", Level: "info", Message: fmt.Sprintf("Score: %.2f", preview.SuggestedPoints)})
+			emit(ExecutionEvent{Type: "log", Level: "info", Message: "── Student Grade (dry run — not persisted) ──"})
+			emit(ExecutionEvent{Type: "log", Level: "info", Message: fmt.Sprintf("Score: %.2f", preview.SuggestedPoints)})
 			if len(preview.RubricScores) > 0 {
-				emit(DryRunEvent{Type: "log", Level: "info", Message: fmt.Sprintf("Rubric: %d criteria scored.", len(preview.RubricScores))})
+				emit(ExecutionEvent{Type: "log", Level: "info", Message: fmt.Sprintf("Rubric: %d criteria scored.", len(preview.RubricScores))})
 			}
 			if strings.TrimSpace(preview.Comment) != "" {
-				emit(DryRunEvent{Type: "log", Level: "info", Message: fmt.Sprintf("Comment: %s", truncateLog(preview.Comment, 400))})
+				emit(ExecutionEvent{Type: "log", Level: "info", Message: fmt.Sprintf("Comment: %s", truncateLog(preview.Comment, 400))})
 			} else {
-				emit(DryRunEvent{Type: "log", Level: "info", Message: "Comment: (none)"})
+				emit(ExecutionEvent{Type: "log", Level: "info", Message: "Comment: (none)"})
 			}
-			emit(DryRunEvent{Type: "result", Result: &preview})
+			emit(ExecutionEvent{Type: "result", Result: &preview})
 		default:
-			emit(DryRunEvent{Type: "log", Level: "warn", Message: fmt.Sprintf("[%s] Skipped unsupported node type %q.", label, node.Type)})
+			emit(ExecutionEvent{Type: "log", Level: "warn", Message: fmt.Sprintf("[%s] Skipped unsupported node type %q.", label, node.Type)})
 		}
 
-		emit(DryRunEvent{
+		emit(ExecutionEvent{
 			Type:                 "node_complete",
 			NodeID:               node.ID,
 			NodeType:             node.Type,
@@ -598,7 +598,7 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 	return preview, nil
 }
 
-func (in DryRunExecutionInput) resolveActivity(itemID string) (string, *assignmentrubric.RubricDefinition, error) {
+func (in ExecutionInput) resolveActivity(itemID string) (string, *assignmentrubric.RubricDefinition, error) {
 	if in.ResolveActivity != nil {
 		return in.ResolveActivity(itemID)
 	}
@@ -745,7 +745,7 @@ func buildPromptContext(
 }
 
 func buildGraderScoreRequest(
-	in DryRunExecutionInput,
+	in ExecutionInput,
 	node WorkflowNode,
 	nodeByID map[string]WorkflowNode,
 	state *executionState,

--- a/server/internal/service/gradingagent/workflow_execute_codetest_test.go
+++ b/server/internal/service/gradingagent/workflow_execute_codetest_test.go
@@ -44,9 +44,9 @@ func sampleGraphWithCodeTestRunner() WorkflowGraph {
 	}
 }
 
-func TestExecuteWorkflowDryRun_codeTestRunner(t *testing.T) {
+func TestExecuteWorkflow_codeTestRunner(t *testing.T) {
 	g := sampleGraphWithCodeTestRunner()
-	preview, err := ExecuteWorkflowDryRun(context.Background(), DryRunExecutionInput{
+	preview, err := ExecuteWorkflow(context.Background(), ExecutionInput{
 		Graph:       &g,
 		Submissions: []string{"print(4)"},
 		MaxPoints:   10,
@@ -54,7 +54,7 @@ func TestExecuteWorkflowDryRun_codeTestRunner(t *testing.T) {
 			{TestCaseID: "t1", Passed: true, Status: codeexecution.StatusPass, ExpectedOutput: "4", ActualOutput: "4"},
 			{TestCaseID: "t2", Passed: false, Status: codeexecution.StatusFail, ExpectedOutput: "4", ActualOutput: "2"},
 		}}},
-		Emit: func(DryRunEvent) {},
+		Emit: func(ExecutionEvent) {},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/server/internal/service/gradingagent/workflow_execute_test.go
+++ b/server/internal/service/gradingagent/workflow_execute_test.go
@@ -33,17 +33,17 @@ func TestTopologicalNodeOrder_respectsDependencies(t *testing.T) {
 	}
 }
 
-func TestExecuteWorkflowDryRun_emitsCompiledPromptForAINode(t *testing.T) {
+func TestExecuteWorkflow_emitsCompiledPromptForAINode(t *testing.T) {
 	g := sampleGraphWithAI("Summarize $Activity.Content")
-	var completeEvent DryRunEvent
-	_, err := ExecuteWorkflowDryRun(context.Background(), DryRunExecutionInput{
+	var completeEvent ExecutionEvent
+	_, err := ExecuteWorkflow(context.Background(), ExecutionInput{
 		Graph:          &g,
 		Submissions:     []string{"Essay body"},
 		MaxPoints:       100,
 		ModelID:         "test/model",
 		DefaultMarkdown: "Assignment instructions",
 		Runner:         stubDryRunRunner{},
-		Emit: func(ev DryRunEvent) {
+		Emit: func(ev ExecutionEvent) {
 			if ev.Type == "node_complete" && ev.NodeID == "ai1" {
 				completeEvent = ev
 			}
@@ -63,11 +63,11 @@ func TestExecuteWorkflowDryRun_emitsCompiledPromptForAINode(t *testing.T) {
 	}
 }
 
-func TestExecuteWorkflowDryRun_logsOutputWithoutPersisting(t *testing.T) {
+func TestExecuteWorkflow_logsOutputWithoutPersisting(t *testing.T) {
 	g := sampleGraphWithGrader("Grade fairly", false, false)
 	var logs []string
 	var nodeStarts []string
-	preview, err := ExecuteWorkflowDryRun(context.Background(), DryRunExecutionInput{
+	preview, err := ExecuteWorkflow(context.Background(), ExecutionInput{
 		Graph:          &g,
 		Submissions: []string{"Essay body"},
 		MaxPoints:   100,
@@ -83,7 +83,7 @@ func TestExecuteWorkflowDryRun_logsOutputWithoutPersisting(t *testing.T) {
 				ModelID: "test/model",
 			},
 		},
-		Emit: func(ev DryRunEvent) {
+		Emit: func(ev ExecutionEvent) {
 			switch ev.Type {
 			case "log":
 				logs = append(logs, ev.Message)


### PR DESCRIPTION
## Summary
- Rename the shared grading workflow engine from `ExecuteWorkflowDryRun` to `ExecuteWorkflow`, with `ExecutionInput` and `ExecutionEvent` types, so the name reflects both WS dry runs and live batch grading.
- Confirm the dead `POST …/grader-agent/dry-run` handler, route, and `postGraderAgentDryRun` client function are already removed (no live code references remain).
- Retain `Service.Score` for legacy configs without a compilable workflow graph; move GA-S2 plan to `docs/completed`.

## Test plan
- [x] `go test ./internal/service/gradingagent/... ./internal/httpserver/... -short`
- [x] `go build ./cmd/server`
- [ ] CI green


Made with [Cursor](https://cursor.com)