### PR TITLE
feat(platform): Status page integration (17.13)

### DIFF
--- a/clients/web/src/components/__tests__/incident-status-banner.test.tsx
+++ b/clients/web/src/components/__tests__/incident-status-banner.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { IncidentStatusBanner } from '../incident-status-banner'
+
+vi.mock('../../lib/status-api', () => ({
+  fetchStatusSummary: vi.fn(),
+  STATUS_POLL_INTERVAL_MS: 300_000,
+}))
+
+import { fetchStatusSummary } from '../../lib/status-api'
+
+const mockFetch = vi.mocked(fetchStatusSummary)
+
+describe('IncidentStatusBanner', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    mockFetch.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders nothing when there are no incidents', async () => {
+    mockFetch.mockResolvedValue({
+      pageUrl: 'https://status.lextures.io',
+      status: 'none',
+      incidents: [],
+      configured: true,
+    })
+    const { container } = render(<IncidentStatusBanner />)
+    await act(async () => {})
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows an incident banner with a status page link', async () => {
+    mockFetch.mockResolvedValue({
+      pageUrl: 'https://status.lextures.io',
+      status: 'minor',
+      incidents: [
+        { id: 'inc-1', name: 'API latency elevated', status: 'investigating', impact: 'minor' },
+      ],
+      configured: true,
+    })
+    render(<IncidentStatusBanner />)
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText(/API latency elevated/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /view system status/i })).toHaveAttribute(
+      'href',
+      'https://status.lextures.io',
+    )
+  })
+
+  it('dismisses the banner for the current session', async () => {
+    mockFetch.mockResolvedValue({
+      pageUrl: 'https://status.lextures.io',
+      status: 'major',
+      incidents: [
+        { id: 'inc-2', name: 'Partial outage', status: 'identified', impact: 'major' },
+      ],
+      configured: true,
+    })
+    const user = userEvent.setup()
+    render(<IncidentStatusBanner />)
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /dismiss incident notice/i }))
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(sessionStorage.getItem('lextures.statusIncident.dismissed')).toContain('inc-2')
+  })
+})

--- a/clients/web/src/components/incident-status-banner.tsx
+++ b/clients/web/src/components/incident-status-banner.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, X } from 'lucide-react'
+import {
+  fetchStatusSummary,
+  STATUS_POLL_INTERVAL_MS,
+  type StatusSummary,
+} from '../lib/status-api'
+
+const DISMISS_SESSION_KEY = 'lextures.statusIncident.dismissed'
+
+function dismissedIncidentIds(): Set<string> {
+  try {
+    const raw = sessionStorage.getItem(DISMISS_SESSION_KEY)
+    if (!raw) return new Set()
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return new Set()
+    return new Set(parsed.filter((v): v is string => typeof v === 'string'))
+  } catch {
+    return new Set()
+  }
+}
+
+function persistDismissed(ids: Set<string>) {
+  sessionStorage.setItem(DISMISS_SESSION_KEY, JSON.stringify([...ids]))
+}
+
+function visibleIncidents(summary: StatusSummary | null): StatusSummary['incidents'] {
+  if (!summary || summary.incidents.length === 0) return []
+  const dismissed = dismissedIncidentIds()
+  return summary.incidents.filter((inc) => !dismissed.has(inc.id))
+}
+
+function bannerTone(impact: string): string {
+  switch (impact.toLowerCase()) {
+    case 'critical':
+    case 'major':
+      return 'border-red-200 bg-red-50 text-red-950 dark:border-red-900/60 dark:bg-red-950/50 dark:text-red-100'
+    default:
+      return 'border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-100'
+  }
+}
+
+export function IncidentStatusBanner() {
+  const [summary, setSummary] = useState<StatusSummary | null>(null)
+  const [dismissedVersion, setDismissedVersion] = useState(0)
+
+  const loadSummary = useCallback(async () => {
+    try {
+      const next = await fetchStatusSummary()
+      setSummary(next)
+    } catch {
+      setSummary(null)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadSummary()
+    const timer = window.setInterval(() => {
+      void loadSummary()
+    }, STATUS_POLL_INTERVAL_MS)
+    return () => window.clearInterval(timer)
+  }, [loadSummary])
+
+  const incidents = useMemo(
+    () => visibleIncidents(summary),
+    [summary, dismissedVersion],
+  )
+  if (incidents.length === 0 || !summary) {
+    return null
+  }
+
+  const primary = incidents[0]
+  const pageUrl = summary.pageUrl || 'https://status.lextures.io'
+
+  function dismissVisible() {
+    const dismissed = dismissedIncidentIds()
+    for (const inc of incidents) {
+      dismissed.add(inc.id)
+    }
+    persistDismissed(dismissed)
+    setDismissedVersion((v) => v + 1)
+  }
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      aria-atomic="true"
+      className={`flex items-start gap-3 border-b px-4 py-2 text-sm ${bannerTone(primary.impact)}`}
+    >
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <p>
+          <strong>{primary.name}</strong>
+          {incidents.length > 1 ? ` (+${incidents.length - 1} more)` : null}.{' '}
+          <a
+            href={pageUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-2"
+          >
+            View system status
+          </a>
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={dismissVisible}
+        className="rounded p-1 transition-[background-color,color,border-color] hover:bg-black/5 dark:hover:bg-white/10"
+        aria-label="Dismiss incident notice for this session"
+      >
+        <X className="h-4 w-4" aria-hidden />
+      </button>
+    </div>
+  )
+}

--- a/clients/web/src/components/layout/app-shell.tsx
+++ b/clients/web/src/components/layout/app-shell.tsx
@@ -22,6 +22,7 @@ import { TopBar } from './top-bar'
 import { UiThemeSync } from './ui-theme-sync'
 import { LocaleBootstrapSync } from './locale-sync'
 import { LmsExperienceRoot } from './lms-experience-root'
+import { IncidentStatusBanner } from '../incident-status-banner'
 import { LegalUpdateBanner } from '../legal/legal-update-banner'
 import { OfflineBanner } from '../offline-banner'
 import { SkipLink } from '../skip-link'
@@ -62,6 +63,7 @@ function AppShellLayout() {
             <TopBar />
           )}
           <OfflineBanner />
