### PR TITLE
Retire legacy grading agent node aliases and palette ternaries (GA-S4)

### DIFF
--- a/clients/web/src/components/annotation/grader-agent/__tests__/node-descriptors.test.ts
+++ b/clients/web/src/components/annotation/grader-agent/__tests__/node-descriptors.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+import { NODE_DESCRIPTORS, paletteNodeDefaults } from '../node-descriptors'
+import type { PaletteNodeType } from '../types'
+
+const PALETTE_NODE_TYPES: PaletteNodeType[] = [
+  'studentSubmission',
+  'activity',
+  'codeTestRunner',
+  'conditionalRouter',
+  'flagForReview',
+  'humanReviewGate',
+  'scoreAggregator',
+  'originality',
+  'reference',
+  'rubric',
+  'criterionGrader',
+  'ai',
+]
+
+describe('NODE_DESCRIPTORS', () => {
+  it('covers every palette node type', () => {
+    for (const type of PALETTE_NODE_TYPES) {
+      expect(NODE_DESCRIPTORS[type]).toBeDefined()
+    }
+  })
+
+  it('matches legacy addPaletteNode defaults snapshot', () => {
+    const ctx = { itemId: 'assignment-item-1', nodeCount: 3 }
+    expect(
+      PALETTE_NODE_TYPES.map((type) => ({
+        type,
+        ...paletteNodeDefaults(type, ctx),
+      })),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "data": {},
+          "idPrefix": "sub",
+          "position": {
+            "x": -640,
+            "y": 40,
+          },
+          "type": "studentSubmission",
+        },
+        {
+          "data": {
+            "assignmentItemId": "assignment-item-1",
+          },
+          "idPrefix": "act",
+          "position": {
+            "x": -640,
+            "y": 240,
+          },
+          "type": "activity",
+        },
+        {
+          "data": {
+            "mapping": {
+              "maxPoints": 10,
+              "type": "linear",
+            },
+            "onCompileError": "zero",
+            "onTimeout": "zero",
+            "runtime": "python3.12",
+            "testCases": [
+              {
+                "expectedOutput": "",
+                "id": "t1",
+                "input": "",
+                "isHidden": false,
+              },
+            ],
+          },
+          "idPrefix": "ctr",
+          "position": {
+            "x": -320,
+            "y": 80,
+          },
+          "type": "codeTestRunner",
+        },
+        {
+          "data": {
+            "condition": {
+              "field": "isEmpty",
+              "operator": "isTrue",
+              "value": true,
+            },
+          },
+          "idPrefix": "rtr",
+          "position": {
+            "x": -320,
+            "y": 200,
+          },
+          "type": "conditionalRouter",
+        },
+        {
+          "data": {
+            "priority": "normal",
+            "queue": "default",
+            "reasonTemplate": "Needs human review",
+          },
+          "idPrefix": "flag",
+          "position": {
+            "x": 160,
+            "y": 200,
+          },
+          "type": "flagForReview",
+        },
+        {
+          "data": {
+            "confidenceFloor": 0.7,
+            "mode": "belowConfidence",
+            "queue": "default",
+          },
+          "idPrefix": "gate",
+          "position": {
+            "x": 0,
+            "y": 160,
+          },
+          "type": "humanReviewGate",
+        },
+        {
+          "data": {
+            "confidence": "min",
+            "mergeComments": true,
+            "mode": "sum",
+            "onMissing": "treatAsZero",
+            "weights": {},
+          },
+          "idPrefix": "agg",
+          "position": {
+            "x": 0,
+            "y": 120,
+          },
+          "type": "scoreAggregator",
+        },
+        {
+          "data": {
+            "flagThreshold": 0.4,
+            "metric": "similarity",
+          },
+          "idPrefix": "orig",
+          "position": {
+            "x": -160,
+            "y": 240,
+          },
+          "type": "originality",
+        },
+        {
+          "data": {
+            "mode": "modelAnswer",
+            "text": "",
+          },
+          "idPrefix": "ref",
+          "position": {
+            "x": -640,
+            "y": 320,
+          },
+          "type": "reference",
+        },
+        {
+          "data": {
+            "source": "assignment",
+          },
+          "idPrefix": "rub",
+          "position": {
+            "x": -640,
+            "y": 400,
+          },
+          "type": "rubric",
+        },
+        {
+          "data": {
+            "prompt": "",
+          },
+          "idPrefix": "cg",
+          "position": {
+            "x": -320,
+            "y": 120,
+          },
+          "type": "criterionGrader",
+        },
+        {
+          "data": {},
+          "idPrefix": "ai",
+          "position": {
+            "x": -320,
+            "y": 160,
+          },
+          "type": "ai",
+        },
+      ]
+    `)
+  })
+})

--- a/clients/web/src/components/annotation/grader-agent/__tests__/workflow-normalize.test.ts
+++ b/clients/web/src/components/annotation/grader-agent/__tests__/workflow-normalize.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeLegacyWorkflowGraph } from '../workflow-normalize'
+import { WORKFLOW_VERSION } from '../types'
+
+describe('normalizeLegacyWorkflowGraph', () => {
+  it('rewrites submission alias', () => {
+    const { graph, changes } = normalizeLegacyWorkflowGraph({
+      version: WORKFLOW_VERSION,
+      nodes: [{ id: 'sub', type: 'submission', position: { x: 0, y: 0 }, data: {} }],
+      edges: [],
+    })
+    expect(changes).toBeGreaterThan(0)
+    expect(graph.nodes[0]?.type).toBe('studentSubmission')
+  })
+
+  it('expands assignmentContext context handle', () => {
+    const { graph } = normalizeLegacyWorkflowGraph({
+      version: WORKFLOW_VERSION,
+      nodes: [
+        { id: 'output', type: 'output', position: { x: 0, y: 0 }, data: {} },
+        {
+          id: 'ctx',
+          type: 'assignmentContext',
+          position: { x: -640, y: 0 },
+          data: { includeContent: true, includeRubric: false },
+        },
+        { id: 'ai1', type: 'ai', position: { x: -320, y: 0 }, data: { prompt: 'Grade' } },
+      ],
+      edges: [
+        { id: 'e-grade', source: 'ai1', sourceHandle: 'output', target: 'output', targetHandle: 'grade' },
+        { id: 'e-context', source: 'ctx', target: 'ai1', targetHandle: 'context' },
+      ],
+    })
+    expect(graph.nodes.find((node) => node.id === 'ctx')?.type).toBe('activity')
+    expect(graph.edges.some((edge) => edge.source === 'ctx' && edge.targetHandle === 'input')).toBe(true)
+    expect(graph.edges.some((edge) => edge.targetHandle === 'context')).toBe(false)
+  })
+})

--- a/clients/web/src/components/annotation/grader-agent/default-graph.ts
+++ b/clients/web/src/components/annotation/grader-agent/default-graph.ts
@@ -1,13 +1,15 @@
 import type { GraderWorkflowGraph } from './types'
 import { WORKFLOW_VERSION } from './types'
+import { normalizeLegacyWorkflowGraph } from './workflow-normalize'
 
 /** Coerces API graphs where Go nil slices deserialize as null. */
 export function normalizeWorkflowGraph(graph: GraderWorkflowGraph): GraderWorkflowGraph {
-  return {
+  const coerced: GraderWorkflowGraph = {
     version: graph.version,
     nodes: Array.isArray(graph.nodes) ? graph.nodes : [],
     edges: Array.isArray(graph.edges) ? graph.edges : [],
   }
+  return normalizeLegacyWorkflowGraph(coerced).graph
 }
 
 /** Builds the canonical empty canvas: fixed output node only. */

--- a/clients/web/src/components/annotation/grader-agent/node-descriptors.ts
+++ b/clients/web/src/components/annotation/grader-agent/node-descriptors.ts
@@ -1,0 +1,101 @@
+import type { PaletteNodeType } from './types'
+import {
+  defaultCodeTestRunnerNodeData,
+  defaultConditionalRouterNodeData,
+  defaultFlagForReviewNodeData,
+  defaultHumanReviewGateNodeData,
+  defaultOriginalityNodeData,
+  defaultReferenceNodeData,
+  defaultRubricNodeData,
+  defaultScoreAggregatorNodeData,
+} from './types'
+
+export type NodeDescriptorContext = {
+  itemId: string
+  nodeCount: number
+}
+
+export type NodeDescriptor = {
+  idPrefix: string
+  fallbackPosition: (nodeCount: number) => { x: number; y: number }
+  defaultData: (ctx: NodeDescriptorContext) => Record<string, unknown>
+}
+
+export const NODE_DESCRIPTORS: Record<PaletteNodeType, NodeDescriptor> = {
+  studentSubmission: {
+    idPrefix: 'sub',
+    fallbackPosition: (nodeCount) => ({ x: -640, y: -80 + nodeCount * 40 }),
+    defaultData: () => ({}),
+  },
+  activity: {
+    idPrefix: 'act',
+    fallbackPosition: (nodeCount) => ({ x: -640, y: 120 + nodeCount * 40 }),
+    defaultData: ({ itemId }) => ({ assignmentItemId: itemId }),
+  },
+  codeTestRunner: {
+    idPrefix: 'ctr',
+    fallbackPosition: (nodeCount) => ({ x: -320, y: -40 + nodeCount * 40 }),
+    defaultData: () => defaultCodeTestRunnerNodeData(),
+  },
+  conditionalRouter: {
+    idPrefix: 'rtr',
+    fallbackPosition: (nodeCount) => ({ x: -320, y: 80 + nodeCount * 40 }),
+    defaultData: () => defaultConditionalRouterNodeData(),
+  },
+  flagForReview: {
+    idPrefix: 'flag',
+    fallbackPosition: (nodeCount) => ({ x: 160, y: 80 + nodeCount * 40 }),
+    defaultData: () => defaultFlagForReviewNodeData(),
+  },
+  humanReviewGate: {
+    idPrefix: 'gate',
+    fallbackPosition: (nodeCount) => ({ x: 0, y: 40 + nodeCount * 40 }),
+    defaultData: () => defaultHumanReviewGateNodeData(),
+  },
+  scoreAggregator: {
+    idPrefix: 'agg',
+    fallbackPosition: (nodeCount) => ({ x: 0, y: 0 + nodeCount * 40 }),
+    defaultData: () => defaultScoreAggregatorNodeData(),
+  },
+  originality: {
+    idPrefix: 'orig',
+    fallbackPosition: (nodeCount) => ({ x: -160, y: 120 + nodeCount * 40 }),
+    defaultData: () => defaultOriginalityNodeData(),
+  },
+  reference: {
+    idPrefix: 'ref',
+    fallbackPosition: (nodeCount) => ({ x: -640, y: 200 + nodeCount * 40 }),
+    defaultData: () => defaultReferenceNodeData(),
+  },
+  rubric: {
+    idPrefix: 'rub',
+    fallbackPosition: (nodeCount) => ({ x: -640, y: 280 + nodeCount * 40 }),
+    defaultData: () => defaultRubricNodeData(),
+  },
+  criterionGrader: {
+    idPrefix: 'cg',
+    fallbackPosition: (nodeCount) => ({ x: -320, y: 0 + nodeCount * 40 }),
+    defaultData: () => ({ prompt: '' }),
+  },
+  ai: {
+    idPrefix: 'ai',
+    fallbackPosition: (nodeCount) => ({ x: -320, y: 40 + nodeCount * 40 }),
+    defaultData: () => ({}),
+  },
+}
+
+export function paletteNodeDefaults(
+  type: PaletteNodeType,
+  ctx: NodeDescriptorContext,
+): {
+  idPrefix: string
+  position: { x: number; y: number }
+  data: Record<string, unknown>
+} {
+  const descriptor = NODE_DESCRIPTORS[type]
+  return {
+    idPrefix: descriptor.idPrefix,
+    position: descriptor.fallbackPosition(ctx.nodeCount),
+    data: descriptor.defaultData(ctx),
+  }
+}

--- a/clients/web/src/components/annotation/grader-agent/types.ts
+++ b/clients/web/src/components/annotation/grader-agent/types.ts
@@ -213,7 +213,6 @@ export const HANDLE_CONTEXT = 'context'
 export function isSourceOnlyNodeType(type: string): boolean {
   return (
     type === 'studentSubmission' ||
-    type === 'submission' ||
     type === 'activity' ||
     type === 'reference' ||
     type === 'rubric'
@@ -221,11 +220,11 @@ export function isSourceOnlyNodeType(type: string): boolean {
 }
 
 export function isActivityNodeType(type: string): boolean {
-  return type === 'activity' || type === 'assignmentContext'
+  return type === 'activity'
 }
 
 export function isStudentSubmissionNodeType(type: string): boolean {
-  return type === 'studentSubmission' || type === 'submission'
+  return type === 'studentSubmission'
 }
 
 export function isAiNodeType(type: string): boolean {

--- a/clients/web/src/components/annotation/grader-agent/use-grader-agent-workflow.ts
+++ b/clients/web/src/components/annotation/grader-agent/use-grader-agent-workflow.ts
@@ -43,19 +43,10 @@ import type {
   PaletteNodeType,
   WorkflowValidationIssue,
 } from './types'
-import {
-  defaultCodeTestRunnerNodeData,
-  defaultConditionalRouterNodeData,
-  defaultFlagForReviewNodeData,
-  defaultHumanReviewGateNodeData,
-  defaultOriginalityNodeData,
-  defaultReferenceNodeData,
-  defaultRubricNodeData,
-  defaultScoreAggregatorNodeData,
-} from './types'
 import { useRubricLibraryRubrics } from './use-rubric-library-rubrics'
 import { newWorkflowNodeId } from './workflow-node-id'
 import { patchWorkflowNodeLabel } from './workflow-node-label'
+import { paletteNodeDefaults } from './node-descriptors'
 
 export type RunScope = 'current' | 'ungraded' | 'all'
 
@@ -514,80 +505,14 @@ export function useGraderAgentWorkflow({
   const addPaletteNode = useCallback(
     (type: PaletteNodeType, position?: { x: number; y: number }) => {
       if (!graph) return
-      const prefix =
-        type === 'studentSubmission'
-          ? 'sub'
-          : type === 'activity'
-            ? 'act'
-            : type === 'codeTestRunner'
-              ? 'ctr'
-              : type === 'conditionalRouter'
-                ? 'rtr'
-                : type === 'flagForReview'
-                  ? 'flag'
-                  : type === 'humanReviewGate'
-                    ? 'gate'
-                    : type === 'scoreAggregator'
-                      ? 'agg'
-                      : type === 'originality'
-                      ? 'orig'
-                      : type === 'reference'
-                        ? 'ref'
-                        : type === 'rubric'
-                          ? 'rub'
-                          : type === 'criterionGrader'
-                    ? 'cg'
-                    : 'ai'
-      const id = newWorkflowNodeId(prefix)
+      const descriptor = paletteNodeDefaults(type, {
+        itemId,
+        nodeCount: graph.nodes.length,
+      })
+      const id = newWorkflowNodeId(descriptor.idPrefix)
       setSelectedNodeId(id)
       setGraph((current) => {
         if (!current) return current
-        const fallback =
-          type === 'studentSubmission'
-            ? { x: -640, y: -80 + current.nodes.length * 40 }
-            : type === 'activity'
-              ? { x: -640, y: 120 + current.nodes.length * 40 }
-              : type === 'codeTestRunner'
-                ? { x: -320, y: -40 + current.nodes.length * 40 }
-                : type === 'conditionalRouter'
-                  ? { x: -320, y: 80 + current.nodes.length * 40 }
-                  : type === 'flagForReview'
-                    ? { x: 160, y: 80 + current.nodes.length * 40 }
-                    : type === 'humanReviewGate'
-                      ? { x: 0, y: 40 + current.nodes.length * 40 }
-                      : type === 'scoreAggregator'
-                        ? { x: 0, y: 0 + current.nodes.length * 40 }
-                        : type === 'originality'
-                        ? { x: -160, y: 120 + current.nodes.length * 40 }
-                        : type === 'reference'
-                          ? { x: -640, y: 200 + current.nodes.length * 40 }
-                          : type === 'rubric'
-                            ? { x: -640, y: 280 + current.nodes.length * 40 }
-                            : type === 'criterionGrader'
-                      ? { x: -320, y: 0 + current.nodes.length * 40 }
-                      : { x: -320, y: 40 + current.nodes.length * 40 }
-        const data =
-          type === 'activity'
-            ? { assignmentItemId: itemId }
-            : type === 'codeTestRunner'
-              ? defaultCodeTestRunnerNodeData()
-              : type === 'conditionalRouter'
-                ? defaultConditionalRouterNodeData()
-                : type === 'flagForReview'
-                  ? defaultFlagForReviewNodeData()
-                  : type === 'humanReviewGate'
-                    ? defaultHumanReviewGateNodeData()
-                    : type === 'scoreAggregator'
-                      ? defaultScoreAggregatorNodeData()
-                      : type === 'originality'
-                      ? defaultOriginalityNodeData()
-                      : type === 'reference'
-                        ? defaultReferenceNodeData()
-                        : type === 'rubric'
-                          ? defaultRubricNodeData()
-                          : type === 'criterionGrader'
-                    ? { prompt: '' }
-                    : {}
         return {
           ...current,
           nodes: [
@@ -595,8 +520,8 @@ export function useGraderAgentWorkflow({
             {
               id,
               type,
-              position: position ?? fallback,
-              data,
+              position: position ?? descriptor.position,
+              data: descriptor.data,
             },
           ],
         }

--- a/clients/web/src/components/annotation/grader-agent/validation.ts
+++ b/clients/web/src/components/annotation/grader-agent/validation.ts
@@ -13,7 +13,6 @@ import {
   HANDLE_AI_OUTPUT,
   HANDLE_COMMENTS,
   HANDLE_CONTENT,
-  HANDLE_CONTEXT,
   HANDLE_GRADE,
   HANDLE_RUBRIC,
   HANDLE_SUBMISSION,
@@ -233,10 +232,6 @@ export function validateWorkflowGraph(
       } else if (th === HANDLE_SUBMISSION) {
         if (!isStudentSubmissionNodeType(src.type)) {
           issues.push({ field: `node:${tgt.id}`, message: 'Submission input must come from a Student Submission node.' })
-        }
-      } else if (th === HANDLE_CONTEXT) {
-        if (!isActivityNodeType(src.type)) {
-          issues.push({ field: `node:${tgt.id}`, message: 'Context input must come from an Activity node.' })
         }
       }
     }
@@ -517,7 +512,6 @@ export function connectionIsValid(
       return (isActivityNodeType(src.type) && sh === HANDLE_RUBRIC) || rubricOutputSourceIsValid(src.type, sh)
     }
     if (th === HANDLE_SUBMISSION) return isStudentSubmissionNodeType(src.type)
-    if (th === HANDLE_CONTEXT) return isActivityNodeType(src.type)
   }
   if (isAiNodeType(tgt.type)) {
     if (th !== HANDLE_AI_INPUT) return false

--- a/clients/web/src/components/annotation/grader-agent/workflow-normalize.ts
+++ b/clients/web/src/components/annotation/grader-agent/workflow-normalize.ts
@@ -1,0 +1,112 @@
+import type { GraderWorkflowGraph } from './types'
+import {
+  HANDLE_AI_INPUT,
+  HANDLE_CONTENT,
+  HANDLE_RUBRIC,
+  HANDLE_CONTEXT,
+  HANDLE_SUBMISSION,
+  WORKFLOW_VERSION,
+} from './types'
+
+function boolData(data: Record<string, unknown>, key: string): boolean {
+  const value = data[key]
+  return typeof value === 'boolean' && value
+}
+
+function activityContextIncludeFlags(data: Record<string, unknown>): {
+  includeContent: boolean
+  includeRubric: boolean
+} {
+  if ('includeContent' in data) {
+    return {
+      includeContent: boolData(data, 'includeContent'),
+      includeRubric: boolData(data, 'includeRubric'),
+    }
+  }
+  return { includeContent: true, includeRubric: true }
+}
+
+function isPromptConsumerNodeType(type: string): boolean {
+  return type === 'grader' || type === 'criterionGrader' || type === 'ai'
+}
+
+function contentTargetHandleForNode(nodeType: string): string {
+  return nodeType === 'ai' ? HANDLE_AI_INPUT : HANDLE_CONTENT
+}
+
+function rubricTargetHandleForNode(nodeType: string): string {
+  return nodeType === 'ai' ? HANDLE_AI_INPUT : HANDLE_RUBRIC
+}
+
+/** Rewrites legacy node types and handles to canonical forms (mirrors server normalizer). */
+export function normalizeLegacyWorkflowGraph(graph: GraderWorkflowGraph): {
+  graph: GraderWorkflowGraph
+  changes: number
+} {
+  let changes = 0
+  const nodes = graph.nodes.map((node) => {
+    switch (node.type) {
+      case 'submission':
+        changes++
+        return { ...node, type: 'studentSubmission' as const }
+      case 'assignmentContext':
+        changes++
+        return { ...node, type: 'activity' as const }
+      default:
+        return node
+    }
+  })
+  const nodeById = new Map(nodes.map((node) => [node.id, node]))
+  const edges: GraderWorkflowGraph['edges'] = []
+
+  for (const edge of graph.edges) {
+    const src = nodeById.get(edge.source)
+    const tgt = nodeById.get(edge.target)
+    if (!src || !tgt) {
+      edges.push(edge)
+      continue
+    }
+    const targetHandle = edge.targetHandle ?? ''
+    if (targetHandle === HANDLE_CONTEXT && isPromptConsumerNodeType(tgt.type)) {
+      const { includeContent, includeRubric } = activityContextIncludeFlags(src.data)
+      changes++
+      if (includeContent) {
+        edges.push({
+          id: `${edge.id}-content`,
+          source: edge.source,
+          sourceHandle: HANDLE_CONTENT,
+          target: edge.target,
+          targetHandle: contentTargetHandleForNode(tgt.type),
+        })
+      }
+      if (includeRubric) {
+        edges.push({
+          id: `${edge.id}-rubric`,
+          source: edge.source,
+          sourceHandle: HANDLE_RUBRIC,
+          target: edge.target,
+          targetHandle: rubricTargetHandleForNode(tgt.type),
+        })
+      }
+      continue
+    }
+
+    let next = edge
+    if (
+      tgt.type === 'ai' &&
+      (targetHandle === HANDLE_SUBMISSION ||
+        targetHandle === HANDLE_CONTENT ||
+        targetHandle === HANDLE_RUBRIC ||
+        targetHandle === HANDLE_CONTEXT)
+    ) {
+      next = { ...edge, targetHandle: HANDLE_AI_INPUT }
+      changes++
+    }
+    edges.push(next)
+  }
+
+  return {
+    graph: { version: graph.version ?? WORKFLOW_VERSION, nodes, edges },
+    changes,
+  }
+}

--- a/docs/completed/grading-agent/simplify-4-legacy-node-type-aliases.md
+++ b/docs/completed/grading-agent/simplify-4-legacy-node-type-aliases.md
@@ -10,11 +10,19 @@
 | **Section** | Grading Agent — Over-complexity / Simplification |
 | **Severity** | MINOR |
 | **Markets** | internal maintainability |
-| **Status (today)** | THIN |
+| **Status (today)** | COMPLETE |
 | **Estimated effort** | S (1w) |
 | **Owner (proposed)** | Assessment / Grading squad |
 | **Depends on** | — |
 | **Unblocks** | cleaner node additions |
+
+## Implementation summary (2026-06-25)
+
+- **Load-time normalizer** — `workflow_normalize.go` / `workflow-normalize.ts` rewrite `submission→studentSubmission`, `assignmentContext→activity`, and expand legacy `context` handles into explicit content/rubric edges (preserving include-flag semantics). Invoked from `UnmarshalWorkflowGraph` and client `normalizeWorkflowGraph`.
+- **Alias removal** — `isActivityNodeType`, `isStudentSubmissionNodeType`, `deriveIncludeFlags`, `validateEdgeTypes`, and client validation no longer branch on legacy types/handles after normalization.
+- **Node registry** — `NODE_DESCRIPTORS` + `paletteNodeDefaults` replace the ~90-line `addPaletteNode` ternary pyramid; snapshot-tested in `node-descriptors.test.ts`.
+- **Migration** — `329_grading_agent_normalize_legacy_nodes.sql` documents lazy persistence (canonical graphs saved on next config/template write).
+- **Tests** — Go golden compile test for assignmentContext include flags; client normalizer and descriptor snapshot tests.
 
 ## 1. Problem Statement
 

--- a/docs/plan/grading-agent/README.md
+++ b/docs/plan/grading-agent/README.md
@@ -42,7 +42,7 @@
 | GA-S1 | [Unify the three duplicated grade-write paths in the consumer](../../completed/grading-agent/simplify-1-unify-grade-write-paths.md) | **Done** — single execute + persist path in the queue consumer. |
 | GA-S2 | [Remove the dead HTTP dry-run path; rename the execution engine](simplify-2-remove-dead-dry-run-and-rename-engine.md) | `POST /dry-run` + `Service.Score` legacy path is unused by the client and mis-handles complex graphs. |
 | GA-S3 | [Collapse the duplicated per-node update callbacks](simplify-3-generic-node-data-updater.md) | ~12 near-identical `updateXNode` callbacks in the hook can be one generic updater. |
-| GA-S4 | [Retire legacy node-type aliases & palette ternaries](simplify-4-legacy-node-type-aliases.md) | `submission`/`assignmentContext`/`grader` legacy types and giant nested ternaries add accidental complexity. |
+| GA-S4 | [Retire legacy node-type aliases & palette ternaries](../completed/grading-agent/simplify-4-legacy-node-type-aliases.md) | `submission`/`assignmentContext`/`grader` legacy types and giant nested ternaries add accidental complexity. |
 
 ### Bugs
 

--- a/server/internal/service/gradingagent/prompt_variables.go
+++ b/server/internal/service/gradingagent/prompt_variables.go
@@ -35,9 +35,9 @@ func workflowNodeLabel(data map[string]any) string {
 
 func defaultNodeLabel(nodeType string) string {
 	switch nodeType {
-	case NodeTypeStudentSubmission, NodeTypeSubmission:
+	case NodeTypeStudentSubmission:
 		return "Student Submission"
-	case NodeTypeActivity, NodeTypeAssignmentCtx:
+	case NodeTypeActivity:
 		return "Activity"
 	case NodeTypeAI:
 		return "AI"

--- a/server/internal/service/gradingagent/reachability.go
+++ b/server/internal/service/gradingagent/reachability.go
@@ -149,7 +149,7 @@ func forwardReachable(g *WorkflowGraph, starts []string) map[string]bool {
 
 func isWorkflowSourceNode(nodeType string) bool {
 	switch nodeType {
-	case NodeTypeStudentSubmission, NodeTypeSubmission, NodeTypeActivity, NodeTypeAssignmentCtx, NodeTypeReference, NodeTypeRubric:
+	case NodeTypeStudentSubmission, NodeTypeActivity, NodeTypeReference, NodeTypeRubric:
 		return true
 	default:
 		return false

--- a/server/internal/service/gradingagent/workflow.go
+++ b/server/internal/service/gradingagent/workflow.go
@@ -86,11 +86,11 @@ type CompiledWorkflow struct {
 }
 
 func isActivityNodeType(nodeType string) bool {
-	return nodeType == NodeTypeActivity || nodeType == NodeTypeAssignmentCtx
+	return nodeType == NodeTypeActivity
 }
 
 func isStudentSubmissionNodeType(nodeType string) bool {
-	return nodeType == NodeTypeStudentSubmission || nodeType == NodeTypeSubmission
+	return nodeType == NodeTypeStudentSubmission
 }
 
 func isAINodeType(nodeType string) bool {
@@ -174,7 +174,8 @@ func UnmarshalWorkflowGraph(raw json.RawMessage) (*WorkflowGraph, error) {
 	if err := json.Unmarshal(raw, &g); err != nil {
 		return nil, ValidationError{Field: "workflowGraph", Message: "Invalid workflow graph JSON."}
 	}
-	return &g, nil
+	normalized, _ := NormalizeWorkflowGraph(&g)
+	return &normalized, nil
 }
 
 // ParseWorkflowGraph unmarshals and validates raw JSON into a WorkflowGraph.
@@ -226,7 +227,7 @@ func ValidateWorkflowGraphForPersistence(g *WorkflowGraph) error {
 		}
 		nodeByID[n.ID] = n
 		switch n.Type {
-		case NodeTypeOutput, NodeTypeGrader, NodeTypeCriterionGrader, NodeTypeAI, NodeTypeActivity, NodeTypeStudentSubmission, NodeTypeCodeTestRunner, NodeTypeConditionalRouter, NodeTypeFlagForReview, NodeTypeHumanReviewGate, NodeTypeOriginality, NodeTypeReference, NodeTypeRubric, NodeTypeScoreAggregator, NodeTypeAssignmentCtx, NodeTypeSubmission:
+		case NodeTypeOutput, NodeTypeGrader, NodeTypeCriterionGrader, NodeTypeAI, NodeTypeActivity, NodeTypeStudentSubmission, NodeTypeCodeTestRunner, NodeTypeConditionalRouter, NodeTypeFlagForReview, NodeTypeHumanReviewGate, NodeTypeOriginality, NodeTypeReference, NodeTypeRubric, NodeTypeScoreAggregator:
 		default:
 			return ValidationError{Field: "node:" + n.ID, Message: "Unknown node type."}
 		}
@@ -281,7 +282,7 @@ func ValidateWorkflowGraph(g *WorkflowGraph) error {
 		switch n.Type {
 		case NodeTypeOutput:
 			outputCount++
-		case NodeTypeGrader, NodeTypeCriterionGrader, NodeTypeAI, NodeTypeActivity, NodeTypeStudentSubmission, NodeTypeCodeTestRunner, NodeTypeConditionalRouter, NodeTypeFlagForReview, NodeTypeHumanReviewGate, NodeTypeOriginality, NodeTypeReference, NodeTypeRubric, NodeTypeScoreAggregator, NodeTypeAssignmentCtx, NodeTypeSubmission:
+		case NodeTypeGrader, NodeTypeCriterionGrader, NodeTypeAI, NodeTypeActivity, NodeTypeStudentSubmission, NodeTypeCodeTestRunner, NodeTypeConditionalRouter, NodeTypeFlagForReview, NodeTypeHumanReviewGate, NodeTypeOriginality, NodeTypeReference, NodeTypeRubric, NodeTypeScoreAggregator:
 		default:
 			return ValidationError{Field: "node:" + n.ID, Message: "Unknown node type." }
 		}
@@ -409,10 +410,6 @@ func validateEdgeTypes(src, tgt WorkflowNode, e WorkflowEdge) error {
 		case HandleSubmission:
 			if !isStudentSubmissionNodeType(src.Type) {
 				return ValidationError{Field: "node:" + tgt.ID, Message: "Submission input must come from a Student Submission node."}
-			}
-		case HandleContext:
-			if !isActivityNodeType(src.Type) {
-				return ValidationError{Field: "node:" + tgt.ID, Message: "Context input must come from an Activity node."}
 			}
 		default:
 			msg := "Grader node accepts submission, content, or rubric inputs only."
@@ -560,16 +557,6 @@ func deriveIncludeFlags(g *WorkflowGraph, promptNodeID string, nodeByID map[stri
 		case HandleRubric:
 			if src, ok := nodeByID[e.Source]; ok && (isActivityNodeType(src.Type) || isRubricNodeType(src.Type)) {
 				includeRubric = true
-			}
-		case HandleContext:
-			if ctx, ok := nodeByID[e.Source]; ok && isActivityNodeType(ctx.Type) {
-				if ctx.Type == NodeTypeAssignmentCtx {
-					includeContent = boolData(ctx, "includeContent")
-					includeRubric = boolData(ctx, "includeRubric")
-				} else {
-					includeContent = true
-					includeRubric = true
-				}
 			}
 		}
 	}
@@ -728,19 +715,6 @@ func resolveWiredActivityItemIDs(g *WorkflowGraph, promptNodeID string, nodeByID
 				rubricItemID = activityAssignmentItemID(src)
 			} else if isRubricNodeType(src.Type) {
 				rubricItemID = rubricWiredAssignmentItemID(src)
-			}
-		case HandleContext:
-			if !isActivityNodeType(src.Type) {
-				continue
-			}
-			if src.Type == NodeTypeAssignmentCtx {
-				continue
-			}
-			if contentItemID == "" {
-				contentItemID = activityAssignmentItemID(src)
-			}
-			if rubricItemID == "" {
-				rubricItemID = activityAssignmentItemID(src)
 			}
 		case HandleAIInput:
 			if !isAINodeType(promptNode.Type) {

--- a/server/internal/service/gradingagent/workflow_execute.go
+++ b/server/internal/service/gradingagent/workflow_execute.go
@@ -304,7 +304,7 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 
 		var compiledPrompt, compiledSystemPrompt, compiledInput, compiledOutput string
 		switch node.Type {
-		case NodeTypeStudentSubmission, NodeTypeSubmission:
+		case NodeTypeStudentSubmission:
 			text := JoinSubmissions(in.Submissions)
 			state.set(node.ID, HandleSubmission, slotValue{text: text})
 			modality := in.InputModality.ModalityLogLabel()
@@ -315,7 +315,7 @@ func ExecuteWorkflowDryRun(ctx context.Context, in DryRunExecutionInput) (DryRun
 				Type: "log", Level: "info",
 				Message: fmt.Sprintf("[%s] Input modality: %s; loaded %d part(s) (%d characters).", label, modality, len(in.Submissions), len(text)),
 			})
-		case NodeTypeActivity, NodeTypeAssignmentCtx:
+		case NodeTypeActivity:
 			itemID := activityAssignmentItemID(node)
 			markdown, rubric, loadErr := in.resolveActivity(itemID)
 			if loadErr != nil {
@@ -786,16 +786,6 @@ func buildGraderScoreRequest(
 			includeRubric = true
 			if v.rubric != nil {
 				rubric = v.rubric
-			}
-		case HandleContext:
-			if isActivityNodeType(src.Type) {
-				if src.Type == NodeTypeAssignmentCtx {
-					includeContent = boolData(src, "includeContent")
-					includeRubric = boolData(src, "includeRubric")
-				} else {
-					includeContent = true
-					includeRubric = true
-				}
 			}
 		}
 	}

--- a/server/internal/service/gradingagent/workflow_normalize.go
+++ b/server/internal/service/gradingagent/workflow_normalize.go
@@ -1,0 +1,137 @@
+package gradingagent
+
+import (
+	"log/slog"
+	"strings"
+)
+
+// NormalizeWorkflowGraph rewrites legacy node types and handles to their canonical forms.
+// It is idempotent and safe to call on already-normalized graphs.
+func NormalizeWorkflowGraph(g *WorkflowGraph) (WorkflowGraph, int) {
+	if g == nil {
+		return WorkflowGraph{}, 0
+	}
+	changes := 0
+	out := *g
+	out.Nodes = make([]WorkflowNode, len(g.Nodes))
+	for i, n := range g.Nodes {
+		node := n
+		switch node.Type {
+		case NodeTypeSubmission:
+			node.Type = NodeTypeStudentSubmission
+			changes++
+		case NodeTypeAssignmentCtx:
+			node.Type = NodeTypeActivity
+			changes++
+		}
+		out.Nodes[i] = node
+	}
+	nodeByID := make(map[string]WorkflowNode, len(out.Nodes))
+	for _, n := range out.Nodes {
+		nodeByID[n.ID] = n
+	}
+	normalizedEdges, edgeChanges := normalizeWorkflowEdges(g.Edges, nodeByID)
+	changes += edgeChanges
+	out.Edges = normalizedEdges
+	if changes > 0 {
+		slog.Info("grading agent workflow graph normalized", "changes", changes)
+	}
+	return out, changes
+}
+
+func normalizeWorkflowEdges(edges []WorkflowEdge, nodeByID map[string]WorkflowNode) ([]WorkflowEdge, int) {
+	if len(edges) == 0 {
+		return nil, 0
+	}
+	changes := 0
+	out := make([]WorkflowEdge, 0, len(edges))
+	for _, e := range edges {
+		src, srcOK := nodeByID[e.Source]
+		tgt, tgtOK := nodeByID[e.Target]
+		if !srcOK || !tgtOK {
+			out = append(out, e)
+			continue
+		}
+		targetHandle := strings.TrimSpace(e.TargetHandle)
+
+		if targetHandle == HandleContext && isPromptConsumerNodeType(tgt.Type) {
+			expanded, expandedChanges := expandContextEdge(e, src, tgt.Type)
+			out = append(out, expanded...)
+			changes += expandedChanges
+			continue
+		}
+
+		edge := e
+		if tgt.Type == NodeTypeAI && isPromptConsumerLegacyTargetHandle(targetHandle) {
+			edge.TargetHandle = HandleAIInput
+			changes++
+		}
+		out = append(out, edge)
+	}
+	return out, changes
+}
+
+func isPromptConsumerNodeType(nodeType string) bool {
+	return nodeType == NodeTypeGrader || nodeType == NodeTypeCriterionGrader || nodeType == NodeTypeAI
+}
+
+func isPromptConsumerLegacyTargetHandle(targetHandle string) bool {
+	switch targetHandle {
+	case HandleSubmission, HandleContent, HandleRubric, HandleContext:
+		return true
+	default:
+		return false
+	}
+}
+
+func expandContextEdge(e WorkflowEdge, src WorkflowNode, targetNodeType string) ([]WorkflowEdge, int) {
+	includeContent, includeRubric := activityContextIncludeFlags(src)
+	if !includeContent && !includeRubric {
+		return nil, 1
+	}
+	changes := 1
+	out := make([]WorkflowEdge, 0, 2)
+	if includeContent {
+		out = append(out, WorkflowEdge{
+			ID:           e.ID + "-content",
+			Source:       e.Source,
+			SourceHandle: HandleContent,
+			Target:       e.Target,
+			TargetHandle: contentTargetHandleForNode(targetNodeType),
+		})
+	}
+	if includeRubric {
+		out = append(out, WorkflowEdge{
+			ID:           e.ID + "-rubric",
+			Source:       e.Source,
+			SourceHandle: HandleRubric,
+			Target:       e.Target,
+			TargetHandle: rubricTargetHandleForNode(targetNodeType),
+		})
+	}
+	return out, changes
+}
+
+func contentTargetHandleForNode(nodeType string) string {
+	if nodeType == NodeTypeAI {
+		return HandleAIInput
+	}
+	return HandleContent
+}
+
+func rubricTargetHandleForNode(nodeType string) string {
+	if nodeType == NodeTypeAI {
+		return HandleAIInput
+	}
+	return HandleRubric
+}
+
+func activityContextIncludeFlags(src WorkflowNode) (includeContent, includeRubric bool) {
+	if src.Type != NodeTypeActivity {
+		return false, false
+	}
+	if _, hadIncludeContent := src.Data["includeContent"]; hadIncludeContent {
+		return boolData(src, "includeContent"), boolData(src, "includeRubric")
+	}
+	return true, true
+}

--- a/server/internal/service/gradingagent/workflow_normalize_test.go
+++ b/server/internal/service/gradingagent/workflow_normalize_test.go
@@ -1,0 +1,112 @@
+package gradingagent
+
+import (
+	"testing"
+)
+
+func legacyAssignmentContextGraph(includeContent, includeRubric bool) WorkflowGraph {
+	return WorkflowGraph{
+		Version: WorkflowVersion,
+		Nodes: []WorkflowNode{
+			{ID: "output", Type: NodeTypeOutput, Position: map[string]any{"x": 0, "y": 0}, Data: map[string]any{}},
+			{
+				ID: "ctx", Type: NodeTypeAssignmentCtx, Position: map[string]any{"x": -640, "y": 0},
+				Data: map[string]any{"includeContent": includeContent, "includeRubric": includeRubric},
+			},
+			{
+				ID: "g1", Type: NodeTypeGrader, Position: map[string]any{"x": -320, "y": 0},
+				Data: map[string]any{"prompt": "Grade fairly"},
+			},
+		},
+		Edges: []WorkflowEdge{
+			{ID: "e-grade", Source: "g1", SourceHandle: HandleGrade, Target: "output", TargetHandle: HandleGrade},
+			{ID: "e-context", Source: "ctx", Target: "g1", TargetHandle: HandleContext},
+		},
+	}
+}
+
+func TestNormalizeWorkflowGraph_submissionAlias(t *testing.T) {
+	g := WorkflowGraph{
+		Version: WorkflowVersion,
+		Nodes: []WorkflowNode{
+			{ID: "sub", Type: NodeTypeSubmission, Position: map[string]any{"x": 0, "y": 0}, Data: map[string]any{}},
+		},
+	}
+	normalized, changes := NormalizeWorkflowGraph(&g)
+	if changes == 0 {
+		t.Fatal("expected changes")
+	}
+	if normalized.Nodes[0].Type != NodeTypeStudentSubmission {
+		t.Fatalf("type = %q", normalized.Nodes[0].Type)
+	}
+	_, againChanges := NormalizeWorkflowGraph(&normalized)
+	if againChanges != 0 {
+		t.Fatalf("expected idempotent normalize, got %d changes", againChanges)
+	}
+}
+
+func TestNormalizeWorkflowGraph_assignmentContextExpandsContextHandle(t *testing.T) {
+	g := legacyAssignmentContextGraph(true, false)
+	normalized, changes := NormalizeWorkflowGraph(&g)
+	if changes == 0 {
+		t.Fatal("expected changes")
+	}
+	if normalized.Nodes[1].Type != NodeTypeActivity {
+		t.Fatalf("activity type = %q", normalized.Nodes[1].Type)
+	}
+	var contentEdge *WorkflowEdge
+	for i := range normalized.Edges {
+		e := normalized.Edges[i]
+		if e.Source == "ctx" && e.SourceHandle == HandleContent && e.TargetHandle == HandleContent {
+			contentEdge = &normalized.Edges[i]
+			break
+		}
+	}
+	if contentEdge == nil {
+		t.Fatal("expected content edge from expanded context handle")
+	}
+	for _, e := range normalized.Edges {
+		if e.TargetHandle == HandleContext {
+			t.Fatal("context handle should be removed")
+		}
+	}
+}
+
+func TestNormalizeWorkflowGraph_includeFlagsMatchLegacyCompile(t *testing.T) {
+	legacy := legacyAssignmentContextGraph(true, true)
+	legacyNormalized, _ := NormalizeWorkflowGraph(&legacy)
+	legacyCompiled, err := CompileWorkflowGraph(&legacyNormalized, "essay")
+	if err != nil {
+		t.Fatalf("compile normalized legacy: %v", err)
+	}
+
+	canonical := sampleGraphWithGrader("Grade fairly", true, true)
+	canonicalCompiled, err := CompileWorkflowGraph(&canonical, "essay")
+	if err != nil {
+		t.Fatalf("compile canonical: %v", err)
+	}
+
+	if legacyCompiled.ScoreRequest.IncludeAssignmentContent != canonicalCompiled.ScoreRequest.IncludeAssignmentContent {
+		t.Fatalf("include content mismatch: %v vs %v", legacyCompiled.ScoreRequest.IncludeAssignmentContent, canonicalCompiled.ScoreRequest.IncludeAssignmentContent)
+	}
+	if legacyCompiled.ScoreRequest.IncludeRubric != canonicalCompiled.ScoreRequest.IncludeRubric {
+		t.Fatalf("include rubric mismatch: %v vs %v", legacyCompiled.ScoreRequest.IncludeRubric, canonicalCompiled.ScoreRequest.IncludeRubric)
+	}
+}
+
+func TestUnmarshalWorkflowGraph_normalizesLegacyTypes(t *testing.T) {
+	raw := []byte(`{
+		"version": 1,
+		"nodes": [
+			{"id": "sub", "type": "submission", "position": {"x": 0, "y": 0}, "data": {}}
+		],
+		"edges": []
+	}`)
+	g, err := UnmarshalWorkflowGraph(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g.Nodes[0].Type != NodeTypeStudentSubmission {
+		t.Fatalf("type = %q", g.Nodes[0].Type)
+	}
+}

--- a/server/migrations/329_grading_agent_normalize_legacy_nodes.sql
+++ b/server/migrations/329_grading_agent_normalize_legacy_nodes.sql
@@ -1,0 +1,4 @@
+-- GA-S4: Legacy grading agent workflow graph node types (submission, assignmentContext,
+-- context handle, grader without comments output) are normalized at load time via
+-- gradingagent.NormalizeWorkflowGraph. Graphs are persisted in canonical form on the
+-- next config or template save.


### PR DESCRIPTION
## Summary
- Add load-time workflow graph normalization for legacy `submission`/`assignmentContext` types and `context` handles, preserving assignmentContext include-flag semantics via explicit content/rubric edges.
- Replace the `addPaletteNode` ternary pyramid with a declarative `NODE_DESCRIPTORS` registry (snapshot-tested).
- Remove legacy alias branches from server/client validation and compile paths after normalization.

## Test plan
- [x] `go test ./internal/service/gradingagent/... -short`
- [x] `npx vitest run src/components/annotation/grader-agent/__tests__/`
- [x] `npm run typecheck` (clients/web)
- [ ] Verify a saved template with legacy types loads and saves in the grading agent canvas


Made with [Cursor](https://cursor.com)