### PR TITLE
feat(marketplace): Marketplace / Plugin System (16.9)

### DIFF
--- a/clients/web/src/lib/marketplace-api.ts
+++ b/clients/web/src/lib/marketplace-api.ts
@@ -1,0 +1,124 @@
+import { authorizedFetch } from './api'
+import { readApiErrorMessage } from './errors'
+
+export type MarketplaceApp = {
+  id: string
+  name: string
+  slug: string
+  description: string
+  logoUrl: string | null
+  requestedScopes: string[]
+}
+
+export type DeveloperApp = {
+  id: string
+  name: string
+  slug: string
+  description: string
+  logoUrl: string | null
+  clientId: string
+  clientSecretPrefix: string
+  redirectUris: string[]
+  requestedScopes: string[]
+  published: boolean
+  createdAt: string
+}
+
+export type ScopeInfo = {
+  scope: string
+  label: string
+  isWrite: boolean
+}
+
+export type OAuthConsentInfo = {
+  state: string
+  appName: string
+  appLogoUrl: string | null
+  scopes: ScopeInfo[]
+}
+
+export type InstalledApp = {
+  id: string
+  appId: string
+  appName: string
+  appSlug: string
+  appLogoUrl: string | null
+  grantedScopes: string[]
+  installedAt: string
+  installedBy: string | null
+  lastUsedAt: string | null
+}
+
+export async function fetchMarketplaceApps(): Promise<MarketplaceApp[]> {
+  const res = await authorizedFetch('/api/v1/marketplace/apps')
+  if (!res.ok) throw new Error(await readApiErrorMessage(res))
+  const data = await res.json()
+  return data.apps ?? []
+}
+
+export async function fetchMarketplaceApp(slug: string): Promise<MarketplaceApp | null> {
+  const res = await authorizedFetch(`/api/v1/marketplace/apps/${slug}`)
+  if (res.status === 404) return null
+  if (!res.ok) throw new Error(await readApiErrorMessage(res))
+  return res.json()
+}
+
+export async function fetchOAuthConsentInfo(params: {
+  clientId: string
+  redirectUri: string
+  scope: string
+  codeChallenge: string
+}): Promise<OAuthConsentInfo> {
+  const q = new URLSearchParams({
+    client_id: params.clientId,
+    redirect_uri: params.redirectUri,
+    scope: params.scope,
+    code_challenge: params.codeChallenge,
+    code_challenge_method: 'S256',
+  })
+  const res = await authorizedFetch(`/oauth/authorize?${q}`)
+  if (!res.ok) throw new Error(await readApiErrorMessage(res))
+  return res.json()
+}
+
+export async function fetchDeveloperApps(): Promise<DeveloperApp[]> {
+  const res = await authorizedFetch('/api/v1/developer/apps')
+  if (!res.ok) throw new Error(await readApiErrorMessage(res))
+  const data = await res.json()
+  return data.apps ?? []
+}
+
+export type CreateAppInput = {
+  name: string
+  slug: string
+  description: string
+  logoUrl?: string
+  redirectUris: string[]
+  requestedScopes: string[]
+}
+
+export type CreateAppResult = DeveloperApp & { clientSecret: string }
+
+export async function createDeveloperApp(input: CreateAppInput): Promise<CreateAppResult> {
+  const res = await authorizedFetch('/api/v1/developer/apps', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  if (!res.ok) throw new Error(await readApiErrorMessage(res))
+  return res.json()
+}
+
+export async function fetchInstalledApps(): Promise<InstalledApp[]> {
+  const res = await authorizedFetch('/api/v1/admin/marketplace/installed')
+  if (!res.ok) throw new Error(await readApiErrorMessage(res))
+  const data = await res.json()
+  return data.installations ?? []
+}
+
+export async function revokeInstalledApp(id: string): Promise<void> {
+  const res = await authorizedFetch(`/api/v1/admin/marketplace/installed/${id}`, {
+    method: 'DELETE',
+  })
+  if (!res.ok && res.status !== 204) throw new Error(await readApiErrorMessage(res))
+}

--- a/clients/web/src/pages/admin/marketplace-installed.tsx
+++ b/clients/web/src/pages/admin/marketplace-installed.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useId, useState } from 'react'
+import { fetchInstalledApps, revokeInstalledApp, type InstalledApp } from '../../lib/marketplace-api'
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+function InstalledRow({
+  app,
+  onRevoke,
+  busy,
+}: {
+  app: InstalledApp
+  onRevoke: (id: string) => void
+  busy: boolean
+}) {
+  return (
+    <tr style={{ borderBottom: '1px solid #f3f4f6' }}>
+      <td style={{ padding: '0.75rem 0.5rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          {app.appLogoUrl && (
+            <img
+              src={app.appLogoUrl}
+              alt=""
+              width={28}
+              height={28}
+              style={{ borderRadius: '0.375rem', objectFit: 'cover' }}
+            />
+          )}
+          <div>
+            <div style={{ fontWeight: 600, fontSize: '0.875rem' }}>{app.appName}</div>
+            <div style={{ fontSize: '0.75rem', color: '#6b7280' }}>{app.appSlug}</div>
+          </div>
+        </div>
+      </td>
+      <td style={{ padding: '0.75rem 0.5rem', fontSize: '0.8rem' }}>
+        {app.grantedScopes.length > 0 ? (
+          <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexWrap: 'wrap', gap: '0.25rem' }}>
+            {app.grantedScopes.map((s) => (
+              <li
+                key={s}
+                style={{
+                  background: '#f3f4f6',
+                  borderRadius: '0.25rem',
+                  padding: '0.1rem 0.35rem',
+                  fontFamily: 'monospace',
+                  fontSize: '0.75rem',
+                }}
+              >
+                {s}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          '—'
+        )}
+      </td>
+      <td style={{ padding: '0.75rem 0.5rem', fontSize: '0.8rem', color: '#374151' }}>
+        {formatDate(app.installedAt)}
+      </td>
+      <td style={{ padding: '0.75rem 0.5rem', fontSize: '0.8rem', color: '#374151' }}>
+        {formatDate(app.lastUsedAt)}
+      </td>
+      <td style={{ padding: '0.75rem 0.5rem', textAlign: 'right' }}>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onRevoke(app.id)}
+          style={{
+            padding: '0.375rem 0.75rem',
+            fontSize: '0.8rem',
+            color: '#dc2626',
+            border: '1px solid #dc2626',
+            background: '#fff',
+            borderRadius: '0.375rem',
+            cursor: busy ? 'not-allowed' : 'pointer',
+            opacity: busy ? 0.5 : 1,
+          }}
+          aria-label={`Revoke access for ${app.appName}`}
+        >
+          Revoke
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+export default function MarketplaceInstalledPage() {
+  const headingId = useId()
+  const [apps, setApps] = useState<InstalledApp[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setApps(await fetchInstalledApps())
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to load installed apps.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { void load() }, [load])
+
+  async function handleRevoke(id: string) {
+    if (!window.confirm('Revoke access for this app? Its tokens will be immediately invalidated.')) return
+    setBusy(id)
+    try {
+      await revokeInstalledApp(id)
+      await load()
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to revoke app.')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <main
+      aria-labelledby={headingId}
+      style={{ maxWidth: '72rem', margin: '0 auto', padding: '2rem 1rem' }}
+    >
+      <header style={{ marginBottom: '1.5rem' }}>
+        <h1 id={headingId} style={{ fontSize: '1.5rem', fontWeight: 700 }}>
+          Installed Apps
+        </h1>
+        <p style={{ color: '#6b7280', fontSize: '0.875rem', marginTop: '0.25rem' }}>
+          Manage third-party apps that have been granted access to your organization.
+        </p>
+      </header>
+
+      {error && (
+        <div role="alert" style={{ color: '#dc2626', background: '#fef2f2', padding: '0.75rem', borderRadius: '0.375rem', marginBottom: '1rem', fontSize: '0.875rem' }}>
+          {error}
+        </div>
+      )}
+
+      {loading && <p>Loading installed apps&hellip;</p>}
+
+      {!loading && apps.length === 0 && (
+        <p style={{ color: '#6b7280' }}>No apps are installed in your organization.</p>
+      )}
+
+      {!loading && apps.length > 0 && (
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
+            <thead>
+              <tr style={{ textAlign: 'left', borderBottom: '2px solid #e5e7eb' }}>
+                <th style={{ padding: '0.5rem' }}>App</th>
+                <th style={{ padding: '0.5rem' }}>Granted Scopes</th>
+                <th style={{ padding: '0.5rem' }}>Installed</th>
+                <th style={{ padding: '0.5rem' }}>Last Used</th>
+                <th style={{ padding: '0.5rem', textAlign: 'right' }}>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {apps.map((a) => (
+                <InstalledRow
+                  key={a.id}
+                  app={a}
+                  onRevoke={(id) => void handleRevoke(id)}
+                  busy={busy === a.id}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  )
+}

--- a/clients/web/src/pages/developer/index.tsx
+++ b/clients/web/src/pages/developer/index.tsx
@@ -1,0 +1,352 @@
+import { useCallback, useEffect, useId, useState } from 'react'
+import {
+  createDeveloperApp,
+  fetchDeveloperApps,
+  type CreateAppInput,
+  type CreateAppResult,
+  type DeveloperApp,
+} from '../../lib/marketplace-api'
+
+function NewSecretBanner({ app, onDismiss }: { app: CreateAppResult; onDismiss: () => void }) {
+  return (
+    <div
+      role="alert"
+      style={{
+        background: '#f0fdf4',
+        border: '1px solid #86efac',
+        borderRadius: '0.5rem',
+        padding: '1rem',
+        marginBottom: '1.5rem',
+      }}
+    >
+      <strong style={{ display: 'block', marginBottom: '0.5rem' }}>
+        App &ldquo;{app.name}&rdquo; created!
+      </strong>
+      <p style={{ margin: '0 0 0.5rem', fontSize: '0.875rem', color: '#166534' }}>
+        Copy your client secret now — it will not be shown again.
+      </p>
+      <div
+        style={{
+          background: '#dcfce7',
+          padding: '0.5rem 0.75rem',
+          borderRadius: '0.375rem',
+          fontFamily: 'monospace',
+          fontSize: '0.85rem',
+          wordBreak: 'break-all',
+        }}
+      >
+        <strong>Client ID:</strong> {app.clientId}
+        <br />
+        <strong>Client Secret:</strong> {app.clientSecret}
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        style={{ marginTop: '0.75rem', fontSize: '0.875rem', cursor: 'pointer' }}
+      >
+        Dismiss
+      </button>
+    </div>
+  )
+}
+
+function AppRow({ app }: { app: DeveloperApp }) {
+  return (
+    <tr>
+      <td style={{ padding: '0.75rem 0.5rem' }}>
+        <div style={{ fontWeight: 600 }}>{app.name}</div>
+        <div style={{ fontSize: '0.75rem', color: '#6b7280' }}>{app.slug}</div>
+      </td>
+      <td style={{ padding: '0.75rem 0.5rem', fontFamily: 'monospace', fontSize: '0.8rem' }}>
+        {app.clientId}
+      </td>
+      <td style={{ padding: '0.75rem 0.5rem', fontSize: '0.875rem' }}>
+        {app.requestedScopes.join(', ') || '—'}
+      </td>
+      <td style={{ padding: '0.75rem 0.5rem' }}>
+        <span
+          style={{
+            fontSize: '0.75rem',
+            padding: '0.125rem 0.5rem',
+            borderRadius: '9999px',
+            background: app.published ? '#d1fae5' : '#f3f4f6',
+            color: app.published ? '#065f46' : '#374151',
+          }}
+        >
+          {app.published ? 'Published' : 'Draft'}
+        </span>
+      </td>
+    </tr>
+  )
+}
+
+const DEFAULT_FORM: CreateAppInput = {
+  name: '',
+  slug: '',
+  description: '',
+  redirectUris: [''],
+  requestedScopes: [],
+}
+
+const AVAILABLE_SCOPES = [
+  'courses:read',
+  'courses:write',
+  'enrollments:read',
+  'users:read',
+  'grades:read',
+  'grades:write',
+  'assignments:read',
+  'pii:read',
+]
+
+export default function DeveloperPortalPage() {
+  const headingId = useId()
+  const formId = useId()
+  const [apps, setApps] = useState<DeveloperApp[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState<CreateAppInput>(DEFAULT_FORM)
+  const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [newApp, setNewApp] = useState<CreateAppResult | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      setApps(await fetchDeveloperApps())
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to load apps.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { void load() }, [load])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    setFormError(null)
+    try {
+      const result = await createDeveloperApp({
+        ...form,
+        redirectUris: form.redirectUris.filter((u) => u.trim() !== ''),
+      })
+      setNewApp(result)
+      setShowForm(false)
+      setForm(DEFAULT_FORM)
+      await load()
+    } catch (e: unknown) {
+      setFormError(e instanceof Error ? e.message : 'Failed to create app.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function toggleScope(scope: string) {
+    setForm((f) => ({
+      ...f,
+      requestedScopes: f.requestedScopes.includes(scope)
+        ? f.requestedScopes.filter((s) => s !== scope)
+        : [...f.requestedScopes, scope],
+    }))
+  }
+
+  return (
+    <main
+      aria-labelledby={headingId}
+      style={{ maxWidth: '64rem', margin: '0 auto', padding: '2rem 1rem' }}
+    >
+      <header style={{ marginBottom: '2rem', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '1rem' }}>
+        <div>
+          <h1 id={headingId} style={{ fontSize: '1.5rem', fontWeight: 700, margin: 0 }}>
+            Developer Portal
+          </h1>
+          <p style={{ color: '#6b7280', marginTop: '0.25rem', fontSize: '0.875rem' }}>
+            Register and manage your Lextures marketplace apps.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowForm((v) => !v)}
+          style={{
+            padding: '0.5rem 1rem',
+            background: '#2563eb',
+            color: '#fff',
+            border: 'none',
+            borderRadius: '0.375rem',
+            fontWeight: 500,
+            cursor: 'pointer',
+          }}
+        >
+          {showForm ? 'Cancel' : 'Register New App'}
+        </button>
+      </header>
+
+      {newApp && (
+        <NewSecretBanner app={newApp} onDismiss={() => setNewApp(null)} />
+      )}
+
+      {showForm && (
+        <section
+          aria-label="Register new app"
+          style={{
+            border: '1px solid #e5e7eb',
+            borderRadius: '0.5rem',
+            padding: '1.5rem',
+            marginBottom: '2rem',
+            background: '#fff',
+          }}
+        >
+          <h2 style={{ fontSize: '1rem', fontWeight: 600, marginBottom: '1rem' }}>
+            New Application
+          </h2>
+          {formError && (
+            <div role="alert" style={{ color: '#dc2626', marginBottom: '1rem', fontSize: '0.875rem' }}>
+              {formError}
+            </div>
+          )}
+          <form id={formId} onSubmit={(e) => void handleSubmit(e)} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem' }}>
+              App Name *
+              <input
+                required
+                value={form.name}
+                onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                style={{ padding: '0.5rem', border: '1px solid #d1d5db', borderRadius: '0.375rem' }}
+              />
+            </label>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem' }}>
+              Slug * (used in URL, lowercase letters and hyphens only)
+              <input
+                required
+                pattern="[a-z0-9-]+"
+                value={form.slug}
+                onChange={(e) => setForm((f) => ({ ...f, slug: e.target.value }))}
+                style={{ padding: '0.5rem', border: '1px solid #d1d5db', borderRadius: '0.375rem' }}
+              />
+            </label>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem' }}>
+              Description
+              <textarea
+                rows={3}
+                value={form.description}
+                onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+                style={{ padding: '0.5rem', border: '1px solid #d1d5db', borderRadius: '0.375rem', resize: 'vertical' }}
+              />
+            </label>
+            <fieldset style={{ border: '1px solid #d1d5db', borderRadius: '0.375rem', padding: '0.75rem' }}>
+              <legend style={{ fontSize: '0.875rem', fontWeight: 500, padding: '0 0.25rem' }}>
+                Redirect URIs *
+              </legend>
+              {form.redirectUris.map((uri, i) => (
+                <div key={i} style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
+                  <input
+                    type="url"
+                    value={uri}
+                    onChange={(e) => {
+                      const next = [...form.redirectUris]
+                      next[i] = e.target.value
+                      setForm((f) => ({ ...f, redirectUris: next }))
+                    }}
+                    style={{ flex: 1, padding: '0.375rem 0.5rem', border: '1px solid #d1d5db', borderRadius: '0.375rem', fontSize: '0.875rem' }}
+                    placeholder="https://yourapp.com/callback"
+                  />
+                  {form.redirectUris.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => setForm((f) => ({ ...f, redirectUris: f.redirectUris.filter((_, j) => j !== i) }))}
+                      style={{ color: '#dc2626', border: 'none', background: 'none', cursor: 'pointer' }}
+                      aria-label="Remove redirect URI"
+                    >
+                      ✕
+                    </button>
+                  )}
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={() => setForm((f) => ({ ...f, redirectUris: [...f.redirectUris, ''] }))}
+                style={{ fontSize: '0.8rem', color: '#2563eb', border: 'none', background: 'none', cursor: 'pointer', padding: 0 }}
+              >
+                + Add another URI
+              </button>
+            </fieldset>
+            <fieldset style={{ border: '1px solid #d1d5db', borderRadius: '0.375rem', padding: '0.75rem' }}>
+              <legend style={{ fontSize: '0.875rem', fontWeight: 500, padding: '0 0.25rem' }}>
+                Requested Scopes
+              </legend>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+                {AVAILABLE_SCOPES.map((scope) => (
+                  <label
+                    key={scope}
+                    style={{ display: 'flex', alignItems: 'center', gap: '0.375rem', fontSize: '0.8rem', cursor: 'pointer' }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={form.requestedScopes.includes(scope)}
+                      onChange={() => toggleScope(scope)}
+                    />
+                    {scope}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+            <div style={{ display: 'flex', gap: '0.75rem' }}>
+              <button
+                type="submit"
+                disabled={submitting}
+                style={{
+                  padding: '0.5rem 1.25rem',
+                  background: '#2563eb',
+                  color: '#fff',
+                  border: 'none',
+                  borderRadius: '0.375rem',
+                  fontWeight: 500,
+                  cursor: submitting ? 'not-allowed' : 'pointer',
+                  opacity: submitting ? 0.6 : 1,
+                }}
+              >
+                {submitting ? 'Creating…' : 'Create App'}
+              </button>
+            </div>
+          </form>
+        </section>
+      )}
+
+      {loading && <p>Loading your apps&hellip;</p>}
+      {error && (
+        <div role="alert" style={{ color: '#dc2626', fontSize: '0.875rem' }}>
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && apps.length === 0 && !showForm && (
+        <p style={{ color: '#6b7280' }}>
+          You have no registered apps yet. Click &ldquo;Register New App&rdquo; to get started.
+        </p>
+      )}
+
+      {apps.length > 0 && (
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
+            <thead>
+              <tr style={{ textAlign: 'left', borderBottom: '2px solid #e5e7eb' }}>
+                <th style={{ padding: '0.5rem' }}>App</th>
+                <th style={{ padding: '0.5rem' }}>Client ID</th>
+                <th style={{ padding: '0.5rem' }}>Scopes</th>
+                <th style={{ padding: '0.5rem' }}>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {apps.map((a) => (
+                <AppRow key={a.id} app={a} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  )
+}

--- a/clients/web/src/pages/marketplace/app-detail.tsx
+++ b/clients/web/src/pages/marketplace/app-detail.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useId, useState } from 'react'
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import { fetchMarketplaceApp, type MarketplaceApp } from '../../lib/marketplace-api'
+
+export default function MarketplaceAppDetailPage() {
+  const { slug } = useParams<{ slug: string }>()
+  const navigate = useNavigate()
+  const headingId = useId()
+  const [app, setApp] = useState<MarketplaceApp | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!slug) return
+    setLoading(true)
+    fetchMarketplaceApp(slug)
+      .then((a) => {
+        if (!a) {
+          void navigate('/marketplace', { replace: true })
+          return
+        }
+        setApp(a)
+      })
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Failed to load app.'))
+      .finally(() => setLoading(false))
+  }, [slug, navigate])
+
+  if (loading) return <main style={{ padding: '2rem' }}>Loading&hellip;</main>
+
+  if (error)
+    return (
+      <main style={{ padding: '2rem' }}>
+        <div role="alert" style={{ color: '#dc2626' }}>
+          {error}
+        </div>
+      </main>
+    )
+
+  if (!app) return null
+
+  const installUrl = `/oauth/authorize?client_id=${encodeURIComponent(app.id)}&scope=${encodeURIComponent(app.requestedScopes.join(' '))}`
+
+  return (
+    <main
+      aria-labelledby={headingId}
+      style={{ maxWidth: '48rem', margin: '0 auto', padding: '2rem 1rem' }}
+    >
+      <nav style={{ marginBottom: '1rem' }}>
+        <Link to="/marketplace" style={{ color: '#2563eb', textDecoration: 'none', fontSize: '0.875rem' }}>
+          &larr; Back to Marketplace
+        </Link>
+      </nav>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '1.5rem' }}>
+        {app.logoUrl ? (
+          <img
+            src={app.logoUrl}
+            alt={`${app.name} logo`}
+            width={64}
+            height={64}
+            style={{ borderRadius: '0.75rem', objectFit: 'cover' }}
+          />
+        ) : (
+          <div
+            aria-hidden="true"
+            style={{
+              width: 64,
+              height: 64,
+              borderRadius: '0.75rem',
+              background: '#e5e7eb',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '2rem',
+              color: '#6b7280',
+            }}
+          >
+            {app.name[0]?.toUpperCase()}
+          </div>
+        )}
+        <h1 id={headingId} style={{ margin: 0, fontSize: '1.5rem', fontWeight: 700 }}>
+          {app.name}
+        </h1>
+      </div>
+
+      <p style={{ color: '#374151', marginBottom: '2rem', fontSize: '1rem', lineHeight: '1.6' }}>
+        {app.description}
+      </p>
+
+      {app.requestedScopes.length > 0 && (
+        <section aria-labelledby="perms-heading" style={{ marginBottom: '2rem' }}>
+          <h2 id="perms-heading" style={{ fontSize: '1rem', fontWeight: 600, marginBottom: '0.75rem' }}>
+            Required Permissions
+          </h2>
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+            {app.requestedScopes.map((scope) => (
+              <li
+                key={scope}
+                style={{
+                  background: '#f3f4f6',
+                  borderRadius: '0.375rem',
+                  padding: '0.5rem 0.75rem',
+                  fontSize: '0.875rem',
+                  fontFamily: 'monospace',
+                }}
+              >
+                {scope}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <Link
+        to={installUrl}
+        style={{
+          display: 'inline-block',
+          padding: '0.75rem 1.5rem',
+          background: '#2563eb',
+          color: '#fff',
+          borderRadius: '0.375rem',
+          textDecoration: 'none',
+          fontWeight: 600,
+          fontSize: '1rem',
+        }}
+      >
+        Install App
+      </Link>
+    </main>
+  )
+}

--- a/clients/web/src/pages/marketplace/index.tsx
+++ b/clients/web/src/pages/marketplace/index.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useId, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { fetchMarketplaceApps, type MarketplaceApp } from '../../lib/marketplace-api'
+
+function AppCard({ app }: { app: MarketplaceApp }) {
+  return (
+    <article
+      style={{
+        border: '1px solid #e5e7eb',
+        borderRadius: '0.5rem',
+        padding: '1.5rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.75rem',
+        background: '#fff',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+        {app.logoUrl ? (
+          <img
+            src={app.logoUrl}
+            alt={`${app.name} logo`}
+            width={40}
+            height={40}
+            style={{ borderRadius: '0.5rem', objectFit: 'cover' }}
+          />
+        ) : (
+          <div
+            aria-hidden="true"
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: '0.5rem',
+              background: '#e5e7eb',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '1.25rem',
+              color: '#6b7280',
+            }}
+          >
+            {app.name[0]?.toUpperCase()}
+          </div>
+        )}
+        <div>
+          <h3 style={{ margin: 0, fontSize: '1rem', fontWeight: 600 }}>{app.name}</h3>
+        </div>
+      </div>
+
+      <p style={{ margin: 0, fontSize: '0.875rem', color: '#374151', flexGrow: 1 }}>
+        {app.description}
+      </p>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.375rem' }}>
+        {app.requestedScopes.map((s) => (
+          <span
+            key={s}
+            style={{
+              fontSize: '0.75rem',
+              background: '#f3f4f6',
+              color: '#374151',
+              borderRadius: '0.25rem',
+              padding: '0.125rem 0.375rem',
+            }}
+          >
+            {s}
+          </span>
+        ))}
+      </div>
+
+      <Link
+        to={`/marketplace/${app.slug}`}
+        style={{
+          display: 'inline-block',
+          padding: '0.5rem 1rem',
+          background: '#2563eb',
+          color: '#fff',
+          borderRadius: '0.375rem',
+          textDecoration: 'none',
+          fontSize: '0.875rem',
+          textAlign: 'center',
+          fontWeight: 500,
+        }}
+      >
+        View &amp; Install
+      </Link>
+    </article>
+  )
+}
+
+export default function MarketplacePage() {
+  const headingId = useId()
+  const [apps, setApps] = useState<MarketplaceApp[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setLoading(true)
+    fetchMarketplaceApps()
+      .then(setApps)
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Failed to load apps.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return (
+    <main aria-labelledby={headingId} style={{ maxWidth: '72rem', margin: '0 auto', padding: '2rem 1rem' }}>
+      <header style={{ marginBottom: '2rem' }}>
+        <h1 id={headingId} style={{ fontSize: '1.875rem', fontWeight: 700 }}>
+          App Marketplace
+        </h1>
+        <p style={{ color: '#6b7280', marginTop: '0.5rem' }}>
+          Browse and install third-party integrations for your organization.
+        </p>
+      </header>
+
+      {loading && <p>Loading apps&hellip;</p>}
+      {error && (
+        <div role="alert" style={{ color: '#dc2626', padding: '1rem', background: '#fef2f2', borderRadius: '0.375rem' }}>
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && apps.length === 0 && (
+        <p style={{ color: '#6b7280' }}>No apps are available in the marketplace yet.</p>
+      )}
+
+      {!loading && apps.length > 0 && (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+            gap: '1.5rem',
+          }}
+        >
+          {apps.map((app) => (
+            <AppCard key={app.id} app={app} />
+          ))}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/clients/web/src/pages/oauth/consent.tsx
+++ b/clients/web/src/pages/oauth/consent.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useId, useState } from 'react'
+import { useSearchParams, useNavigate } from 'react-router-dom'
+import { fetchOAuthConsentInfo, type OAuthConsentInfo, type ScopeInfo } from '../../lib/marketplace-api'
+
+function ScopeRow({ scope }: { scope: ScopeInfo }) {
+  return (
+    <li
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: '0.5rem',
+        padding: '0.625rem 0',
+        borderBottom: '1px solid #f3f4f6',
+      }}
+    >
+      {scope.isWrite && (
+        <span
+          aria-label="Write permission warning"
+          title="This permission allows the app to modify data"
+          style={{ color: '#f59e0b', fontSize: '1rem', flexShrink: 0 }}
+        >
+          ⚠
+        </span>
+      )}
+      <div>
+        <span style={{ fontSize: '0.875rem', color: '#111827', display: 'block' }}>
+          {scope.label}
+        </span>
+        <span style={{ fontSize: '0.75rem', color: '#6b7280', fontFamily: 'monospace' }}>
+          {scope.scope}
+        </span>
+      </div>
+    </li>
+  )
+}
+
+export default function OAuthConsentPage() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const headingId = useId()
+
+  const clientId = searchParams.get('client_id') ?? ''
+  const redirectUri = searchParams.get('redirect_uri') ?? ''
+  const scope = searchParams.get('scope') ?? ''
+  const codeChallenge = searchParams.get('code_challenge') ?? ''
+
+  const [info, setInfo] = useState<OAuthConsentInfo | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!clientId || !redirectUri || !codeChallenge) {
+      setError('Missing required OAuth parameters.')
+      setLoading(false)
+      return
+    }
+    fetchOAuthConsentInfo({ clientId, redirectUri, scope, codeChallenge })
+      .then(setInfo)
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Failed to load app info.'))
+      .finally(() => setLoading(false))
+  }, [clientId, redirectUri, scope, codeChallenge])
+
+  function handleAllow() {
+    if (!info) return
+    // Redirect back with the signed state as the authorization code
+    const cbUrl = new URL(redirectUri)
+    cbUrl.searchParams.set('code', info.state)
+    cbUrl.searchParams.set('state', searchParams.get('state') ?? '')
+    window.location.href = cbUrl.toString()
+  }
+
+  function handleDeny() {
+    const cbUrl = new URL(redirectUri)
+    cbUrl.searchParams.set('error', 'access_denied')
+    cbUrl.searchParams.set('state', searchParams.get('state') ?? '')
+    window.location.href = cbUrl.toString()
+  }
+
+  if (loading)
+    return (
+      <main style={{ padding: '2rem', textAlign: 'center' }}>
+        Loading authorization details&hellip;
+      </main>
+    )
+
+  if (error)
+    return (
+      <main style={{ maxWidth: '24rem', margin: '4rem auto', padding: '0 1rem' }}>
+        <div role="alert" style={{ color: '#dc2626', background: '#fef2f2', padding: '1rem', borderRadius: '0.5rem' }}>
+          {error}
+        </div>
+        <button
+          type="button"
+          onClick={() => void navigate(-1)}
+          style={{ marginTop: '1rem', padding: '0.5rem 1rem', cursor: 'pointer' }}
+        >
+          Go Back
+        </button>
+      </main>
+    )
+
+  if (!info) return null
+
+  return (
+    <main
+      aria-labelledby={headingId}
+      style={{
+        maxWidth: '26rem',
+        margin: '4rem auto',
+        padding: '0 1rem',
+      }}
+    >
+      <div
+        style={{
+          border: '1px solid #e5e7eb',
+          borderRadius: '0.75rem',
+          padding: '2rem',
+          background: '#fff',
+        }}
+      >
+        <header style={{ textAlign: 'center', marginBottom: '1.5rem' }}>
+          {info.appLogoUrl && (
+            <img
+              src={info.appLogoUrl}
+              alt={`${info.appName} logo`}
+              width={56}
+              height={56}
+              style={{ borderRadius: '0.75rem', objectFit: 'cover', marginBottom: '0.75rem' }}
+            />
+          )}
+          <h1 id={headingId} style={{ fontSize: '1.125rem', fontWeight: 700, margin: 0 }}>
+            {info.appName} wants access
+          </h1>
+          <p style={{ fontSize: '0.875rem', color: '#6b7280', margin: '0.5rem 0 0' }}>
+            Review the permissions this app is requesting for your organization.
+          </p>
+        </header>
+
+        {info.scopes.length > 0 && (
+          <section aria-label="Requested permissions">
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+              {info.scopes.map((s) => (
+                <ScopeRow key={s.scope} scope={s} />
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {info.scopes.length === 0 && (
+          <p style={{ color: '#6b7280', fontSize: '0.875rem', textAlign: 'center' }}>
+            This app requests no special permissions.
+          </p>
+        )}
+
+        <div style={{ display: 'flex', gap: '0.75rem', marginTop: '1.5rem' }}>
+          <button
+            type="button"
+            onClick={handleAllow}
+            style={{
+              flex: 1,
+              padding: '0.625rem',
+              background: '#2563eb',
+              color: '#fff',
+              border: 'none',
+              borderRadius: '0.375rem',
+              fontWeight: 600,
+              fontSize: '0.9375rem',
+              cursor: 'pointer',
+            }}
+          >
+            Allow
+          </button>
+          <button
+            type="button"
+            onClick={handleDeny}
+            style={{
+              flex: 1,
+              padding: '0.625rem',
+              background: '#fff',
+              color: '#374151',
+              border: '1px solid #d1d5db',
+              borderRadius: '0.375rem',
+              fontWeight: 500,
+              fontSize: '0.9375rem',
+              cursor: 'pointer',
+            }}
+          >
+            Deny
+          </button>
+        </div>
+
+        <p style={{ fontSize: '0.75rem', color: '#9ca3af', marginTop: '1rem', textAlign: 'center' }}>
+          You are granting access on behalf of your entire organization.
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/docs/completed/16.9-marketplace-plugin-system.md
+++ b/docs/completed/16.9-marketplace-plugin-system.md
@@ -1,0 +1,201 @@
+# 16.9 — Marketplace / Plugin System
+
+> Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §16.9.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | 16.9 |
+| **Section** | Integrations & Extensibility |
+| **Severity** | MINOR |
+| **Markets** | K12, HE, SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | XL (>2 mo) |
+| **Owner (proposed)** | Platform / Ecosystem team |
+| **Depends on** | 16.1 (public API), 16.2 (API tokens + scopes), 16.3 (webhooks), 16.8 (payments for paid plugins) |
+| **Unblocks** | 16.10 (Zapier is first marketplace app), ecosystem growth |
+
+---
+
+## 1. Problem Statement
+
+Lextures has no mechanism for third-party developers or EdTech vendors to extend the platform. Without a marketplace, the integration story requires Lextures to build every possible connector in-house — a maintenance burden that does not scale. A plugin system based on OAuth 2.0 app authorization (similar to Slack App Directory or Shopify App Store) allows the ecosystem to grow organically, converts integration partners into platform advocates, and unlocks revenue-sharing opportunities for both Lextures and plugin developers.
+
+## 2. Goals
+
+- Define a plugin/app model: OAuth 2.0 client app with declared scopes, webhook subscriptions, and optional UI extension points (module item types, sidebar panels).
+- Build a developer portal for registering apps, managing OAuth credentials, and viewing usage analytics.
+- Build a public marketplace listing page where admins can discover and install apps.
+- Implement secure app installation (OAuth authorization code flow per organization).
+- Provide a sandboxed module item type extension point so plugins can embed custom iframes.
+
+## 3. Non-Goals
+
+- Native plugin execution within the Lextures Go process (security risk; only API + iframe extensions in scope).
+- Revenue split / payout infrastructure (16.8 handles payment; payout is phase 2).
+- Certification / vetting process for public listing (manual review process defined separately).
+- Plugin-specific data storage inside Lextures DB (plugins use their own backends via the public API).
+
+## 4. Personas & User Stories
+
+- **As an EdTech tool developer**, I want to register my app in the Lextures developer portal so that schools using Lextures can install my tool with one click.
+- **As an org admin**, I want to browse the marketplace and install a plagiarism-detection app so that it is available to all instructors in my organization.
+- **As an instructor**, I want to add a Quizlet embed as a module item through a marketplace-installed plugin so that my students get interactive flashcards inside Lextures.
+- **As a developer**, I want OAuth scopes to be requested at install time so that my app only gets the permissions it needs and admins can review them before approving.
+- **As a security officer**, I want to see all installed apps and their granted scopes so that I can audit third-party data access during a compliance review.
+
+## 5. Functional Requirements
+
+- **FR-1.** The system MUST provide an app registry: developers can register an app with name, description, OAuth redirect URIs, requested scopes, and webhook event subscriptions.
+- **FR-2.** The system MUST implement OAuth 2.1 authorization-code flow for app installation, presenting an admin consent screen showing requested scopes before granting.
+- **FR-3.** The system MUST issue per-installation access tokens (scoped to the installing organization) and refresh tokens, stored encrypted (17.17).
+- **FR-4.** The system MUST support app revocation: org admin can revoke an installed app, immediately invalidating its tokens via Redis pub/sub (16.2 pattern).
+- **FR-5.** The system MUST provide a public marketplace listing page (browsable without login) showing app name, description, screenshots, required scopes, and install button.
+- **FR-6.** The system MUST support the "external tool" module item type extension point: a marketplace app can register a launch URL that is rendered as a sandboxed iframe in a course module.
+- **FR-7.** The system SHOULD support a "sidebar panel" extension point: a marketplace app can register a React component URL that is rendered in the course sidebar as an iframe.
+- **FR-8.** The system MAY support app webhooks: a marketplace app can register webhook subscriptions during the OAuth install flow (backed by 16.3 infrastructure).
+- **FR-9.** The system MUST display installed apps to org admins with install date, granted scopes, last API activity, and revoke button.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — Marketplace listing page loads ≤ 1 s (SSR or static generation); OAuth flow redirect latency ≤ 500 ms.
+- **Security** — OAuth consent screen must clearly enumerate all requested scopes in plain language. iFrame extension points sandboxed with `sandbox="allow-scripts allow-same-origin allow-forms"` and Content Security Policy restricting allowed origins to approved app domains. App client secrets hashed (never retrievable after creation — same pattern as API tokens in 16.2).
+- **Privacy & Compliance** — Installed app's data access governed by the installing org's DPA addendum with the app developer. Lextures acts as data processor; app developer is sub-processor. List of installed apps included in sub-processor disclosure (10.x).
+- **Accessibility** — Marketplace listing page and consent screen WCAG 2.1 AA; iframe extension points must include accessible `title` attribute.
+- **Scalability** — Marketplace listing cached at CDN layer (17.5); app registry DB reads cached in Redis. OAuth flows stateless with signed `state` parameter.
+- **Reliability** — App token refresh failures must not break non-plugin LMS functionality; circuit breaker per app.
+- **Observability** — Counter `marketplace_app_api_calls_total{app_id,endpoint,status}`; alert on app exceeding per-app rate limit.
+- **Maintainability** — App model schema versioned; adding a new extension point type requires a migration entry and a new React renderer, not server code changes.
+- **Internationalization** — App descriptions in English only for MVP; marketplace UI fully i18n-ready.
+- **Backward compatibility** — Existing LTI 1.1 tool embeds (16.4) continue to work; marketplace plugin model is additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a developer registers an app in the developer portal with `courses:read` scope, *When* an org admin installs it via OAuth consent flow, *Then* the app receives an access token and can successfully call `GET /api/v1/courses`.
+- **AC-2.** *Given* an installed app's access token expires, *When* the app uses its refresh token to obtain a new access token, *Then* a new short-lived token is issued and the old one is invalidated.
+- **AC-3.** *Given* an org admin revokes an installed app, *When* the app attempts to use its previously valid token within 30 seconds, *Then* the API returns HTTP 401.
+- **AC-4.** *Given* a marketplace app has registered an "external tool" extension, *When* an instructor adds it as a module item, *Then* the iframe renders with the correct CSP sandbox attributes and the app's launch URL.
+- **AC-5.** *Given* the marketplace listing page is loaded, *When* no authentication cookie is present, *Then* the page renders with all listed apps — no login required.
+- **AC-6.** *Given* an OAuth consent screen is shown, *When* the requested scopes include `grades:write`, *Then* the consent screen displays a human-readable warning: "This app can modify grades in your organization."
+
+## 8. Data Model
+
+```sql
+-- server/migrations/080_marketplace.sql
+CREATE TABLE marketplace.apps (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    developer_user_id UUID REFERENCES user.users(id),
+    name            TEXT NOT NULL,
+    slug            TEXT NOT NULL UNIQUE,
+    description     TEXT,
+    logo_url        TEXT,
+    redirect_uris   TEXT[] NOT NULL,
+    requested_scopes TEXT[] NOT NULL,
+    client_id       TEXT NOT NULL UNIQUE DEFAULT gen_random_uuid()::text,
+    client_secret_hash TEXT NOT NULL,
+    published       BOOLEAN NOT NULL DEFAULT false,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE marketplace.installations (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    app_id          UUID NOT NULL REFERENCES marketplace.apps(id),
+    org_id          UUID NOT NULL,
+    access_token_hash TEXT NOT NULL UNIQUE,
+    refresh_token_hash TEXT NOT NULL UNIQUE,
+    granted_scopes  TEXT[] NOT NULL,
+    installed_by    UUID REFERENCES user.users(id),
+    installed_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    revoked_at      TIMESTAMPTZ,
+    UNIQUE (app_id, org_id)
+);
+```
+
+## 9. API Surface
+
+| Method | Path | Auth | Notes |
+|--------|------|------|-------|
+| GET | `/marketplace` | public | Marketplace listing (SSR) |
+| GET | `/marketplace/{slug}` | public | App detail page |
+| GET | `/oauth/authorize` | user session | OAuth consent screen |
+| POST | `/oauth/token` | app client_id/secret | Token exchange |
+| POST | `/oauth/revoke` | app token | Token revocation |
+| GET | `/developer/apps` | JWT session | List developer's apps |
+| POST | `/developer/apps` | JWT session | Register new app |
+| GET | `/admin/marketplace/installed` | admin JWT | List installed apps |
+| DELETE | `/admin/marketplace/installed/{id}` | admin JWT | Revoke app |
+
+## 10. UI / UX
+
+- **Public marketplace page:** grid of app cards with logo, name, description, scope tags, install button.
+- **App detail page:** full description, screenshots carousel, permission list, install button.
+- **OAuth consent screen:** app name and logo, requested scopes with plain-language descriptions, "Allow" / "Deny" buttons. Scope items with warning icons for write permissions.
+- **Admin → Marketplace → Installed Apps:** table with app name, installed date, granted scopes, last active, revoke button.
+- **Developer portal:** app registration form, client secret display (once), OAuth credentials copy panel.
+- Mobile: marketplace page responsive; consent screen full-screen on mobile.
+
+## 11. AI / ML Considerations
+
+Not applicable for the plugin infrastructure itself. Future: AI-assisted app discovery ("suggest integrations for my course type").
+
+## 12. Integration Points
+
+- **Internal:** 16.2 (token pattern reused for app tokens), 16.3 (webhooks for app event subscriptions), 16.1 (public API as the integration surface apps call).
+- **Internal:** `clients/web/src/pages/marketplace/` — new React pages.
+- **External:** Third-party app servers make API calls to Lextures.
+
+## 13. Dependencies & Sequencing
+
+- Must ship after: 16.1, 16.2, 16.3 (all prerequisite infrastructure).
+- Must ship before: nothing strictly, but 16.10 (Zapier) will be the first marketplace app.
+- Shared infra: Redis (17.2), secrets (17.17), job queue (17.3).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Malicious app requests overly broad scopes | M | H | Scope review in app approval process; consent screen highlights write scopes |
+| CSP iframe escape by crafted app | M | H | Strict `sandbox` attribute; CSP allowlist; security review of extension point |
+| App ecosystem stays empty without developer outreach | H | M | Launch Zapier connector (16.10) as first first-party app; publish API reference (20.5) |
+| OAuth PKCE not enforced | L | H | Require PKCE (RFC 7636) for all app installs |
+
+## 15. Rollout Plan
+
+- **Feature flag:** `marketplace_enabled` (OpenFeature, default `false`).
+- **Phase 1:** Developer portal + OAuth infrastructure; internal first-party apps only.
+- **Phase 2:** Public marketplace listing; Zapier app as first listing; invite-only developer program.
+- **Phase 3:** Open developer registration; app review process; GA.
+- **Rollback:** Disable flag; installed apps' tokens remain but API calls return 503.
+
+## 16. Test Plan
+
+- **Unit** — OAuth PKCE code challenge/verifier; scope permission check; token hash.
+- **Integration** — Full OAuth install flow; app API call with granted scope; revocation propagation.
+- **End-to-end** — Playwright: browse marketplace; install app via OAuth; verify API call works; admin revokes; verify 401.
+- **Security** — PKCE bypass attempt; cross-org token use; CSP iframe sandbox escape attempt.
+- **Accessibility** — Marketplace listing page; consent screen axe-core; keyboard navigation.
+- **Performance / load** — k6: marketplace page load under 1,000 concurrent users; OAuth flow latency.
+- **Manual exploratory** — QA: developer portal app creation; consent screen scope display; iframe extension point.
+
+## 17. Documentation & Training
+
+- Developer documentation: "Building a Lextures app" — OAuth flow, scopes, extension points.
+- Admin guide: "Managing installed apps."
+- Internal runbook: app approval process, abuse handling, token revocation.
+
+## 18. Open Questions
+
+1. Should we support server-to-server (client credentials) OAuth flow for apps that don't act on behalf of a user?
+2. What is the review/approval process for public marketplace listing — manual review, automated security scan, or both?
+3. Should apps be able to add navigation items to the Lextures sidebar, or only iframe embeds within modules?
+4. How do we handle apps that break after a Lextures API change — deprecation period, automated testing?
+
+## 19. References
+
+- `server/internal/httpserver/` — new `oauth/`, `marketplace/`, `developer/` route modules.
+- `clients/web/src/pages/` — new marketplace, consent, developer portal pages.
+- `clients/web/package.json` — no new deps expected.
+- OAuth 2.1: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1
+- RFC 7636 PKCE: https://datatracker.ietf.org/doc/html/rfc7636
+- Related plans: `../16-integrations-extensibility/16.1-public-rest-graphql-api.md`, `../16-integrations-extensibility/16.2-api-tokens.md`, `../16-integrations-extensibility/16.10-zapier-make-connector.md`.

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -461,6 +461,9 @@ type Config struct {
 	// FFTaxCollection enables Stripe Tax calculation, collection, and reporting (plan 15.13).
 	// Managed in Settings → Global platform (not process env).
 	FFTaxCollection bool
+	// FFMarketplace enables the marketplace / plugin system with OAuth 2.1 app authorization (plan 16.9).
+	// Managed in Settings → Global platform (not process env).
+	FFMarketplace bool
 
 	// StripeSecretKey is the Stripe API secret key (sk_live_… or sk_test_…).
 	StripeSecretKey string

--- a/server/internal/httpserver/marketplace_http.go
+++ b/server/internal/httpserver/marketplace_http.go
@@ -1,0 +1,643 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/lextures/lextures/server/internal/apierr"
+	repoMarket "github.com/lextures/lextures/server/internal/repos/marketplace"
+	"github.com/lextures/lextures/server/internal/repos/organization"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+	svcMarket "github.com/lextures/lextures/server/internal/service/marketplace"
+)
+
+func (d Deps) marketplaceEnabled(w http.ResponseWriter) bool {
+	if !d.effectiveConfig().FFMarketplace {
+		apierr.WriteJSON(w, http.StatusNotImplemented, apierr.CodeNotImplemented, "Marketplace is not enabled on this server.")
+		return false
+	}
+	return true
+}
+
+func (d Deps) marketplaceService() *svcMarket.Service {
+	cfg := d.effectiveConfig()
+	secret := cfg.JWTSecret
+	if len(cfg.PlatformSecretsKey) > 0 {
+		secret = string(cfg.PlatformSecretsKey)
+	}
+	return svcMarket.New([]byte(secret))
+}
+
+func (d Deps) registerMarketplaceRoutes(r chi.Router) {
+	// Public marketplace listing (no auth required)
+	r.Get("/api/v1/marketplace/apps", d.handleMarketplaceList())
+	r.Get("/api/v1/marketplace/apps/{slug}", d.handleMarketplaceAppDetail())
+
+	// OAuth 2.1 flow
+	r.Get("/oauth/authorize", d.handleOAuthAuthorize())
+	r.Post("/oauth/token", d.handleOAuthToken())
+	r.Post("/oauth/revoke", d.handleOAuthRevoke())
+
+	// Developer portal
+	r.Get("/api/v1/developer/apps", d.handleDeveloperListApps())
+	r.Post("/api/v1/developer/apps", d.handleDeveloperCreateApp())
+
+	// Admin — installed apps
+	r.Get("/api/v1/admin/marketplace/installed", d.handleAdminListInstalled())
+	r.Delete("/api/v1/admin/marketplace/installed/{id}", d.handleAdminRevokeInstalled())
+}
+
+// --- Public marketplace ---
+
+type marketplaceAppJSON struct {
+	ID              string   `json:"id"`
+	Name            string   `json:"name"`
+	Slug            string   `json:"slug"`
+	Description     string   `json:"description"`
+	LogoURL         *string  `json:"logoUrl"`
+	RequestedScopes []string `json:"requestedScopes"`
+}
+
+func appToJSON(a repoMarket.App) marketplaceAppJSON {
+	return marketplaceAppJSON{
+		ID:              a.ID.String(),
+		Name:            a.Name,
+		Slug:            a.Slug,
+		Description:     a.Description,
+		LogoURL:         a.LogoURL,
+		RequestedScopes: a.RequestedScopes,
+	}
+}
+
+func (d Deps) handleMarketplaceList() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.marketplaceEnabled(w) {
+			return
+		}
+		apps, err := repoMarket.ListPublishedApps(r.Context(), d.Pool)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to list apps.")
+			return
+		}
+		out := make([]marketplaceAppJSON, 0, len(apps))
+		for _, a := range apps {
+			out = append(out, appToJSON(a))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"apps": out})
+	}
+}
+
+func (d Deps) handleMarketplaceAppDetail() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.marketplaceEnabled(w) {
+			return
+		}
+		slug := chi.URLParam(r, "slug")
+		a, err := repoMarket.GetAppBySlug(r.Context(), d.Pool, slug)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to fetch app.")
+			return
+		}
+		if a == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "App not found.")
+			return
+		}
+		writeJSON(w, http.StatusOK, appToJSON(*a))
+	}
+}
+
+// --- OAuth 2.1 authorize ---
+
+type oauthAuthorizeResponse struct {
+	State      string          `json:"state"`
+	AppName    string          `json:"appName"`
+	AppLogoURL *string         `json:"appLogoUrl"`
+	Scopes     []scopeInfoJSON `json:"scopes"`
+}
+
+type scopeInfoJSON struct {
+	Scope   string `json:"scope"`
+	Label   string `json:"label"`
+	IsWrite bool   `json:"isWrite"`
+}
+
+// GET /oauth/authorize?client_id=&redirect_uri=&scope=&code_challenge=&code_challenge_method=S256
+// Returns JSON for the SPA to render the consent screen.
+func (d Deps) handleOAuthAuthorize() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.marketplaceEnabled(w) {
+			return
+		}
+		userID, ok := d.meSessionUserID(w, r)
+		if !ok {
+			return
+		}
+		q := r.URL.Query()
+		clientID := strings.TrimSpace(q.Get("client_id"))
+		redirectURI := strings.TrimSpace(q.Get("redirect_uri"))
+		scopeStr := strings.TrimSpace(q.Get("scope"))
+		codeChallenge := strings.TrimSpace(q.Get("code_challenge"))
+		challengeMethod := strings.TrimSpace(q.Get("code_challenge_method"))
+
+		if clientID == "" || redirectURI == "" || codeChallenge == "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Missing required parameters: client_id, redirect_uri, code_challenge.")
+			return
+		}
+		if challengeMethod != "S256" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Only code_challenge_method=S256 is supported.")
+			return
+		}
+
+		app, err := repoMarket.GetAppByClientID(r.Context(), d.Pool, clientID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to look up app.")
+			return
+		}
+		if app == nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Unknown client_id.")
+			return
+		}
+		if !svcMarket.ValidateRedirectURI(app.RedirectURIs, redirectURI) {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "redirect_uri not registered for this app.")
+			return
+		}
+
+		scopes := splitScopes(scopeStr)
+		grantedScopes := filterScopes(scopes, app.RequestedScopes)
+
+		orgID, err := organization.OrgIDForUser(r.Context(), d.Pool, userID)
+		if err != nil || orgID == uuid.Nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to resolve org.")
+			return
+		}
+
+		svc := d.marketplaceService()
+		state, err := svc.BuildConsentURL(orgID, userID, clientID, redirectURI, grantedScopes, codeChallenge)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to build consent state.")
+			return
+		}
+
+		scopeInfos := make([]scopeInfoJSON, 0, len(grantedScopes))
+		for _, s := range grantedScopes {
+			scopeInfos = append(scopeInfos, scopeInfoJSON{
+				Scope:   s,
+				Label:   svcMarket.ScopeLabel(s),
+				IsWrite: svcMarket.ScopeIsWrite(s),
+			})
+		}
+
+		writeJSON(w, http.StatusOK, oauthAuthorizeResponse{
+			State:      state,
+			AppName:    app.Name,
+			AppLogoURL: app.LogoURL,
+			Scopes:     scopeInfos,
+		})
+	}
+}
+
+// POST /oauth/token — authorization_code or refresh_token grant
+func (d Deps) handleOAuthToken() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.marketplaceEnabled(w) {
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid form body.")
+			return
+		}
+		grantType := r.FormValue("grant_type")
+
+		switch grantType {
+		case "authorization_code":
+			d.handleOAuthTokenAuthCode(w, r)
+		case "refresh_token":
+			d.handleOAuthTokenRefresh(w, r)
+		default:
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Unsupported grant_type.")
+		}
+	}
+}
+
+type oauthTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+}
+
+func (d Deps) handleOAuthTokenAuthCode(w http.ResponseWriter, r *http.Request) {
+	clientID := r.FormValue("client_id")
+	clientSecret := r.FormValue("client_secret")
+	code := r.FormValue("code") // the signed state returned from /oauth/authorize
+	codeVerifier := r.FormValue("code_verifier")
+
+	if clientID == "" || clientSecret == "" || code == "" || codeVerifier == "" {
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Missing required fields: client_id, client_secret, code, code_verifier.")
+		return
+	}
+
+	app, valid, err := repoMarket.ValidateClientSecret(r.Context(), d.Pool, clientID, clientSecret)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to validate credentials.")
+		return
+	}
+	if !valid || app == nil {
+		apierr.WriteJSON(w, http.StatusUnauthorized, apierr.CodeInvalidCredentials, "Invalid client credentials.")
+		return
+	}
+
+	svc := d.marketplaceService()
+	claims, err := svc.VerifyConsentState(code)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid or expired authorization code.")
+		return
+	}
+	if claims.ClientID != clientID {
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "client_id mismatch.")
+		return
+	}
+	if !svcMarket.VerifyPKCE(claims.CodeChallenge, codeVerifier) {
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid code_verifier.")
+		return
+	}
+
+	accessToken, accessHash, accessPrefix, err := repoMarket.GenerateAccessToken()
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to generate access token.")
+		return
+	}
+	refreshToken, refreshHash, refreshPrefix, err := repoMarket.GenerateRefreshToken()
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to generate refresh token.")
+		return
+	}
+
+	_, err = repoMarket.CreateInstallation(r.Context(), d.Pool, repoMarket.CreateInstallationParams{
+		AppID:              app.ID,
+		OrgID:              claims.OrgID,
+		AccessTokenHash:    accessHash,
+		AccessTokenPrefix:  accessPrefix,
+		RefreshTokenHash:   refreshHash,
+		RefreshTokenPrefix: refreshPrefix,
+		GrantedScopes:      claims.Scopes,
+		InstalledBy:        claims.UserID,
+	})
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to record installation.")
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, oauthTokenResponse{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		TokenType:    "Bearer",
+		ExpiresIn:    3600,
+	})
+}
+
+func (d Deps) handleOAuthTokenRefresh(w http.ResponseWriter, r *http.Request) {
+	clientID := r.FormValue("client_id")
+	clientSecret := r.FormValue("client_secret")
+	rawRefresh := r.FormValue("refresh_token")
+
+	if clientID == "" || clientSecret == "" || rawRefresh == "" {
+		apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Missing required fields: client_id, client_secret, refresh_token.")
+		return
+	}
+
+	app, valid, err := repoMarket.ValidateClientSecret(r.Context(), d.Pool, clientID, clientSecret)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to validate credentials.")
+		return
+	}
+	if !valid || app == nil {
+		apierr.WriteJSON(w, http.StatusUnauthorized, apierr.CodeInvalidCredentials, "Invalid client credentials.")
+		return
+	}
+
+	ins, err := repoMarket.GetInstallationByRefreshToken(r.Context(), d.Pool, rawRefresh)
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to look up token.")
+		return
+	}
+	if ins == nil || ins.AppID != app.ID {
+		apierr.WriteJSON(w, http.StatusUnauthorized, apierr.CodeInvalidCredentials, "Invalid refresh token.")
+		return
+	}
+
+	newAccess, newAccessHash, newAccessPrefix, err := repoMarket.GenerateAccessToken()
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to generate access token.")
+		return
+	}
+	newRefresh, newRefreshHash, newRefreshPrefix, err := repoMarket.GenerateRefreshToken()
+	if err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to generate refresh token.")
+		return
+	}
+
+	if err := repoMarket.RotateTokens(r.Context(), d.Pool, ins.ID,
+		newAccessHash, newAccessPrefix, newRefreshHash, newRefreshPrefix); err != nil {
+		apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to rotate tokens.")
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, oauthTokenResponse{
+		AccessToken:  newAccess,
+		RefreshToken: newRefresh,
+		TokenType:    "Bearer",
+		ExpiresIn:    3600,
+	})
+}
+
+// POST /oauth/revoke
+func (d Deps) handleOAuthRevoke() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.marketplaceEnabled(w) {
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid form body.")
+			return
+		}
+		rawToken := r.FormValue("token")
+		if rawToken == "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Missing token parameter.")
+			return
+		}
+		ins, err := repoMarket.GetInstallationByAccessToken(r.Context(), d.Pool, rawToken)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to look up token.")
+			return
+		}
+		if ins == nil {
+			// Per RFC 7009: already revoked or not found → 200 OK
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if err := repoMarket.RevokeInstallation(r.Context(), d.Pool, ins.ID, ins.OrgID); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to revoke token.")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+// --- Developer portal ---
+
+type developerAppJSON struct {
+	ID                 string   `json:"id"`
+	Name               string   `json:"name"`
+	Slug               string   `json:"slug"`
+	Description        string   `json:"description"`
+	LogoURL            *string  `json:"logoUrl"`
+	ClientID           string   `json:"clientId"`
+	ClientSecretPrefix string   `json:"clientSecretPrefix"`
+	RedirectURIs       []string `json:"redirectUris"`
+	RequestedScopes    []string `json:"requestedScopes"`
+	Published          bool     `json:"published"`
+	CreatedAt          string   `json:"createdAt"`
+}
+
+func devAppToJSON(a repoMarket.App) developerAppJSON {
+	return developerAppJSON{
+		ID:                 a.ID.String(),
+		Name:               a.Name,
+		Slug:               a.Slug,
+		Description:        a.Description,
+		LogoURL:            a.LogoURL,
+		ClientID:           a.ClientID,
+		ClientSecretPrefix: a.ClientSecretPrefix,
+		RedirectURIs:       a.RedirectURIs,
+		RequestedScopes:    a.RequestedScopes,
+		Published:          a.Published,
+		CreatedAt:          a.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+	}
+}
+
+func (d Deps) handleDeveloperListApps() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.marketplaceEnabled(w) {
+			return
+		}
+		userID, ok := d.meSessionUserID(w, r)
+		if !ok {
+			return
+		}
+		apps, err := repoMarket.ListAppsByDeveloper(r.Context(), d.Pool, userID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to list apps.")
+			return
+		}
+		out := make([]developerAppJSON, 0, len(apps))
+		for _, a := range apps {
+			out = append(out, devAppToJSON(a))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"apps": out})
+	}
+}
+
+type createAppInput struct {
+	Name            string   `json:"name"`
+	Slug            string   `json:"slug"`
+	Description     string   `json:"description"`
+	LogoURL         *string  `json:"logoUrl"`
+	RedirectURIs    []string `json:"redirectUris"`
+	RequestedScopes []string `json:"requestedScopes"`
+}
+
+type createAppResponse struct {
+	developerAppJSON
+	ClientSecret string `json:"clientSecret"`
+}
+
+func (d Deps) handleDeveloperCreateApp() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.marketplaceEnabled(w) {
+			return
+		}
+		userID, ok := d.meSessionUserID(w, r)
+		if !ok {
+			return
+		}
+		var in createAppInput
+		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&in); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		if strings.TrimSpace(in.Name) == "" || strings.TrimSpace(in.Slug) == "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "name and slug are required.")
+			return
+		}
+		if len(in.RedirectURIs) == 0 {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "At least one redirect_uri is required.")
+			return
+		}
+
+		rawSecret, secretHash, secretPrefix, err := repoMarket.GenerateClientSecret()
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to generate credentials.")
+			return
+		}
+
+		app, err := repoMarket.CreateApp(r.Context(), d.Pool, repoMarket.CreateAppParams{
+			DeveloperUserID:    userID,
+			Name:               in.Name,
+			Slug:               in.Slug,
+			Description:        in.Description,
+			LogoURL:            in.LogoURL,
+			RedirectURIs:       in.RedirectURIs,
+			RequestedScopes:    in.RequestedScopes,
+			ClientSecretHash:   secretHash,
+			ClientSecretPrefix: secretPrefix,
+		})
+		if err != nil {
+			if err == repoMarket.ErrDuplicateSlug {
+				apierr.WriteJSON(w, http.StatusConflict, apierr.CodeConflict, "App slug is already taken.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to create app.")
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, createAppResponse{
+			developerAppJSON: devAppToJSON(app),
+			ClientSecret:     rawSecret,
+		})
+	}
+}
+
+// --- Admin installed apps ---
+
+type installedAppJSON struct {
+	ID            string   `json:"id"`
+	AppID         string   `json:"appId"`
+	AppName       string   `json:"appName"`
+	AppSlug       string   `json:"appSlug"`
+	AppLogoURL    *string  `json:"appLogoUrl"`
+	GrantedScopes []string `json:"grantedScopes"`
+	InstalledAt   string   `json:"installedAt"`
+	InstalledBy   *string  `json:"installedBy"`
+	LastUsedAt    *string  `json:"lastUsedAt"`
+}
+
+func installationToJSON(ins repoMarket.Installation) installedAppJSON {
+	out := installedAppJSON{
+		ID:            ins.ID.String(),
+		AppID:         ins.AppID.String(),
+		AppName:       ins.AppName,
+		AppSlug:       ins.AppSlug,
+		AppLogoURL:    ins.AppLogoURL,
+		GrantedScopes: ins.GrantedScopes,
+		InstalledAt:   ins.InstalledAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+	}
+	if ins.InstalledBy != nil {
+		s := ins.InstalledBy.String()
+		out.InstalledBy = &s
+	}
+	if ins.LastUsedAt != nil {
+		s := ins.LastUsedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+		out.LastUsedAt = &s
+	}
+	return out
+}
+
+func (d Deps) handleAdminListInstalled() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.marketplaceEnabled(w) {
+			return
+		}
+		actorID, ok := d.meSessionUserID(w, r)
+		if !ok {
+			return
+		}
+		isAdmin, err := rbac.UserHasPermission(r.Context(), d.Pool, actorID, permGlobalRBACManage)
+		if err != nil || !isAdmin {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "Admin access required.")
+			return
+		}
+		orgID, err := organization.OrgIDForUser(r.Context(), d.Pool, actorID)
+		if err != nil || orgID == uuid.Nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to resolve org.")
+			return
+		}
+		installations, err := repoMarket.ListInstallationsByOrg(r.Context(), d.Pool, orgID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to list installed apps.")
+			return
+		}
+		out := make([]installedAppJSON, 0, len(installations))
+		for _, ins := range installations {
+			out = append(out, installationToJSON(ins))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"installations": out})
+	}
+}
+
+func (d Deps) handleAdminRevokeInstalled() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.marketplaceEnabled(w) {
+			return
+		}
+		actorID, ok := d.meSessionUserID(w, r)
+		if !ok {
+			return
+		}
+		isAdmin, err := rbac.UserHasPermission(r.Context(), d.Pool, actorID, permGlobalRBACManage)
+		if err != nil || !isAdmin {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "Admin access required.")
+			return
+		}
+		orgID, err := organization.OrgIDForUser(r.Context(), d.Pool, actorID)
+		if err != nil || orgID == uuid.Nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to resolve org.")
+			return
+		}
+		idStr := chi.URLParam(r, "id")
+		id, err := uuid.Parse(idStr)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid installation id.")
+			return
+		}
+		if err := repoMarket.RevokeInstallation(r.Context(), d.Pool, id, orgID); err != nil {
+			if err == repoMarket.ErrNotFound {
+				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Installation not found.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to revoke installation.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// --- helpers ---
+
+func splitScopes(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Fields(s)
+}
+
+func filterScopes(requested, allowed []string) []string {
+	allowedSet := make(map[string]bool, len(allowed))
+	for _, s := range allowed {
+		allowedSet[s] = true
+	}
+	var out []string
+	for _, s := range requested {
+		if allowedSet[s] {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/server/internal/httpserver/marketplace_nodb_test.go
+++ b/server/internal/httpserver/marketplace_nodb_test.go
@@ -1,0 +1,94 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/config"
+)
+
+func TestMarketplace_FeatureOff(t *testing.T) {
+	d := Deps{Config: config.Config{FFMarketplace: false}}
+	h := NewHandler(d)
+
+	paths := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/marketplace/apps"},
+		{http.MethodGet, "/api/v1/marketplace/apps/some-slug"},
+		{http.MethodGet, "/oauth/authorize"},
+		{http.MethodPost, "/oauth/token"},
+		{http.MethodPost, "/oauth/revoke"},
+		{http.MethodGet, "/api/v1/developer/apps"},
+		{http.MethodPost, "/api/v1/developer/apps"},
+		{http.MethodGet, "/api/v1/admin/marketplace/installed"},
+		{http.MethodDelete, "/api/v1/admin/marketplace/installed/00000000-0000-4000-8000-000000000001"},
+	}
+	for _, tc := range paths {
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusNotImplemented {
+			t.Errorf("%s %s: want 501 got %d", tc.method, tc.path, w.Code)
+		}
+	}
+}
+
+func TestMarketplacePublic_NoAuth_FeatureOn(t *testing.T) {
+	// Public marketplace listing should 501 when feature is off but succeed (return something)
+	// when feature is on — even without a database (returns 500 because Pool is nil).
+	d := Deps{Config: config.Config{FFMarketplace: true}}
+	h := NewHandler(d)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/marketplace/apps", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	// No pool → internal error, but NOT 501 (feature is on).
+	if w.Code == http.StatusNotImplemented {
+		t.Fatalf("GET /api/v1/marketplace/apps returned 501 even with feature on")
+	}
+}
+
+func TestOAuthAuthorize_Unauthenticated(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	d := Deps{Config: config.Config{FFMarketplace: true}, JWTSigner: signer}
+	h := NewHandler(d)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?client_id=test&redirect_uri=https://example.com/cb&code_challenge=abc&code_challenge_method=S256", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("GET /oauth/authorize without session: want 401 got %d", w.Code)
+	}
+}
+
+func TestOAuthToken_MissingGrantType(t *testing.T) {
+	d := Deps{Config: config.Config{FFMarketplace: true}}
+	h := NewHandler(d)
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", nil)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("POST /oauth/token without grant_type: want 400 got %d", w.Code)
+	}
+}
+
+func TestDeveloperApps_Unauthenticated(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	d := Deps{Config: config.Config{FFMarketplace: true}, JWTSigner: signer}
+	h := NewHandler(d)
+
+	for _, path := range []string{"/api/v1/developer/apps", "/api/v1/admin/marketplace/installed"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("GET %s without session: want 401 got %d", path, w.Code)
+		}
+	}
+}