+          <IncidentStatusBanner />
           <LegalUpdateBanner />
           <main
             id="main-content"

--- a/clients/web/src/components/layout/app-shell.tsx
+++ b/clients/web/src/components/layout/app-shell.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { lazy, Suspense, useEffect } from 'react'
 import { Outlet, useLocation } from 'react-router-dom'
 import { CommandPaletteProvider } from '../command-palette/command-palette-provider'
 import { KeyboardShortcutsProvider } from '../keyboard-shortcuts/keyboard-shortcuts-provider'
@@ -22,8 +22,11 @@ import { TopBar } from './top-bar'
 import { UiThemeSync } from './ui-theme-sync'
 import { LocaleBootstrapSync } from './locale-sync'
 import { LmsExperienceRoot } from './lms-experience-root'
-import { IncidentStatusBanner } from '../incident-status-banner'
 import { LegalUpdateBanner } from '../legal/legal-update-banner'
+
+const IncidentStatusBanner = lazy(() =>
+  import('../incident-status-banner').then((m) => ({ default: m.IncidentStatusBanner })),
+)
 import { OfflineBanner } from '../offline-banner'
 import { SkipLink } from '../skip-link'
 import { useFocusOnRoute } from '../../lib/a11y'
@@ -63,7 +66,9 @@ function AppShellLayout() {
             <TopBar />
           )}
           <OfflineBanner />
-          <IncidentStatusBanner />
+          <Suspense fallback={null}>
+            <IncidentStatusBanner />
+          </Suspense>
           <LegalUpdateBanner />
           <main
             id="main-content"

--- a/clients/web/src/lib/status-api.ts
+++ b/clients/web/src/lib/status-api.ts
@@ -1,0 +1,27 @@
+import { apiUrl } from './api'
+
+export type StatusIncident = {
+  id: string
+  name: string
+  status: string
+  impact: string
+}
+
+export type StatusSummary = {
+  pageUrl: string
+  status: string
+  incidents: StatusIncident[]
+  configured: boolean
+}
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000
+
+export const STATUS_POLL_INTERVAL_MS = POLL_INTERVAL_MS
+
+export async function fetchStatusSummary(): Promise<StatusSummary> {
+  const res = await fetch(apiUrl('/api/v1/status-summary'))
+  if (!res.ok) {
+    throw new Error(`Failed to load status summary (${res.status})`)
+  }
+  return res.json() as Promise<StatusSummary>
+}

--- a/docs/completed/17-platform-performance-operability/17.13-status-page.md
+++ b/docs/completed/17-platform-performance-operability/17.13-status-page.md
@@ -10,7 +10,7 @@
 | **Section** | Platform, Performance & Operability |
 | **Severity** | MINOR |
 | **Markets** | K12, HE, SL |
-| **Status (today)** | MISSING |
+| **Status (today)** | DONE |
 | **Estimated effort** | S (3–5 d) |
 | **Owner (proposed)** | Platform / DevOps team |
 | **Depends on** | 17.7 (observability for incident detection), 17.8 (health checks as status source) |

--- a/docs/monitoring/alertmanager-statuspage.example.yml
+++ b/docs/monitoring/alertmanager-statuspage.example.yml
@@ -1,0 +1,21 @@
+# Example Alertmanager receiver for Statuspage component automation (plan 17.13).
+# Point this receiver at the Lextures API internal webhook after 17.7 Alertmanager is deployed.
+
+receivers:
+  - name: statuspage-webhook
+    webhook_configs:
+      - url: https://api.lextures.io/api/v1/internal/ops/alertmanager-webhook
+        http_config:
+          authorization:
+            type: Bearer
+            credentials: ${ALERTMANAGER_WEBHOOK_SECRET}
+        send_resolved: true
+
+route:
+  routes:
+    - matchers:
+        - statuspage_component=~".+"
+      receiver: statuspage-webhook
+      group_wait: 5m
+      group_interval: 5m
+      repeat_interval: 30m

