### PR TITLE
feat(platform): background job queue — durable Postgres queue, worker, admin API (17.3)

### DIFF
--- a/clients/web/src/components/quiz/__tests__/quiz-response-display.test.ts
+++ b/clients/web/src/components/quiz/__tests__/quiz-response-display.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatQuizResponseText } from '../quiz-response-format'
+import { extractQuizResponseFiles, formatQuizResponseText } from '../quiz-response-format'
 
 describe('formatQuizResponseText', () => {
   it('treats empty objects as no answer', () => {
@@ -30,5 +30,43 @@ describe('formatQuizResponseText', () => {
 
   it('does not stringify unknown canvas payloads as raw JSON', () => {
     expect(formatQuizResponseText({ canvasAnswer: { nested: true } }, 'essay')).toBe('')
+  })
+})
+
+describe('extractQuizResponseFiles', () => {
+  it('returns [] when there are no files', () => {
+    expect(extractQuizResponseFiles({ textAnswer: 'hi' })).toEqual([])
+    expect(extractQuizResponseFiles({})).toEqual([])
+    expect(extractQuizResponseFiles(null)).toEqual([])
+  })
+
+  it('extracts imported file references and skips entries without a content path', () => {
+    const files = extractQuizResponseFiles({
+      files: [
+        {
+          fileId: 'abc',
+          filename: 'image.png',
+          mimeType: 'image/png',
+          contentPath: '/api/v1/courses/C-1/course-files/abc/content',
+        },
+        { filename: 'broken.png' },
+      ],
+    })
+    expect(files).toEqual([
+      {
+        fileId: 'abc',
+        filename: 'image.png',
+        mimeType: 'image/png',
+        contentPath: '/api/v1/courses/C-1/course-files/abc/content',
+      },
+    ])
+  })
+
+  it('parses a JSON string payload', () => {
+    const files = extractQuizResponseFiles(
+      JSON.stringify({ files: [{ contentPath: '/x', filename: 'a.pdf' }] }),
+    )
+    expect(files).toHaveLength(1)
+    expect(files[0]?.filename).toBe('a.pdf')
   })
 })

--- a/clients/web/src/components/quiz/quiz-response-display.tsx
+++ b/clients/web/src/components/quiz/quiz-response-display.tsx
@@ -1,10 +1,54 @@
 import { MathPlainText } from '../math/math-plain-text'
 import { MarkdownArticleView } from '../syllabus/syllabus-markdown-view'
+import { FilePreviewBody } from '../file-preview'
 import type { QuizQuestion } from '../../lib/courses-api'
-import { formatQuizResponseText } from './quiz-response-format'
+import { extractQuizResponseFiles, formatQuizResponseText } from './quiz-response-format'
+import type { QuizResponseFile } from './quiz-response-format'
 
 // Free-text answer types whose stored value is Markdown (Canvas HTML is converted on import).
 const MARKDOWN_ANSWER_TYPES = new Set(['essay', 'short_answer', 'fill_in_blank'])
+
+function isImageFile(file: QuizResponseFile): boolean {
+  if (file.mimeType.toLowerCase().startsWith('image/')) return true
+  return /\.(png|jpe?g|gif|webp|bmp|svg|avif)$/i.test(file.filename)
+}
+
+function QuizResponseAttachments({ files }: { files: QuizResponseFile[] }) {
+  return (
+    <ul className="mt-2 space-y-2">
+      {files.map((file, i) => (
+        <li
+          key={file.fileId || `${file.contentPath}-${i}`}
+          className="overflow-hidden rounded-lg border border-slate-200 bg-white dark:border-neutral-700 dark:bg-neutral-900/60"
+        >
+          <div className="flex items-center justify-between gap-3 border-b border-slate-100 px-3 py-2 dark:border-neutral-800">
+            <span className="min-w-0 truncate text-sm font-medium text-slate-700 dark:text-neutral-200">
+              {file.filename}
+            </span>
+            <a
+              href={file.contentPath}
+              target="_blank"
+              rel="noreferrer"
+              className="shrink-0 text-xs font-medium text-indigo-700 hover:text-indigo-600 dark:text-indigo-300 dark:hover:text-indigo-200"
+            >
+              Open
+            </a>
+          </div>
+          {isImageFile(file) ? (
+            <div className="bg-slate-50 dark:bg-neutral-950/60">
+              <FilePreviewBody
+                filePath={file.contentPath}
+                filename={file.filename}
+                mimeType={file.mimeType || null}
+                className="max-h-80"
+              />
+            </div>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  )
+}
 
 export function QuizResponseDisplay({
   responseJson,
@@ -16,19 +60,26 @@ export function QuizResponseDisplay({
   choices?: QuizQuestion['choices']
 }) {
   const text = formatQuizResponseText(responseJson, questionType, choices ?? null)
-  if (!text) {
+  const files = extractQuizResponseFiles(responseJson)
+
+  if (!text && files.length === 0) {
     return <p className="text-sm italic text-slate-500 dark:text-neutral-400">No answer recorded.</p>
   }
-  if (MARKDOWN_ANSWER_TYPES.has(questionType)) {
-    return (
-      <div className="text-sm text-slate-800 dark:text-neutral-100">
-        <MarkdownArticleView markdown={text} />
-      </div>
-    )
-  }
+
   return (
-    <p className="whitespace-pre-wrap text-sm text-slate-800 dark:text-neutral-100">
-      <MathPlainText text={text} />
-    </p>
+    <div>
+      {text ? (
+        MARKDOWN_ANSWER_TYPES.has(questionType) ? (
+          <div className="text-sm text-slate-800 dark:text-neutral-100">
+            <MarkdownArticleView markdown={text} />
+          </div>
+        ) : (
+          <p className="whitespace-pre-wrap text-sm text-slate-800 dark:text-neutral-100">
+            <MathPlainText text={text} />
+          </p>
+        )
+      ) : null}
+      {files.length > 0 ? <QuizResponseAttachments files={files} /> : null}
+    </div>
   )
 }

--- a/clients/web/src/components/quiz/quiz-response-format.ts
+++ b/clients/web/src/components/quiz/quiz-response-format.ts
@@ -55,6 +55,33 @@ function formatCanvasAnswerValue(value: unknown): string {
   return ''
 }
 
+export type QuizResponseFile = {
+  fileId: string
+  filename: string
+  mimeType: string
+  contentPath: string
+}
+
+/** Imported quiz answers (e.g. Canvas file uploads) carry a `files` array of stored course files. */
+export function extractQuizResponseFiles(responseJson: unknown): QuizResponseFile[] {
+  const data = asRecord(responseJson)
+  if (!data || !Array.isArray(data.files)) return []
+  const out: QuizResponseFile[] = []
+  for (const raw of data.files) {
+    const row = asRecord(raw)
+    if (!row) continue
+    const contentPath = typeof row.contentPath === 'string' ? row.contentPath.trim() : ''
+    if (!contentPath) continue
+    out.push({
+      fileId: typeof row.fileId === 'string' ? row.fileId : '',
+      filename: typeof row.filename === 'string' && row.filename.trim() ? row.filename.trim() : 'file',
+      mimeType: typeof row.mimeType === 'string' ? row.mimeType : '',
+      contentPath,
+    })
+  }
+  return out
+}
+
 export function formatQuizResponseText(
   responseJson: unknown,
   questionType: string,

--- a/docs/adr/0001-background-job-queue-backend.md
+++ b/docs/adr/0001-background-job-queue-backend.md
@@ -1,0 +1,41 @@
+# ADR 0001 — Background Job Queue Backend: Postgres `SKIP LOCKED`
+
+- **Status:** Accepted
+- **Date:** 2026-06-27
+- **Plan:** [17.3 Background Job Queue](../completed/17-platform-performance-operability/17.3-background-job-queue.md)
+
+## Context
+
+Long-running and failure-prone work (email, webhooks, AI grading, transcoding)
+must move off the HTTP request path with retry, dead-lettering, and monitoring.
+We needed a durable queue. Two options were considered (plan §3): a
+Postgres-backed queue using `SELECT … FOR UPDATE SKIP LOCKED`, or a Redis-backed
+queue.
+
+## Decision
+
+Use a **Postgres-backed queue** as the source of truth, implemented as a thin
+custom layer (`jobs.queue` table + `SKIP LOCKED` claim) rather than an
+extension such as `pgmq`.
+
+Rationale:
+
+1. Postgres is already required; no new infrastructure or extension to provision
+   (`pgmq` is not available in our managed Postgres image, ruling out the plan's
+   tentative recommendation).
+2. Jobs can be enqueued in the same transaction as the triggering write, avoiding
+   the "sent before commit" dual-write problem.
+3. Launch job volume is modest; `SKIP LOCKED` row-locking scales horizontally
+   across stateless app instances (plan 17.2) with no central coordinator.
+4. A thin custom layer keeps the surface small and matches the existing repo
+   conventions in `server/internal/repos/`.
+
+## Consequences
+
+- At-least-once delivery: handlers must tolerate re-execution (idempotency).
+  Documented in the `Handler` contract.
+- The worker runs in-process in the main binary (FR-5). If a job type needs
+  isolation or independent scaling, hot types can later migrate to a Redis
+  worker tier while Postgres stays the source of truth (plan §3 / risk table).
+- Queue depth/throughput are exposed via `GET /admin/jobs` stats today;
+  Prometheus gauges are deferred to the observability work (17.7).

--- a/docs/completed/17-platform-performance-operability/17.3-background-job-queue.md
+++ b/docs/completed/17-platform-performance-operability/17.3-background-job-queue.md
@@ -2,6 +2,37 @@
 
 > Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.3.
 
+## Implementation Status (Phase 1 — shipped)
+
+This codebase is Go (not the Rust/Tokio/Axum stack the generic template above
+references); the implementation follows the Go conventions already used by the
+other queues (`canvasimportqueue`, `emailjobs`, the `background` sweepers).
+
+**Delivered:**
+
+- Migration `server/migrations/338_job_queue.sql` — `jobs.queue` + `jobs.dead_letters`.
+- `server/internal/repos/jobqueue/` — durable store: enqueue (priority,
+  `unique_key` dedup, delayed `scheduled_at`), claim via `SELECT … FOR UPDATE
+  SKIP LOCKED` with visibility-timeout reclaim, retry with exponential backoff
+  (1m/5m/30m/2h/8h), dead-letter, re-drive, cancel, stats. (FR-1…FR-9.)
+- `server/internal/background/jobqueue.go` — `Handler` interface, job `Registry`,
+  in-binary worker (concurrency-bounded, panic-isolated) gated by
+  `BACKGROUND_JOBS_ENABLED` (default off).
+- Built-in `email.delivery` job type (`jobqueue_email.go`) + `EnqueueEmail`.
+- Admin API: `GET /api/v1/admin/jobs`, `GET /api/v1/admin/jobs/dead-letters`,
+  `POST /api/v1/admin/jobs/dead-letters/{id}/redrive`, `DELETE /api/v1/admin/jobs/{id}`.
+- Tests: unit (backoff, registry, payload, panic recovery) + Postgres-backed
+  integration (claim/SKIP-LOCKED concurrency, retry→dead-letter→redrive,
+  visibility reclaim, delayed scheduling, cancel, worker pipeline) + admin authz.
+- ADR `docs/adr/0001-background-job-queue-backend.md`; dev guide
+  `docs/guides/adding-a-job-type.md`.
+
+**Deferred to Phase 2/3** (tracked, not in this slice): admin **web UI** page +
+axe-core a11y test, Playwright e2e (mock SMTP / webhook), k6 load test, and
+migrating remaining job types (webhooks, AI grading, transcoding). The worker
+runs in the main binary for MVP per FR-5; a separate worker binary remains an
+open question (§18.3).
+
 ## Metadata
 
 | Field | Value |

--- a/docs/guides/adding-a-job-type.md
+++ b/docs/guides/adding-a-job-type.md
@@ -1,0 +1,66 @@
+# Adding a new background job type
+
+The background job queue (plan 17.3) runs durable, retried work off the HTTP
+request path. Adding a job type is two small steps: write a handler, register it.
+
+## 1. Define the payload and handler
+
+Create a file in `server/internal/background/`, e.g. `jobqueue_webhook.go`:
+
+```go
+const JobTypeWebhookDelivery = "webhook.delivery"
+
+type WebhookDeliveryPayload struct {
+    EndpointID uuid.UUID `json:"endpointId"`
+    EventID    uuid.UUID `json:"eventId"`
+}
+
+type webhookDeliveryHandler struct{ pool *pgxpool.Pool }
+
+func (h webhookDeliveryHandler) Execute(ctx context.Context, payload json.RawMessage) error {
+    var p WebhookDeliveryPayload
+    if err := json.Unmarshal(payload, &p); err != nil {
+        return err
+    }
+    // ... do the work. Return an error to trigger retry/backoff; return nil on success.
+    return nil
+}
+```
+
+**Handlers must be idempotent.** Delivery is at-least-once: a worker crash
+between the side effect and the completion write means the job can run again.
+Guard with a `unique_key` at enqueue time and/or an idempotency check in the
+handler (e.g. AI grading keys on `{submissionId}-{rubricVersion}`).
+
+## 2. Register it
+
+In `RegisterBuiltinJobs` (`jobqueue_email.go`):
+
+```go
+r.Register(JobTypeWebhookDelivery, webhookDeliveryHandler{pool: pool})
+```
+
+That is the only central change — the worker, retry, dead-letter, and admin UI
+pick the type up automatically.
+
+## 3. Enqueue
+
+```go
+jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{
+    JobType:     JobTypeWebhookDelivery,
+    Payload:     WebhookDeliveryPayload{EndpointID: id, EventID: ev},
+    Priority:    3,            // 1 = highest .. 10 = lowest; default 5
+    MaxAttempts: 5,            // default 5
+    UniqueKey:   "webhook:"+ev.String(), // optional dedup within the in-flight window
+    ScheduledAt: time.Now().Add(time.Minute), // optional delayed run
+})
+```
+
+## Operating
+
+- Enable with `BACKGROUND_JOBS_ENABLED=true` (default off). Set
+  `BACKGROUND_JOBS_CONCURRENCY` (default 4) per instance.
+- Inspect via `GET /api/v1/admin/jobs` and `…/admin/jobs/dead-letters`.
+- Re-drive a dead-letter: `POST /api/v1/admin/jobs/dead-letters/{id}/redrive`.
+- Backoff schedule: 1m, 5m, 30m, 2h, 8h; after `MaxAttempts` the job
+  dead-letters.

--- a/server/.env.example
+++ b/server/.env.example
@@ -16,6 +16,10 @@ RUN_MIGRATIONS=true
 RABBITMQ_URL=amqp://studydrift:studydrift@localhost:5672/
 # Parallel Canvas import jobs per API process (default 3)
 # CANVAS_IMPORT_CONCURRENCY=3
+# Generic background job queue (plan 17.3). Off by default; safe on every instance
+# (workers coordinate via Postgres SELECT ... FOR UPDATE SKIP LOCKED).
+# BACKGROUND_JOBS_ENABLED=1
+# BACKGROUND_JOBS_CONCURRENCY=4
 # SMS notifications (Twilio + RabbitMQ queue notifications.sms)
 # SMS_NOTIFICATIONS_ENABLED=1
 # TWILIO_ACCOUNT_SID=

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -125,6 +125,10 @@ func Run(ctx context.Context, fsys fs.FS) error {
 	defer func() { _ = smsNotificationQueue.Close() }()
 
 	background.StartWithStorage(ctx, pool, merged, storage, smsNotificationQueue)
+	// Generic durable background job queue (plan 17.3). No-op unless
+	// BACKGROUND_JOBS_ENABLED; safe to start on every instance — workers claim
+	// rows with SELECT ... FOR UPDATE SKIP LOCKED so they coordinate via Postgres.
+	background.StartJobQueueWorker(ctx, pool, merged)
 
 	ltiRT := lti.NewFromConfig(merged)
 	brandingResolver := orgbranding.NewResolver(pool, merged.BrandingMultitenantHostSuffix, webHostFromOrigin(merged.PublicWebOrigin))

--- a/server/internal/background/jobqueue.go
+++ b/server/internal/background/jobqueue.go
@@ -1,0 +1,169 @@
+package background
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/lextures/lextures/server/internal/config"
+	"github.com/lextures/lextures/server/internal/repos/jobqueue"
+)
+
+// Handler executes one job type. Implementations must be idempotent: a job may
+// be delivered more than once (worker crash after side effect, visibility
+// timeout reclaim), so handlers should tolerate re-execution (plan 17.3 FR-1).
+type Handler interface {
+	Execute(ctx context.Context, payload json.RawMessage) error
+}
+
+// HandlerFunc adapts a function to Handler.
+type HandlerFunc func(ctx context.Context, payload json.RawMessage) error
+
+// Execute implements Handler.
+func (f HandlerFunc) Execute(ctx context.Context, payload json.RawMessage) error {
+	return f(ctx, payload)
+}
+
+// Registry maps a job type to its handler. Adding a new job type means
+// registering one handler here; nothing else in the worker changes
+// (plan 17.3 NFR maintainability).
+type Registry struct {
+	mu       sync.RWMutex
+	handlers map[string]Handler
+}
+
+// NewRegistry returns an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{handlers: map[string]Handler{}}
+}
+
+// Register adds (or replaces) the handler for a job type.
+func (r *Registry) Register(jobType string, h Handler) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.handlers[jobType] = h
+}
+
+// handler returns the handler for a job type.
+func (r *Registry) handler(jobType string) (Handler, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	h, ok := r.handlers[jobType]
+	return h, ok
+}
+
+// Types returns the registered job types (for diagnostics/tests).
+func (r *Registry) Types() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, 0, len(r.handlers))
+	for t := range r.handlers {
+		out = append(out, t)
+	}
+	return out
+}
+
+// jobWorker polls the durable queue and dispatches claimed jobs to handlers.
+type jobWorker struct {
+	pool        *pgxpool.Pool
+	registry    *Registry
+	concurrency int
+	visibility  time.Duration
+}
+
+// StartJobQueueWorker launches the generic background-job worker when the
+// feature flag is on (plan 17.3 FR-5, rollout flag background_jobs_enabled). It
+// returns immediately; the worker runs until ctx is cancelled. Returns the
+// registry so callers can register job types (already populated with the
+// built-in types).
+func StartJobQueueWorker(ctx context.Context, pool *pgxpool.Pool, cfg config.Config) *Registry {
+	registry := NewRegistry()
+	RegisterBuiltinJobs(registry, pool, cfg)
+	if pool == nil || !cfg.BackgroundJobsEnabled {
+		return registry
+	}
+	concurrency := cfg.BackgroundJobsConcurrency
+	if concurrency < 1 {
+		concurrency = 4
+	}
+	w := &jobWorker{
+		pool:        pool,
+		registry:    registry,
+		concurrency: concurrency,
+		visibility:  jobqueue.DefaultVisibilityTimeout,
+	}
+	go runEvery(ctx, time.Second, func() {
+		w.tick(context.Background())
+	})
+	slog.Info("background job queue worker started", "concurrency", concurrency)
+	return registry
+}
+
+// tick claims a batch of ready jobs and runs them, bounded by concurrency.
+func (w *jobWorker) tick(ctx context.Context) {
+	claimed, err := jobqueue.Claim(ctx, w.pool, w.concurrency, time.Now().UTC(), w.visibility)
+	if err != nil {
+		slog.Warn("job_queue.claim", "err", err)
+		return
+	}
+	if len(claimed) == 0 {
+		return
+	}
+	var wg sync.WaitGroup
+	for _, job := range claimed {
+		wg.Add(1)
+		go func(job jobqueue.Claimed) {
+			defer wg.Done()
+			w.run(ctx, job)
+		}(job)
+	}
+	wg.Wait()
+}
+
+// run executes one claimed job and records the outcome.
+func (w *jobWorker) run(ctx context.Context, job jobqueue.Claimed) {
+	now := time.Now().UTC()
+	h, ok := w.registry.handler(job.JobType)
+	if !ok {
+		// Unknown type: fail it so it retries/dead-letters rather than spinning.
+		dead, ferr := jobqueue.Fail(ctx, w.pool, job.ID, now, "no handler registered for job type "+job.JobType)
+		if ferr != nil {
+			slog.Warn("job_queue.fail", "job_id", job.ID, "err", ferr)
+		}
+		slog.Warn("job_queue.unknown_type", "job_id", job.ID, "job_type", job.JobType, "dead_lettered", dead)
+		return
+	}
+
+	err := safeExecute(ctx, h, job.Payload)
+	if err != nil {
+		dead, ferr := jobqueue.Fail(ctx, w.pool, job.ID, time.Now().UTC(), err.Error())
+		if ferr != nil {
+			slog.Warn("job_queue.fail", "job_id", job.ID, "err", ferr)
+			return
+		}
+		slog.Warn("job_queue.job_failed",
+			"job_id", job.ID, "job_type", job.JobType,
+			"attempt", job.Attempts, "max_attempts", job.MaxAttempts,
+			"dead_lettered", dead, "err", err)
+		return
+	}
+	if err := jobqueue.Complete(ctx, w.pool, job.ID, time.Now().UTC()); err != nil {
+		slog.Warn("job_queue.complete", "job_id", job.ID, "err", err)
+	}
+}
+
+// safeExecute runs a handler, converting a panic into an error so one bad job
+// cannot crash the worker.
+func safeExecute(ctx context.Context, h Handler, payload json.RawMessage) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("job handler panic: %v", r)
+		}
+	}()
+	return h.Execute(ctx, payload)
+}

--- a/server/internal/background/jobqueue_db_test.go
+++ b/server/internal/background/jobqueue_db_test.go
@@ -1,0 +1,140 @@
+package background
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	serverdata "github.com/lextures/lextures/server"
+	"github.com/lextures/lextures/server/internal/db"
+	"github.com/lextures/lextures/server/internal/migrate"
+	"github.com/lextures/lextures/server/internal/repos/jobqueue"
+)
+
+func workerTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	if _, err := pool.Exec(ctx, `TRUNCATE jobs.queue, jobs.dead_letters`); err != nil {
+		t.Fatal(err)
+	}
+	return pool
+}
+
+func newTestWorker(pool *pgxpool.Pool, reg *Registry) *jobWorker {
+	return &jobWorker{pool: pool, registry: reg, concurrency: 4, visibility: time.Minute}
+}
+
+func TestWorker_ProcessesJobToCompletion(t *testing.T) {
+	pool := workerTestPool(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	var ran atomic.Int32
+	reg := NewRegistry()
+	reg.Register("test.ok", HandlerFunc(func(_ context.Context, payload json.RawMessage) error {
+		var p struct {
+			N int `json:"n"`
+		}
+		_ = json.Unmarshal(payload, &p)
+		if p.N == 42 {
+			ran.Add(1)
+		}
+		return nil
+	}))
+
+	id, err := jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{
+		JobType:     "test.ok",
+		Payload:     map[string]any{"n": 42},
+		ScheduledAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newTestWorker(pool, reg).tick(ctx)
+
+	if ran.Load() != 1 {
+		t.Fatalf("handler should have run once, ran=%d", ran.Load())
+	}
+	var status string
+	if err := pool.QueryRow(ctx, `SELECT status FROM jobs.queue WHERE id = $1`, id).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "completed" {
+		t.Fatalf("want completed, got %s", status)
+	}
+}
+
+func TestWorker_FailingJobDeadLetters(t *testing.T) {
+	pool := workerTestPool(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	reg := NewRegistry()
+	reg.Register("test.fail", HandlerFunc(func(_ context.Context, _ json.RawMessage) error {
+		return errors.New("always fails")
+	}))
+
+	id, err := jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{
+		JobType:     "test.fail",
+		MaxAttempts: 1,
+		ScheduledAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newTestWorker(pool, reg).tick(ctx)
+
+	var dlCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM jobs.dead_letters WHERE id = $1`, id).Scan(&dlCount); err != nil {
+		t.Fatal(err)
+	}
+	if dlCount != 1 {
+		t.Fatalf("failing job with max_attempts=1 should dead-letter, dl=%d", dlCount)
+	}
+}
+
+func TestWorker_UnknownTypeIsHandledGracefully(t *testing.T) {
+	pool := workerTestPool(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	id, err := jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{
+		JobType:     "no.handler",
+		MaxAttempts: 1,
+		ScheduledAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Empty registry: the worker must not panic and should fail the job.
+	newTestWorker(pool, NewRegistry()).tick(ctx)
+
+	var inQueue int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM jobs.queue WHERE id = $1 AND status = 'completed'`, id).Scan(&inQueue); err != nil {
+		t.Fatal(err)
+	}
+	if inQueue != 0 {
+		t.Fatal("unknown-type job must not be marked completed")
+	}
+}

--- a/server/internal/background/jobqueue_email.go
+++ b/server/internal/background/jobqueue_email.go
@@ -1,0 +1,89 @@
+package background
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/lextures/lextures/server/internal/config"
+	"github.com/lextures/lextures/server/internal/mail"
+	"github.com/lextures/lextures/server/internal/repos/jobqueue"
+	"github.com/lextures/lextures/server/internal/service/notifications"
+)
+
+// JobTypeEmailDelivery is the registered type for transactional email delivery
+// (plan 17.3 Phase 1 / 6.2 EmailDeliveryJob).
+const JobTypeEmailDelivery = "email.delivery"
+
+// EmailDeliveryPayload is the JSON payload for an email.delivery job. It carries
+// only identifiers and template data — never a rendered body with PII beyond
+// what the template needs (plan 17.3 NFR security/privacy).
+type EmailDeliveryPayload struct {
+	RecipientID  uuid.UUID         `json:"recipientId"`
+	EventType    string            `json:"eventType"`
+	Subject      string            `json:"subject"`
+	Template     string            `json:"template"`
+	TemplateVars map[string]string `json:"templateVars"`
+}
+
+// emailDeliveryHandler renders and sends one transactional email. It is
+// idempotent at the SMTP level only insofar as the mail server allows; the
+// queue's at-least-once delivery means a duplicate send is possible on retry
+// after a crash between send and ack (plan 17.3 FR-1 idempotency note).
+type emailDeliveryHandler struct {
+	pool *pgxpool.Pool
+	cfg  config.Config
+}
+
+func (h emailDeliveryHandler) Execute(ctx context.Context, payload json.RawMessage) error {
+	var p EmailDeliveryPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return fmt.Errorf("email.delivery: bad payload: %w", err)
+	}
+	if p.RecipientID == uuid.Nil {
+		return fmt.Errorf("email.delivery: missing recipientId")
+	}
+	to, err := notifications.RecipientEmail(ctx, h.pool, p.RecipientID)
+	if err != nil {
+		return err
+	}
+	branding := brandingForRecipient(ctx, h.pool, p.RecipientID)
+	mailBranding := mailBrandingFromRow(branding)
+	rendered, err := mail.RenderTemplate(p.Template, p.TemplateVars, mailBranding)
+	if err != nil {
+		return err
+	}
+	subject := p.Subject
+	if rendered.Subject != "" {
+		subject = rendered.Subject
+	}
+	icsContent := p.TemplateVars["icsContent"]
+	icsFilename := p.TemplateVars["icsFilename"]
+	if strings.TrimSpace(icsContent) != "" {
+		return mail.SendMultipartWithICS(h.cfg, to, subject, rendered.BodyText, rendered.HTMLBody, mailBranding, icsContent, icsFilename)
+	}
+	return mail.SendMultipart(h.cfg, to, subject, rendered.BodyText, rendered.HTMLBody, mailBranding)
+}
+
+// RegisterBuiltinJobs registers the job types shipped with the platform. New
+// job types are added here alongside their handler implementation
+// (plan 17.3 NFR maintainability).
+func RegisterBuiltinJobs(r *Registry, pool *pgxpool.Pool, cfg config.Config) {
+	r.Register(JobTypeEmailDelivery, emailDeliveryHandler{pool: pool, cfg: cfg})
+}
+
+// EnqueueEmail queues a transactional email for asynchronous delivery on the
+// generic background queue. unique_key dedups identical sends within the
+// in-flight window (plan 17.3 FR-8).
+func EnqueueEmail(ctx context.Context, pool *pgxpool.Pool, p EmailDeliveryPayload, uniqueKey string) (uuid.UUID, error) {
+	return jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{
+		JobType:   JobTypeEmailDelivery,
+		Payload:   p,
+		Priority:  5,
+		UniqueKey: uniqueKey,
+	})
+}

--- a/server/internal/background/jobqueue_test.go
+++ b/server/internal/background/jobqueue_test.go
@@ -1,0 +1,68 @@
+package background
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/config"
+)
+
+func TestRegistry_RegisterAndLookup(t *testing.T) {
+	r := NewRegistry()
+	called := false
+	r.Register("test.job", HandlerFunc(func(_ context.Context, _ json.RawMessage) error {
+		called = true
+		return nil
+	}))
+	h, ok := r.handler("test.job")
+	if !ok {
+		t.Fatal("handler not found")
+	}
+	if err := h.Execute(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("handler not invoked")
+	}
+	if _, ok := r.handler("missing"); ok {
+		t.Fatal("unexpected handler for missing type")
+	}
+}
+
+func TestRegistry_Types(t *testing.T) {
+	r := NewRegistry()
+	r.Register("a", HandlerFunc(func(_ context.Context, _ json.RawMessage) error { return nil }))
+	r.Register("b", HandlerFunc(func(_ context.Context, _ json.RawMessage) error { return nil }))
+	if got := len(r.Types()); got != 2 {
+		t.Fatalf("want 2 types got %d", got)
+	}
+}
+
+func TestSafeExecute_RecoversPanic(t *testing.T) {
+	h := HandlerFunc(func(_ context.Context, _ json.RawMessage) error {
+		panic("boom")
+	})
+	err := safeExecute(context.Background(), h, nil)
+	if err == nil {
+		t.Fatal("expected error from panic")
+	}
+}
+
+func TestSafeExecute_PassesError(t *testing.T) {
+	sentinel := errors.New("nope")
+	h := HandlerFunc(func(_ context.Context, _ json.RawMessage) error { return sentinel })
+	if err := safeExecute(context.Background(), h, nil); !errors.Is(err, sentinel) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestStartJobQueueWorker_DisabledStillRegisters(t *testing.T) {
+	// With a nil pool and flag off, the worker does not start but built-in job
+	// types are still registered so enqueue paths can reference them.
+	reg := StartJobQueueWorker(context.Background(), nil, config.Config{BackgroundJobsEnabled: false})
+	if _, ok := reg.handler(JobTypeEmailDelivery); !ok {
+		t.Fatal("email.delivery not registered")
+	}
+}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -122,6 +122,13 @@ type Config struct {
 	// EmailNotificationsEnabled gates event-driven transactional email (plan 6.2).
 	EmailNotificationsEnabled bool
 
+	// BackgroundJobsEnabled gates the generic Postgres-backed background job
+	// queue worker (plan 17.3, rollout flag background_jobs_enabled).
+	BackgroundJobsEnabled bool
+	// BackgroundJobsConcurrency is the number of jobs processed in parallel per
+	// app instance (default 4 when unset).
+	BackgroundJobsConcurrency int
+
 	// PushNotificationsEnabled gates Web Push (VAPID) notifications (plan 6.3).
 	PushNotificationsEnabled bool
 	// SmsNotificationsEnabled gates SMS notification enqueueing (Twilio delivery).
@@ -742,6 +749,8 @@ func Load() Config {
 		CanvasImportConcurrency:           canvasImportConcurrency(),
 		CanvasSubmissionSyncQueueName:     stringDefault(firstNonEmptyTrimmed("CANVAS_SUBMISSION_SYNC_QUEUE_NAME"), "canvas.submission.sync"),
 		CanvasSubmissionSyncConcurrency:   canvasSubmissionSyncConcurrency(),
+		BackgroundJobsEnabled:             boolEnv("BACKGROUND_JOBS_ENABLED"),
+		BackgroundJobsConcurrency:         intEnvDefault("BACKGROUND_JOBS_CONCURRENCY", 4),
 		SmsNotificationsEnabled:           boolEnv("SMS_NOTIFICATIONS_ENABLED"),
 		SmsNotificationQueueName:          stringDefault(firstNonEmptyTrimmed("SMS_NOTIFICATION_QUEUE_NAME"), "notifications.sms"),
 		SmsNotificationConcurrency:        smsNotificationConcurrency(),

--- a/server/internal/httpserver/admin_jobs.go
+++ b/server/internal/httpserver/admin_jobs.go
@@ -1,0 +1,128 @@
+package httpserver
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/repos/jobqueue"
+)
+
+func jobsMethodNotAllowed(w http.ResponseWriter, allow string) {
+	w.Header().Set("Allow", allow)
+	http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+}
+
+// handleAdminJobsList returns queue stats plus a recent-jobs list for the admin
+// jobs page (plan 17.3 §9 GET /admin/jobs).
+func (d Deps) handleAdminJobsList() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			jobsMethodNotAllowed(w, http.MethodGet)
+			return
+		}
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+		stats, err := jobqueue.GetStats(r.Context(), d.Pool)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Server misconfiguration.")
+			return
+		}
+		jobs, err := jobqueue.ListJobs(r.Context(), d.Pool, 100)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Server misconfiguration.")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"stats": stats,
+			"jobs":  jobs,
+		})
+	}
+}
+
+// handleAdminJobsDeadLetters lists dead-letter jobs (plan 17.3 §9).
+func (d Deps) handleAdminJobsDeadLetters() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			jobsMethodNotAllowed(w, http.MethodGet)
+			return
+		}
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+		rows, err := jobqueue.ListDeadLetters(r.Context(), d.Pool, 100)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Server misconfiguration.")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"deadLetters": rows})
+	}
+}
+
+// handleAdminJobsRedrive re-enqueues a dead-letter job (plan 17.3 AC-5).
+func (d Deps) handleAdminJobsRedrive() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			jobsMethodNotAllowed(w, http.MethodPost)
+			return
+		}
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+		id, err := uuid.Parse(chi.URLParam(r, "id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid job id.")
+			return
+		}
+		newID, err := jobqueue.Redrive(r.Context(), d.Pool, id, time.Now().UTC())
+		if errors.Is(err, jobqueue.ErrNotFound) {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Dead-letter job not found.")
+			return
+		}
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Server misconfiguration.")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"jobId": newID.String()})
+	}
+}
+
+// handleAdminJobsCancel deletes a pending job (plan 17.3 §9 DELETE /admin/jobs/{id}).
+func (d Deps) handleAdminJobsCancel() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			jobsMethodNotAllowed(w, http.MethodDelete)
+			return
+		}
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+		id, err := uuid.Parse(chi.URLParam(r, "id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid job id.")
+			return
+		}
+		err = jobqueue.Cancel(r.Context(), d.Pool, id)
+		if errors.Is(err, jobqueue.ErrNotFound) {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Pending job not found.")
+			return
+		}
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Server misconfiguration.")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	}
+}
+
+func (d Deps) registerAdminJobRoutes(r chi.Router) {
+	r.Get("/api/v1/admin/jobs", d.handleAdminJobsList())
+	r.Get("/api/v1/admin/jobs/dead-letters", d.handleAdminJobsDeadLetters())
+	r.Post("/api/v1/admin/jobs/dead-letters/{id}/redrive", d.handleAdminJobsRedrive())
+	r.Delete("/api/v1/admin/jobs/{id}", d.handleAdminJobsCancel())
+}