--- a/server/internal/httpserver/server.go
+++ b/server/internal/httpserver/server.go
@@ -206,6 +206,7 @@ func NewHandler(d Deps) http.Handler {
 	d.registerCloudProviderRoutes(r)
 	d.registerIntegrationRoutes(r)
 	d.registerBotRoutes(r)
+	d.registerMarketplaceRoutes(r)
 	d.registerLegalRoutes(r)
 	d.registerTrustRoutes(r)
 	d.registerFERPARoutes(r)

--- a/server/internal/repos/marketplace/repo.go
+++ b/server/internal/repos/marketplace/repo.go
@@ -1,0 +1,455 @@
+// Package marketplace stores marketplace apps and per-org installations (plan 16.9).
+package marketplace
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	appSecretPrefix    = "mcs_"
+	tokenPrefixLabel   = "mkt_"
+	refreshPrefixLabel = "mkr_"
+)
+
+// ErrNotFound is returned when a queried record does not exist.
+var ErrNotFound = errors.New("marketplace: not found")
+
+// ErrDuplicateSlug is returned when an app slug is already taken.
+var ErrDuplicateSlug = errors.New("marketplace: slug already taken")
+
+// App is a registered marketplace application.
+type App struct {
+	ID                 uuid.UUID
+	DeveloperUserID    *uuid.UUID
+	Name               string
+	Slug               string
+	Description        string
+	LogoURL            *string
+	RedirectURIs       []string
+	RequestedScopes    []string
+	ClientID           string
+	ClientSecretPrefix string
+	Published          bool
+	CreatedAt          time.Time
+}
+
+// Installation is a per-org app installation.
+type Installation struct {
+	ID                 uuid.UUID
+	AppID              uuid.UUID
+	OrgID              uuid.UUID
+	AppName            string
+	AppSlug            string
+	AppLogoURL         *string
+	AccessTokenPrefix  string
+	GrantedScopes      []string
+	InstalledBy        *uuid.UUID
+	InstalledAt        time.Time
+	RevokedAt          *time.Time
+	LastUsedAt         *time.Time
+}
+
+// GenerateClientSecret returns a new mcs_ client secret, its SHA-256 hex hash and 8-char prefix.
+func GenerateClientSecret() (secret, hashHex, prefix string, err error) {
+	b := make([]byte, 32)
+	if _, err = rand.Read(b); err != nil {
+		return "", "", "", err
+	}
+	secret = appSecretPrefix + base64.RawURLEncoding.EncodeToString(b)
+	sum := sha256.Sum256([]byte(secret))
+	hashHex = hex.EncodeToString(sum[:])
+	prefix = secret[:8]
+	return secret, hashHex, prefix, nil
+}
+
+// GenerateAccessToken returns a new mkt_ bearer token, its hash and prefix.
+func GenerateAccessToken() (token, hashHex, prefix string, err error) {
+	return generateToken(tokenPrefixLabel)
+}
+
+// GenerateRefreshToken returns a new mkr_ refresh token, its hash and prefix.
+func GenerateRefreshToken() (token, hashHex, prefix string, err error) {
+	return generateToken(refreshPrefixLabel)
+}
+
+func generateToken(pfx string) (token, hashHex, prefix string, err error) {
+	b := make([]byte, 32)
+	if _, err = rand.Read(b); err != nil {
+		return "", "", "", err
+	}
+	token = pfx + base64.RawURLEncoding.EncodeToString(b)
+	sum := sha256.Sum256([]byte(token))
+	hashHex = hex.EncodeToString(sum[:])
+	prefix = token[:8]
+	return token, hashHex, prefix, nil
+}
+
+// HashToken returns the SHA-256 hex hash of a token.
+func HashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+// CreateAppParams is the input for CreateApp.
+type CreateAppParams struct {
+	DeveloperUserID uuid.UUID
+	Name            string
+	Slug            string
+	Description     string
+	LogoURL         *string
+	RedirectURIs    []string
+	RequestedScopes []string
+	ClientSecretHash   string
+	ClientSecretPrefix string
+}
+
+// CreateApp inserts a new marketplace app and returns it.
+func CreateApp(ctx context.Context, pool *pgxpool.Pool, p CreateAppParams) (App, error) {
+	var a App
+	err := pool.QueryRow(ctx, `
+		INSERT INTO marketplace.apps
+		    (developer_user_id, name, slug, description, logo_url, redirect_uris,
+		     requested_scopes, client_secret_hash, client_secret_prefix)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+		RETURNING id, developer_user_id, name, slug, description, logo_url,
+		          redirect_uris, requested_scopes, client_id, client_secret_prefix,
+		          published, created_at
+	`, p.DeveloperUserID, p.Name, p.Slug, p.Description, p.LogoURL,
+		p.RedirectURIs, p.RequestedScopes, p.ClientSecretHash, p.ClientSecretPrefix,
+	).Scan(
+		&a.ID, &a.DeveloperUserID, &a.Name, &a.Slug, &a.Description, &a.LogoURL,
+		&a.RedirectURIs, &a.RequestedScopes, &a.ClientID, &a.ClientSecretPrefix,
+		&a.Published, &a.CreatedAt,
+	)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return App{}, ErrDuplicateSlug
+		}
+		return App{}, err
+	}
+	return a, nil
+}
+
+// ListAppsByDeveloper returns all apps registered by a developer.
+func ListAppsByDeveloper(ctx context.Context, pool *pgxpool.Pool, developerUserID uuid.UUID) ([]App, error) {
+	rows, err := pool.Query(ctx, `
+		SELECT id, developer_user_id, name, slug, description, logo_url,
+		       redirect_uris, requested_scopes, client_id, client_secret_prefix,
+		       published, created_at
+		FROM marketplace.apps
+		WHERE developer_user_id = $1
+		ORDER BY created_at DESC
+	`, developerUserID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanApps(rows)
+}
+
+// ListPublishedApps returns all published marketplace apps ordered by name.
+func ListPublishedApps(ctx context.Context, pool *pgxpool.Pool) ([]App, error) {
+	rows, err := pool.Query(ctx, `
+		SELECT id, developer_user_id, name, slug, description, logo_url,
+		       redirect_uris, requested_scopes, client_id, client_secret_prefix,
+		       published, created_at
+		FROM marketplace.apps
+		WHERE published = true
+		ORDER BY name ASC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanApps(rows)
+}
+
+// GetAppBySlug returns a published app by its slug.
+func GetAppBySlug(ctx context.Context, pool *pgxpool.Pool, slug string) (*App, error) {
+	a, err := getApp(ctx, pool, `slug = $1 AND published = true`, slug)
+	if errors.Is(err, ErrNotFound) {
+		return nil, nil
+	}
+	return a, err
+}
+
+// GetAppByClientID returns any app by OAuth client_id (used during consent/token exchange).
+func GetAppByClientID(ctx context.Context, pool *pgxpool.Pool, clientID string) (*App, error) {
+	a, err := getApp(ctx, pool, `client_id = $1`, clientID)
+	if errors.Is(err, ErrNotFound) {
+		return nil, nil
+	}
+	return a, err
+}
+
+// GetAppByID returns an app by primary key.
+func GetAppByID(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID) (*App, error) {
+	a, err := getApp(ctx, pool, `id = $1`, id)
+	if errors.Is(err, ErrNotFound) {
+		return nil, nil
+	}
+	return a, err
+}
+
+func getApp(ctx context.Context, pool *pgxpool.Pool, where string, args ...any) (*App, error) {
+	var a App
+	err := pool.QueryRow(ctx,
+		`SELECT id, developer_user_id, name, slug, description, logo_url,
+		        redirect_uris, requested_scopes, client_id, client_secret_prefix,
+		        published, created_at
+		 FROM marketplace.apps
+		 WHERE `+where,
+		args...,
+	).Scan(
+		&a.ID, &a.DeveloperUserID, &a.Name, &a.Slug, &a.Description, &a.LogoURL,
+		&a.RedirectURIs, &a.RequestedScopes, &a.ClientID, &a.ClientSecretPrefix,
+		&a.Published, &a.CreatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	return &a, err
+}
+
+func scanApps(rows pgx.Rows) ([]App, error) {
+	var out []App
+	for rows.Next() {
+		var a App
+		if err := rows.Scan(
+			&a.ID, &a.DeveloperUserID, &a.Name, &a.Slug, &a.Description, &a.LogoURL,
+			&a.RedirectURIs, &a.RequestedScopes, &a.ClientID, &a.ClientSecretPrefix,
+			&a.Published, &a.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// ValidateClientSecret verifies a raw client secret against the stored hash.
+func ValidateClientSecret(ctx context.Context, pool *pgxpool.Pool, clientID, rawSecret string) (*App, bool, error) {
+	var a App
+	var storedHash string
+	err := pool.QueryRow(ctx, `
+		SELECT id, developer_user_id, name, slug, description, logo_url,
+		       redirect_uris, requested_scopes, client_id, client_secret_prefix,
+		       published, created_at, client_secret_hash
+		FROM marketplace.apps
+		WHERE client_id = $1
+	`, clientID).Scan(
+		&a.ID, &a.DeveloperUserID, &a.Name, &a.Slug, &a.Description, &a.LogoURL,
+		&a.RedirectURIs, &a.RequestedScopes, &a.ClientID, &a.ClientSecretPrefix,
+		&a.Published, &a.CreatedAt, &storedHash,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return &a, HashToken(rawSecret) == storedHash, nil
+}
+
+// CreateInstallationParams is the input for CreateInstallation.
+type CreateInstallationParams struct {
+	AppID              uuid.UUID
+	OrgID              uuid.UUID
+	AccessTokenHash    string
+	AccessTokenPrefix  string
+	RefreshTokenHash   string
+	RefreshTokenPrefix string
+	GrantedScopes      []string
+	InstalledBy        uuid.UUID
+}
+
+// CreateInstallation records a new app installation for an org (upsert by app+org).
+func CreateInstallation(ctx context.Context, pool *pgxpool.Pool, p CreateInstallationParams) (Installation, error) {
+	var ins Installation
+	err := pool.QueryRow(ctx, `
+		INSERT INTO marketplace.installations
+		    (app_id, org_id, access_token_hash, access_token_prefix,
+		     refresh_token_hash, refresh_token_prefix, granted_scopes, installed_by)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+		ON CONFLICT (app_id, org_id) DO UPDATE
+		    SET access_token_hash    = EXCLUDED.access_token_hash,
+		        access_token_prefix  = EXCLUDED.access_token_prefix,
+		        refresh_token_hash   = EXCLUDED.refresh_token_hash,
+		        refresh_token_prefix = EXCLUDED.refresh_token_prefix,
+		        granted_scopes       = EXCLUDED.granted_scopes,
+		        installed_by         = EXCLUDED.installed_by,
+		        installed_at         = now(),
+		        revoked_at           = NULL
+		RETURNING id, app_id, org_id,
+		          (SELECT name FROM marketplace.apps WHERE id = EXCLUDED.app_id),
+		          (SELECT slug FROM marketplace.apps WHERE id = EXCLUDED.app_id),
+		          (SELECT logo_url FROM marketplace.apps WHERE id = EXCLUDED.app_id),
+		          access_token_prefix, granted_scopes, installed_by,
+		          installed_at, revoked_at, last_used_at
+	`, p.AppID, p.OrgID, p.AccessTokenHash, p.AccessTokenPrefix,
+		p.RefreshTokenHash, p.RefreshTokenPrefix, p.GrantedScopes, p.InstalledBy,
+	).Scan(
+		&ins.ID, &ins.AppID, &ins.OrgID,
+		&ins.AppName, &ins.AppSlug, &ins.AppLogoURL,
+		&ins.AccessTokenPrefix, &ins.GrantedScopes,
+		&ins.InstalledBy, &ins.InstalledAt, &ins.RevokedAt, &ins.LastUsedAt,
+	)
+	return ins, err
+}
+
+// GetInstallationByAccessToken finds a non-revoked installation by bearer token.
+func GetInstallationByAccessToken(ctx context.Context, pool *pgxpool.Pool, rawToken string) (*Installation, error) {
+	hash := HashToken(rawToken)
+	var ins Installation
+	err := pool.QueryRow(ctx, `
+		SELECT i.id, i.app_id, i.org_id,
+		       a.name, a.slug, a.logo_url,
+		       i.access_token_prefix, i.granted_scopes,
+		       i.installed_by, i.installed_at, i.revoked_at, i.last_used_at
+		FROM marketplace.installations i
+		JOIN marketplace.apps a ON a.id = i.app_id
+		WHERE i.access_token_hash = $1
+		  AND i.revoked_at IS NULL
+	`, hash).Scan(
+		&ins.ID, &ins.AppID, &ins.OrgID,
+		&ins.AppName, &ins.AppSlug, &ins.AppLogoURL,
+		&ins.AccessTokenPrefix, &ins.GrantedScopes,
+		&ins.InstalledBy, &ins.InstalledAt, &ins.RevokedAt, &ins.LastUsedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return &ins, err
+}
+
+// GetInstallationByRefreshToken finds a non-revoked installation by refresh token.
+func GetInstallationByRefreshToken(ctx context.Context, pool *pgxpool.Pool, rawToken string) (*Installation, error) {
+	hash := HashToken(rawToken)
+	var ins Installation
+	err := pool.QueryRow(ctx, `
+		SELECT i.id, i.app_id, i.org_id,
+		       a.name, a.slug, a.logo_url,
+		       i.access_token_prefix, i.granted_scopes,
+		       i.installed_by, i.installed_at, i.revoked_at, i.last_used_at
+		FROM marketplace.installations i
+		JOIN marketplace.apps a ON a.id = i.app_id
+		WHERE i.refresh_token_hash = $1
+		  AND i.revoked_at IS NULL
+	`, hash).Scan(
+		&ins.ID, &ins.AppID, &ins.OrgID,
+		&ins.AppName, &ins.AppSlug, &ins.AppLogoURL,
+		&ins.AccessTokenPrefix, &ins.GrantedScopes,
+		&ins.InstalledBy, &ins.InstalledAt, &ins.RevokedAt, &ins.LastUsedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return &ins, err
+}
+
+// ListInstallationsByOrg returns all active installations for an org.
+func ListInstallationsByOrg(ctx context.Context, pool *pgxpool.Pool, orgID uuid.UUID) ([]Installation, error) {
+	rows, err := pool.Query(ctx, `
+		SELECT i.id, i.app_id, i.org_id,
+		       a.name, a.slug, a.logo_url,
+		       i.access_token_prefix, i.granted_scopes,
+		       i.installed_by, i.installed_at, i.revoked_at, i.last_used_at
+		FROM marketplace.installations i
+		JOIN marketplace.apps a ON a.id = i.app_id
+		WHERE i.org_id = $1
+		  AND i.revoked_at IS NULL
+		ORDER BY i.installed_at DESC
+	`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanInstallations(rows)
+}
+
+func scanInstallations(rows pgx.Rows) ([]Installation, error) {
+	var out []Installation
+	for rows.Next() {
+		var ins Installation
+		if err := rows.Scan(
+			&ins.ID, &ins.AppID, &ins.OrgID,
+			&ins.AppName, &ins.AppSlug, &ins.AppLogoURL,
+			&ins.AccessTokenPrefix, &ins.GrantedScopes,
+			&ins.InstalledBy, &ins.InstalledAt, &ins.RevokedAt, &ins.LastUsedAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, ins)
+	}
+	return out, rows.Err()
+}
+
+// RevokeInstallation marks an installation as revoked by ID, checking org ownership.
+func RevokeInstallation(ctx context.Context, pool *pgxpool.Pool, id, orgID uuid.UUID) error {
+	tag, err := pool.Exec(ctx, `
+		UPDATE marketplace.installations
+		SET revoked_at = now()
+		WHERE id = $1 AND org_id = $2 AND revoked_at IS NULL
+	`, id, orgID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// RotateTokens replaces the access and refresh tokens for an installation.
+func RotateTokens(ctx context.Context, pool *pgxpool.Pool, installationID uuid.UUID,
+	newAccessHash, newAccessPrefix, newRefreshHash, newRefreshPrefix string) error {
+	_, err := pool.Exec(ctx, `
+		UPDATE marketplace.installations
+		SET access_token_hash    = $2,
+		    access_token_prefix  = $3,
+		    refresh_token_hash   = $4,
+		    refresh_token_prefix = $5,
+		    last_used_at         = now()
+		WHERE id = $1 AND revoked_at IS NULL
+	`, installationID, newAccessHash, newAccessPrefix, newRefreshHash, newRefreshPrefix)
+	return err
+}
+
+// TouchLastUsed updates the last_used_at timestamp for an installation.
+func TouchLastUsed(ctx context.Context, pool *pgxpool.Pool, installationID uuid.UUID) {
+	_, _ = pool.Exec(ctx, `
+		UPDATE marketplace.installations
+		SET last_used_at = now()
+		WHERE id = $1
+	`, installationID)
+}
+
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	return contains(err.Error(), "unique") || contains(err.Error(), "duplicate")
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsStr(s, sub))
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/repos/marketplace/repo_test.go
+++ b/server/internal/repos/marketplace/repo_test.go
@@ -1,0 +1,86 @@
+package marketplace_test
+
+import (
+	"testing"
+
+	repoMarket "github.com/lextures/lextures/server/internal/repos/marketplace"
+)
+
+func TestGenerateClientSecret_Format(t *testing.T) {
+	secret, hash, prefix, err := repoMarket.GenerateClientSecret()
+	if err != nil {
+		t.Fatalf("GenerateClientSecret error: %v", err)
+	}
+	if len(secret) < 10 {
+		t.Errorf("secret too short: %q", secret)
+	}
+	if hash == "" {
+		t.Error("hash should not be empty")
+	}
+	if prefix == "" || len(prefix) != 8 {
+		t.Errorf("prefix should be 8 chars, got %q", prefix)
+	}
+	if secret[:8] != prefix {
+		t.Errorf("prefix mismatch: secret[:8]=%q prefix=%q", secret[:8], prefix)
+	}
+}
+
+func TestGenerateAccessToken_Format(t *testing.T) {
+	token, hash, prefix, err := repoMarket.GenerateAccessToken()
+	if err != nil {
+		t.Fatalf("GenerateAccessToken error: %v", err)
+	}
+	if len(token) < 10 {
+		t.Error("access token too short")
+	}
+	if hash == "" {
+		t.Error("hash should not be empty")
+	}
+	if len(prefix) != 8 {
+		t.Errorf("prefix should be 8 chars, got %q", prefix)
+	}
+}
+
+func TestGenerateRefreshToken_Format(t *testing.T) {
+	token, hash, prefix, err := repoMarket.GenerateRefreshToken()
+	if err != nil {
+		t.Fatalf("GenerateRefreshToken error: %v", err)
+	}
+	if len(token) < 10 {
+		t.Error("refresh token too short")
+	}
+	if hash == "" {
+		t.Error("hash should not be empty")
+	}
+	if len(prefix) != 8 {
+		t.Errorf("prefix should be 8 chars, got %q", prefix)
+	}
+}
+
+func TestHashToken_Deterministic(t *testing.T) {
+	token := "mkt_abc123"
+	h1 := repoMarket.HashToken(token)
+	h2 := repoMarket.HashToken(token)
+	if h1 != h2 {
+		t.Error("HashToken should be deterministic")
+	}
+	if h1 == "" {
+		t.Error("HashToken should not return empty string")
+	}
+}
+
+func TestHashToken_DifferentForDifferentTokens(t *testing.T) {
+	h1 := repoMarket.HashToken("mkt_token1")
+	h2 := repoMarket.HashToken("mkt_token2")
+	if h1 == h2 {
+		t.Error("different tokens should have different hashes")
+	}
+}
+
+func TestTokensAreUnique(t *testing.T) {
+	t1, _, _, _ := repoMarket.GenerateAccessToken()
+	t2, _, _, _ := repoMarket.GenerateAccessToken()
+	if t1 == t2 {
+		t.Error("two generated tokens should be unique")
+	}
+}

--- a/server/internal/repos/platformconfig/features.go
+++ b/server/internal/repos/platformconfig/features.go
@@ -88,6 +88,7 @@ func applyPlatformBools(out *config.Config, db *Row, def Defaults) {
 	out.FFTranscripts = mergeBool(db.FFTranscripts, false)
 	out.FFWebhooks = mergeBool(db.FFWebhooks, false)
 	out.FFZapierConnector = mergeBool(db.FFZapierConnector, false)
+	out.FFMarketplace = mergeBool(db.FFMarketplace, false)
 	out.FFAdvisingIntegration = mergeBool(db.FFAdvisingIntegration, false)
 	out.FFResearchConsent = mergeBool(db.FFResearchConsent, false)
 	out.FFAccessibilityIntake = mergeBool(db.FFAccessibilityIntake, false)

--- a/server/internal/repos/platformconfig/patch.go
+++ b/server/internal/repos/platformconfig/patch.go
@@ -156,6 +156,7 @@ func patch(ctx context.Context, pool *pgxpool.Pool, w *Write) error {
 	addBool("ff_transcripts", w.FFTranscripts)
 	addBool("ff_webhooks", w.FFWebhooks)
 	addBool("ff_zapier_connector", w.FFZapierConnector)
+	addBool("ff_marketplace_enabled", w.FFMarketplace)
 	addBool("ff_advising_integration", w.FFAdvisingIntegration)
 	addBool("ff_research_consent", w.FFResearchConsent)
 	addBool("ff_accessibility_intake", w.FFAccessibilityIntake)

--- a/server/internal/repos/platformconfig/platformconfig.go
+++ b/server/internal/repos/platformconfig/platformconfig.go
@@ -122,6 +122,7 @@ type Row struct {
 	FFTranscripts                   *bool
 	FFWebhooks                      *bool
 	FFZapierConnector               *bool
+	FFMarketplace                   *bool
 	FFAdvisingIntegration           *bool
 	FFResearchConsent               *bool
 	FFAccessibilityIntake           *bool
@@ -284,6 +285,7 @@ type Write struct {
 	FFTranscripts                   *bool
 	FFWebhooks                      *bool
 	FFZapierConnector               *bool
+	FFMarketplace                   *bool
 	FFAdvisingIntegration           *bool
 	FFResearchConsent               *bool
 	FFAccessibilityIntake           *bool
@@ -443,6 +445,7 @@ SELECT
 	ff_transcripts,
 	ff_webhooks,
 	ff_zapier_connector,
+	ff_marketplace_enabled,
 	ff_advising_integration,
 	ff_research_consent,
 	ff_accessibility_intake,
@@ -596,6 +599,7 @@ WHERE id = 1
 		&r.FFTranscripts,
 		&r.FFWebhooks,
 		&r.FFZapierConnector,
+		&r.FFMarketplace,
 		&r.FFAdvisingIntegration,
 		&r.FFResearchConsent,
 		&r.FFAccessibilityIntake,
@@ -800,6 +804,7 @@ INSERT INTO settings.platform_app_settings (
 	ff_transcripts,
 	ff_webhooks,
 	ff_zapier_connector,
+	ff_marketplace_enabled,
 	ff_advising_integration,
 	ff_research_consent,
 	ff_accessibility_intake,
@@ -958,6 +963,7 @@ ON CONFLICT (id) DO UPDATE SET
 	ff_transcripts = COALESCE(EXCLUDED.ff_transcripts, settings.platform_app_settings.ff_transcripts),
 	ff_webhooks = COALESCE(EXCLUDED.ff_webhooks, settings.platform_app_settings.ff_webhooks),
 	ff_zapier_connector = COALESCE(EXCLUDED.ff_zapier_connector, settings.platform_app_settings.ff_zapier_connector),
+	ff_marketplace_enabled = COALESCE(EXCLUDED.ff_marketplace_enabled, settings.platform_app_settings.ff_marketplace_enabled),
 	ff_advising_integration = COALESCE(EXCLUDED.ff_advising_integration, settings.platform_app_settings.ff_advising_integration),
 	ff_research_consent = COALESCE(EXCLUDED.ff_research_consent, settings.platform_app_settings.ff_research_consent),
 	ff_accessibility_intake = COALESCE(EXCLUDED.ff_accessibility_intake, settings.platform_app_settings.ff_accessibility_intake),
@@ -1109,6 +1115,7 @@ ON CONFLICT (id) DO UPDATE SET
 		w.FFTranscripts,
 		w.FFWebhooks,
 		w.FFZapierConnector,
+		w.FFMarketplace,
 		w.FFAdvisingIntegration,
 		w.FFResearchConsent,
 		w.FFAccessibilityIntake,

--- a/server/internal/service/marketplace/service.go
+++ b/server/internal/service/marketplace/service.go
@@ -1,0 +1,160 @@
+// Package marketplace implements OAuth 2.1 app authorization for the plugin marketplace (plan 16.9).
+package marketplace
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ErrInvalidState is returned when an OAuth callback state fails verification.
+var ErrInvalidState = errors.New("marketplace: invalid or expired oauth state")
+
+// ErrInvalidCodeChallenge is returned when PKCE code_verifier doesn't match challenge.
+var ErrInvalidCodeChallenge = errors.New("marketplace: invalid pkce code_verifier")
+
+// ErrInvalidRedirectURI is returned when the redirect_uri is not registered.
+var ErrInvalidRedirectURI = errors.New("marketplace: redirect_uri not registered for this app")
+
+// ErrInvalidClientCredentials is returned when client_id/secret are wrong.
+var ErrInvalidClientCredentials = errors.New("marketplace: invalid client credentials")
+
+const stateTTL = 10 * time.Minute
+
+// OAuthStateClaims is the signed payload stored in the OAuth state parameter.
+type OAuthStateClaims struct {
+	ClientID      string    `json:"c"`
+	OrgID         uuid.UUID `json:"o"`
+	UserID        uuid.UUID `json:"u"`
+	RedirectURI   string    `json:"r"`
+	Scopes        []string  `json:"s"`
+	CodeChallenge string    `json:"cc"` // PKCE S256 challenge
+	Nonce         string    `json:"n"`
+	Exp           int64     `json:"e"`
+}
+
+// Service holds dependencies for the marketplace OAuth flow.
+type Service struct {
+	StateSecret []byte
+	now         func() time.Time
+}
+
+// New returns a ready Service.
+func New(stateSecret []byte) *Service {
+	return &Service{StateSecret: stateSecret, now: time.Now}
+}
+
+// BuildConsentURL creates a signed state token for the OAuth consent redirect.
+// Returns the state string that the frontend uses to build /oauth/authorize.
+func (s *Service) BuildConsentURL(orgID, userID uuid.UUID, clientID, redirectURI string, scopes []string, codeChallenge string) (string, error) {
+	state := s.signState(OAuthStateClaims{
+		ClientID:      clientID,
+		OrgID:         orgID,
+		UserID:        userID,
+		RedirectURI:   redirectURI,
+		Scopes:        scopes,
+		CodeChallenge: codeChallenge,
+		Nonce:         randomNonce(),
+		Exp:           s.now().Add(stateTTL).Unix(),
+	})
+	return state, nil
+}
+
+// VerifyConsentState verifies the signed state and returns the embedded claims.
+func (s *Service) VerifyConsentState(state string) (OAuthStateClaims, error) {
+	return s.verifyState(state)
+}
+
+// VerifyPKCE checks that SHA-256(verifier) == base64url(challenge).
+func VerifyPKCE(challenge, verifier string) bool {
+	return verifyPKCE(challenge, verifier)
+}
+
+func verifyPKCE(challenge, verifier string) bool {
+	if challenge == "" || verifier == "" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	computed := base64.RawURLEncoding.EncodeToString(sum[:])
+	return computed == challenge
+}
+
+// ScopeLabel returns a human-readable label for a known scope.
+func ScopeLabel(scope string) string {
+	labels := map[string]string{
+		"courses:read":     "Read course information",
+		"courses:write":    "Create and modify courses",
+		"enrollments:read": "Read enrollment records",
+		"users:read":       "Read user profiles",
+		"grades:read":      "Read grade data",
+		"grades:write":     "This app can modify grades in your organization.",
+		"assignments:read": "Read assignment details",
+		"pii:read":         "Access personally identifiable information",
+	}
+	if l, ok := labels[scope]; ok {
+		return l
+	}
+	return scope
+}
+
+// ScopeIsWrite returns true if the scope grants write access (used for consent screen warnings).
+func ScopeIsWrite(scope string) bool {
+	return strings.HasSuffix(scope, ":write")
+}
+
+// ValidateRedirectURI checks that redirectURI is in the registered list.
+func ValidateRedirectURI(registeredURIs []string, redirectURI string) bool {
+	for _, u := range registeredURIs {
+		if u == redirectURI {
+			return true
+		}
+	}
+	return false
+}
+
+func randomNonce() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func (s *Service) signState(c OAuthStateClaims) string {
+	payload, _ := json.Marshal(c)
+	enc := base64.RawURLEncoding.EncodeToString(payload)
+	mac := hmac.New(sha256.New, s.StateSecret)
+	mac.Write([]byte(enc))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return enc + "." + sig
+}
+
+func (s *Service) verifyState(token string) (OAuthStateClaims, error) {
+	parts := strings.SplitN(token, ".", 2)
+	if len(parts) != 2 {
+		return OAuthStateClaims{}, ErrInvalidState
+	}
+	mac := hmac.New(sha256.New, s.StateSecret)
+	mac.Write([]byte(parts[0]))
+	expected := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(expected), []byte(parts[1])) {
+		return OAuthStateClaims{}, ErrInvalidState
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return OAuthStateClaims{}, ErrInvalidState
+	}
+	var c OAuthStateClaims
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return OAuthStateClaims{}, ErrInvalidState
+	}
+	if s.now().Unix() > c.Exp {
+		return OAuthStateClaims{}, ErrInvalidState
+	}
+	return c, nil
+}

--- a/server/internal/service/marketplace/service_test.go
+++ b/server/internal/service/marketplace/service_test.go
@@ -1,0 +1,122 @@
+package marketplace_test
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+
+	"github.com/google/uuid"
+
+	svcMarket "github.com/lextures/lextures/server/internal/service/marketplace"
+)
+
+func TestPKCE_Valid(t *testing.T) {
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	if !svcMarket.VerifyPKCE(challenge, verifier) {
+		t.Fatal("PKCE should be valid")
+	}
+}
+
+func TestPKCE_Invalid(t *testing.T) {
+	if svcMarket.VerifyPKCE("challenge", "wrong-verifier") {
+		t.Fatal("PKCE should be invalid")
+	}
+}
+
+func TestPKCE_EmptyInputs(t *testing.T) {
+	if svcMarket.VerifyPKCE("", "verifier") {
+		t.Fatal("empty challenge should be invalid")
+	}
+	if svcMarket.VerifyPKCE("challenge", "") {
+		t.Fatal("empty verifier should be invalid")
+	}
+}
+
+func TestStateSignRoundtrip(t *testing.T) {
+	secret := []byte("test-secret-32-bytes-long-enough!")
+	svc := svcMarket.New(secret)
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	clientID := "my-client-id"
+	redirectURI := "https://app.example.com/callback"
+	scopes := []string{"courses:read", "grades:read"}
+	challenge := "abc123"
+
+	state, err := svc.BuildConsentURL(orgID, userID, clientID, redirectURI, scopes, challenge)
+	if err != nil {
+		t.Fatalf("BuildConsentURL error: %v", err)
+	}
+
+	claims, err := svc.VerifyConsentState(state)
+	if err != nil {
+		t.Fatalf("VerifyConsentState error: %v", err)
+	}
+
+	if claims.OrgID != orgID {
+		t.Errorf("org_id mismatch: got %v want %v", claims.OrgID, orgID)
+	}
+	if claims.UserID != userID {
+		t.Errorf("user_id mismatch: got %v want %v", claims.UserID, userID)
+	}
+	if claims.ClientID != clientID {
+		t.Errorf("client_id mismatch: got %v want %v", claims.ClientID, clientID)
+	}
+	if claims.CodeChallenge != challenge {
+		t.Errorf("code_challenge mismatch: got %v want %v", claims.CodeChallenge, challenge)
+	}
+}
+
+func TestStateVerify_TamperedSignature(t *testing.T) {
+	svc := svcMarket.New([]byte("secret"))
+	state, _ := svc.BuildConsentURL(uuid.New(), uuid.New(), "c", "https://x.com", nil, "cc")
+
+	tampered := state[:len(state)-3] + "xxx"
+	_, err := svc.VerifyConsentState(tampered)
+	if err == nil {
+		t.Fatal("expected error for tampered state")
+	}
+}
+
+func TestStateVerify_WrongSecret(t *testing.T) {
+	svc1 := svcMarket.New([]byte("secret-1"))
+	svc2 := svcMarket.New([]byte("secret-2"))
+
+	state, _ := svc1.BuildConsentURL(uuid.New(), uuid.New(), "c", "https://x.com", nil, "cc")
+	_, err := svc2.VerifyConsentState(state)
+	if err == nil {
+		t.Fatal("expected error for wrong secret")
+	}
+}
+
+func TestScopeLabel_GradesWrite(t *testing.T) {
+	label := svcMarket.ScopeLabel("grades:write")
+	if label == "grades:write" {
+		t.Error("grades:write should have a human-readable label, not the scope string itself")
+	}
+}
+
+func TestScopeIsWrite(t *testing.T) {
+	if !svcMarket.ScopeIsWrite("grades:write") {
+		t.Error("grades:write should be identified as a write scope")
+	}
+	if svcMarket.ScopeIsWrite("grades:read") {
+		t.Error("grades:read should not be identified as a write scope")
+	}
+}
+
+func TestValidateRedirectURI(t *testing.T) {
+	registered := []string{"https://app.example.com/cb", "https://dev.example.com/cb"}
+	if !svcMarket.ValidateRedirectURI(registered, "https://app.example.com/cb") {
+		t.Error("registered URI should be valid")
+	}
+	if svcMarket.ValidateRedirectURI(registered, "https://evil.example.com/cb") {
+		t.Error("unregistered URI should be invalid")
+	}
+	if svcMarket.ValidateRedirectURI(registered, "") {
+		t.Error("empty URI should be invalid")
+	}
+}

--- a/server/migrations/334_marketplace.sql
+++ b/server/migrations/334_marketplace.sql
@@ -1,0 +1,62 @@
+-- Plan 16.9 — Marketplace / Plugin System.
+
+CREATE SCHEMA IF NOT EXISTS marketplace;
+
+CREATE TABLE IF NOT EXISTS marketplace.apps (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    developer_user_id   UUID REFERENCES "user".users (id) ON DELETE SET NULL,
+    name                TEXT NOT NULL,
+    slug                TEXT NOT NULL UNIQUE,
+    description         TEXT NOT NULL DEFAULT '',
+    logo_url            TEXT,
+    redirect_uris       TEXT[] NOT NULL DEFAULT '{}',
+    requested_scopes    TEXT[] NOT NULL DEFAULT '{}',
+    client_id           TEXT NOT NULL UNIQUE DEFAULT gen_random_uuid()::text,
+    client_secret_hash  TEXT NOT NULL,
+    client_secret_prefix TEXT NOT NULL,
+    published           BOOLEAN NOT NULL DEFAULT false,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_apps_developer
+    ON marketplace.apps (developer_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_apps_published
+    ON marketplace.apps (published)
+    WHERE published = true;
+
+CREATE TABLE IF NOT EXISTS marketplace.installations (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    app_id              UUID NOT NULL REFERENCES marketplace.apps (id) ON DELETE CASCADE,
+    org_id              UUID NOT NULL,
+    access_token_hash   TEXT NOT NULL UNIQUE,
+    access_token_prefix TEXT NOT NULL,
+    refresh_token_hash  TEXT NOT NULL UNIQUE,
+    refresh_token_prefix TEXT NOT NULL,
+    granted_scopes      TEXT[] NOT NULL DEFAULT '{}',
+    installed_by        UUID REFERENCES "user".users (id) ON DELETE SET NULL,
+    installed_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    revoked_at          TIMESTAMPTZ,
+    last_used_at        TIMESTAMPTZ,
+    UNIQUE (app_id, org_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_installations_org
+    ON marketplace.installations (org_id)
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_installations_access_token
+    ON marketplace.installations (access_token_hash)
+    WHERE revoked_at IS NULL;
+
+ALTER TABLE settings.platform_app_settings
+    ADD COLUMN IF NOT EXISTS ff_marketplace_enabled BOOLEAN;
+
+COMMENT ON COLUMN settings.platform_app_settings.ff_marketplace_enabled IS
+    'Plan 16.9: Enables marketplace / plugin system with OAuth 2.1 app authorization (default false).';
+
+COMMENT ON TABLE marketplace.apps IS
+    'Registered third-party apps in the Lextures developer/marketplace ecosystem (plan 16.9).';
+
+COMMENT ON TABLE marketplace.installations IS
+    'Per-organisation marketplace app installations with scoped OAuth tokens (plan 16.9).';


### PR DESCRIPTION
## Summary

- **DB migration** (`334_marketplace.sql`): `marketplace.apps` and `marketplace.installations` tables with `ff_marketplace_enabled` feature flag column on `settings.platform_app_settings`
- **Go repo layer** (`repos/marketplace/`): CRUD for apps and installations; token generation/hashing; PKCE utilities
- **Go service layer** (`service/marketplace/`): OAuth 2.1 HMAC-signed state tokens, PKCE S256 verification, scope labels/write detection
- **HTTP handlers** (`httpserver/marketplace_http.go`): 9 routes — public marketplace listing, OAuth authorize/token/revoke, developer portal app registration, admin installed-apps management with revocation
- **Config/platformconfig wiring**: `FFMarketplace` config field + all 7 platformconfig.go insertion points + features.go + patch.go
- **Frontend** (`clients/web/src/`): marketplace listing page, app detail page, OAuth consent screen with write-scope warnings, developer portal with app registration form, admin installed-apps table with revoke button
- **Tests**: 37 new unit tests (service PKCE/state signing, repo token generation, httpserver no-DB routing); all 905 existing httpserver tests still pass

## Key security properties
- PKCE S256 required on all installs (RFC 7636)
- Client secrets hashed (SHA-256 hex) — never retrievable after creation
- Per-installation tokens (access + refresh) stored as hashes only
- Token revocation via DB `revoked_at` timestamp; old tokens invalidated immediately
- Feature gated behind `ff_marketplace_enabled` (default false)

## Test plan
- [x] `go build ./internal/...` — clean
- [x] `go vet ./internal/...` — clean
- [x] `go test ./internal/...` — 905+ pass
- [x] `tsc --noEmit` — no TypeScript errors
- [ ] Manual: start dev server, navigate to `/marketplace`, `/oauth/authorize`, `/developer`, `/admin/marketplace/installed`
- [ ] Integration: run DB migration, register app via developer portal, complete OAuth flow, call API with token, revoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)