--- a/docs/runbooks/status-page-incident.md
+++ b/docs/runbooks/status-page-incident.md
@@ -1,0 +1,32 @@
+# Runbook: Posting an incident update during an outage
+
+Use this when Lextures is degraded or unavailable and users need a public status update.
+
+## Prerequisites
+
+- Statuspage.io admin access for `status.lextures.io`
+- On-call engineer or platform operator role
+
+## Steps
+
+1. Open the [Statuspage admin](https://manage.statuspage.io/) for the Lextures page.
+2. Click **Create incident**.
+3. Select affected components (API, Web App, Database, Job Queue, AI Services, Media/File Storage).
+4. Set impact (`Minor`, `Major`, or `Critical`) and initial status (`Investigating`).
+5. Publish the first update with a plain-language summary for instructors and students.
+6. Post follow-up updates at least every 30 minutes until resolved.
+7. Resolve the incident and publish a short postmortem summary when service is stable.
+
+## In-app banner
+
+The web app polls `GET /api/v1/status-summary` every five minutes. Active incidents appear automatically in the incident banner with a link to `status.lextures.io`. No code deployment is required.
+
+## Automated component updates
+
+When Alertmanager fires a sustained alert (≥ 5 minutes), it posts to:
+
+`POST /api/v1/internal/ops/alertmanager-webhook`
+
+with `Authorization: Bearer <ALERTMANAGER_WEBHOOK_SECRET>`. Alerts should include a `statuspage_component` label (`api`, `web_app`, `database`, `job_queue`, `ai_services`, `media_storage`).
+
+If automation over-reports degradation, tune alert thresholds in Prometheus and resolve the incident manually in Statuspage.

--- a/docs/runbooks/status-page-maintenance.md
+++ b/docs/runbooks/status-page-maintenance.md
@@ -1,0 +1,26 @@
+# Runbook: Scheduling a maintenance window
+
+Use this for planned maintenance that may affect Lextures availability.
+
+## Prerequisites
+
+- Statuspage.io admin access
+- Maintenance window approved by platform lead
+
+## Steps
+
+1. Open the Statuspage admin for `status.lextures.io`.
+2. Click **Create maintenance** (scheduled maintenance).
+3. Select affected components and the maintenance window start/end times.
+4. Schedule at least 48 hours in advance when possible so email subscribers receive advance notice.
+5. Describe expected user impact (read-only mode, brief login disruption, etc.).
+6. Post a reminder update 1 hour before the window begins.
+7. Mark maintenance **In progress** at start time and **Completed** when finished.
+
+## Subscriber notifications
+
+Email and RSS subscribers are notified automatically by Statuspage when the maintenance is scheduled and when it begins or ends. No separate mailing list update is required.
+
+## Rollback
+
+If maintenance must be cancelled, edit the scheduled maintenance in Statuspage and mark it completed with a cancellation note.

--- a/e2e/tests/status-page.spec.ts
+++ b/e2e/tests/status-page.spec.ts
@@ -4,7 +4,9 @@
 import { test, expect } from '../fixtures/test.js'
 
 test.describe('Status page incident banner', () => {
-  test('shows incident banner when status summary reports an active incident', async ({ page }) => {
+  test('shows incident banner when status summary reports an active incident', async ({
+    authedPage: page,
+  }) => {
     await page.route('**/api/v1/status-summary', async (route) => {
       await route.fulfill({
         status: 200,
@@ -25,9 +27,10 @@ test.describe('Status page incident banner', () => {
       })
     })
 
-    await page.goto('/dashboard')
-    await expect(page.getByRole('alert')).toContainText(/Elevated API latency/i)
-    await expect(page.getByRole('link', { name: /view system status/i })).toHaveAttribute(
+    await page.goto('/')
+    const banner = page.getByRole('alert').filter({ hasText: /Elevated API latency/i })
+    await expect(banner).toBeVisible({ timeout: 15_000 })
+    await expect(banner.getByRole('link', { name: /view system status/i })).toHaveAttribute(
       'href',
       'https://status.lextures.io',
     )

--- a/e2e/tests/status-page.spec.ts
+++ b/e2e/tests/status-page.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * Status page incident banner (plan 17.13)
+ */
+import { test, expect } from '../fixtures/test.js'
+
+test.describe('Status page incident banner', () => {
+  test('shows incident banner when status summary reports an active incident', async ({ page }) => {
+    await page.route('**/api/v1/status-summary', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          pageUrl: 'https://status.lextures.io',
+          status: 'minor',
+          configured: true,
+          incidents: [
+            {
+              id: 'e2e-incident-1',
+              name: 'Elevated API latency',
+              status: 'investigating',
+              impact: 'minor',
+            },
+          ],
+        }),
+      })
+    })
+
+    await page.goto('/dashboard')
+    await expect(page.getByRole('alert')).toContainText(/Elevated API latency/i)
+    await expect(page.getByRole('link', { name: /view system status/i })).toHaveAttribute(
+      'href',
+      'https://status.lextures.io',
+    )
+  })
+
+  test('status summary API is publicly accessible', async () => {
+    const apiBase = process.env.E2E_API_URL ?? 'http://localhost:8080'
+    const res = await fetch(`${apiBase}/api/v1/status-summary`)
+    expect(res.ok).toBeTruthy()
+    const body = (await res.json()) as { incidents?: unknown[]; pageUrl?: string }
+    expect(Array.isArray(body.incidents)).toBeTruthy()
+    expect(body.pageUrl).toBeTruthy()
+  })
+})

--- a/iac/production/statuspage.tf
+++ b/iac/production/statuspage.tf
@@ -1,0 +1,60 @@
+# Statuspage.io configuration (plan 17.13).
+# The page itself is created in the Statuspage admin UI; import it before first apply.
+#
+#   terraform import statuspage_page.lextures <page_id>
+#   terraform import statuspage_component.api <page_id>/<component_id>
+#
+# Set STATUSPAGE_API_KEY in Terraform Cloud / secrets manager (never commit the key).
+
+variable "statuspage_page_id" {
+  description = "Statuspage.io page ID for status.lextures.io."
+  type        = string
+  default     = ""
+}
+
+variable "statuspage_api_key" {
+  description = "Statuspage.io API key with page configuration permissions."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+provider "statuspage" {
+  api_key = var.statuspage_api_key
+}
+
+resource "statuspage_page" "lextures" {
+  count = var.statuspage_page_id != "" ? 1 : 0
+
+  id                      = var.statuspage_page_id
+  name                    = "Lextures Status"
+  page_description        = "Current operational status for Lextures platform services."
+  subdomain               = "lextures"
+  time_zone               = "America/New_York"
+  allow_page_subscribers  = true
+  allow_email_subscribers = true
+  allow_rss_atom_feeds    = true
+  domain                  = "status.lextures.io"
+}
+
+locals {
+  statuspage_components = {
+    api            = "API"
+    web_app        = "Web App"
+    database       = "Database"
+    job_queue      = "Job Queue"
+    ai_services    = "AI Services"
+    media_storage  = "Media/File Storage"
+  }
+}
+
+resource "statuspage_component" "service" {
+  for_each = var.statuspage_page_id != "" ? local.statuspage_components : {}
+
+  page_id     = var.statuspage_page_id
+  name        = each.value
+  description = "${each.value} component for Lextures."
+  status      = "operational"
+  showcase    = true
+  position    = index(keys(local.statuspage_components), each.key)
+}

--- a/iac/production/terraform.tfvars.example
+++ b/iac/production/terraform.tfvars.example
@@ -16,3 +16,7 @@ eks_node_instance_types = ["t3.large"]
 tags = {
   Owner = "platform"
 }
+
+# Statuspage.io (plan 17.13). Leave page_id empty until the page is created and imported.
+# statuspage_page_id = ""
+# statuspage_api_key = ""  # set via TF_VAR_statuspage_api_key or secrets manager

--- a/iac/production/versions.tf
+++ b/iac/production/versions.tf
@@ -15,5 +15,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.80"
     }
+    statuspage = {
+      source  = "winebarrel/statuspage"
+      version = "~> 1.0"
+    }
   }
 }

--- a/server/.env.example
+++ b/server/.env.example
@@ -39,5 +39,14 @@ PUBLIC_WEB_ORIGIN=http://localhost:5173
 # STRIPE_MONTHLY_PRICE_ID=
 # STRIPE_ANNUAL_PRICE_ID=
 
+# Status page integration (plan 17.13; Statuspage.io)
+# STATUS_PAGE_ENABLED=1
+# STATUS_PAGE_URL=https://status.lextures.io
+# STATUSPAGE_API_KEY=
+# STATUSPAGE_PAGE_ID=
+# STATUSPAGE_COMPONENT_MAP_PATH=config/statuspage-components.json
+# ALERTMANAGER_WEBHOOK_SECRET=
+# STATUS_PAGE_SUMMARY_CACHE_SECS=60
+
 # Feature enable/disable, MFA, LTI, SSO gates, and similar toggles live in the LMS under
 # Settings → Global platform (settings.platform_app_settings), not in environment variables.

--- a/server/config/statuspage-components.json
+++ b/server/config/statuspage-components.json
@@ -1,0 +1,8 @@
+{
+  "api": "",
+  "web_app": "",
+  "database": "",
+  "job_queue": "",
+  "ai_services": "",
+  "media_storage": ""
+}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -526,6 +526,21 @@ type Config struct {
 	TwilioAuthToken string
 	// TwilioFromNumber is the Twilio sender phone number (E.164).
 	TwilioFromNumber string
+
+	// StatusPageEnabled gates the public status summary proxy and Alertmanager webhook (plan 17.13).
+	StatusPageEnabled bool
+	// StatusPageURL is the public status page URL shown in the incident banner.
+	StatusPageURL string
+	// StatuspageAPIKey is the Statuspage.io API key (stored in secrets manager in production).
+	StatuspageAPIKey string
+	// StatuspagePageID is the Statuspage.io page identifier.
+	StatuspagePageID string
+	// StatuspageComponentMapJSON maps logical component keys to Statuspage component IDs.
+	StatuspageComponentMapJSON string
+	// AlertmanagerWebhookSecret authenticates Alertmanager webhook posts.
+	AlertmanagerWebhookSecret string
+	// StatusPageSummaryCacheSecs is the in-memory cache TTL for the summary proxy.
+	StatusPageSummaryCacheSecs int
 }
 
 // Load reads configuration from the environment.
@@ -702,6 +717,14 @@ func Load() Config {
 		EnableAPIDocs: boolEnv("ENABLE_API_DOCS"),
 
 		AiProviderAbstractionEnabled: boolEnv("AI_PROVIDER_ABSTRACTION_ENABLED"),
+
+		StatusPageEnabled:            boolEnv("STATUS_PAGE_ENABLED"),
+		StatusPageURL:                stringDefault(firstNonEmptyTrimmed("STATUS_PAGE_URL"), "https://status.lextures.io"),
+		StatuspageAPIKey:             firstNonEmptyTrimmed("STATUSPAGE_API_KEY"),
+		StatuspagePageID:             firstNonEmptyTrimmed("STATUSPAGE_PAGE_ID"),
+		StatuspageComponentMapJSON:   statuspageComponentMapJSON(),
+		AlertmanagerWebhookSecret:    firstNonEmptyTrimmed("ALERTMANAGER_WEBHOOK_SECRET"),
+		StatusPageSummaryCacheSecs:   statusPageSummaryCacheSecs(),
 	}
 }
 
@@ -996,6 +1019,33 @@ func commaSeparatedEnv(key string) []string {
 		}
 	}
 	return out
+}
+
+func statusPageSummaryCacheSecs() int {
+	raw := strings.TrimSpace(os.Getenv("STATUS_PAGE_SUMMARY_CACHE_SECS"))
+	if raw == "" {
+		return 60
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return 60
+	}
+	return n
+}
+
+func statuspageComponentMapJSON() string {
+	if raw := strings.TrimSpace(os.Getenv("STATUSPAGE_COMPONENT_MAP_JSON")); raw != "" {
+		return raw
+	}
+	path := strings.TrimSpace(os.Getenv("STATUSPAGE_COMPONENT_MAP_PATH"))
+	if path == "" {
+		path = "config/statuspage-components.json"
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 func storageUseSSL() bool {

--- a/server/internal/httpserver/server.go
+++ b/server/internal/httpserver/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/lextures/lextures/server/internal/service/oidcauth"
 	"github.com/lextures/lextures/server/internal/service/openrouter"
 	"github.com/lextures/lextures/server/internal/service/storagequota"
+	statuspageservice "github.com/lextures/lextures/server/internal/service/statuspage"
 	"github.com/lextures/lextures/server/internal/smsnotificationqueue"
 )
 
@@ -83,6 +84,8 @@ type Deps struct {
 	Integrations *integrationsservice.Service
 	// Bots powers Slack/Teams/Discord classroom bots (plan 16.6). When nil, endpoints return 501.
 	Bots *botsservice.Service
+	// StatusPageClient overrides the default Statuspage.io client (tests). When nil, built from Config.
+	StatusPageClient *statuspageservice.Client
 }
 
 func (d Deps) effectiveConfig() config.Config {
@@ -219,6 +222,7 @@ func NewHandler(d Deps) http.Handler {
 	d.registerAIDisclosureRoutes(r)
 	d.registerAIProviderSettingsRoutes(r)
 	d.registerBackupOpsRoutes(r)
+	d.registerStatusRoutes(r)
 	d.registerPIIRedactionRoutes(r)
 	d.registerUnimplementedV1(r)
 	d.mountRouterErrorHandlers(r)

--- a/server/internal/httpserver/status_http.go
+++ b/server/internal/httpserver/status_http.go
@@ -1,0 +1,113 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/lextures/lextures/server/internal/apierr"
+	statuspageservice "github.com/lextures/lextures/server/internal/service/statuspage"
+)
+
+func (d Deps) statusPageClient() *statuspageservice.Client {
+	if d.StatusPageClient != nil {
+		return d.StatusPageClient
+	}
+	cfg := d.effectiveConfig()
+	componentMap, err := statuspageservice.ParseComponentMap(cfg.StatuspageComponentMapJSON)
+	if err != nil {
+		componentMap = statuspageservice.ComponentMap{}
+	}
+	return statuspageservice.NewClient(statuspageservice.Config{
+		Enabled:      cfg.StatusPageEnabled,
+		PageURL:      cfg.StatusPageURL,
+		APIKey:       cfg.StatuspageAPIKey,
+		PageID:       cfg.StatuspagePageID,
+		ComponentMap: componentMap,
+		CacheTTL:     time.Duration(cfg.StatusPageSummaryCacheSecs) * time.Second,
+	})
+}
+
+func (d Deps) registerStatusRoutes(r chi.Router) {
+	r.Get("/api/v1/status-summary", d.handleGetStatusSummary())
+	r.Post("/api/v1/internal/ops/alertmanager-webhook", d.handleAlertmanagerWebhook())
+}
+
+// GET /api/v1/status-summary
+func (d Deps) handleGetStatusSummary() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		summary, err := d.statusPageClient().Summary(r.Context())
+		if err != nil && len(summary.Incidents) == 0 {
+			apierr.WriteJSON(w, http.StatusBadGateway, apierr.CodeInternal, "Could not load status summary.")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		_ = json.NewEncoder(w).Encode(summary)
+	}
+}
+
+// POST /api/v1/internal/ops/alertmanager-webhook
+func (d Deps) handleAlertmanagerWebhook() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cfg := d.effectiveConfig()
+		if !cfg.StatusPageEnabled {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Status page integration is not enabled.")
+			return
+		}
+		if !d.verifyAlertmanagerWebhookAuth(r, cfg.AlertmanagerWebhookSecret) {
+			apierr.WriteJSON(w, http.StatusUnauthorized, apierr.CodeUnauthorized, "Invalid webhook credentials.")
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Could not read request body.")
+			return
+		}
+		payload, err := statuspageservice.ParseAlertmanagerWebhook(body)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid Alertmanager payload.")
+			return
+		}
+		if err := d.statusPageClient().ApplyAlertmanagerWebhook(r.Context(), payload); err != nil {
+			if strings.Contains(err.Error(), "not configured") {
+				apierr.WriteJSON(w, http.StatusServiceUnavailable, apierr.CodeInternal, "Statuspage is not configured.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusBadGateway, apierr.CodeInternal, "Could not update status page components.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (d Deps) verifyAlertmanagerWebhookAuth(r *http.Request, secret string) bool {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return false
+	}
+	auth := strings.TrimSpace(r.Header.Get("Authorization"))
+	if strings.HasPrefix(strings.ToLower(auth), "bearer ") {
+		return subtleConstantTimeEqual(auth[7:], secret)
+	}
+	if token := strings.TrimSpace(r.Header.Get("X-Alertmanager-Token")); token != "" {
+		return subtleConstantTimeEqual(token, secret)
+	}
+	return false
+}
+
+func subtleConstantTimeEqual(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if len(a) != len(b) {
+		return false
+	}
+	var diff byte
+	for i := 0; i < len(a); i++ {
+		diff |= a[i] ^ b[i]
+	}
+	return diff == 0
+}

--- a/server/internal/httpserver/status_nodb_test.go
+++ b/server/internal/httpserver/status_nodb_test.go
@@ -1,0 +1,94 @@
+package httpserver
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/lextures/lextures/server/internal/config"
+	statuspageservice "github.com/lextures/lextures/server/internal/service/statuspage"
+)
+
+func TestStatusSummary_Public_ReturnsOperationalWhenDisabled(t *testing.T) {
+	d := Deps{Config: config.Config{StatusPageEnabled: false}}
+	h := NewHandler(d)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/status-summary", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte(`"incidents"`)) {
+		t.Fatalf("body=%s", w.Body.String())
+	}
+}
+
+func TestAlertmanagerWebhook_Disabled_Returns404(t *testing.T) {
+	d := Deps{Config: config.Config{StatusPageEnabled: false}}
+	h := NewHandler(d)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/internal/ops/alertmanager-webhook", bytes.NewReader([]byte(`{"alerts":[]}`)))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status=%d", w.Code)
+	}
+}
+
+func TestAlertmanagerWebhook_InvalidAuth_Returns401(t *testing.T) {
+	d := Deps{Config: config.Config{
+		StatusPageEnabled:         true,
+		AlertmanagerWebhookSecret: "secret-token",
+	}}
+	h := NewHandler(d)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/internal/ops/alertmanager-webhook", bytes.NewReader([]byte(`{"alerts":[]}`)))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d", w.Code)
+	}
+}
+
+func TestAlertmanagerWebhook_UpdatesComponent(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method=%s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	client := statuspageservice.NewClient(statuspageservice.Config{
+		Enabled:      true,
+		PageURL:      "https://status.lextures.io",
+		APIKey:       "key",
+		PageID:       "page-1",
+		APIBaseURL:   upstream.URL,
+		HTTPClient:   upstream.Client(),
+		CacheTTL:     time.Minute,
+		ComponentMap: statuspageservice.ComponentMap{"api": "comp-api"},
+	})
+
+	d := Deps{
+		Config: config.Config{
+			StatusPageEnabled:         true,
+			AlertmanagerWebhookSecret: "secret-token",
+		},
+		StatusPageClient: client,
+	}
+	h := NewHandler(d)
+
+	body := []byte(`{
+		"status":"firing",
+		"alerts":[{"status":"firing","labels":{"statuspage_component":"api","severity":"warning"}}]
+	}`)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/internal/ops/alertmanager-webhook", bytes.NewReader(body))
+	r.Header.Set("Authorization", "Bearer secret-token")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+}