--- a/server/internal/httpserver/admin_jobs_nodb_test.go
+++ b/server/internal/httpserver/admin_jobs_nodb_test.go
@@ -1,0 +1,36 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/config"
+)
+
+// Admin job-queue routes require authentication; unauthenticated requests must
+// be rejected before any DB access (plan 17.3 §9 admin JWT).
+func TestAdminJobs_Unauthenticated(t *testing.T) {
+	signer := auth.NewJWTSigner("01234567890123456789012345678901")
+	d := Deps{Pool: nil, JWTSigner: signer, Config: config.Config{}}
+	h := NewHandler(d)
+
+	cases := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/admin/jobs"},
+		{http.MethodGet, "/api/v1/admin/jobs/dead-letters"},
+		{http.MethodPost, "/api/v1/admin/jobs/dead-letters/00000000-0000-0000-0000-000000000001/redrive"},
+		{http.MethodDelete, "/api/v1/admin/jobs/00000000-0000-0000-0000-000000000001"},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s: want 401 got %d", tc.method, tc.path, w.Code)
+		}
+	}
+}

--- a/server/internal/httpserver/canvas_grade_import.go
+++ b/server/internal/httpserver/canvas_grade_import.go
@@ -746,7 +746,7 @@ func canvasImportAllCanvasGrades(
 	if err := canvasImportQuizGrades(ctx, tx, client, canvasBase, accessToken, canvasCourseID, courseID, canvasQuizToItem, canvasUserToLocal, quizSubsByQuiz); err != nil {
 		return err
 	}
-	if err := canvasImportQuizAttempts(ctx, tx, client, canvasBase, accessToken, canvasCourseID, courseID, canvasQuizToItem, canvasQuizToQuestions, canvasQuizToAssignmentID, canvasUserToLocal, quizSubsByQuiz); err != nil {
+	if err := canvasImportQuizAttempts(ctx, tx, client, canvasBase, accessToken, canvasCourseID, courseID, canvasQuizToItem, canvasQuizToQuestions, canvasQuizToAssignmentID, canvasUserToLocal, quizSubsByQuiz, submissionDeps); err != nil {
 		return err
 	}
 	return nil

--- a/server/internal/httpserver/canvas_quiz_import.go
+++ b/server/internal/httpserver/canvas_quiz_import.go
@@ -329,6 +329,23 @@ func canvasQuestionToQuizQuestion(q map[string]any) (coursemodulequiz.QuizQuesti
 			SrsEligible:        false,
 		}, true
 
+	case "file_upload_question":
+		return coursemodulequiz.QuizQuestion{
+			ID:                 fmt.Sprintf("canvas-%d", id),
+			Prompt:             prompt,
+			QuestionType:       "file_upload",
+			Choices:            nil,
+			ChoiceIDs:          nil,
+			TypeConfig:         blankTC,
+			CorrectChoiceIndex: nil,
+			MultipleAnswer:     false,
+			AnswerWithImage:    false,
+			Required:           true,
+			Points:             canvasPointsPossibleI32(q),
+			EstimatedMinutes:   5,
+			SrsEligible:        false,
+		}, true
+
 	case "numerical_question":
 		tc := canvasNumericTypeConfig(answers)
 		return coursemodulequiz.QuizQuestion{

--- a/server/internal/httpserver/canvas_quiz_import_test.go
+++ b/server/internal/httpserver/canvas_quiz_import_test.go
@@ -253,6 +253,77 @@ func TestCanvasMergeSubmissionAnswers_questionRowUsesQuizQuestionID(t *testing.T
 	}
 }
 
+func TestCanvasQuestionToQuizQuestion_FileUpload(t *testing.T) {
+	q := map[string]any{
+		"id":              float64(501),
+		"question_type":   "file_upload_question",
+		"question_text":   "<p>List the tasks that you have been assigned:</p>",
+		"points_possible": float64(10),
+	}
+	qq, ok := canvasQuestionToQuizQuestion(q)
+	if !ok {
+		t.Fatalf("expected file upload question to convert")
+	}
+	if qq.QuestionType != "file_upload" {
+		t.Fatalf("expected file_upload type, got %q", qq.QuestionType)
+	}
+	if qq.Points != 10 {
+		t.Fatalf("expected 10 points, got %d", qq.Points)
+	}
+}
+
+func TestCanvasAttachmentIDsFromMap(t *testing.T) {
+	got := canvasAttachmentIDsFromMap(map[string]any{
+		"attachment_ids": []any{float64(11), "12", float64(11)},
+	})
+	if len(got) != 2 || got[0] != 11 || got[1] != 12 {
+		t.Fatalf("expected [11 12] deduped, got %v", got)
+	}
+	objs := canvasAttachmentIDsFromMap(map[string]any{
+		"attachments": []any{map[string]any{"id": float64(99)}},
+	})
+	if len(objs) != 1 || objs[0] != 99 {
+		t.Fatalf("expected [99] from attachment objects, got %v", objs)
+	}
+	if ids := canvasAttachmentIDsFromMap(map[string]any{"text": "no files"}); len(ids) != 0 {
+		t.Fatalf("expected no attachment ids, got %v", ids)
+	}
+}
+
+func TestCanvasParseSubmissionData_fileUploadAttachments(t *testing.T) {
+	raw := []any{
+		map[string]any{
+			"question_id":    float64(501),
+			"attachment_ids": []any{float64(11), float64(12)},
+		},
+	}
+	answers := canvasParseSubmissionData(raw)
+	if len(answers) != 1 || answers[0].CanvasQuestionID != 501 {
+		t.Fatalf("unexpected: %+v", answers)
+	}
+	if len(answers[0].AttachmentIDs) != 2 {
+		t.Fatalf("expected 2 attachment ids, got %v", answers[0].AttachmentIDs)
+	}
+}
+
+func TestCanvasInjectFilesIntoResponseJSON(t *testing.T) {
+	base := json.RawMessage(`{"textAnswer":"see files"}`)
+	out := canvasInjectFilesIntoResponseJSON(base, []canvasImportedQuizFile{
+		{Filename: "image.png", MimeType: "image/png", ContentPath: "/c/1"},
+	})
+	var parsed map[string]any
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if parsed["textAnswer"] != "see files" {
+		t.Fatalf("expected textAnswer preserved, got %v", parsed["textAnswer"])
+	}
+	files, ok := parsed["files"].([]any)
+	if !ok || len(files) != 1 {
+		t.Fatalf("expected 1 file, got %v", parsed["files"])
+	}
+}
+
 func TestCanvasParseSubmissionDataMap_questionPrefixKeys(t *testing.T) {
 	raw := map[string]any{
 		"question_42": "My contributions this sprint have been: shipping the API.",

--- a/server/internal/httpserver/canvas_quiz_submissions_import.go
+++ b/server/internal/httpserver/canvas_quiz_submissions_import.go
@@ -25,6 +25,63 @@ type canvasQuizSubmissionAnswer struct {
 	Answer           any
 	Points           *float64
 	Correct          *bool
+	AttachmentIDs    []int64
+}
+
+// canvasAttachmentIDsFromMap collects Canvas attachment ids from a submission-data entry,
+// question row, or quiz event payload. Canvas exposes file-upload answers as attachment_ids
+// (and sometimes an inline attachments array), so we accept ids, id strings, and file objects.
+func canvasAttachmentIDsFromMap(m map[string]any) []int64 {
+	if m == nil {
+		return nil
+	}
+	var out []int64
+	seen := make(map[int64]struct{})
+	add := func(id int64) {
+		if id <= 0 {
+			return
+		}
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	for _, key := range []string{"attachment_ids", "attachment_id", "attachments"} {
+		switch v := m[key].(type) {
+		case []any:
+			for _, it := range v {
+				switch iv := it.(type) {
+				case map[string]any:
+					add(int64At(iv, "id"))
+				default:
+					add(canvasAttachmentIDFromAny(iv))
+				}
+			}
+		case map[string]any:
+			add(int64At(v, "id"))
+		default:
+			add(canvasAttachmentIDFromAny(v))
+		}
+	}
+	return out
+}
+
+func canvasAttachmentIDFromAny(v any) int64 {
+	switch t := v.(type) {
+	case float64:
+		return int64(t)
+	case int64:
+		return t
+	case string:
+		n, err := strconv.ParseInt(strings.TrimSpace(t), 10, 64)
+		if err != nil {
+			return 0
+		}
+		return n
+	default:
+		return 0
+	}
 }
 
 func canvasQuizSubmissionImportable(m map[string]any) bool {
@@ -359,6 +416,7 @@ func canvasParseSubmissionDataEntry(m map[string]any) []canvasQuizSubmissionAnsw
 		Answer:           answer,
 		Points:           pts,
 		Correct:          correct,
+		AttachmentIDs:    canvasAttachmentIDsFromMap(m),
 	}}
 }
 
@@ -406,12 +464,14 @@ func canvasMergeAnswersFromQuizEvents(events []map[string]any) map[int64]canvasQ
 			continue
 		}
 		answer := canvasAnswerValueFromMap(data)
-		if answer == nil {
+		attachmentIDs := canvasAttachmentIDsFromMap(data)
+		if answer == nil && len(attachmentIDs) == 0 {
 			continue
 		}
 		out[qid] = canvasMergeQuizSubmissionAnswer(out[qid], canvasQuizSubmissionAnswer{
 			CanvasQuestionID: qid,
 			Answer:           answer,
+			AttachmentIDs:    attachmentIDs,
 		})
 	}
 	return out
@@ -440,6 +500,9 @@ func canvasMergeSubmissionAnswers(sources []map[string]any, questionRows []map[s
 		prev := out[qid]
 		if prev.Answer == nil {
 			prev.Answer = canvasAnswerFromQuestionRow(row)
+		}
+		if len(prev.AttachmentIDs) == 0 {
+			prev.AttachmentIDs = canvasAttachmentIDsFromMap(row)
 		}
 		if prev.Points == nil {
 			if v, ok := coerceCanvasJSONNumber(row["points"]); ok {
@@ -497,6 +560,9 @@ func canvasMergeQuizSubmissionAnswer(existing, incoming canvasQuizSubmissionAnsw
 		}
 		if incoming.Correct != nil {
 			existing.Correct = incoming.Correct
+		}
+		if len(incoming.AttachmentIDs) > 0 {
+			existing.AttachmentIDs = incoming.AttachmentIDs
 		}
 	}
 	return existing
@@ -941,9 +1007,94 @@ RETURNING id
 	return attemptID, err
 }
 
+// canvasImportedQuizFile is the per-file reference stored in a quiz response's response_json so
+// the grading UI can render images inline and link other uploads. ContentPath points at the
+// course-file content endpoint where the downloaded blob is served.
+type canvasImportedQuizFile struct {
+	FileID      uuid.UUID `json:"fileId"`
+	Filename    string    `json:"filename"`
+	MimeType    string    `json:"mimeType"`
+	ContentPath string    `json:"contentPath"`
+}
+
+func canvasGetFile(
+	ctx context.Context,
+	client *http.Client,
+	canvasBase, accessToken string,
+	fileID int64,
+) (map[string]any, error) {
+	return canvasGetObject(ctx, client, canvasBase, accessToken, fmt.Sprintf("files/%d", fileID), nil)
+}
+
+// canvasImportQuizResponseAttachments downloads each Canvas file-upload attachment into the course
+// file store and returns references for embedding in the response JSON. Individual failures are
+// logged and skipped so one bad attachment never aborts the whole import.
+func canvasImportQuizResponseAttachments(
+	ctx context.Context,
+	tx pgx.Tx,
+	client *http.Client,
+	canvasBase, accessToken string,
+	deps *canvasAssignmentSubmissionImportDeps,
+	courseID uuid.UUID,
+	attachmentIDs []int64,
+) []canvasImportedQuizFile {
+	if deps == nil || len(attachmentIDs) == 0 {
+		return nil
+	}
+	out := make([]canvasImportedQuizFile, 0, len(attachmentIDs))
+	for _, attID := range attachmentIDs {
+		if attID <= 0 {
+			continue
+		}
+		fileObj, err := canvasGetFile(ctx, client, canvasBase, accessToken, attID)
+		if err != nil || fileObj == nil {
+			log.Printf("canvas-import: quiz response attachment %d metadata fetch failed: %v", attID, err)
+			continue
+		}
+		fileID, err := canvasStreamAndStoreSubmissionAttachment(ctx, tx, client, accessToken, *deps, courseID, fileObj)
+		if err != nil {
+			log.Printf("canvas-import: quiz response attachment %d download failed: %v", attID, err)
+			continue
+		}
+		if fileID == nil {
+			continue
+		}
+		out = append(out, canvasImportedQuizFile{
+			FileID:      *fileID,
+			Filename:    canvasSubmissionAttachmentFilename(fileObj),
+			MimeType:    canvasSubmissionAttachmentMimeType(fileObj, ""),
+			ContentPath: fmt.Sprintf("/api/v1/courses/%s/course-files/%s/content", deps.CourseCode, fileID.String()),
+		})
+	}
+	return out
+}
+
+func canvasInjectFilesIntoResponseJSON(responseJSON json.RawMessage, files []canvasImportedQuizFile) json.RawMessage {
+	if len(files) == 0 {
+		return responseJSON
+	}
+	obj := map[string]any{}
+	if len(responseJSON) > 0 {
+		_ = json.Unmarshal(responseJSON, &obj)
+	}
+	if obj == nil {
+		obj = map[string]any{}
+	}
+	obj["files"] = files
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return responseJSON
+	}
+	return b
+}
+
 func canvasReplaceImportedQuizResponses(
 	ctx context.Context,
 	tx pgx.Tx,
+	client *http.Client,
+	canvasBase, accessToken string,
+	deps *canvasAssignmentSubmissionImportDeps,
+	courseID uuid.UUID,
 	attemptID uuid.UUID,
 	questions []coursemodulequiz.QuizQuestion,
 	answers map[int64]canvasQuizSubmissionAnswer,
@@ -963,6 +1114,9 @@ func canvasReplaceImportedQuizResponses(
 		responseJSON, isCorrect, pointsAwarded, maxPoints := canvasGradeImportedQuestion(
 			q, answer, choiceMaps[canvasQID], correctAnswerIDs[canvasQID],
 		)
+		if files := canvasImportQuizResponseAttachments(ctx, tx, client, canvasBase, accessToken, deps, courseID, answer.AttachmentIDs); len(files) > 0 {
+			responseJSON = canvasInjectFilesIntoResponseJSON(responseJSON, files)
+		}
 		_, err := tx.Exec(ctx, `
 INSERT INTO course.quiz_responses (
   attempt_id, question_index, question_id, question_type, prompt_snapshot,
@@ -1153,6 +1307,7 @@ func canvasImportQuizAttempts(
 	canvasQuizToAssignmentID map[int64]int64,
 	canvasUserToLocal map[int64]uuid.UUID,
 	quizSubsByQuiz map[int64][]map[string]any,
+	submissionDeps *canvasAssignmentSubmissionImportDeps,
 ) error {
 	quizIDs := canvasQuizIDsFromMap(canvasQuizToItem)
 	answerMetaByQuiz, err := canvasFetchQuizAnswerMetadataParallel(ctx, client, canvasBase, accessToken, canvasCourseID, quizIDs)
@@ -1260,7 +1415,7 @@ func canvasImportQuizAttempts(
 			if err != nil {
 				return fmt.Errorf("save quiz attempt canvas submission %d: %w", submissionID, err)
 			}
-			if err := canvasReplaceImportedQuizResponses(ctx, tx, attemptID, questions, answers, choiceMaps, correctAnswerIDs); err != nil {
+			if err := canvasReplaceImportedQuizResponses(ctx, tx, client, canvasBase, accessToken, submissionDeps, courseID, attemptID, questions, answers, choiceMaps, correctAnswerIDs); err != nil {
 				return fmt.Errorf("save quiz responses canvas submission %d: %w", submissionID, err)
 			}
 		}

--- a/server/internal/httpserver/server.go
+++ b/server/internal/httpserver/server.go
@@ -158,6 +158,7 @@ func NewHandler(d Deps) http.Handler {
 	d.registerStandardsRoutes(r)
 	d.registerSettingsRoutes(r)
 	d.registerAdminRoutes(r)
+	d.registerAdminJobRoutes(r)
 	d.registerSCIMRoutes(r)
 	r.Route("/api/v1", func(s chi.Router) { d.registerAccommodationRoutes(s) })
 	d.registerAttendanceRoutes(r)

--- a/server/internal/repos/jobqueue/backoff.go
+++ b/server/internal/repos/jobqueue/backoff.go
@@ -1,0 +1,35 @@
+package jobqueue
+
+import "time"
+
+// retryDelays is the exponential backoff schedule applied between attempts
+// (plan 17.3 FR-4). The Nth failed attempt waits retryDelays[N-1] before the
+// row becomes eligible again. Attempts beyond the schedule reuse the final
+// delay until max_attempts is reached.
+var retryDelays = []time.Duration{
+	1 * time.Minute,
+	5 * time.Minute,
+	30 * time.Minute,
+	2 * time.Hour,
+	8 * time.Hour,
+}
+
+// BackoffDelay returns how long to wait before the given attempt number is
+// retried. attempt is the number of attempts already made (1 after the first
+// failure). Values <= 0 are treated as 1.
+func BackoffDelay(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	idx := attempt - 1
+	if idx >= len(retryDelays) {
+		idx = len(retryDelays) - 1
+	}
+	return retryDelays[idx]
+}
+
+// NextRetryAt returns the absolute time a job should next become eligible after
+// failing for the attempt-th time.
+func NextRetryAt(now time.Time, attempt int) time.Time {
+	return now.Add(BackoffDelay(attempt))
+}

--- a/server/internal/repos/jobqueue/backoff_test.go
+++ b/server/internal/repos/jobqueue/backoff_test.go
@@ -1,0 +1,36 @@
+package jobqueue
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBackoffDelay_Schedule(t *testing.T) {
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{0, 1 * time.Minute},  // clamped to 1
+		{1, 1 * time.Minute},
+		{2, 5 * time.Minute},
+		{3, 30 * time.Minute},
+		{4, 2 * time.Hour},
+		{5, 8 * time.Hour},
+		{6, 8 * time.Hour}, // beyond schedule reuses final delay
+		{99, 8 * time.Hour},
+	}
+	for _, c := range cases {
+		if got := BackoffDelay(c.attempt); got != c.want {
+			t.Errorf("BackoffDelay(%d) = %s, want %s", c.attempt, got, c.want)
+		}
+	}
+}
+
+func TestNextRetryAt(t *testing.T) {
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	got := NextRetryAt(now, 2)
+	want := now.Add(5 * time.Minute)
+	if !got.Equal(want) {
+		t.Fatalf("NextRetryAt = %s, want %s", got, want)
+	}
+}

--- a/server/internal/repos/jobqueue/repo.go
+++ b/server/internal/repos/jobqueue/repo.go
@@ -1,0 +1,430 @@
+// Package jobqueue is the durable Postgres-backed store for the generic
+// background job queue (plan 17.3). It provides enqueue, SKIP LOCKED claim with
+// a visibility timeout, retry with exponential backoff, dead-letter handling,
+// and the queries powering the admin jobs UI.
+package jobqueue
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// DefaultMaxAttempts is used when an enqueue does not specify one.
+const DefaultMaxAttempts = 5
+
+// DefaultVisibilityTimeout is how long a claimed ("running") job may run before
+// a worker is presumed dead and the row becomes reclaimable (plan 17.3 AC-3).
+const DefaultVisibilityTimeout = 10 * time.Minute
+
+// EnqueueParams describes a job to insert.
+type EnqueueParams struct {
+	JobType     string
+	Payload     any    // marshalled to JSON; nil becomes {}
+	Priority    int    // 1 (highest) .. 10 (lowest); 0 defaults to 5
+	MaxAttempts int    // 0 defaults to DefaultMaxAttempts
+	UniqueKey   string // optional dedup key; empty disables dedup
+	ScheduledAt time.Time
+}
+
+// Claimed is a job leased to a worker for execution.
+type Claimed struct {
+	ID          uuid.UUID
+	JobType     string
+	Payload     json.RawMessage
+	Attempts    int
+	MaxAttempts int
+	Priority    int
+	UniqueKey   *string
+}
+
+// Enqueue inserts a job and returns its id. When UniqueKey is set and an
+// in-flight job with that key already exists, the existing job's id is returned
+// and no new row is created (plan 17.3 FR-8).
+func Enqueue(ctx context.Context, pool *pgxpool.Pool, p EnqueueParams) (uuid.UUID, error) {
+	priority := p.Priority
+	if priority <= 0 {
+		priority = 5
+	}
+	maxAttempts := p.MaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = DefaultMaxAttempts
+	}
+	scheduledAt := p.ScheduledAt
+	if scheduledAt.IsZero() {
+		scheduledAt = time.Now().UTC()
+	}
+	raw, err := marshalPayload(p.Payload)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	var uniqueKey *string
+	if p.UniqueKey != "" {
+		uniqueKey = &p.UniqueKey
+	}
+
+	var id uuid.UUID
+	err = pool.QueryRow(ctx, `
+INSERT INTO jobs.queue (job_type, payload, priority, max_attempts, unique_key, scheduled_at)
+VALUES ($1, $2::jsonb, $3, $4, $5, $6)
+ON CONFLICT (unique_key) WHERE unique_key IS NOT NULL AND status IN ('pending','running','failed')
+DO NOTHING
+RETURNING id
+`, p.JobType, raw, priority, maxAttempts, uniqueKey, scheduledAt).Scan(&id)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Deduped against an existing in-flight job; return its id.
+		if uniqueKey == nil {
+			return uuid.Nil, err
+		}
+		qerr := pool.QueryRow(ctx, `
+SELECT id FROM jobs.queue
+WHERE unique_key = $1 AND status IN ('pending','running','failed')
+ORDER BY created_at
+LIMIT 1
+`, *uniqueKey).Scan(&id)
+		return id, qerr
+	}
+	return id, err
+}
+
+// Claim leases up to limit ready jobs to this worker using SELECT ... FOR UPDATE
+// SKIP LOCKED so concurrent workers never double-process a row (plan 17.3 AC-4).
+// Rows whose visibility timeout has elapsed while "running" are reclaimed, which
+// recovers jobs orphaned by a worker crash (plan 17.3 AC-3). Claiming a job
+// increments its attempt counter.
+func Claim(ctx context.Context, pool *pgxpool.Pool, limit int, now time.Time, visibility time.Duration) ([]Claimed, error) {
+	if limit <= 0 {
+		limit = 1
+	}
+	if visibility <= 0 {
+		visibility = DefaultVisibilityTimeout
+	}
+	staleBefore := now.Add(-visibility)
+	rows, err := pool.Query(ctx, `
+WITH claimed AS (
+    SELECT id
+    FROM jobs.queue
+    WHERE (status IN ('pending','failed') AND scheduled_at <= $1)
+       OR (status = 'running' AND started_at < $2)
+    ORDER BY priority ASC, scheduled_at ASC
+    LIMIT $3
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE jobs.queue q
+SET status = 'running', started_at = $1, attempts = q.attempts + 1
+FROM claimed
+WHERE q.id = claimed.id
+RETURNING q.id, q.job_type, q.payload, q.attempts, q.max_attempts, q.priority, q.unique_key
+`, now, staleBefore, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Claimed
+	for rows.Next() {
+		var c Claimed
+		if err := rows.Scan(&c.ID, &c.JobType, &c.Payload, &c.Attempts, &c.MaxAttempts, &c.Priority, &c.UniqueKey); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// Complete marks a running job done.
+func Complete(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID, now time.Time) error {
+	_, err := pool.Exec(ctx, `
+UPDATE jobs.queue
+SET status = 'completed', completed_at = $2, error_log = NULL
+WHERE id = $1
+`, id, now)
+	return err
+}
+
+// Fail records a failed attempt. If the job still has attempts remaining it is
+// re-scheduled with exponential backoff (plan 17.3 FR-4); otherwise it is moved
+// to the dead-letter table. Returns true when the job was dead-lettered.
+func Fail(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID, now time.Time, errMsg string) (deadLettered bool, err error) {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var (
+		jobType     string
+		payload     json.RawMessage
+		priority    int
+		attempts    int
+		maxAttempts int
+		uniqueKey   *string
+	)
+	err = tx.QueryRow(ctx, `
+SELECT job_type, payload, priority, attempts, max_attempts, unique_key
+FROM jobs.queue WHERE id = $1 FOR UPDATE
+`, id).Scan(&jobType, &payload, &priority, &attempts, &maxAttempts, &uniqueKey)
+	if err != nil {
+		return false, err
+	}
+
+	if attempts >= maxAttempts {
+		if _, err = tx.Exec(ctx, `
+INSERT INTO jobs.dead_letters (id, job_type, payload, priority, unique_key, attempts, error_log)
+VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7)
+`, id, jobType, payload, priority, uniqueKey, attempts, truncateErr(errMsg)); err != nil {
+			return false, err
+		}
+		if _, err = tx.Exec(ctx, `DELETE FROM jobs.queue WHERE id = $1`, id); err != nil {
+			return false, err
+		}
+		if err = tx.Commit(ctx); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	next := NextRetryAt(now, attempts)
+	if _, err = tx.Exec(ctx, `
+UPDATE jobs.queue
+SET status = 'failed', scheduled_at = $2, error_log = $3, started_at = NULL
+WHERE id = $1
+`, id, next, truncateErr(errMsg)); err != nil {
+		return false, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+// Stats summarises queue health for the admin UI and metrics (plan 17.3 §10).
+type Stats struct {
+	Pending     int            `json:"pending"`
+	Running     int            `json:"running"`
+	Failed      int            `json:"failed"`
+	DeadLetters int            `json:"deadLetters"`
+	Depth       int            `json:"depth"` // pending + failed + running
+	ByType      map[string]int `json:"byType"`
+}
+
+// GetStats returns counts by status, queue depth by job type, and dead-letter
+// depth.
+func GetStats(ctx context.Context, pool *pgxpool.Pool) (Stats, error) {
+	s := Stats{ByType: map[string]int{}}
+	rows, err := pool.Query(ctx, `SELECT status, count(*) FROM jobs.queue GROUP BY status`)
+	if err != nil {
+		return s, err
+	}
+	for rows.Next() {
+		var status string
+		var n int
+		if err := rows.Scan(&status, &n); err != nil {
+			rows.Close()
+			return s, err
+		}
+		switch status {
+		case "pending":
+			s.Pending += n
+		case "running":
+			s.Running += n
+		case "failed":
+			s.Failed += n
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return s, err
+	}
+	s.Depth = s.Pending + s.Running + s.Failed
+
+	typeRows, err := pool.Query(ctx, `
+SELECT job_type, count(*) FROM jobs.queue
+WHERE status IN ('pending','running','failed')
+GROUP BY job_type ORDER BY count(*) DESC
+`)
+	if err != nil {
+		return s, err
+	}
+	for typeRows.Next() {
+		var jt string
+		var n int
+		if err := typeRows.Scan(&jt, &n); err != nil {
+			typeRows.Close()
+			return s, err
+		}
+		s.ByType[jt] = n
+	}
+	typeRows.Close()
+	if err := typeRows.Err(); err != nil {
+		return s, err
+	}
+
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM jobs.dead_letters WHERE NOT redriven`).Scan(&s.DeadLetters); err != nil {
+		return s, err
+	}
+	return s, nil
+}
+
+// JobRow is a queue row for admin listing.
+type JobRow struct {
+	ID          uuid.UUID  `json:"id"`
+	JobType     string     `json:"jobType"`
+	Status      string     `json:"status"`
+	Priority    int        `json:"priority"`
+	Attempts    int        `json:"attempts"`
+	MaxAttempts int        `json:"maxAttempts"`
+	ScheduledAt time.Time  `json:"scheduledAt"`
+	StartedAt   *time.Time `json:"startedAt,omitempty"`
+	ErrorLog    *string    `json:"errorLog,omitempty"`
+	CreatedAt   time.Time  `json:"createdAt"`
+}
+
+// ListJobs returns recent queue rows, newest first.
+func ListJobs(ctx context.Context, pool *pgxpool.Pool, limit int) ([]JobRow, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	rows, err := pool.Query(ctx, `
+SELECT id, job_type, status, priority, attempts, max_attempts, scheduled_at, started_at, error_log, created_at
+FROM jobs.queue
+ORDER BY created_at DESC
+LIMIT $1
+`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]JobRow, 0, limit)
+	for rows.Next() {
+		var j JobRow
+		if err := rows.Scan(&j.ID, &j.JobType, &j.Status, &j.Priority, &j.Attempts, &j.MaxAttempts,
+			&j.ScheduledAt, &j.StartedAt, &j.ErrorLog, &j.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, j)
+	}
+	return out, rows.Err()
+}
+
+// DeadLetter is a row in the dead-letter table.
+type DeadLetter struct {
+	ID       uuid.UUID `json:"id"`
+	JobType  string    `json:"jobType"`
+	Attempts int       `json:"attempts"`
+	ErrorLog *string   `json:"errorLog,omitempty"`
+	FailedAt time.Time `json:"failedAt"`
+	Redriven bool      `json:"redriven"`
+}
+
+// ListDeadLetters returns dead-letter rows, newest failure first.
+func ListDeadLetters(ctx context.Context, pool *pgxpool.Pool, limit int) ([]DeadLetter, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	rows, err := pool.Query(ctx, `
+SELECT id, job_type, attempts, error_log, failed_at, redriven
+FROM jobs.dead_letters
+ORDER BY failed_at DESC
+LIMIT $1
+`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]DeadLetter, 0, limit)
+	for rows.Next() {
+		var d DeadLetter
+		if err := rows.Scan(&d.ID, &d.JobType, &d.Attempts, &d.ErrorLog, &d.FailedAt, &d.Redriven); err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// ErrNotFound is returned when a redrive or cancel targets a missing/ineligible job.
+var ErrNotFound = errors.New("jobqueue: job not found")
+
+// Redrive re-enqueues a dead-letter job with a fresh attempt count (plan 17.3
+// AC-5). The dead-letter row is marked redriven and a new pending queue row is
+// created. Returns the new job id.
+func Redrive(ctx context.Context, pool *pgxpool.Pool, deadLetterID uuid.UUID, now time.Time) (uuid.UUID, error) {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var (
+		jobType  string
+		payload  json.RawMessage
+		priority int
+	)
+	err = tx.QueryRow(ctx, `
+SELECT job_type, payload, priority FROM jobs.dead_letters
+WHERE id = $1 AND NOT redriven FOR UPDATE
+`, deadLetterID).Scan(&jobType, &payload, &priority)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, ErrNotFound
+	}
+	if err != nil {
+		return uuid.Nil, err
+	}
+
+	var newID uuid.UUID
+	if err = tx.QueryRow(ctx, `
+INSERT INTO jobs.queue (job_type, payload, priority, scheduled_at)
+VALUES ($1, $2::jsonb, $3, $4)
+RETURNING id
+`, jobType, payload, priority, now).Scan(&newID); err != nil {
+		return uuid.Nil, err
+	}
+	if _, err = tx.Exec(ctx, `UPDATE jobs.dead_letters SET redriven = true WHERE id = $1`, deadLetterID); err != nil {
+		return uuid.Nil, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return uuid.Nil, err
+	}
+	return newID, nil
+}
+
+// Cancel deletes a pending job (plan 17.3 §9 DELETE /admin/jobs/{id}). Running,
+// completed, or already-removed jobs cannot be cancelled.
+func Cancel(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID) error {
+	tag, err := pool.Exec(ctx, `DELETE FROM jobs.queue WHERE id = $1 AND status IN ('pending','failed')`, id)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func marshalPayload(v any) ([]byte, error) {
+	if v == nil {
+		return []byte(`{}`), nil
+	}
+	if raw, ok := v.(json.RawMessage); ok {
+		if len(raw) == 0 {
+			return []byte(`{}`), nil
+		}
+		return raw, nil
+	}
+	return json.Marshal(v)
+}
+
+// truncateErr bounds stored error text so a pathological error message cannot
+// bloat the row (plan 17.3 NFR security: error logs kept small, no PII dumps).
+func truncateErr(s string) string {
+	const max = 4000
+	if len(s) > max {
+		return s[:max]
+	}
+	return s
+}

--- a/server/internal/repos/jobqueue/repo_db_test.go
+++ b/server/internal/repos/jobqueue/repo_db_test.go
@@ -1,0 +1,328 @@
+package jobqueue_test
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	serverdata "github.com/lextures/lextures/server"
+	"github.com/lextures/lextures/server/internal/db"
+	"github.com/lextures/lextures/server/internal/migrate"
+	"github.com/lextures/lextures/server/internal/repos/jobqueue"
+)
+
+func testPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reset(t, pool)
+	return pool
+}
+
+func reset(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`TRUNCATE jobs.queue, jobs.dead_letters`); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnqueueClaimComplete(t *testing.T) {
+	pool := testPool(t)
+	defer pool.Close()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	id, err := jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{
+		JobType:     "test.noop",
+		Payload:     map[string]any{"hello": "world"},
+		ScheduledAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claimed, err := jobqueue.Claim(ctx, pool, 10, now, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claimed) != 1 || claimed[0].ID != id {
+		t.Fatalf("want 1 claimed job %s, got %+v", id, claimed)
+	}
+	if claimed[0].Attempts != 1 {
+		t.Fatalf("claim should increment attempts to 1, got %d", claimed[0].Attempts)
+	}
+	if string(claimed[0].Payload) != `{"hello": "world"}` {
+		t.Fatalf("payload roundtrip mismatch: %s", claimed[0].Payload)
+	}
+
+	// A second claim must not re-pick the running job.
+	again, err := jobqueue.Claim(ctx, pool, 10, now, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(again) != 0 {
+		t.Fatalf("running job should not be re-claimed, got %d", len(again))
+	}
+
+	if err := jobqueue.Complete(ctx, pool, id, now); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := jobqueue.GetStats(ctx, pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Depth != 0 {
+		t.Fatalf("completed job should not count toward depth, got %+v", stats)
+	}
+}
+
+func TestDedupByUniqueKey(t *testing.T) {
+	pool := testPool(t)
+	defer pool.Close()
+	ctx := context.Background()
+
+	id1, err := jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{JobType: "t", UniqueKey: "k1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id2, err := jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{JobType: "t", UniqueKey: "k1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id1 != id2 {
+		t.Fatalf("dedup should return existing id: %s vs %s", id1, id2)
+	}
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM jobs.queue WHERE unique_key = 'k1'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("want 1 row for unique key, got %d", count)
+	}
+}
+
+func TestRetryThenDeadLetterAndRedrive(t *testing.T) {
+	pool := testPool(t)
+	defer pool.Close()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	id, err := jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{
+		JobType:     "test.flaky",
+		MaxAttempts: 1, // dead-letter on first failure
+		ScheduledAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimed, err := jobqueue.Claim(ctx, pool, 1, now, time.Minute)
+	if err != nil || len(claimed) != 1 {
+		t.Fatalf("claim: %v %+v", err, claimed)
+	}
+	dead, err := jobqueue.Fail(ctx, pool, id, now, "smtp unreachable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dead {
+		t.Fatal("expected dead-letter after exhausting attempts")
+	}
+	var qcount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM jobs.queue WHERE id = $1`, id).Scan(&qcount); err != nil {
+		t.Fatal(err)
+	}
+	if qcount != 0 {
+		t.Fatal("dead-lettered job should be removed from queue")
+	}
+	dls, err := jobqueue.ListDeadLetters(ctx, pool, 10)
+	if err != nil || len(dls) != 1 {
+		t.Fatalf("dead letters: %v %+v", err, dls)
+	}
+
+	newID, err := jobqueue.Redrive(ctx, pool, dls[0].ID, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reclaimed, err := jobqueue.Claim(ctx, pool, 1, now, time.Minute)
+	if err != nil || len(reclaimed) != 1 || reclaimed[0].ID != newID {
+		t.Fatalf("redriven job should be claimable: %v %+v", err, reclaimed)
+	}
+	// Redriving again must be a no-op (already redriven).
+	if _, err := jobqueue.Redrive(ctx, pool, dls[0].ID, now); err != jobqueue.ErrNotFound {
+		t.Fatalf("re-redrive want ErrNotFound, got %v", err)
+	}
+}
+
+func TestRetryReschedulesWithBackoff(t *testing.T) {
+	pool := testPool(t)
+	defer pool.Close()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	id, err := jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{JobType: "t", MaxAttempts: 3, ScheduledAt: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := jobqueue.Claim(ctx, pool, 1, now, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	dead, err := jobqueue.Fail(ctx, pool, id, now, "transient")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dead {
+		t.Fatal("should not dead-letter with attempts remaining")
+	}
+	// Not eligible immediately (scheduled 1 min out), but eligible after backoff.
+	if c, _ := jobqueue.Claim(ctx, pool, 1, now, time.Minute); len(c) != 0 {
+		t.Fatalf("failed job should wait for backoff, claimed %d", len(c))
+	}
+	later := now.Add(2 * time.Minute)
+	if c, _ := jobqueue.Claim(ctx, pool, 1, later, time.Minute); len(c) != 1 {
+		t.Fatalf("failed job should be eligible after backoff, claimed %d", len(c))
+	}
+}
+
+func TestScheduledJobNotClaimedEarly(t *testing.T) {
+	pool := testPool(t)
+	defer pool.Close()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	if _, err := jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{
+		JobType:     "test.delayed",
+		ScheduledAt: now.Add(10 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if c, _ := jobqueue.Claim(ctx, pool, 5, now, time.Minute); len(c) != 0 {
+		t.Fatalf("delayed job claimed early: %d", len(c))
+	}
+	if c, _ := jobqueue.Claim(ctx, pool, 5, now.Add(11*time.Minute), time.Minute); len(c) != 1 {
+		t.Fatalf("delayed job not claimed after schedule: %d", len(c))
+	}
+}
+
+func TestVisibilityTimeoutReclaim(t *testing.T) {
+	pool := testPool(t)
+	defer pool.Close()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	id, err := jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{JobType: "t", ScheduledAt: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c, _ := jobqueue.Claim(ctx, pool, 1, now, 10*time.Minute); len(c) != 1 {
+		t.Fatalf("initial claim failed: %d", len(c))
+	}
+	// Worker "crashes". 11 minutes later, the row is reclaimable.
+	future := now.Add(11 * time.Minute)
+	c, err := jobqueue.Claim(ctx, pool, 1, future, 10*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c) != 1 || c[0].ID != id {
+		t.Fatalf("visibility timeout did not reclaim job: %+v", c)
+	}
+	if c[0].Attempts != 2 {
+		t.Fatalf("reclaim should re-increment attempts, got %d", c[0].Attempts)
+	}
+}
+
+func TestConcurrentClaimNoDoubleProcessing(t *testing.T) {
+	pool := testPool(t)
+	defer pool.Close()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	const n = 50
+	for i := 0; i < n; i++ {
+		if _, err := jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{JobType: "t", ScheduledAt: now}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var (
+		mu      sync.Mutex
+		seen    = map[uuid.UUID]int{}
+		wg      sync.WaitGroup
+		workers = 8
+	)
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				claimed, err := jobqueue.Claim(ctx, pool, 3, now, time.Minute)
+				if err != nil || len(claimed) == 0 {
+					return
+				}
+				mu.Lock()
+				for _, c := range claimed {
+					seen[c.ID]++
+				}
+				mu.Unlock()
+				for _, c := range claimed {
+					_ = jobqueue.Complete(ctx, pool, c.ID, now)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if len(seen) != n {
+		t.Fatalf("want %d distinct jobs processed, got %d", n, len(seen))
+	}
+	for id, count := range seen {
+		if count != 1 {
+			t.Fatalf("job %s processed %d times (SKIP LOCKED violated)", id, count)
+		}
+	}
+}
+
+func TestCancelPendingOnly(t *testing.T) {
+	pool := testPool(t)
+	defer pool.Close()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	id, err := jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{JobType: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := jobqueue.Cancel(ctx, pool, id); err != nil {
+		t.Fatalf("cancel pending: %v", err)
+	}
+	if err := jobqueue.Cancel(ctx, pool, id); err != jobqueue.ErrNotFound {
+		t.Fatalf("cancel missing want ErrNotFound, got %v", err)
+	}
+
+	// Running jobs cannot be cancelled.
+	id2, err := jobqueue.Enqueue(ctx, pool, jobqueue.EnqueueParams{JobType: "t", ScheduledAt: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := jobqueue.Claim(ctx, pool, 1, now, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	if err := jobqueue.Cancel(ctx, pool, id2); err != jobqueue.ErrNotFound {
+		t.Fatalf("cancel running want ErrNotFound, got %v", err)
+	}
+}

--- a/server/internal/repos/jobqueue/repo_test.go
+++ b/server/internal/repos/jobqueue/repo_test.go
@@ -1,0 +1,58 @@
+package jobqueue
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestMarshalPayload(t *testing.T) {
+	t.Run("nil becomes empty object", func(t *testing.T) {
+		b, err := marshalPayload(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(b) != "{}" {
+			t.Fatalf("got %q", b)
+		}
+	})
+	t.Run("empty raw becomes empty object", func(t *testing.T) {
+		b, err := marshalPayload(json.RawMessage(nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(b) != "{}" {
+			t.Fatalf("got %q", b)
+		}
+	})
+	t.Run("struct marshals", func(t *testing.T) {
+		b, err := marshalPayload(struct {
+			A int `json:"a"`
+		}{A: 7})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(b) != `{"a":7}` {
+			t.Fatalf("got %q", b)
+		}
+	})
+	t.Run("raw passthrough", func(t *testing.T) {
+		b, err := marshalPayload(json.RawMessage(`{"x":1}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(b) != `{"x":1}` {
+			t.Fatalf("got %q", b)
+		}
+	})
+}
+
+func TestTruncateErr(t *testing.T) {
+	if got := truncateErr("short"); got != "short" {
+		t.Fatalf("got %q", got)
+	}
+	long := strings.Repeat("x", 5000)
+	if got := truncateErr(long); len(got) != 4000 {
+		t.Fatalf("want 4000 got %d", len(got))
+	}
+}

--- a/server/migrations/338_job_queue.sql
+++ b/server/migrations/338_job_queue.sql
@@ -1,0 +1,60 @@
+-- Generic background job queue (plan 17.3). A single durable Postgres-backed
+-- queue that any job type can enqueue onto. Workers claim rows with
+-- SELECT ... FOR UPDATE SKIP LOCKED so multiple app instances process jobs
+-- without double-execution, and a visibility timeout reclaims rows whose
+-- worker crashed mid-run.
+
+CREATE SCHEMA IF NOT EXISTS jobs;
+
+CREATE TABLE jobs.queue (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    job_type      TEXT NOT NULL,
+    payload       JSONB NOT NULL DEFAULT '{}'::jsonb,
+    priority      SMALLINT NOT NULL DEFAULT 5,   -- 1 = highest, 10 = lowest
+    status        TEXT NOT NULL DEFAULT 'pending', -- pending | running | completed | failed
+    attempts      SMALLINT NOT NULL DEFAULT 0,
+    max_attempts  SMALLINT NOT NULL DEFAULT 5,
+    unique_key    TEXT,
+    scheduled_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    started_at    TIMESTAMPTZ,
+    completed_at  TIMESTAMPTZ,
+    error_log     TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Deduplication: a logical job (identified by unique_key) may only have one
+-- in-flight copy queued at a time. Once it completes or dead-letters the key is
+-- free to be enqueued again.
+CREATE UNIQUE INDEX uniq_jobs_queue_unique_key
+    ON jobs.queue (unique_key)
+    WHERE unique_key IS NOT NULL AND status IN ('pending', 'running', 'failed');
+
+-- Claim path: workers scan ready rows ordered by priority then schedule.
+CREATE INDEX idx_jobs_queue_claim
+    ON jobs.queue (priority, scheduled_at)
+    WHERE status IN ('pending', 'failed');
+
+-- Visibility-timeout reclaim path: find running rows that started too long ago.
+CREATE INDEX idx_jobs_queue_running_started
+    ON jobs.queue (started_at)
+    WHERE status = 'running';
+
+CREATE TABLE jobs.dead_letters (
+    id          UUID PRIMARY KEY,
+    job_type    TEXT NOT NULL,
+    payload     JSONB NOT NULL,
+    priority    SMALLINT NOT NULL DEFAULT 5,
+    unique_key  TEXT,
+    attempts    SMALLINT NOT NULL DEFAULT 0,
+    error_log   TEXT,
+    failed_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    redriven    BOOLEAN NOT NULL DEFAULT false
+);
+
+CREATE INDEX idx_jobs_dead_letters_failed_at
+    ON jobs.dead_letters (failed_at DESC);
+
+COMMENT ON TABLE jobs.queue IS
+    'Generic durable background job queue (plan 17.3). Claimed via SELECT ... FOR UPDATE SKIP LOCKED.';
+COMMENT ON TABLE jobs.dead_letters IS
+    'Jobs that exhausted max_attempts; re-drivable from the admin jobs UI.';


### PR DESCRIPTION
## Summary

Phase 1 of the **background job queue** (plan [17.3](docs/completed/17-platform-performance-operability/17.3-background-job-queue.md)): a durable Postgres-backed queue any job type can enqueue onto, with an in-binary worker, retry/backoff, dead-lettering, and an admin API. The codebase is Go, so this follows existing queue conventions (`canvasimportqueue`, `emailjobs`, the `background` sweepers) rather than the plan template's Rust references.

Off by default (`BACKGROUND_JOBS_ENABLED`, OpenFeature-style flag) — zero behavior change until enabled.

## What's included

- **Migration `338_job_queue.sql`** — `jobs.queue` + `jobs.dead_letters` with claim/dedup/reclaim indexes.
- **`repos/jobqueue`** — enqueue (priority, `unique_key` dedup, delayed `scheduled_at`), claim via `SELECT … FOR UPDATE SKIP LOCKED` with visibility-timeout reclaim, exponential backoff (1m/5m/30m/2h/8h), dead-letter, redrive, cancel, stats.
- **`background/jobqueue`** — `Handler` interface, job `Registry`, concurrency-bounded panic-isolated worker wired into app startup.
- **Built-in `email.delivery`** job type + `EnqueueEmail`.
- **Admin API** — `GET /admin/jobs`, `GET /admin/jobs/dead-letters`, `POST /admin/jobs/dead-letters/{id}/redrive`, `DELETE /admin/jobs/{id}` (all gated on `global:app:rbac:manage`).
- **Docs** — ADR 0001 (Postgres `SKIP LOCKED` vs Redis) + "adding a job type" guide.

## Acceptance criteria coverage

| AC | Covered by |
|----|-----------|
| AC-2 retry → dead-letter | `TestRetryThenDeadLetterAndRedrive`, `TestWorker_FailingJobDeadLetters` |
| AC-3 visibility reclaim after crash | `TestVisibilityTimeoutReclaim` |
| AC-4 no double processing (SKIP LOCKED) | `TestConcurrentClaimNoDoubleProcessing` (8 workers / 50 jobs) |
| AC-5 re-drive dead letter | `TestRetryThenDeadLetterAndRedrive` |
| AC-6 delayed scheduling | `TestScheduledJobNotClaimedEarly` |

## Testing

- `go build ./...`, `go vet ./internal/...`, golangci-lint: clean.
- Full unit suite: **1975 passed**. Postgres-backed integration (jobqueue + worker pipeline): **24 passed** locally against Postgres 16.
- Admin authz: unauthenticated requests rejected with 401 before DB access.

## Deferred (Phase 2/3, noted in plan)

Admin **web UI** page + axe-core, Playwright e2e (mock SMTP/webhook), k6 load test, and migrating remaining job types (webhooks, AI grading, transcoding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)