### PR TITLE
refactor(grading-agent): generic updateNodeData replaces per-node callbacks (GA-S3)

### DIFF
--- a/clients/web/src/components/annotation/grader-agent/__tests__/inspector-panel.test.tsx
+++ b/clients/web/src/components/annotation/grader-agent/__tests__/inspector-panel.test.tsx
@@ -34,9 +34,7 @@ function workflowStub(overrides: Partial<GraderAgentWorkflowState> = {}): Grader
   return {
     graph,
     selectedNodeId: null,
-    updateGraderNode: vi.fn(),
-    updateAiNode: vi.fn(),
-    updateActivityNode: vi.fn(),
+    updateNodeData: vi.fn(),
     removeNode: vi.fn(),
     nodeDryRunDetails: {},
     nodeExecutionStates: {},

--- a/clients/web/src/components/annotation/grader-agent/__tests__/use-grader-agent-workflow-graph-mutations.test.ts
+++ b/clients/web/src/components/annotation/grader-agent/__tests__/use-grader-agent-workflow-graph-mutations.test.ts
@@ -1,0 +1,158 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useGraderAgentWorkflow, type GraderAgentWorkflowSeed } from '../use-grader-agent-workflow'
+import { WORKFLOW_VERSION } from '../types'
+
+const stableT = (key: string): string => key
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: stableT }),
+}))
+
+vi.mock('../../../../context/platform-features-context', () => ({
+  usePlatformFeatures: () => ({
+    graderAgentSuggestModeEnabled: false,
+    graderAgentRunFiltersEnabled: false,
+  }),
+}))
+
+vi.mock('../../../../lib/courses-api', () => ({
+  fetchGraderAgentConfig: vi.fn(),
+  fetchGraderAgentRun: vi.fn(),
+  fetchCourseCanvasLink: vi.fn().mockResolvedValue({ linked: false, gradeSyncEnabled: false }),
+  postGraderAgentRun: vi.fn(),
+  putGraderAgentConfig: vi.fn(),
+  putSubmissionGrade: vi.fn(),
+  streamGraderAgentDryRun: vi.fn(),
+  postGraderAgentTemplate: vi.fn(),
+  putGraderAgentTemplate: vi.fn(),
+  fetchSubmissionGrade: vi.fn(),
+}))
+
+vi.mock('../use-rubric-library-rubrics', () => ({
+  useRubricLibraryRubrics: () => ({ libraryRubrics: [], setLibraryRubricAvailability: vi.fn() }),
+}))
+
+vi.mock('../../canvas/canvas-grade-sync', () => ({
+  queueCanvasGradeSync: vi.fn().mockReturnValue(null),
+}))
+
+vi.mock('../validation', () => ({
+  validateWorkflowGraph: () => [],
+  isWorkflowRunnable: () => true,
+}))
+
+const templateMode = { name: 'Template' } as const
+
+const aiPatchSeedWorkflow: GraderAgentWorkflowSeed = {
+  prompt: '',
+  includeAssignmentContent: false,
+  includeRubric: false,
+  workflowGraph: {
+    version: WORKFLOW_VERSION,
+    nodes: [
+      { id: 'ai-1', type: 'ai' as const, position: { x: 0, y: 0 }, data: { prompt: 'before' } },
+      { id: 'output', type: 'output' as const, position: { x: 200, y: 0 }, data: {} },
+    ],
+    edges: [],
+  },
+}
+
+const removeNodeSeedWorkflow: GraderAgentWorkflowSeed = {
+  prompt: '',
+  includeAssignmentContent: false,
+  includeRubric: false,
+  workflowGraph: {
+    version: WORKFLOW_VERSION,
+    nodes: [
+      { id: 'ai-1', type: 'ai' as const, position: { x: 0, y: 0 }, data: {} },
+      { id: 'output', type: 'output' as const, position: { x: 200, y: 0 }, data: {} },
+    ],
+    edges: [{ id: 'e-1', source: 'ai-1', target: 'output' }],
+  },
+}
+
+const removeEdgeSeedWorkflow: GraderAgentWorkflowSeed = {
+  prompt: '',
+  includeAssignmentContent: false,
+  includeRubric: false,
+  workflowGraph: {
+    version: WORKFLOW_VERSION,
+    nodes: [
+      { id: 'ai-1', type: 'ai' as const, position: { x: 0, y: 0 }, data: {} },
+      { id: 'output', type: 'output' as const, position: { x: 200, y: 0 }, data: {} },
+    ],
+    edges: [
+      { id: 'e-1', source: 'ai-1', target: 'output' },
+      { id: 'e-2', source: 'ai-1', target: 'output', targetHandle: 'comments' },
+    ],
+  },
+}
+
+function templateWorkflowArgs(seedWorkflow: GraderAgentWorkflowSeed) {
+  return {
+    open: true,
+    courseCode: 'demo',
+    itemId: 'item-1',
+    submissionId: null,
+    templateMode,
+    seedWorkflow,
+  }
+}
+
+describe('useGraderAgentWorkflow graph mutations', () => {
+  it('updateNodeData merges a patch into the selected node', async () => {
+    const { result } = renderHook(() =>
+      useGraderAgentWorkflow(templateWorkflowArgs(aiPatchSeedWorkflow)),
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    act(() => {
+      result.current.updateNodeData('ai-1', { prompt: 'after' })
+    })
+
+    const aiNode = result.current.graph?.nodes.find((node) => node.id === 'ai-1')
+    expect(aiNode?.data.prompt).toBe('after')
+  })
+
+  it('removeNode drops the node, connected edges, and clears selection', async () => {
+    const { result } = renderHook(() =>
+      useGraderAgentWorkflow(templateWorkflowArgs(removeNodeSeedWorkflow)),
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    act(() => {
+      result.current.setSelectedNodeId('ai-1')
+    })
+    act(() => {
+      result.current.removeNode('ai-1')
+    })
+
+    expect(result.current.graph?.nodes.some((node) => node.id === 'ai-1')).toBe(false)
+    expect(result.current.graph?.edges).toEqual([])
+    expect(result.current.selectedNodeId).toBeNull()
+  })
+
+  it('removeEdge drops only the matching edge', async () => {
+    const { result } = renderHook(() =>
+      useGraderAgentWorkflow(templateWorkflowArgs(removeEdgeSeedWorkflow)),
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    act(() => {
+      result.current.removeEdge('e-1')
+    })
+
+    expect(result.current.graph?.edges).toEqual([
+      { id: 'e-2', source: 'ai-1', target: 'output', targetHandle: 'comments' },
+    ])
+  })
+})

--- a/clients/web/src/components/annotation/grader-agent/inspector-panel.tsx
+++ b/clients/web/src/components/annotation/grader-agent/inspector-panel.tsx
@@ -71,18 +71,7 @@ export function InspectorPanel({
   const {
     graph,
     selectedNodeId,
-    updateGraderNode,
-    updateAiNode,
-    updateCriterionGraderNode,
-    updateActivityNode,
-    updateCodeTestRunnerNode,
-    updateConditionalRouterNode,
-    updateFlagForReviewNode,
-    updateHumanReviewGateNode,
-    updateScoreAggregatorNode,
-    updateOriginalityNode,
-    updateReferenceNode,
-    updateRubricNode,
+    updateNodeData,
     setLibraryRubricAvailability,
     removeNode,
     nodeDryRunDetails,
@@ -200,7 +189,7 @@ export function InspectorPanel({
           <span className="mb-1.5 block font-medium">{t('gradingAgent.prompt.label')}</span>
           <WorkflowPromptEditor
             value={typeof node.data.prompt === 'string' ? node.data.prompt : ''}
-            onChange={(prompt) => updateGraderNode(node.id, { prompt })}
+            onChange={(prompt) => updateNodeData(node.id, { prompt })}
             graph={graph}
             promptNodeId={node.id}
             defaults={variableDefaults}
@@ -212,7 +201,7 @@ export function InspectorPanel({
           <span className="mb-1.5 block font-medium">{t('gradingAgent.model.label')}</span>
           <select
             value={modelId}
-            onChange={(e) => updateGraderNode(node.id, { modelId: e.target.value || null })}
+            onChange={(e) => updateNodeData(node.id, { modelId: e.target.value || null })}
             className={fieldClass}
           >
             <option value="">{t('gradingAgent.model.default')}</option>
@@ -253,7 +242,7 @@ export function InspectorPanel({
             filterPlaceholder={t('gradingAgent.canvas.inspector.activityAssignmentFilter')}
             emptyLabel={t('gradingAgent.canvas.inspector.activityAssignmentEmpty')}
             noMatchLabel={t('gradingAgent.canvas.inspector.activityAssignmentNoMatch')}
-            onChange={(assignmentId) => updateActivityNode(node.id, { assignmentItemId: assignmentId })}
+            onChange={(assignmentId) => updateNodeData(node.id, { assignmentItemId: assignmentId })}
           />
           <p className="mt-1.5 text-xs text-slate-500 dark:text-neutral-400">
             {t('gradingAgent.canvas.inspector.activityAssignmentHelp')}
@@ -294,7 +283,7 @@ export function InspectorPanel({
           <span className="mb-1.5 block font-medium">{t('gradingAgent.canvas.inspector.criterion')}</span>
           <select
             value={criterionId}
-            onChange={(e) => updateCriterionGraderNode(node.id, { criterionId: e.target.value || undefined })}
+            onChange={(e) => updateNodeData(node.id, { criterionId: e.target.value || undefined })}
             className={fieldClass}
             disabled={criteria.length === 0}
             aria-label={t('gradingAgent.canvas.inspector.criterion')}
@@ -332,7 +321,7 @@ export function InspectorPanel({
           <span className="mb-1.5 block font-medium">{t('gradingAgent.prompt.label')}</span>
           <WorkflowPromptEditor
             value={typeof node.data.prompt === 'string' ? node.data.prompt : ''}
-            onChange={(prompt) => updateCriterionGraderNode(node.id, { prompt })}
+            onChange={(prompt) => updateNodeData(node.id, { prompt })}
             graph={graph}
             promptNodeId={node.id}
             defaults={variableDefaults}
@@ -344,7 +333,7 @@ export function InspectorPanel({
           <span className="mb-1.5 block font-medium">{t('gradingAgent.model.label')}</span>
           <select
             value={modelId}
-            onChange={(e) => updateCriterionGraderNode(node.id, { modelId: e.target.value || null })}
+            onChange={(e) => updateNodeData(node.id, { modelId: e.target.value || null })}
             className={fieldClass}
           >
             <option value="">{t('gradingAgent.model.default')}</option>
@@ -382,7 +371,7 @@ export function InspectorPanel({
           <span className="mb-1.5 block font-medium">{t('gradingAgent.prompt.label')}</span>
           <WorkflowPromptEditor
             value={typeof node.data.prompt === 'string' ? node.data.prompt : ''}
-            onChange={(prompt) => updateAiNode(node.id, { prompt })}
+            onChange={(prompt) => updateNodeData(node.id, { prompt })}
             graph={graph}
             promptNodeId={node.id}
             defaults={variableDefaults}
@@ -425,7 +414,7 @@ export function InspectorPanel({
         data={node.data}
         maxPoints={maxPoints}
         title={nodeTitle('gradingAgent.canvas.nodes.codeTests.title')}
-        onChange={(patch) => updateCodeTestRunnerNode(node.id, patch)}
+        onChange={(patch) => updateNodeData(node.id, patch)}
         onDelete={() => removeNode(node.id)}
       />
     )
@@ -438,7 +427,7 @@ export function InspectorPanel({
         graph={graph}
         data={node.data}
         title={nodeTitle('gradingAgent.canvas.nodes.router.title')}
-        onChange={(patch) => updateConditionalRouterNode(node.id, patch)}
+        onChange={(patch) => updateNodeData(node.id, patch)}
         onDelete={() => removeNode(node.id)}
       />
     )
@@ -453,7 +442,7 @@ export function InspectorPanel({
         <ReferenceInspector
           courseCode={courseCode}
           data={node.data}
-          onChange={(patch) => updateReferenceNode(node.id, patch)}
+          onChange={(patch) => updateNodeData(node.id, patch)}
           onDelete={() => removeNode(node.id)}
           fieldClass={fieldClass}
         />
@@ -473,7 +462,7 @@ export function InspectorPanel({
           assignmentHasRubric={Boolean(rubric?.criteria?.length)}
           maxPoints={maxPoints}
           data={node.data}
-          onChange={(patch) => updateRubricNode(node.id, patch)}
+          onChange={(patch) => updateNodeData(node.id, patch)}
           onDelete={() => removeNode(node.id)}
           onLibraryRubricResolved={setLibraryRubricAvailability}
           fieldClass={fieldClass}
@@ -491,7 +480,7 @@ export function InspectorPanel({
         <OriginalityInspector
           data={node.data}
           aiLikelihoodAllowed={ffPlagiarismChecks}
-          onChange={(patch) => updateOriginalityNode(node.id, patch)}
+          onChange={(patch) => updateNodeData(node.id, patch)}
           onDelete={() => removeNode(node.id)}
           fieldClass={fieldClass}
         />
@@ -509,7 +498,7 @@ export function InspectorPanel({
           nodeId={node.id}
           graph={graph}
           data={node.data}
-          onChange={(patch) => updateScoreAggregatorNode(node.id, patch)}
+          onChange={(patch) => updateNodeData(node.id, patch)}
           onDelete={() => removeNode(node.id)}
           fieldClass={fieldClass}
         />
@@ -525,7 +514,7 @@ export function InspectorPanel({
         </p>
         <HumanReviewGateInspector
           data={node.data}
-          onChange={(patch) => updateHumanReviewGateNode(node.id, patch)}
+          onChange={(patch) => updateNodeData(node.id, patch)}
           onDelete={() => removeNode(node.id)}
           fieldClass={fieldClass}
         />
@@ -544,7 +533,7 @@ export function InspectorPanel({
           data={node.data}
           graph={graph}
           defaults={variableDefaults}
-          onChange={(patch) => updateFlagForReviewNode(node.id, patch)}
+          onChange={(patch) => updateNodeData(node.id, patch)}
           onDelete={() => removeNode(node.id)}
           fieldClass={fieldClass}
         />

--- a/clients/web/src/components/annotation/grader-agent/use-grader-agent-workflow.ts
+++ b/clients/web/src/components/annotation/grader-agent/use-grader-agent-workflow.ts
@@ -29,20 +29,7 @@ import {
   type RunAgentFilterState,
 } from './run-agent-filter-picker'
 import { isWorkflowRunnable, validateWorkflowGraph } from './validation'
-import type {
-  CodeTestRunnerNodeData,
-  ConditionalRouterNodeData,
-  CriterionGraderNodeData,
-  FlagForReviewNodeData,
-  HumanReviewGateNodeData,
-  OriginalityNodeData,
-  ReferenceNodeData,
-  RubricNodeData,
-  ScoreAggregatorNodeData,
-  GraderWorkflowGraph,
-  PaletteNodeType,
-  WorkflowValidationIssue,
-} from './types'
+import type { GraderWorkflowGraph, PaletteNodeType, WorkflowValidationIssue } from './types'
 import {
   defaultCodeTestRunnerNodeData,
   defaultConditionalRouterNodeData,
@@ -472,44 +459,17 @@ export function useGraderAgentWorkflow({
     setGraph(next)
   }, [])
 
-  const updateGraderNode = useCallback(
-    (nodeId: string, patch: { prompt?: string; modelId?: string | null }) => {
-      if (!graph) return
-      setGraph({
-        ...graph,
-        nodes: graph.nodes.map((n) =>
+  const updateNodeData = useCallback(<T extends object>(nodeId: string, patch: Partial<T>) => {
+    setGraph((prev) => {
+      if (!prev) return prev
+      return {
+        ...prev,
+        nodes: prev.nodes.map((n) =>
           n.id === nodeId ? { ...n, data: { ...n.data, ...patch } } : n,
         ),
-      })
-    },
-    [graph],
-  )
-
-  const updateAiNode = useCallback(
-    (nodeId: string, patch: { prompt?: string }) => {
-      if (!graph) return
-      setGraph({
-        ...graph,
-        nodes: graph.nodes.map((n) =>
-          n.id === nodeId ? { ...n, data: { ...n.data, ...patch } } : n,
-        ),
-      })
-    },
-    [graph],
-  )
-
-  const updateCriterionGraderNode = useCallback(
-    (nodeId: string, patch: Partial<CriterionGraderNodeData>) => {
-      if (!graph) return
-      setGraph({
-        ...graph,
-        nodes: graph.nodes.map((n) =>
-          n.id === nodeId ? { ...n, data: { ...n.data, ...patch } } : n,
-        ),
-      })
-    },
-    [graph],
-  )
+      }
+    })
+  }, [])
 
   const addPaletteNode = useCallback(
     (type: PaletteNodeType, position?: { x: number; y: number }) => {
@@ -605,110 +565,6 @@ export function useGraderAgentWorkflow({
     [graph, itemId],
   )
 
-  const updateCodeTestRunnerNode = useCallback(
-    (nodeId: string, patch: Partial<CodeTestRunnerNodeData>) => {
-      if (!graph) return
-      setGraph({
-        ...graph,
-        nodes: graph.nodes.map((n) =>
-          n.id === nodeId ? { ...n, data: { ...n.data, ...patch } } : n,
-        ),
-      })
-    },
-    [graph],
-  )
-
-  const updateConditionalRouterNode = useCallback(
-    (nodeId: string, patch: Partial<ConditionalRouterNodeData>) => {
-      if (!graph) return
-      setGraph({
-        ...graph,
-        nodes: graph.nodes.map((n) =>
-          n.id === nodeId ? { ...n, data: { ...n.data, ...patch } } : n,
-        ),
-      })
-    },
-    [graph],
-  )
-
-  const updateFlagForReviewNode = useCallback(
-    (nodeId: string, patch: Partial<FlagForReviewNodeData>) => {
-      if (!graph) return
-      setGraph({
-        ...graph,
-        nodes: graph.nodes.map((n) =>
-          n.id === nodeId ? { ...n, data: { ...n.data, ...patch } } : n,
-        ),
-      })
-    },
-    [graph],
-  )
-
-  const updateOriginalityNode = useCallback(
-    (nodeId: string, patch: Partial<OriginalityNodeData>) => {
-      if (!graph) return
-      setGraph({
-        ...graph,
-        nodes: graph.nodes.map((n) =>
-          n.id === nodeId ? { ...n, data: { ...n.data, ...patch } } : n,
-        ),
-      })
-    },
-    [graph],
-  )
-
-  const updateReferenceNode = useCallback(
-    (nodeId: string, patch: Partial<ReferenceNodeData>) => {
-      if (!graph) return
-      setGraph({
-        ...graph,
-        nodes: graph.nodes.map((n) =>
-          n.id === nodeId ? { ...n, data: { ...n.data, ...patch } } : n,
-        ),
-      })
-    },
-    [graph],
-  )
-
-  const updateRubricNode = useCallback(
-    (nodeId: string, patch: Partial<RubricNodeData>) => {
-      if (!graph) return
-      setGraph({
-        ...graph,
-        nodes: graph.nodes.map((n) =>
-          n.id === nodeId ? { ...n, data: { ...n.data, ...patch } } : n,
-        ),
-      })
-    },
-    [graph],
-  )
-
-  const updateHumanReviewGateNode = useCallback(
-    (nodeId: string, patch: Partial<HumanReviewGateNodeData>) => {
-      if (!graph) return
-      setGraph({
-        ...graph,
-        nodes: graph.nodes.map((n) =>
-          n.id === nodeId ? { ...n, data: { ...n.data, ...patch } } : n,
-        ),
-      })
-    },
-    [graph],
-  )
-
-  const updateScoreAggregatorNode = useCallback(
-    (nodeId: string, patch: Partial<ScoreAggregatorNodeData>) => {
-      if (!graph) return
-      setGraph({
-        ...graph,
-        nodes: graph.nodes.map((n) =>
-          n.id === nodeId ? { ...n, data: { ...n.data, ...patch } } : n,
-        ),
-      })
-    },
-    [graph],
-  )
-
   const refreshRunResults = useCallback(async () => {
     if (!runId) return
     const run = await fetchGraderAgentRun(courseCode, itemId, runId)
@@ -721,55 +577,40 @@ export function useGraderAgentWorkflow({
     onApplied?.()
   }, [courseCode, itemId, onApplied, runId])
 
-  const updateActivityNode = useCallback(
-    (nodeId: string, patch: { assignmentItemId?: string | null }) => {
-      if (!graph) return
-      setGraph({
-        ...graph,
-        nodes: graph.nodes.map((n) =>
-          n.id === nodeId ? { ...n, data: { ...n.data, ...patch } } : n,
-        ),
-      })
-    },
-    [graph],
-  )
-
-  const updateNodeLabel = useCallback(
-    (nodeId: string, label: string | null) => {
-      if (!graph) return
-      setGraph({
-        ...graph,
-        nodes: graph.nodes.map((n) =>
+  const updateNodeLabel = useCallback((nodeId: string, label: string | null) => {
+    setGraph((prev) => {
+      if (!prev) return prev
+      return {
+        ...prev,
+        nodes: prev.nodes.map((n) =>
           n.id === nodeId ? { ...n, data: patchWorkflowNodeLabel(n.data, label) } : n,
         ),
-      })
-    },
-    [graph],
-  )
+      }
+    })
+  }, [])
 
-  const removeNode = useCallback(
-    (nodeId: string) => {
-      if (!graph || nodeId === 'output') return
-      setGraph({
-        ...graph,
-        nodes: graph.nodes.filter((n) => n.id !== nodeId),
-        edges: graph.edges.filter((e) => e.source !== nodeId && e.target !== nodeId),
-      })
-      if (selectedNodeId === nodeId) setSelectedNodeId(null)
-    },
-    [graph, selectedNodeId],
-  )
+  const removeNode = useCallback((nodeId: string) => {
+    if (nodeId === 'output') return
+    setGraph((prev) => {
+      if (!prev) return prev
+      return {
+        ...prev,
+        nodes: prev.nodes.filter((n) => n.id !== nodeId),
+        edges: prev.edges.filter((e) => e.source !== nodeId && e.target !== nodeId),
+      }
+    })
+    setSelectedNodeId((current) => (current === nodeId ? null : current))
+  }, [])
 
-  const removeEdge = useCallback(
-    (edgeId: string) => {
-      if (!graph) return
-      setGraph({
-        ...graph,
-        edges: graph.edges.filter((e) => e.id !== edgeId),
-      })
-    },
-    [graph],
-  )
+  const removeEdge = useCallback((edgeId: string) => {
+    setGraph((prev) => {
+      if (!prev) return prev
+      return {
+        ...prev,
+        edges: prev.edges.filter((e) => e.id !== edgeId),
+      }
+    })
+  }, [])
 
   const resetDryRunVisualState = useCallback(() => {
     setNodeExecutionStates({})
@@ -1120,18 +961,7 @@ export function useGraderAgentWorkflow({
     validationIssues,
     runnable,
     updateGraph,
-    updateGraderNode,
-    updateAiNode,
-    updateCriterionGraderNode,
-    updateActivityNode,
-    updateCodeTestRunnerNode,
-    updateConditionalRouterNode,
-    updateFlagForReviewNode,
-    updateHumanReviewGateNode,
-    updateScoreAggregatorNode,
-    updateOriginalityNode,
-    updateReferenceNode,
-    updateRubricNode,
+    updateNodeData,
     setLibraryRubricAvailability,
     refreshRunResults,
     updateNodeLabel,

--- a/docs/completed/grading-agent/simplify-3-generic-node-data-updater.md
+++ b/docs/completed/grading-agent/simplify-3-generic-node-data-updater.md
@@ -1,6 +1,6 @@
 # GA-S3 — Collapse the duplicated per-node update callbacks
 
-> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](README.md).
+> Implementation plan. Source: grading-agent audit (2026-06-24). See [README](../../plan/grading-agent/README.md).
 
 ## Metadata
 
@@ -10,11 +10,18 @@
 | **Section** | Grading Agent — Over-complexity / Simplification |
 | **Severity** | MINOR |
 | **Markets** | internal maintainability |
-| **Status (today)** | THIN |
+| **Status (today)** | COMPLETE |
 | **Estimated effort** | XS (≤1d) |
 | **Owner (proposed)** | Web / Grading squad |
 | **Depends on** | — |
 | **Unblocks** | faster node-config work |
+
+## Implementation summary (2026-06-25)
+
+- **Generic updater** — `updateNodeData<T>(nodeId, patch)` in `use-grader-agent-workflow.ts` uses `setGraph(prev => …)` with stable empty-deps `useCallback`.
+- **Removed duplication** — twelve per-node `updateXNode` callbacks deleted; `inspector-panel.tsx` calls `updateNodeData` directly.
+- **Functional graph helpers** — `updateNodeLabel`, `removeNode`, and `removeEdge` also use functional updates (including clearing selection on node removal).
+- **Tests** — `use-grader-agent-workflow-graph-mutations.test.ts` covers patch merge, node removal, and edge removal; existing inspector tests updated.
 
 ## 1. Problem Statement
 
@@ -91,7 +98,7 @@ duplication and a steady tax on adding nodes.
 
 ## 13. Dependencies & Sequencing
 
-- Independent; low risk. Good warm-up before [GA-S4](simplify-4-legacy-node-type-aliases.md).
+- Independent; low risk. Good warm-up before [GA-S4](../../plan/grading-agent/simplify-4-legacy-node-type-aliases.md).
 
 ## 14. Risks & Mitigations
 
@@ -117,8 +124,9 @@ duplication and a steady tax on adding nodes.
 ## 18. Open Questions
 
 1. Keep typed wrappers for every node or only those whose inspectors want a narrowed signature?
+   - **Resolved:** no per-node wrappers; inspectors call `updateNodeData` directly.
 
 ## 19. References
 
 - `clients/web/src/components/annotation/grader-agent/use-grader-agent-workflow.ts` (lines defining `updateGraderNode` … `updateScoreAggregatorNode`).
-- Related: [GA-S4](simplify-4-legacy-node-type-aliases.md).
+- Related: [GA-S4](../../plan/grading-agent/simplify-4-legacy-node-type-aliases.md).


### PR DESCRIPTION
## Summary
- Replace twelve duplicated `updateXNode` callbacks in `use-grader-agent-workflow.ts` with a single `updateNodeData<T>` using functional `setGraph(prev => …)` updates.
- Route all inspector panel edits through `updateNodeData`; also convert `updateNodeLabel`, `removeNode`, and `removeEdge` to functional updates for stable callback identities.
- Add graph mutation unit tests and move GA-S3 plan to `docs/completed`.

## Test plan
- [x] `npm run typecheck` (clients/web)
- [x] `npx oxlint .` (clients/web)
- [x] `npx vitest run` for grader-agent graph mutation and inspector tests
- [ ] Manual: edit one field per node type in the workflow canvas and confirm save persists


Made with [Cursor](https://cursor.com)