--- a/server/internal/service/statuspage/alertmanager.go
+++ b/server/internal/service/statuspage/alertmanager.go
@@ -1,0 +1,98 @@
+package statuspage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// AlertmanagerWebhook is the Alertmanager webhook payload (v4).
+type AlertmanagerWebhook struct {
+	Status string            `json:"status"`
+	Alerts []AlertmanagerAlert `json:"alerts"`
+}
+
+// AlertmanagerAlert is a single alert in an Alertmanager webhook.
+type AlertmanagerAlert struct {
+	Status       string            `json:"status"`
+	Labels       map[string]string `json:"labels"`
+	Annotations  map[string]string `json:"annotations"`
+}
+
+func ParseAlertmanagerWebhook(body []byte) (AlertmanagerWebhook, error) {
+	var payload AlertmanagerWebhook
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return AlertmanagerWebhook{}, fmt.Errorf("invalid alertmanager payload: %w", err)
+	}
+	return payload, nil
+}
+
+// ApplyAlertmanagerWebhook updates Statuspage components for firing/resolved alerts.
+func (c *Client) ApplyAlertmanagerWebhook(ctx context.Context, payload AlertmanagerWebhook) error {
+	if c == nil || !c.Configured() {
+		return fmt.Errorf("statuspage is not configured")
+	}
+	if len(payload.Alerts) == 0 {
+		return nil
+	}
+	updates := make(map[string]string)
+	for _, alert := range payload.Alerts {
+		key := componentKeyFromAlert(alert)
+		if key == "" {
+			continue
+		}
+		componentID, ok := c.cfg.ComponentMap.IDForKey(key)
+		if !ok {
+			continue
+		}
+		severity := alert.Labels["severity"]
+		if severity == "" {
+			severity = alert.Annotations["severity"]
+		}
+		status := ComponentStatusForAlert(alert.Status, severity)
+		updates[componentID] = status
+	}
+	for componentID, status := range updates {
+		if err := c.UpdateComponentStatus(ctx, componentID, status); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func componentKeyFromAlert(alert AlertmanagerAlert) string {
+	if alert.Labels != nil {
+		if v := strings.TrimSpace(alert.Labels["statuspage_component"]); v != "" {
+			return v
+		}
+		if v := strings.TrimSpace(alert.Labels["component"]); v != "" {
+			return v
+		}
+	}
+	if alert.Annotations != nil {
+		if v := strings.TrimSpace(alert.Annotations["statuspage_component"]); v != "" {
+			return v
+		}
+	}
+	if alert.Labels == nil {
+		return ""
+	}
+	name := strings.ToLower(strings.TrimSpace(alert.Labels["alertname"]))
+	switch {
+	case strings.Contains(name, "api"), strings.Contains(name, "http"), strings.Contains(name, "error_rate"):
+		return "api"
+	case strings.Contains(name, "web"), strings.Contains(name, "frontend"):
+		return "web_app"
+	case strings.Contains(name, "database"), strings.Contains(name, "postgres"), strings.Contains(name, "db"):
+		return "database"
+	case strings.Contains(name, "queue"), strings.Contains(name, "rabbit"), strings.Contains(name, "dead_letter"):
+		return "job_queue"
+	case strings.Contains(name, "ai"), strings.Contains(name, "openrouter"):
+		return "ai_services"
+	case strings.Contains(name, "storage"), strings.Contains(name, "s3"), strings.Contains(name, "media"):
+		return "media_storage"
+	default:
+		return ""
+	}
+}

--- a/server/internal/service/statuspage/client.go
+++ b/server/internal/service/statuspage/client.go
@@ -118,7 +118,7 @@ func (c *Client) fetchUpstreamSummary(ctx context.Context) (upstreamSummary, err
 	if err != nil {
 		return upstreamSummary{}, err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	body, err := io.ReadAll(io.LimitReader(res.Body, 1<<20))
 	if err != nil {
 		return upstreamSummary{}, err
@@ -160,7 +160,7 @@ func (c *Client) UpdateComponentStatus(ctx context.Context, componentID, status 
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
 		return fmt.Errorf("statuspage component update: status %d: %s", res.StatusCode, strings.TrimSpace(string(body)))

--- a/server/internal/service/statuspage/client.go
+++ b/server/internal/service/statuspage/client.go
@@ -1,0 +1,169 @@
+package statuspage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const defaultAPIBase = "https://api.statuspage.io/v1"
+
+// Config drives the Statuspage integration.
+type Config struct {
+	Enabled         bool
+	PageURL         string
+	APIKey          string
+	PageID          string
+	ComponentMap    ComponentMap
+	CacheTTL        time.Duration
+	HTTPClient      *http.Client
+	APIBaseURL      string
+}
+
+// Client proxies Statuspage summary data and updates component status.
+type Client struct {
+	cfg Config
+
+	mu          sync.RWMutex
+	cached      Summary
+	cachedAt    time.Time
+	httpClient  *http.Client
+	apiBaseURL  string
+}
+
+func NewClient(cfg Config) *Client {
+	ttl := cfg.CacheTTL
+	if ttl <= 0 {
+		ttl = time.Minute
+	}
+	hc := cfg.HTTPClient
+	if hc == nil {
+		hc = &http.Client{Timeout: 10 * time.Second}
+	}
+	base := strings.TrimRight(strings.TrimSpace(cfg.APIBaseURL), "/")
+	if base == "" {
+		base = defaultAPIBase
+	}
+	pageURL := strings.TrimSpace(cfg.PageURL)
+	if pageURL == "" {
+		pageURL = "https://status.lextures.io"
+	}
+	return &Client{
+		cfg: Config{
+			Enabled:      cfg.Enabled,
+			PageURL:      pageURL,
+			APIKey:       strings.TrimSpace(cfg.APIKey),
+			PageID:       strings.TrimSpace(cfg.PageID),
+			ComponentMap: cfg.ComponentMap,
+			CacheTTL:     ttl,
+		},
+		httpClient: hc,
+		apiBaseURL: base,
+	}
+}
+
+func (c *Client) Configured() bool {
+	return c != nil && c.cfg.Enabled && c.cfg.APIKey != "" && c.cfg.PageID != ""
+}
+
+func (c *Client) Summary(ctx context.Context) (Summary, error) {
+	if c == nil || !c.Configured() {
+		pageURL := "https://status.lextures.io"
+		if c != nil && strings.TrimSpace(c.cfg.PageURL) != "" {
+			pageURL = c.cfg.PageURL
+		}
+		return emptySummary(pageURL, false), nil
+	}
+
+	c.mu.RLock()
+	if !c.cachedAt.IsZero() && time.Since(c.cachedAt) < c.cfg.CacheTTL {
+		out := c.cached
+		c.mu.RUnlock()
+		return out, nil
+	}
+	c.mu.RUnlock()
+
+	raw, err := c.fetchUpstreamSummary(ctx)
+	if err != nil {
+		c.mu.RLock()
+		defer c.mu.RUnlock()
+		if !c.cachedAt.IsZero() {
+			return c.cached, nil
+		}
+		return emptySummary(c.cfg.PageURL, true), err
+	}
+	out := normalizeSummary(c.cfg.PageURL, raw)
+
+	c.mu.Lock()
+	c.cached = out
+	c.cachedAt = time.Now()
+	c.mu.Unlock()
+	return out, nil
+}
+
+func (c *Client) fetchUpstreamSummary(ctx context.Context) (upstreamSummary, error) {
+	url := fmt.Sprintf("%s/pages/%s/summary.json", c.apiBaseURL, c.cfg.PageID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return upstreamSummary{}, err
+	}
+	req.Header.Set("Authorization", "OAuth "+c.cfg.APIKey)
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return upstreamSummary{}, err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if err != nil {
+		return upstreamSummary{}, err
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return upstreamSummary{}, fmt.Errorf("statuspage summary: status %d", res.StatusCode)
+	}
+	var raw upstreamSummary
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return upstreamSummary{}, err
+	}
+	return raw, nil
+}
+
+func (c *Client) UpdateComponentStatus(ctx context.Context, componentID, status string) error {
+	if c == nil || !c.Configured() {
+		return fmt.Errorf("statuspage is not configured")
+	}
+	componentID = strings.TrimSpace(componentID)
+	status = strings.TrimSpace(status)
+	if componentID == "" || status == "" {
+		return fmt.Errorf("component id and status are required")
+	}
+	url := fmt.Sprintf("%s/pages/%s/components/%s", c.apiBaseURL, c.cfg.PageID, componentID)
+	payload := map[string]any{
+		"component": map[string]string{"status": status},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "OAuth "+c.cfg.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+		return fmt.Errorf("statuspage component update: status %d: %s", res.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return nil
+}

--- a/server/internal/service/statuspage/client_test.go
+++ b/server/internal/service/statuspage/client_test.go
@@ -1,0 +1,63 @@
+package statuspage
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClientSummary_UsesCache(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"page": {"id":"page-1","url":"https://status.example.com"},
+			"incidents": [{"id":"1","name":"Outage","status":"investigating","impact":"major"}]
+		}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(Config{
+		Enabled:      true,
+		PageURL:      "https://status.lextures.io",
+		APIKey:       "test-key",
+		PageID:       "page-1",
+		CacheTTL:     time.Minute,
+		APIBaseURL:   srv.URL,
+		HTTPClient:   srv.Client(),
+		ComponentMap: ComponentMap{},
+	})
+
+	ctx := context.Background()
+	first, err := client.Summary(ctx)
+	if err != nil {
+		t.Fatalf("summary: %v", err)
+	}
+	second, err := client.Summary(ctx)
+	if err != nil {
+		t.Fatalf("summary cached: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("upstream calls=%d want 1", calls)
+	}
+	if len(first.Incidents) != 1 || first.Incidents[0].Name != "Outage" {
+		t.Fatalf("first=%+v", first)
+	}
+	if second.Status != "major" {
+		t.Fatalf("status=%q", second.Status)
+	}
+}
+
+func TestClientSummary_NotConfigured(t *testing.T) {
+	client := NewClient(Config{Enabled: false})
+	out, err := client.Summary(context.Background())
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if out.Configured || len(out.Incidents) != 0 {
+		t.Fatalf("out=%+v", out)
+	}
+}

--- a/server/internal/service/statuspage/components.go
+++ b/server/internal/service/statuspage/components.go
@@ -1,0 +1,48 @@
+package statuspage
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ComponentMap maps logical service keys to Statuspage component IDs.
+type ComponentMap map[string]string
+
+func ParseComponentMap(raw string) (ComponentMap, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ComponentMap{}, nil
+	}
+	var m ComponentMap
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return nil, fmt.Errorf("parse statuspage component map: %w", err)
+	}
+	return m, nil
+}
+
+func (m ComponentMap) IDForKey(key string) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	id := strings.TrimSpace(m[strings.ToLower(strings.TrimSpace(key))])
+	if id == "" {
+		return "", false
+	}
+	return id, true
+}
+
+// ComponentStatusForAlert maps an Alertmanager alert to a Statuspage component status.
+func ComponentStatusForAlert(alertStatus, severity string) string {
+	if strings.EqualFold(strings.TrimSpace(alertStatus), "resolved") {
+		return "operational"
+	}
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "critical", "page":
+		return "major_outage"
+	case "warning", "warn":
+		return "degraded_performance"
+	default:
+		return "degraded_performance"
+	}
+}

--- a/server/internal/service/statuspage/summary.go
+++ b/server/internal/service/statuspage/summary.go
@@ -1,0 +1,90 @@
+package statuspage
+
+import "strings"
+
+func emptySummary(pageURL string, configured bool) Summary {
+	return Summary{
+		PageURL:    pageURL,
+		Status:     "none",
+		Incidents:  []SummaryIncident{},
+		Configured: configured,
+	}
+}
+
+func normalizeSummary(pageURL string, raw upstreamSummary) Summary {
+	out := Summary{
+		PageURL:    pageURL,
+		Status:     "none",
+		Incidents:  make([]SummaryIncident, 0),
+		Configured: true,
+	}
+	if u := strings.TrimSpace(raw.Page.URL); u != "" {
+		out.PageURL = u
+	}
+	maxImpact := "none"
+	for _, inc := range raw.Incidents {
+		if !isActiveIncident(inc.Status) {
+			continue
+		}
+		out.Incidents = append(out.Incidents, SummaryIncident{
+			ID:     inc.ID,
+			Name:   inc.Name,
+			Status: inc.Status,
+			Impact: inc.Impact,
+		})
+		maxImpact = maxImpactRank(maxImpact, inc.Impact)
+	}
+	for _, maint := range raw.ScheduledMaintenances {
+		if !isActiveMaintenance(maint.Status) {
+			continue
+		}
+		out.Incidents = append(out.Incidents, SummaryIncident{
+			ID:     maint.ID,
+			Name:   maint.Name,
+			Status: maint.Status,
+			Impact: maint.Impact,
+		})
+		maxImpact = maxImpactRank(maxImpact, maint.Impact)
+	}
+	out.Status = maxImpact
+	return out
+}
+
+func isActiveIncident(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "resolved", "postmortem":
+		return false
+	default:
+		return status != ""
+	}
+}
+
+func isActiveMaintenance(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed":
+		return false
+	default:
+		return status != ""
+	}
+}
+
+func maxImpactRank(current, next string) string {
+	rank := func(v string) int {
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "critical":
+			return 4
+		case "major":
+			return 3
+		case "minor":
+			return 2
+		case "none", "":
+			return 0
+		default:
+			return 1
+		}
+	}
+	if rank(next) > rank(current) {
+		return strings.ToLower(strings.TrimSpace(next))
+	}
+	return current
+}

--- a/server/internal/service/statuspage/summary_test.go
+++ b/server/internal/service/statuspage/summary_test.go
@@ -1,0 +1,52 @@
+package statuspage
+
+import "testing"
+
+func TestNormalizeSummary_ActiveIncident(t *testing.T) {
+	raw := upstreamSummary{}
+	raw.Page.URL = "https://status.example.com"
+	raw.Incidents = []struct {
+		ID     string `json:"id"`
+		Name   string `json:"name"`
+		Status string `json:"status"`
+		Impact string `json:"impact"`
+	}{
+		{ID: "inc-1", Name: "API latency elevated", Status: "investigating", Impact: "minor"},
+		{ID: "inc-2", Name: "Resolved outage", Status: "resolved", Impact: "major"},
+	}
+	out := normalizeSummary("https://status.lextures.io", raw)
+	if out.PageURL != "https://status.example.com" {
+		t.Fatalf("pageUrl=%q", out.PageURL)
+	}
+	if len(out.Incidents) != 1 {
+		t.Fatalf("incidents=%d want 1", len(out.Incidents))
+	}
+	if out.Status != "minor" {
+		t.Fatalf("status=%q want minor", out.Status)
+	}
+}
+
+func TestComponentKeyFromAlert(t *testing.T) {
+	alert := AlertmanagerAlert{
+		Status: "firing",
+		Labels: map[string]string{
+			"alertname":            "HighErrorRate",
+			"statuspage_component": "api",
+		},
+	}
+	if got := componentKeyFromAlert(alert); got != "api" {
+		t.Fatalf("key=%q want api", got)
+	}
+}
+
+func TestComponentStatusForAlert(t *testing.T) {
+	if got := ComponentStatusForAlert("resolved", "critical"); got != "operational" {
+		t.Fatalf("resolved=%q", got)
+	}
+	if got := ComponentStatusForAlert("firing", "critical"); got != "major_outage" {
+		t.Fatalf("critical=%q", got)
+	}
+	if got := ComponentStatusForAlert("firing", "warning"); got != "degraded_performance" {
+		t.Fatalf("warning=%q", got)
+	}
+}

--- a/server/internal/service/statuspage/types.go
+++ b/server/internal/service/statuspage/types.go
@@ -1,0 +1,38 @@
+package statuspage
+
+// Summary is the normalized response for GET /api/v1/status-summary.
+type Summary struct {
+	PageURL    string            `json:"pageUrl"`
+	Status     string            `json:"status"`
+	Incidents  []SummaryIncident `json:"incidents"`
+	Configured bool              `json:"configured"`
+}
+
+// SummaryIncident is an active incident surfaced to the web app banner.
+type SummaryIncident struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Impact string `json:"impact"`
+}
+
+// upstreamSummary mirrors Statuspage GET /pages/{id}/summary.json.
+type upstreamSummary struct {
+	Page struct {
+		ID  string `json:"id"`
+		URL string `json:"url"`
+	} `json:"page"`
+	Incidents []struct {
+		ID     string `json:"id"`
+		Name   string `json:"name"`
+		Status string `json:"status"`
+		Impact string `json:"impact"`
+	} `json:"incidents"`
+	ScheduledMaintenances []struct {
+		ID          string `json:"id"`
+		Name        string `json:"name"`
+		Status      string `json:"status"`
+		Impact      string `json:"impact"`
+		ScheduledFor string `json:"scheduled_for"`
+	} `json:"scheduled_maintenances"`
+}


### PR DESCRIPTION
## Summary

Implements plan 17.13 — public status page integration with Statuspage.io:

- **API:** `GET /api/v1/status-summary` proxies Statuspage summary data for the in-app banner
- **Ops:** `POST /api/v1/internal/ops/alertmanager-webhook` updates Statuspage components from Alertmanager alerts
- **Web:** Session-dismissible incident banner polls every 5 minutes and links to `status.lextures.io`
- **IaC:** Statuspage Terraform provider config for production components
- **Docs:** Incident and maintenance runbooks, Alertmanager receiver example

## Test plan

- [x] Go unit tests (`statuspage` service + HTTP handlers)
- [x] Frontend unit tests (`IncidentStatusBanner`)
- [x] Frontend lint + typecheck
- [ ] E2E `status-page.spec.ts` (requires Playwright browsers in CI)