### PR TITLE
feat(mobile): Speed Grader and course hero images on iOS and Android

### DIFF
--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/lms/LmsApi.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/lms/LmsApi.kt
@@ -203,7 +203,35 @@ object LmsApi {
         var path = "/api/v1/courses/${encodePath(courseCode)}/assignments/${encodePath(itemId)}/submissions"
         if (!graded.isNullOrEmpty()) path += "?graded=$graded"
         val (body, _) = client.request(path, accessToken = accessToken)
-        decode<SubmissionsListResponse>(body).submissions
+        // Drop roster placeholders (enrolled students with no submission) — no id to grade.
+        decode<SubmissionsListResponse>(body).submissions.filter { it.id.isNotBlank() }
+    }
+
+    suspend fun fetchQuizAttempts(
+        courseCode: String,
+        itemId: String,
+        accessToken: String,
+    ): List<QuizAttemptSummary> = withContext(Dispatchers.IO) {
+        val (body, _) = client.request(
+            "/api/v1/courses/${encodePath(courseCode)}/quizzes/${encodePath(itemId)}/attempts",
+            accessToken = accessToken,
+        )
+        decode<QuizAttemptsListResponse>(body).attempts
+    }
+
+    suspend fun fetchGradingSubmissions(
+        courseCode: String,
+        backlogItem: GradingBacklogItem,
+        graded: String?,
+        accessToken: String,
+    ): List<AssignmentSubmission> = withContext(Dispatchers.IO) {
+        if (backlogItem.isQuiz) {
+            val attempts = fetchQuizAttempts(courseCode, backlogItem.resolvedItemId, accessToken)
+            val submissions = GradingSubmissionMapper.quizAttemptsToSubmissions(attempts)
+            GradingSubmissionMapper.filterSubmissions(submissions, graded ?: "all")
+        } else {
+            fetchSubmissions(courseCode, backlogItem.resolvedItemId, graded, accessToken)
+        }
     }
 
     suspend fun fetchSubmissionGrade(

--- a/clients/android/app/src/main/kotlin/com/lextures/android/core/lms/LmsFeatureModels.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/core/lms/LmsFeatureModels.kt
@@ -185,17 +185,24 @@ data class SyllabusPayload(
 /** Row from `/assignments/{item}/submissions` and `/submissions/mine`. */
 @Serializable
 data class AssignmentSubmission(
-    val id: String,
+    // Defaulted so roster placeholder rows (enrolled students with no submission yet,
+    // which the list endpoint returns without an `id`) decode instead of failing the
+    // whole list; callers drop the blank-id rows since they aren't gradeable.
+    val id: String = "",
     val submittedBy: String? = null,
     val submittedByDisplayName: String? = null,
     val blindLabel: String? = null,
     val attachmentFilename: String? = null,
+    val attachmentMimeType: String? = null,
+    val attachmentContentPath: String? = null,
+    val bodyText: String? = null,
     val submittedAt: String = "",
     val updatedAt: String? = null,
     val versionNumber: Int? = null,
     val resubmissionRequested: Boolean? = null,
     val revisionDueAt: String? = null,
     val revisionFeedback: String? = null,
+    val isGraded: Boolean? = null,
 ) {
     /** Name shown in staff lists; respects blind grading. */
     val displayName: String
@@ -234,15 +241,77 @@ data class SubmissionGradePut(
 
 // endregion
 
+// region Quiz attempts (staff)
+
+/** Row from GET `/quizzes/{item}/attempts`. */
+@Serializable
+data class QuizAttemptSummary(
+    val id: String,
+    val studentUserId: String? = null,
+    val attemptNumber: Int = 1,
+    val submittedAt: String = "",
+    val scorePercent: Double? = null,
+    val pointsEarned: Double = 0.0,
+    val pointsPossible: Double = 0.0,
+    val studentName: String? = null,
+    val needsManualGrading: Boolean? = null,
+)
+
+@Serializable
+data class QuizAttemptsListResponse(
+    val attempts: List<QuizAttemptSummary> = emptyList(),
+)
+
+// endregion
+
 // region Grading backlog (staff)
 
 /** Row from GET `/courses/{code}/grading-backlog`. */
 @Serializable
 data class GradingBacklogItem(
+    val itemId: String? = null,
+    val itemType: String? = null, // "assignment" | "quiz"
     val assignmentId: String,
     val assignmentTitle: String = "",
     val ungradedCount: Int = 0,
-)
+) {
+    val resolvedItemId: String get() = itemId ?: assignmentId
+    val isQuiz: Boolean get() = itemType == "quiz"
+}
+
+object GradingSubmissionMapper {
+    fun quizAttemptsToSubmissions(attempts: List<QuizAttemptSummary>): List<AssignmentSubmission> {
+        val byStudent = linkedMapOf<String, QuizAttemptSummary>()
+        for (attempt in attempts) {
+            val key = attempt.studentUserId?.trim()?.takeIf { it.isNotEmpty() } ?: attempt.id
+            val existing = byStudent[key]
+            if (existing == null || attempt.attemptNumber >= existing.attemptNumber) {
+                byStudent[key] = attempt
+            }
+        }
+        return byStudent.values
+            .sortedBy { it.studentName.orEmpty() }
+            .map { attempt ->
+                AssignmentSubmission(
+                    id = attempt.id,
+                    submittedBy = attempt.studentUserId,
+                    submittedByDisplayName = attempt.studentName,
+                    submittedAt = attempt.submittedAt,
+                    versionNumber = attempt.attemptNumber.takeIf { it > 1 },
+                    isGraded = attempt.needsManualGrading == false,
+                )
+            }
+    }
+
+    fun filterSubmissions(submissions: List<AssignmentSubmission>, graded: String?): List<AssignmentSubmission> {
+        if (graded.isNullOrEmpty() || graded == "all") return submissions
+        return if (graded == "graded") {
+            submissions.filter { it.isGraded == true }
+        } else {
+            submissions.filter { it.isGraded != true }
+        }
+    }
+}
 
 @Serializable
 data class GradingBacklogResponse(

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/dashboard/DashboardTab.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/dashboard/DashboardTab.kt
@@ -72,6 +72,7 @@ import com.lextures.android.features.grading.GradingBacklogScreen
 import com.lextures.android.features.home.HomeShellState
 import com.lextures.android.features.home.LmsAvatarChip
 import com.lextures.android.features.home.LmsCard
+import com.lextures.android.features.home.CourseHeroImage
 import com.lextures.android.features.home.LmsEmptyState
 import com.lextures.android.features.home.LmsErrorBanner
 import com.lextures.android.features.home.LmsSectionHeader
@@ -242,9 +243,9 @@ fun DashboardTab(
         return
     }
 
-    LazyColumn(
+        LazyColumn(
         modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(16.dp),
+        contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 24.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         item {
@@ -419,6 +420,7 @@ fun DashboardTab(
                         CourseCarouselCard(
                             course = course,
                             counts = courseCounts[course.courseCode],
+                            accessToken = accessToken,
                             onClick = { openCourse = course },
                         )
                     }
@@ -612,9 +614,9 @@ fun AnnouncementCard(
 private fun CourseCarouselCard(
     course: CourseSummary,
     counts: Pair<Int, Int>?,
+    accessToken: String?,
     onClick: () -> Unit,
 ) {
-    val dark = isDarkTheme()
     Column(
         modifier = Modifier
             .width(190.dp)
@@ -622,12 +624,13 @@ private fun CourseCarouselCard(
             .background(cardBackground())
             .clickable(onClick = onClick),
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(84.dp)
-                .background(coverBrush(course.courseCode)),
-        ) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            CourseHeroImage(
+                url = course.heroImageUrl,
+                fallbackKey = course.courseCode,
+                accessToken = accessToken,
+                height = 84.dp,
+            )
             Icon(
                 Icons.AutoMirrored.Filled.MenuBook,
                 contentDescription = null,

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/grading/GradingScreens.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/grading/GradingScreens.kt
@@ -127,12 +127,30 @@ fun GradingBacklogSection(
                             )
                         }
                         Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                            Text(
-                                text = item.assignmentTitle,
-                                fontSize = 14.sp,
-                                fontWeight = FontWeight.Medium,
-                                color = textPrimary(),
-                            )
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    text = item.assignmentTitle,
+                                    fontSize = 14.sp,
+                                    fontWeight = FontWeight.Medium,
+                                    color = textPrimary(),
+                                    modifier = Modifier.weight(1f, fill = false),
+                                )
+                                if (item.isQuiz) {
+                                    Text(
+                                        text = "Quiz",
+                                        fontSize = 10.sp,
+                                        fontWeight = FontWeight.SemiBold,
+                                        color = LexturesColors.Amber,
+                                        modifier = Modifier
+                                            .clip(RoundedCornerShape(50))
+                                            .background(LexturesColors.Amber.copy(alpha = 0.14f))
+                                            .padding(horizontal = 6.dp, vertical = 2.dp),
+                                    )
+                                }
+                            }
                             Text(
                                 text = "${item.ungradedCount} ungraded submission${if (item.ungradedCount == 1) "" else "s"}",
                                 fontSize = 12.sp,
@@ -233,21 +251,32 @@ fun SubmissionsListScreen(
     var submissions by remember { mutableStateOf<List<AssignmentSubmission>>(emptyList()) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var loading by remember { mutableStateOf(true) }
-    var grading by remember { mutableStateOf<AssignmentSubmission?>(null) }
+    var quizInfo by remember { mutableStateOf<AssignmentSubmission?>(null) }
+    // Frozen submissions snapshot + starting index for the speed grader.
+    var speedGrader by remember { mutableStateOf<Pair<List<AssignmentSubmission>, Int>?>(null) }
     var reloadKey by remember { mutableStateOf(0) }
 
     BackHandler(onBack = onBack)
 
-    grading?.let { submission ->
-        GradeSubmissionScreen(
+    quizInfo?.let { submission ->
+        QuizAttemptInfoScreen(
+            backlogItem = backlogItem,
+            submission = submission,
+            onDone = { quizInfo = null },
+            modifier = modifier,
+        )
+        return
+    }
+
+    speedGrader?.let { (snapshot, startIndex) ->
+        SpeedGraderScreen(
             session = session,
             course = course,
-            assignmentId = backlogItem.assignmentId,
-            submission = submission,
-            onDone = { saved ->
-                grading = null
-                if (saved) reloadKey++
-            },
+            assignmentId = backlogItem.resolvedItemId,
+            submissions = snapshot,
+            startIndex = startIndex,
+            onSaved = { reloadKey++ },
+            onBack = { speedGrader = null },
             modifier = modifier,
         )
         return
@@ -258,9 +287,9 @@ fun SubmissionsListScreen(
         loading = true
         errorMessage = null
         try {
-            submissions = LmsApi.fetchSubmissions(
+            submissions = LmsApi.fetchGradingSubmissions(
                 courseCode = course.courseCode,
-                itemId = backlogItem.assignmentId,
+                backlogItem = backlogItem,
                 graded = filter.takeIf { it != "all" },
                 accessToken = token,
             )
@@ -324,7 +353,13 @@ fun SubmissionsListScreen(
                 }
             } else {
                 items(submissions, key = { it.id }) { submission ->
-                    LmsCard(onClick = { grading = submission }) {
+                    LmsCard(onClick = {
+                        if (backlogItem.isQuiz) {
+                            quizInfo = submission
+                        } else {
+                            speedGrader = submissions to submissions.indexOf(submission)
+                        }
+                    }) {
                         Row(
                             horizontalArrangement = Arrangement.spacedBy(12.dp),
                             verticalAlignment = Alignment.CenterVertically,
@@ -400,42 +435,15 @@ fun SubmissionsListScreen(
     }
 }
 
-/** Full-screen grade entry: points + comment for one submission. */
+/** Quiz attempts must be graded per question on web (mobile v1 is read-only). */
 @Composable
-fun GradeSubmissionScreen(
-    session: AuthSession,
-    course: CourseSummary,
-    assignmentId: String,
+fun QuizAttemptInfoScreen(
+    backlogItem: GradingBacklogItem,
     submission: AssignmentSubmission,
-    onDone: (saved: Boolean) -> Unit,
+    onDone: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val accessToken by session.accessToken.collectAsState()
-    val scope = rememberCoroutineScope()
-
-    var pointsText by remember { mutableStateOf("") }
-    var comment by remember { mutableStateOf("") }
-    var maxPoints by remember { mutableStateOf<Double?>(null) }
-    var errorMessage by remember { mutableStateOf<String?>(null) }
-    var saving by remember { mutableStateOf(false) }
-
-    BackHandler { onDone(false) }
-
-    LaunchedEffect(accessToken, submission.id) {
-        val token = accessToken ?: return@LaunchedEffect
-        // Pre-fill when a grade already exists; also learns maxPoints for validation.
-        runCatching {
-            LmsApi.fetchSubmissionGrade(course.courseCode, assignmentId, submission.id, token)
-        }.getOrNull()?.let { grade ->
-            maxPoints = grade.maxPoints
-            grade.pointsEarned?.let { pointsText = formatPoints(it) }
-            comment = grade.instructorComment.orEmpty()
-        }
-    }
-
-    val pointsValue = pointsText.replace(',', '.').toDoubleOrNull()
-    val pointsValid = pointsValue != null && pointsValue >= 0 &&
-        (maxPoints == null || pointsValue <= maxPoints!!)
+    BackHandler(onBack = onDone)
 
     Column(modifier = modifier.fillMaxSize()) {
         Row(
@@ -444,11 +452,11 @@ fun GradeSubmissionScreen(
                 .padding(top = 8.dp, end = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            IconButton(onClick = { onDone(false) }) {
+            IconButton(onClick = onDone) {
                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", tint = textPrimary())
             }
             Text(
-                text = "Grade submission",
+                text = "Quiz attempt",
                 fontSize = 18.sp,
                 fontWeight = FontWeight.SemiBold,
                 color = textPrimary(),
@@ -460,10 +468,6 @@ fun GradeSubmissionScreen(
             contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            errorMessage?.let { message ->
-                item { LmsErrorBanner(message) }
-            }
-
             item {
                 LmsCard {
                     Text(text = submission.displayName, style = LexturesType.display(18), color = textPrimary())
@@ -472,132 +476,25 @@ fun GradeSubmissionScreen(
                         fontSize = 12.sp,
                         color = textSecondary(),
                     )
-                    submission.attachmentFilename?.takeIf { it.isNotEmpty() }?.let { filename ->
-                        Text(text = filename, fontSize = 12.sp, color = textSecondary())
+                    submission.versionNumber?.takeIf { it > 1 }?.let { attempt ->
                         Text(
-                            text = "Open the web app to review file submissions in full.",
-                            fontSize = 11.sp,
-                            fontStyle = FontStyle.Italic,
+                            text = "Attempt $attempt",
+                            fontSize = 12.sp,
                             color = textSecondary(),
                         )
                     }
                 }
             }
-
             item {
                 LmsCard {
-                    Text(text = "Score", style = LexturesType.display(17), color = textPrimary())
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(10.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        OutlinedTextField(
-                            value = pointsText,
-                            onValueChange = { pointsText = it },
-                            label = { Text("Points") },
-                            isError = pointsText.isNotEmpty() && !pointsValid,
-                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                            singleLine = true,
-                            colors = OutlinedTextFieldDefaults.colors(
-                                focusedBorderColor = LexturesColors.Primary,
-                                cursorColor = LexturesColors.Primary,
-                            ),
-                            modifier = Modifier.weight(1f),
-                        )
-                        maxPoints?.let {
-                            Text(
-                                text = "/ ${formatPoints(it)} pts",
-                                fontSize = 14.sp,
-                                fontWeight = FontWeight.SemiBold,
-                                color = textSecondary(),
-                            )
-                        }
-                    }
-                    if (pointsText.isNotEmpty() && !pointsValid) {
-                        Text(
-                            text = maxPoints?.let { "Enter a number between 0 and ${formatPoints(it)}." }
-                                ?: "Enter a valid number.",
-                            fontSize = 12.sp,
-                            color = LexturesColors.Error,
-                        )
-                    }
-                }
-            }
-
-            item {
-                LmsCard {
-                    Text(text = "Feedback", style = LexturesType.display(17), color = textPrimary())
-                    OutlinedTextField(
-                        value = comment,
-                        onValueChange = { comment = it },
-                        label = { Text("Comment for the student (optional)") },
-                        minLines = 3,
-                        colors = OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = LexturesColors.Primary,
-                            cursorColor = LexturesColors.Primary,
-                        ),
-                        modifier = Modifier.fillMaxWidth(),
+                    Text(text = "Grade on web", style = LexturesType.display(17), color = textPrimary())
+                    Text(
+                        text = "Quiz answers are graded question by question. Open the web app to review responses and enter scores for ${backlogItem.assignmentTitle}.",
+                        fontSize = 14.sp,
+                        color = textSecondary(),
                     )
-                }
-            }
-
-            item {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(14.dp))
-                        .background(
-                            if (pointsValid && !saving) LexturesColors.Primary
-                            else LexturesColors.Primary.copy(alpha = 0.55f),
-                        )
-                        .clickable(enabled = pointsValid && !saving) {
-                            val token = accessToken ?: return@clickable
-                            val points = pointsValue ?: return@clickable
-                            scope.launch {
-                                saving = true
-                                errorMessage = null
-                                runCatching {
-                                    LmsApi.putSubmissionGrade(
-                                        courseCode = course.courseCode,
-                                        itemId = assignmentId,
-                                        submissionId = submission.id,
-                                        gradeBody = SubmissionGradePut(
-                                            pointsEarned = points,
-                                            instructorComment = comment.trim().takeIf { it.isNotEmpty() },
-                                        ),
-                                        accessToken = token,
-                                    )
-                                }.onSuccess {
-                                    saving = false
-                                    onDone(true)
-                                }.onFailure {
-                                    saving = false
-                                    errorMessage = session.mapError(it)
-                                }
-                            }
-                        }
-                        .padding(vertical = 14.dp),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    if (saving) {
-                        CircularProgressIndicator(
-                            color = Color.White,
-                            modifier = Modifier.size(18.dp),
-                            strokeWidth = 2.dp,
-                        )
-                    } else {
-                        Text(
-                            text = "Save grade",
-                            fontSize = 15.sp,
-                            fontWeight = FontWeight.SemiBold,
-                            color = Color.White,
-                        )
-                    }
                 }
             }
         }
     }
 }
-
-private fun formatPoints(points: Double): String =
-    if (points % 1.0 == 0.0) points.toLong().toString() else points.toString()

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/grading/SpeedGraderScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/grading/SpeedGraderScreen.kt
@@ -1,0 +1,440 @@
+package com.lextures.android.features.grading
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.lextures.android.core.auth.AuthSession
+import com.lextures.android.core.design.LexturesColors
+import com.lextures.android.core.design.LexturesType
+import com.lextures.android.core.design.accentColor
+import com.lextures.android.core.design.coverBrush
+import com.lextures.android.core.design.fieldBorder
+import com.lextures.android.core.design.textPrimary
+import com.lextures.android.core.design.textSecondary
+import com.lextures.android.core.lms.AssignmentSubmission
+import com.lextures.android.core.lms.CourseSummary
+import com.lextures.android.core.lms.LmsApi
+import com.lextures.android.core.lms.LmsDates
+import com.lextures.android.core.lms.SubmissionGradePut
+import com.lextures.android.features.home.LmsCard
+import com.lextures.android.features.home.LmsErrorBanner
+import kotlinx.coroutines.launch
+
+/**
+ * SpeedGrader-style flow: page through an assignment's submissions, read each one,
+ * and enter a score/feedback without returning to the list. Seeded with the loaded
+ * submissions snapshot and the index of the tapped student.
+ */
+@Composable
+fun SpeedGraderScreen(
+    session: AuthSession,
+    course: CourseSummary,
+    assignmentId: String,
+    submissions: List<AssignmentSubmission>,
+    startIndex: Int,
+    onSaved: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val accessToken by session.accessToken.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    var index by remember { mutableStateOf(startIndex.coerceIn(0, (submissions.size - 1).coerceAtLeast(0))) }
+    var gradedIds by remember {
+        mutableStateOf(submissions.filter { it.isGraded == true }.map { it.id }.toSet())
+    }
+    var pointsText by remember { mutableStateOf("") }
+    var comment by remember { mutableStateOf("") }
+    var maxPoints by remember { mutableStateOf<Double?>(null) }
+    var loading by remember { mutableStateOf(true) }
+    var saving by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    BackHandler(onBack = onBack)
+
+    val current = submissions.getOrNull(index)
+    val remainingUngraded = submissions.count { it.id !in gradedIds }
+
+    LaunchedEffect(accessToken, index) {
+        val token = accessToken ?: return@LaunchedEffect
+        val submission = current ?: return@LaunchedEffect
+        loading = true
+        errorMessage = null
+        pointsText = ""
+        comment = ""
+        maxPoints = null
+        runCatching {
+            LmsApi.fetchSubmissionGrade(course.courseCode, assignmentId, submission.id, token)
+        }.getOrNull()?.let { grade ->
+            maxPoints = grade.maxPoints
+            grade.pointsEarned?.let {
+                pointsText = formatGradePoints(it)
+                gradedIds = gradedIds + submission.id
+            }
+            comment = grade.instructorComment.orEmpty()
+        }
+        loading = false
+    }
+
+    val pointsValue = pointsText.replace(',', '.').toDoubleOrNull()
+    val pointsValid = pointsValue != null && pointsValue >= 0 &&
+        (maxPoints == null || pointsValue <= maxPoints!!)
+
+    fun nextUngradedIndex(from: Int): Int? {
+        if (submissions.isEmpty()) return null
+        for (offset in 1..submissions.size) {
+            val candidate = (from + offset) % submissions.size
+            if (candidate == from) break
+            if (submissions[candidate].id !in gradedIds) return candidate
+        }
+        return null
+    }
+
+    fun save() {
+        val token = accessToken ?: return
+        val points = pointsValue ?: return
+        val submission = current ?: return
+        scope.launch {
+            saving = true
+            errorMessage = null
+            runCatching {
+                LmsApi.putSubmissionGrade(
+                    courseCode = course.courseCode,
+                    itemId = assignmentId,
+                    submissionId = submission.id,
+                    gradeBody = SubmissionGradePut(
+                        pointsEarned = points,
+                        instructorComment = comment.trim().takeIf { it.isNotEmpty() },
+                    ),
+                    accessToken = token,
+                )
+            }.onSuccess {
+                saving = false
+                gradedIds = gradedIds + submission.id
+                onSaved()
+                nextUngradedIndex(index)?.let { index = it }
+            }.onFailure {
+                saving = false
+                errorMessage = session.mapError(it)
+            }
+        }
+    }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp, end = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", tint = textPrimary())
+            }
+            Text(
+                text = "Speed grader",
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = textPrimary(),
+            )
+        }
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "${index + 1} of ${submissions.size}",
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = textPrimary(),
+                    )
+                    Box(modifier = Modifier.weight(1f))
+                    val tint = if (remainingUngraded == 0) accentColor() else LexturesColors.Amber
+                    Text(
+                        text = if (remainingUngraded == 0) "All graded" else "$remainingUngraded ungraded",
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = tint,
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(50))
+                            .background(tint.copy(alpha = 0.14f))
+                            .padding(horizontal = 9.dp, vertical = 3.dp),
+                    )
+                }
+            }
+
+            errorMessage?.let { message ->
+                item { LmsErrorBanner(message) }
+            }
+
+            val submission = current
+            if (submission == null) {
+                item {
+                    Text(
+                        text = "No submissions in this view.",
+                        fontSize = 14.sp,
+                        color = textSecondary(),
+                    )
+                }
+            } else {
+                item {
+                    LmsCard {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(42.dp)
+                                    .clip(CircleShape)
+                                    .background(coverBrush(submission.displayName)),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text(
+                                    text = submission.displayName.take(2).uppercase(),
+                                    fontSize = 14.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    color = Color.White,
+                                )
+                            }
+                            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                Text(text = submission.displayName, style = LexturesType.display(18), color = textPrimary())
+                                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                                    Text(
+                                        text = "Submitted ${LmsDates.shortDateTime(submission.submittedAt)}",
+                                        fontSize = 12.sp,
+                                        color = textSecondary(),
+                                    )
+                                    submission.versionNumber?.takeIf { it > 1 }?.let {
+                                        Text(
+                                            text = "v$it",
+                                            fontSize = 12.sp,
+                                            fontWeight = FontWeight.SemiBold,
+                                            color = accentColor(),
+                                        )
+                                    }
+                                }
+                            }
+                            if (submission.id in gradedIds) {
+                                Icon(
+                                    Icons.Default.CheckCircle,
+                                    contentDescription = "Graded",
+                                    tint = accentColor(),
+                                    modifier = Modifier.size(20.dp),
+                                )
+                            }
+                        }
+                    }
+                }
+
+                item {
+                    LmsCard {
+                        Text(text = "Submission", style = LexturesType.display(17), color = textPrimary())
+                        val body = submission.bodyText?.trim().orEmpty()
+                        val filename = submission.attachmentFilename?.takeIf { it.isNotEmpty() }
+                        when {
+                            body.isNotEmpty() || filename != null -> {
+                                if (body.isNotEmpty()) {
+                                    Text(text = body, fontSize = 14.sp, color = textPrimary())
+                                }
+                                filename?.let {
+                                    Text(text = it, fontSize = 12.sp, color = textSecondary())
+                                    Text(
+                                        text = "Open the web app to review file submissions in full.",
+                                        fontSize = 11.sp,
+                                        fontStyle = FontStyle.Italic,
+                                        color = textSecondary(),
+                                    )
+                                }
+                            }
+                            else -> Text(
+                                text = "No text or attachment was submitted.",
+                                fontSize = 14.sp,
+                                color = textSecondary(),
+                            )
+                        }
+                    }
+                }
+
+                item {
+                    LmsCard {
+                        Text(text = "Score", style = LexturesType.display(17), color = textPrimary())
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(10.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            OutlinedTextField(
+                                value = pointsText,
+                                onValueChange = { pointsText = it },
+                                label = { Text("Points") },
+                                isError = pointsText.isNotEmpty() && !pointsValid,
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                                singleLine = true,
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    focusedBorderColor = LexturesColors.Primary,
+                                    cursorColor = LexturesColors.Primary,
+                                ),
+                                modifier = Modifier.weight(1f),
+                            )
+                            maxPoints?.let {
+                                Text(
+                                    text = "/ ${formatGradePoints(it)} pts",
+                                    fontSize = 14.sp,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = textSecondary(),
+                                )
+                            }
+                        }
+                        if (pointsText.isNotEmpty() && !pointsValid) {
+                            Text(
+                                text = maxPoints?.let { "Enter a number between 0 and ${formatGradePoints(it)}." }
+                                    ?: "Enter a valid number.",
+                                fontSize = 12.sp,
+                                color = LexturesColors.Error,
+                            )
+                        }
+                    }
+                }
+
+                item {
+                    LmsCard {
+                        Text(text = "Feedback", style = LexturesType.display(17), color = textPrimary())
+                        OutlinedTextField(
+                            value = comment,
+                            onValueChange = { comment = it },
+                            label = { Text("Comment for the student (optional)") },
+                            minLines = 3,
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = LexturesColors.Primary,
+                                cursorColor = LexturesColors.Primary,
+                            ),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(14.dp))
+                            .background(
+                                if (pointsValid && !saving) LexturesColors.Primary
+                                else LexturesColors.Primary.copy(alpha = 0.55f),
+                            )
+                            .clickable(enabled = pointsValid && !saving) { save() }
+                            .padding(vertical = 14.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        if (saving) {
+                            CircularProgressIndicator(
+                                color = Color.White,
+                                modifier = Modifier.size(18.dp),
+                                strokeWidth = 2.dp,
+                            )
+                        } else {
+                            Text(
+                                text = if (remainingUngraded <= 1) "Save grade" else "Save & next",
+                                fontSize = 15.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                color = Color.White,
+                            )
+                        }
+                    }
+                }
+
+                item {
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        SpeedGraderNavButton(
+                            label = "Previous",
+                            icon = Icons.Default.ChevronLeft,
+                            enabled = index > 0 && !saving,
+                            modifier = Modifier.weight(1f),
+                        ) { index = (index - 1).coerceAtLeast(0) }
+                        SpeedGraderNavButton(
+                            label = "Next",
+                            icon = Icons.Default.ChevronRight,
+                            enabled = index < submissions.size - 1 && !saving,
+                            modifier = Modifier.weight(1f),
+                        ) { index = (index + 1).coerceAtMost(submissions.size - 1) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SpeedGraderNavButton(
+    label: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    val tint = if (enabled) accentColor() else textSecondary().copy(alpha = 0.5f)
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .border(1.dp, fieldBorder(), RoundedCornerShape(12.dp))
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(vertical = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(18.dp))
+            Text(text = label, fontSize = 14.sp, fontWeight = FontWeight.SemiBold, color = tint)
+        }
+    }
+}
+
+private fun formatGradePoints(points: Double): String =
+    if (points % 1.0 == 0.0) points.toLong().toString() else points.toString()

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/home/CourseHeroImage.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/home/CourseHeroImage.kt
@@ -1,0 +1,67 @@
+package com.lextures.android.features.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.lextures.android.core.config.AppConfiguration
+import com.lextures.android.core.design.coverBrush
+
+/**
+ * Course banner image with auth for `/course-files/.../content` URLs (parity with web).
+ * Falls back to the course cover gradient when no image is set or loading fails.
+ */
+@Composable
+fun CourseHeroImage(
+    url: String?,
+    fallbackKey: String,
+    accessToken: String?,
+    modifier: Modifier = Modifier,
+    height: Dp = 84.dp,
+) {
+    val context = LocalContext.current
+    val trimmed = url?.trim().orEmpty()
+    val resolved = when {
+        trimmed.startsWith("/") -> AppConfiguration.apiUrl(trimmed).toString()
+        trimmed.startsWith("http://") || trimmed.startsWith("https://") -> trimmed
+        else -> null
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(height),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(coverBrush(fallbackKey)),
+        )
+        if (resolved != null) {
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(resolved)
+                    .apply {
+                        if (!accessToken.isNullOrBlank()) {
+                            setHeader("Authorization", "Bearer $accessToken")
+                        }
+                    }
+                    .crossfade(true)
+                    .build(),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}

--- a/clients/android/app/src/main/kotlin/com/lextures/android/features/home/HomeScreen.kt
+++ b/clients/android/app/src/main/kotlin/com/lextures/android/features/home/HomeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -96,41 +97,43 @@ fun HomeScreen(session: AuthSession, modifier: Modifier = Modifier) {
             .fillMaxSize()
             .background(sceneBackground()),
     ) {
-        // Content leaves room for the floating bar so lists and FABs stay reachable.
-        val contentModifier = Modifier
-            .fillMaxSize()
-            .navigationBarsPadding()
-            .padding(bottom = 96.dp)
-        when (selectedTab) {
-            HomeTab.Dashboard.name -> DashboardTab(
-                session = session,
-                shell = shell,
-                onOpenProfile = { selectedTab = HomeTab.Profile.name },
-                modifier = contentModifier,
-            )
-            HomeTab.Courses.name -> CoursesTab(session = session, modifier = contentModifier)
-            HomeTab.Notebooks.name -> NotebooksTab(session = session, modifier = contentModifier)
-            HomeTab.Inbox.name -> InboxTab(
-                session = session,
-                onUnreadChanged = { shell.unreadInbox = it },
-                modifier = contentModifier,
-            )
-            HomeTab.Profile.name -> ProfileTab(
-                session = session,
-                shell = shell,
-                modifier = contentModifier,
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .navigationBarsPadding(),
+        ) {
+            Box(modifier = Modifier.weight(1f)) {
+                when (selectedTab) {
+                    HomeTab.Dashboard.name -> DashboardTab(
+                        session = session,
+                        shell = shell,
+                        onOpenProfile = { selectedTab = HomeTab.Profile.name },
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                    HomeTab.Courses.name -> CoursesTab(session = session, modifier = Modifier.fillMaxSize())
+                    HomeTab.Notebooks.name -> NotebooksTab(session = session, modifier = Modifier.fillMaxSize())
+                    HomeTab.Inbox.name -> InboxTab(
+                        session = session,
+                        onUnreadChanged = { shell.unreadInbox = it },
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                    HomeTab.Profile.name -> ProfileTab(
+                        session = session,
+                        shell = shell,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+
+            LexturesTabBar(
+                selected = selectedTab,
+                unreadInbox = shell.unreadInbox,
+                onSelect = { selectedTab = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 24.dp, end = 24.dp, top = 8.dp, bottom = 6.dp),
             )
         }
-
-        LexturesTabBar(
-            selected = selectedTab,
-            unreadInbox = shell.unreadInbox,
-            onSelect = { selectedTab = it },
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .navigationBarsPadding()
-                .padding(start = 24.dp, end = 24.dp, bottom = 10.dp),
-        )
     }
 }
 

--- a/clients/ios/Lextures.xcodeproj/project.pbxproj
+++ b/clients/ios/Lextures.xcodeproj/project.pbxproj
@@ -3,397 +3,403 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		03F24D1C7C2F4D36B4A9974F /* AuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3941BAE0D344B68BF9E193 /* AuthSession.swift */; };
-		0644413C280E461CA9E6706E /* NotebookEditorSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A343609093054EA184419E0C /* NotebookEditorSupportViews.swift */; };
-		8F2B0D55C3E45076B9F2DAE1 /* NotebookPagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1A9C44B2D34F65A8E1C9D0 /* NotebookPagesView.swift */; };
-		0BAA37D85E8E4EDE9FFD08F2 /* BrandLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953659958FBB407CBDC047CF /* BrandLogoView.swift */; };
-		0BE9D62E48EA4C629B1F40DD /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8CF7A84DC94363A73F8456 /* RootView.swift */; };
-		0C932BCA11A64A85835C8E11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9FA16F1B714D4D58BCE19915 /* Assets.xcassets */; };
-		0CA81952480A4469B881EA68 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 357472B1C1F8463F8839C0CC /* APIError.swift */; };
-		0F71D9420CA1496A9052C76F /* LMSAPIFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80DC4827EA145A8AB99F667 /* LMSAPIFeatures.swift */; };
-		1123E8C06A88423D9A7C4FC9 /* AuthFieldRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2470B77A957A41DF89F953F1 /* AuthFieldRepresentable.swift */; };
-		14B500CFD7E242ADAA4D83ED /* ItemDetailRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30443FB933004FECBBA59B9D /* ItemDetailRows.swift */; };
-		154D39BCA6D0413690460016 /* NetworkBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = A509C8A545194C9C86B3C40D /* NetworkBootstrap.swift */; };
-		19F5F42A3DE740889E74539A /* AnnouncementsViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A38DE510264A5FBE3AC6A9 /* AnnouncementsViews.swift */; };
-		1D4876D8A2864F01915DC900 /* NotebookTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F06B4482F7548C8A4CC6160 /* NotebookTree.swift */; };
-		2386914D66FE44068A2F9D11 /* NotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19EF45568F604C7E8453AF99 /* NotificationsView.swift */; };
-		250204AD53A545ECAE48AF36 /* LexturesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36607F9A72EC4C07BC51791F /* LexturesApp.swift */; };
-		259B10F0F6F34A00853E6DE9 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77F64B7E38D44B095C03DB2 /* KeychainStore.swift */; };
-		2E4D4CC7DBAE477B849B34E6 /* CourseDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219FBAE5655846D7B3A3F6E0 /* CourseDetailView.swift */; };
-		2F6739E5496D46E08D307057 /* SignupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06360273D8746FD83D7BA65 /* SignupView.swift */; };
-		32F3955E9F524838A2933774 /* NotebookEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12D6FCA93BB4E949D2EE063 /* NotebookEditorView.swift */; };
-		38B6DDE61E534BFAA25470A3 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDC70291C494F3490824596 /* MainTabView.swift */; };
-		47B7567DAEDA4C98B1DAAAC7 /* CourseSyllabusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D5650BAD074CC1819B9AF4 /* CourseSyllabusView.swift */; };
-		4AB48FBB013B4D93BFFE082E /* NotebookDrawingViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = F456288D9FFB41E4B3702CE3 /* NotebookDrawingViews.swift */; };
-		4FC39E85E000400A84539C68 /* LexturesTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C113EBC16E44CCAABEBE21 /* LexturesTheme.swift */; };
-		5EB87BB18EEF448DBA298195 /* LMSAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335FDBE756D94916BC24BD93 /* LMSAPI.swift */; };
-		5FA504A6F2C24DB3A47DA51D /* NotebooksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CC4CFA0F9B47E8AB3B663E /* NotebooksListView.swift */; };
-		63D7E5CF6E074933A11B7966 /* LMSModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A7771E217847828945B3E1 /* LMSModels.swift */; };
-		6432F2AE481E47B09FD6D673 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EA27A24AB547BDA105CB06 /* ProfileView.swift */; };
-		6E09A7B233E34534949D4962 /* LMSFeatureModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAF108D251F4A5386FAF52B /* LMSFeatureModels.swift */; };
-		73C9BB2170AE486F8AEBC7BD /* NotebookStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6619ACFC275F41938F4E1B97 /* NotebookStore.swift */; };
-		77BC611BB30E490E9E6AEFC0 /* InboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB61B2251914FD5BEC68339 /* InboxView.swift */; };
-		7EF1B2948974453BA4281BAC /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9923C19FAF184135947A2EFA /* APIClient.swift */; };
-		98219FA136424EE98E2CCB96 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED56AA5D5B79458D98C2BECA /* AppDelegate.swift */; };
-		A12E78A380AF4D6A998B8505 /* NotebookSlashCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACBFB4CD30C241AC9289EBF4 /* NotebookSlashCommands.swift */; };
-		A325645C108543E3B6FA2855 /* NotebookSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89C0585A260648F4A02EB2C7 /* NotebookSync.swift */; };
-		A7696158D521432BBEBD7060 /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E381B02ECFC049589D2DC497 /* AuthAPI.swift */; };
-		A92FFD7126524313B2CFA84C /* NotebookDrawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CAE14244332488E81018E1C /* NotebookDrawing.swift */; };
-		B3ECEB502E794C60AC4A63E0 /* AuthFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A68AE1AAD401DAB85F224 /* AuthFlowView.swift */; };
-		B5057044BF7D4838BE865AD0 /* ComposeMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00371559A0064F3C8680FB17 /* ComposeMessageView.swift */; };
-		B57A14D017DD44ABBEC6B1C2 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23089B014BAF49B897BD0C17 /* AppConfiguration.swift */; };
-		D465FEB62870425D94160B9C /* CourseAttendanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51F2F553BE742D9960B30B4 /* CourseAttendanceView.swift */; };
-		D4F36BF7CA994F059B15D1A6 /* GradingBacklogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA054AB3A094E1988E5022F /* GradingBacklogView.swift */; };
-		DA48336D51074394A319EEB1 /* CoursesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A601CB268464C82BDF40DA7 /* CoursesListView.swift */; };
-		DCE07FE1A75345BDB9A5DFD5 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8774038A25634D38AB45603F /* DashboardView.swift */; };
-		E126575B54E04CF2A499DD50 /* CourseGradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CFD443255C48F3845EF170 /* CourseGradesView.swift */; };
-		E5BA8E3802B8404BAE92B450 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8002F9C7CEBB408DB40A34CD /* SplashView.swift */; };
-		E7DB3F2216844788863F034B /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99E27F3887C4B56AB4D4770 /* LoginView.swift */; };
-		EAE21D487BD843B8B61AF258 /* NotebookMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C672F5CEEC43E896E03582 /* NotebookMarkdown.swift */; };
-		F182B961441740608636D510 /* MessageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342A38D5616F47F7BDEB10A5 /* MessageDetailView.swift */; };
-		F1FE04A22BAF43DAB45741CA /* ItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D469F06C9A22485794436C7D /* ItemDetailView.swift */; };
+		82F50A6D5D5E43828442CCBD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1301A212010F4351854D97E2 /* AppDelegate.swift */; };
+		784E0470C7624962A401A324 /* LexturesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D415D032C1844FE8F45BEF8 /* LexturesApp.swift */; };
+		F8965C4982244EE78E5EE37C /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05C698800AC4B4982D29CB3 /* RootView.swift */; };
+		7F15AC9A98B6416298F0E2E7 /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D739C14D557424987C25589 /* AuthAPI.swift */; };
+		907C146ACDEB442EA8753A33 /* AuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6181CDF4144C6DA7F52348 /* AuthSession.swift */; };
+		1F5C1A2103634B1AA90F6FC7 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56C6051B7BF8414390521478 /* KeychainStore.swift */; };
+		5B469EA7D91B48A19F2E8B23 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD67529F427421A959CDE06 /* AppConfiguration.swift */; };
+		A8355B9444DD4689B446E3C3 /* AuthFieldRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB6FB1565C8C4741B4BDB608 /* AuthFieldRepresentable.swift */; };
+		E451AEA9FC0744499CB5C433 /* BrandLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B7BF1060994AC5B0F29552 /* BrandLogoView.swift */; };
+		702C67F952FC4D46AA84A8BC /* LexturesTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B958A7508C42DC8E698769 /* LexturesTheme.swift */; };
+		0DDD0A011A774ACDA7D98719 /* CourseHeroImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3057DF4A62FB48B3B0E0F19D /* CourseHeroImage.swift */; };
+		45B8F60107DA4FB89F79ABD3 /* LMSAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E56F3D33F844AF2A9078879 /* LMSAPI.swift */; };
+		E432DCE16E254852AF729D02 /* LMSAPIFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783FB56FEA8646E493E1F892 /* LMSAPIFeatures.swift */; };
+		C1BAFCCDB8774722A856622B /* LMSFeatureModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67EC2E472DF4AC496EE5228 /* LMSFeatureModels.swift */; };
+		A2B6E36705424B8CA8A44435 /* LMSModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30950446704F46C39BC5C627 /* LMSModels.swift */; };
+		1FCD610119E1473CAC908160 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCBFDA4B1F445E48F9384EB /* APIClient.swift */; };
+		14CE03443A8745428D2C58C0 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81475601FE54C2396AFD164 /* APIError.swift */; };
+		948089F4A7D94BA6B6B440B3 /* NetworkBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A158EF966AA4F73BBA4DD3F /* NetworkBootstrap.swift */; };
+		FE442D38DF5943658F411B8C /* NotebookDrawing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CA06827D1441A39B9E9CB8 /* NotebookDrawing.swift */; };
+		B8CB210AE90B4A6D89B78AAC /* NotebookMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = B470832CAE1B4390B7E1F400 /* NotebookMarkdown.swift */; };
+		FA4D6C553EAC4506B9C6EC18 /* NotebookSlashCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBB821FDA5141A090CF8ED1 /* NotebookSlashCommands.swift */; };
+		14ABFC0C18D4485380E22A6F /* NotebookStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18AB274F28DA4765B6936B7D /* NotebookStore.swift */; };
+		67CBB3E91C854E7C8CBBCAD8 /* NotebookSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFC6E7A1E8742C694CAE9D3 /* NotebookSync.swift */; };
+		7336F2BDCAD344028E65F1C9 /* NotebookTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F690D75FCF4CAE9E31A8BE /* NotebookTree.swift */; };
+		DC7055D49D6C4FBEA9CC12A6 /* AuthFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD2BF03169B40F8BB4603F9 /* AuthFlowView.swift */; };
+		2146B0E97CB74C5C8D915307 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA08181B1FD143698CFE9F1D /* LoginView.swift */; };
+		BBD20591AAB84D09A1484AC4 /* SignupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158C7F82B9C44AAD9C19D313 /* SignupView.swift */; };
+		9F5FA2B4FB834CB4BAF8B162 /* CourseAttendanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD0FD4519034CFF87ACDD97 /* CourseAttendanceView.swift */; };
+		24AFD590C4D448EEBC569D77 /* CourseDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83819D2C91854BAA87DD64C9 /* CourseDetailView.swift */; };
+		A438FB26B7F0432490351D64 /* CourseGradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0AD28460E743AF8914E93B /* CourseGradesView.swift */; };
+		5E1483A418784253841907CB /* CourseSyllabusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6879EF8BB3B4773A6AB90B3 /* CourseSyllabusView.swift */; };
+		3971A8515B0F4D838E1A7640 /* CoursesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4EA2DF1FEE40ED88024562 /* CoursesListView.swift */; };
+		758D9D32FFA44F0DB20E2769 /* ItemDetailRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E26170E6E246CDA60E2648 /* ItemDetailRows.swift */; };
+		2BC799521809413B8DC138DE /* ItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66635F9C2404AEBB6C0D702 /* ItemDetailView.swift */; };
+		8F35B2C6D54048F1B527BE2C /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7044CD091D4D44B29700AA65 /* DashboardView.swift */; };
+		43088A0355A74E9E9EAEC991 /* GradingBacklogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA929DA3E86949FCA7458E25 /* GradingBacklogView.swift */; };
+		296E6CBE9A1B4B48B5C9228A /* SpeedGraderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4C9DD73050B4C399A795450 /* SpeedGraderView.swift */; };
+		AC1EDDCFE1F946999F54E5A0 /* AnnouncementsViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62E6ECC3E1F485BABFD045C /* AnnouncementsViews.swift */; };
+		266BCB111888433A920A873F /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B217EF481094A78ABCE9D57 /* MainTabView.swift */; };
+		F0A827C700444C738EBCDEBC /* ComposeMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F1EB560B414CE5BC72DEE6 /* ComposeMessageView.swift */; };
+		1D2FC8DA7AE24011BC76220F /* InboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB66BAF728D40CB940CE163 /* InboxView.swift */; };
+		EA17F526D17B4487B1EFCFE5 /* MessageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C73DF511F2A44B59807813A /* MessageDetailView.swift */; };
+		A1DB372571294385BDCE6F00 /* NotebookDrawingViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88989E14E9745ADB033A900 /* NotebookDrawingViews.swift */; };
+		8C87B19F5D184B45BF3B6562 /* NotebookEditorSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75620A8776714D22A8755B24 /* NotebookEditorSupportViews.swift */; };
+		325F0F9BFA324FCF9074196C /* NotebookEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0039BFFD2DB74196B025B372 /* NotebookEditorView.swift */; };
+		BE3FBB94981149DE9DC6F9A2 /* NotebookPagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7226267AC7F04A61943EB563 /* NotebookPagesView.swift */; };
+		5F02869576C64C3198D1981F /* NotebooksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47260659CDF34919A49376AD /* NotebooksListView.swift */; };
+		AA5F25AC893F4E8E8AA9A00B /* NotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD437F6AD0D46B49256D2F8 /* NotificationsView.swift */; };
+		F9669A6F09A94BC998E3846F /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0560960CA0824DD4A44A525A /* ProfileView.swift */; };
+		1C871944AD4A4331BB1FDF04 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EECC55348A146E6A8930358 /* SplashView.swift */; };
+		8295FCA9E58242AEBF0D6B24 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 570B2FDFD3F84458BF4B2290 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		000A68AE1AAD401DAB85F224 /* AuthFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFlowView.swift; sourceTree = "<group>"; };
-		00371559A0064F3C8680FB17 /* ComposeMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeMessageView.swift; sourceTree = "<group>"; };
-		01D5650BAD074CC1819B9AF4 /* CourseSyllabusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyllabusView.swift; sourceTree = "<group>"; };
-		0AAF108D251F4A5386FAF52B /* LMSFeatureModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModels.swift; sourceTree = "<group>"; };
-		19EF45568F604C7E8453AF99 /* NotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsView.swift; sourceTree = "<group>"; };
-		219FBAE5655846D7B3A3F6E0 /* CourseDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailView.swift; sourceTree = "<group>"; };
-		23089B014BAF49B897BD0C17 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
-		23E537FADE8F4B5E8A491A87 /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
-		2470B77A957A41DF89F953F1 /* AuthFieldRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFieldRepresentable.swift; sourceTree = "<group>"; };
-		30443FB933004FECBBA59B9D /* ItemDetailRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailRows.swift; sourceTree = "<group>"; };
-		335FDBE756D94916BC24BD93 /* LMSAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPI.swift; sourceTree = "<group>"; };
-		342A38D5616F47F7BDEB10A5 /* MessageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDetailView.swift; sourceTree = "<group>"; };
-		357472B1C1F8463F8839C0CC /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
-		35C672F5CEEC43E896E03582 /* NotebookMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookMarkdown.swift; sourceTree = "<group>"; };
-		36607F9A72EC4C07BC51791F /* LexturesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesApp.swift; sourceTree = "<group>"; };
-		39EA27A24AB547BDA105CB06 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
-		5CAE14244332488E81018E1C /* NotebookDrawing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawing.swift; sourceTree = "<group>"; };
-		5F06B4482F7548C8A4CC6160 /* NotebookTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookTree.swift; sourceTree = "<group>"; };
-		6619ACFC275F41938F4E1B97 /* NotebookStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookStore.swift; sourceTree = "<group>"; };
-		6A3941BAE0D344B68BF9E193 /* AuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
-		8002F9C7CEBB408DB40A34CD /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
-		8774038A25634D38AB45603F /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
-		89C0585A260648F4A02EB2C7 /* NotebookSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSync.swift; sourceTree = "<group>"; };
-		8A601CB268464C82BDF40DA7 /* CoursesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesListView.swift; sourceTree = "<group>"; };
-		8CB61B2251914FD5BEC68339 /* InboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxView.swift; sourceTree = "<group>"; };
-		8FC8324422AE44CDA7A40993 /* Lextures.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lextures.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		93CFD443255C48F3845EF170 /* CourseGradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradesView.swift; sourceTree = "<group>"; };
-		953659958FBB407CBDC047CF /* BrandLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandLogoView.swift; sourceTree = "<group>"; };
-		9923C19FAF184135947A2EFA /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
-		9FA16F1B714D4D58BCE19915 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		A343609093054EA184419E0C /* NotebookEditorSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorSupportViews.swift; sourceTree = "<group>"; };
-		7E1A9C44B2D34F65A8E1C9D0 /* NotebookPagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookPagesView.swift; sourceTree = "<group>"; };
-		A509C8A545194C9C86B3C40D /* NetworkBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkBootstrap.swift; sourceTree = "<group>"; };
-		A77F64B7E38D44B095C03DB2 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
-		ACBFB4CD30C241AC9289EBF4 /* NotebookSlashCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSlashCommands.swift; sourceTree = "<group>"; };
-		ACDC70291C494F3490824596 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
-		C0CC4CFA0F9B47E8AB3B663E /* NotebooksListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebooksListView.swift; sourceTree = "<group>"; };
-		D06360273D8746FD83D7BA65 /* SignupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupView.swift; sourceTree = "<group>"; };
-		D0792B2CF8534C8B9D32B1F8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D12D6FCA93BB4E949D2EE063 /* NotebookEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorView.swift; sourceTree = "<group>"; };
-		D469F06C9A22485794436C7D /* ItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailView.swift; sourceTree = "<group>"; };
-		D4A7771E217847828945B3E1 /* LMSModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSModels.swift; sourceTree = "<group>"; };
-		E381B02ECFC049589D2DC497 /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
-		E4C113EBC16E44CCAABEBE21 /* LexturesTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesTheme.swift; sourceTree = "<group>"; };
-		E99E27F3887C4B56AB4D4770 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
-		ED56AA5D5B79458D98C2BECA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		EDA054AB3A094E1988E5022F /* GradingBacklogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradingBacklogView.swift; sourceTree = "<group>"; };
-		F2A38DE510264A5FBE3AC6A9 /* AnnouncementsViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsViews.swift; sourceTree = "<group>"; };
-		F456288D9FFB41E4B3702CE3 /* NotebookDrawingViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawingViews.swift; sourceTree = "<group>"; };
-		F51F2F553BE742D9960B30B4 /* CourseAttendanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAttendanceView.swift; sourceTree = "<group>"; };
-		F80DC4827EA145A8AB99F667 /* LMSAPIFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIFeatures.swift; sourceTree = "<group>"; };
-		FC8CF7A84DC94363A73F8456 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		254C11EEEC9D4475BD749587 /* Lextures.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lextures.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1301A212010F4351854D97E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		0D415D032C1844FE8F45BEF8 /* LexturesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesApp.swift; sourceTree = "<group>"; };
+		A05C698800AC4B4982D29CB3 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		1D739C14D557424987C25589 /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
+		AA6181CDF4144C6DA7F52348 /* AuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
+		56C6051B7BF8414390521478 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
+		AAD67529F427421A959CDE06 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
+		FB6FB1565C8C4741B4BDB608 /* AuthFieldRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFieldRepresentable.swift; sourceTree = "<group>"; };
+		E0B7BF1060994AC5B0F29552 /* BrandLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandLogoView.swift; sourceTree = "<group>"; };
+		F0B958A7508C42DC8E698769 /* LexturesTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LexturesTheme.swift; sourceTree = "<group>"; };
+		3057DF4A62FB48B3B0E0F19D /* CourseHeroImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseHeroImage.swift; sourceTree = "<group>"; };
+		3E56F3D33F844AF2A9078879 /* LMSAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPI.swift; sourceTree = "<group>"; };
+		783FB56FEA8646E493E1F892 /* LMSAPIFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSAPIFeatures.swift; sourceTree = "<group>"; };
+		A67EC2E472DF4AC496EE5228 /* LMSFeatureModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSFeatureModels.swift; sourceTree = "<group>"; };
+		30950446704F46C39BC5C627 /* LMSModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LMSModels.swift; sourceTree = "<group>"; };
+		2BCBFDA4B1F445E48F9384EB /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		C81475601FE54C2396AFD164 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
+		8A158EF966AA4F73BBA4DD3F /* NetworkBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkBootstrap.swift; sourceTree = "<group>"; };
+		61CA06827D1441A39B9E9CB8 /* NotebookDrawing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawing.swift; sourceTree = "<group>"; };
+		B470832CAE1B4390B7E1F400 /* NotebookMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookMarkdown.swift; sourceTree = "<group>"; };
+		BEBB821FDA5141A090CF8ED1 /* NotebookSlashCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSlashCommands.swift; sourceTree = "<group>"; };
+		18AB274F28DA4765B6936B7D /* NotebookStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookStore.swift; sourceTree = "<group>"; };
+		0AFC6E7A1E8742C694CAE9D3 /* NotebookSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookSync.swift; sourceTree = "<group>"; };
+		A7F690D75FCF4CAE9E31A8BE /* NotebookTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookTree.swift; sourceTree = "<group>"; };
+		7CD2BF03169B40F8BB4603F9 /* AuthFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFlowView.swift; sourceTree = "<group>"; };
+		AA08181B1FD143698CFE9F1D /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		158C7F82B9C44AAD9C19D313 /* SignupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupView.swift; sourceTree = "<group>"; };
+		0BD0FD4519034CFF87ACDD97 /* CourseAttendanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseAttendanceView.swift; sourceTree = "<group>"; };
+		83819D2C91854BAA87DD64C9 /* CourseDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailView.swift; sourceTree = "<group>"; };
+		CB0AD28460E743AF8914E93B /* CourseGradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseGradesView.swift; sourceTree = "<group>"; };
+		A6879EF8BB3B4773A6AB90B3 /* CourseSyllabusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyllabusView.swift; sourceTree = "<group>"; };
+		6B4EA2DF1FEE40ED88024562 /* CoursesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesListView.swift; sourceTree = "<group>"; };
+		38E26170E6E246CDA60E2648 /* ItemDetailRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailRows.swift; sourceTree = "<group>"; };
+		A66635F9C2404AEBB6C0D702 /* ItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailView.swift; sourceTree = "<group>"; };
+		7044CD091D4D44B29700AA65 /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
+		CA929DA3E86949FCA7458E25 /* GradingBacklogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradingBacklogView.swift; sourceTree = "<group>"; };
+		A4C9DD73050B4C399A795450 /* SpeedGraderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedGraderView.swift; sourceTree = "<group>"; };
+		A62E6ECC3E1F485BABFD045C /* AnnouncementsViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsViews.swift; sourceTree = "<group>"; };
+		3B217EF481094A78ABCE9D57 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
+		55F1EB560B414CE5BC72DEE6 /* ComposeMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeMessageView.swift; sourceTree = "<group>"; };
+		AEB66BAF728D40CB940CE163 /* InboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxView.swift; sourceTree = "<group>"; };
+		9C73DF511F2A44B59807813A /* MessageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDetailView.swift; sourceTree = "<group>"; };
+		A88989E14E9745ADB033A900 /* NotebookDrawingViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookDrawingViews.swift; sourceTree = "<group>"; };
+		75620A8776714D22A8755B24 /* NotebookEditorSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorSupportViews.swift; sourceTree = "<group>"; };
+		0039BFFD2DB74196B025B372 /* NotebookEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEditorView.swift; sourceTree = "<group>"; };
+		7226267AC7F04A61943EB563 /* NotebookPagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookPagesView.swift; sourceTree = "<group>"; };
+		47260659CDF34919A49376AD /* NotebooksListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebooksListView.swift; sourceTree = "<group>"; };
+		9FD437F6AD0D46B49256D2F8 /* NotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsView.swift; sourceTree = "<group>"; };
+		0560960CA0824DD4A44A525A /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		9EECC55348A146E6A8930358 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
+		570B2FDFD3F84458BF4B2290 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		CCCEE0D2EF1C437894E4B4CE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C69D6A1902944F5482EC8494 /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		C5A3C66FEAAB416CB9BB0223 /* Frameworks */ = {
+		C7EC4AFCB13D433CBBF5F709 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
+			runOnlyForDeploymentPostprocessing = 0;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		070D25A998FF4806B82E55F1 /* Config */ = {
+		5088BEAA630644AC80095F60 /* Lextures */ = {
 			isa = PBXGroup;
 			children = (
-				23089B014BAF49B897BD0C17 /* AppConfiguration.swift */,
-			);
-			path = Config;
-			sourceTree = "<group>";
-		};
-		13E124657D6B4586BFD4CEEC /* Networking */ = {
-			isa = PBXGroup;
-			children = (
-				9923C19FAF184135947A2EFA /* APIClient.swift */,
-				357472B1C1F8463F8839C0CC /* APIError.swift */,
-				A509C8A545194C9C86B3C40D /* NetworkBootstrap.swift */,
-			);
-			path = Networking;
-			sourceTree = "<group>";
-		};
-		2623CB23DECD4D42A9A6D7A2 /* Dashboard */ = {
-			isa = PBXGroup;
-			children = (
-				8774038A25634D38AB45603F /* DashboardView.swift */,
-			);
-			path = Dashboard;
-			sourceTree = "<group>";
-		};
-		33B7E91146634370A8982796 /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				E4980B748EA14558B271A540 /* Auth */,
-				070D25A998FF4806B82E55F1 /* Config */,
-				C56D83944C4B46C0BADDE606 /* Design */,
-				D9000027D86F4BBEA773CF67 /* LMS */,
-				13E124657D6B4586BFD4CEEC /* Networking */,
-				9302FB656B1D499A84759E93 /* Notebook */,
-			);
-			path = Core;
-			sourceTree = "<group>";
-		};
-		3B146E15EEA147E18AA7AA17 /* Features */ = {
-			isa = PBXGroup;
-			children = (
-				966625AA644F492D9C65F86C /* Auth */,
-				D247FBA9779B4BF1B3F86302 /* Courses */,
-				2623CB23DECD4D42A9A6D7A2 /* Dashboard */,
-				8B48816C2AAF4297ADBC6A6A /* Grading */,
-				AF76197835F44EF8BDFD479B /* Home */,
-				EBAE4996735E499690B16F07 /* Inbox */,
-				9644F06393DC47CC856D5B04 /* Notebooks */,
-				92062D83A33B4B6C92B4D1BD /* Profile */,
-				A9CC0F11171E4F17928B6985 /* Splash */,
-			);
-			path = Features;
-			sourceTree = "<group>";
-		};
-		564F1220D41B424C85BB83FB /* Lextures */ = {
-			isa = PBXGroup;
-			children = (
-				6F079D67B912406388F19CDA /* Resources */,
-				8425669E02D3410CB45639A3 /* App */,
-				33B7E91146634370A8982796 /* Core */,
-				3B146E15EEA147E18AA7AA17 /* Features */,
+				879E070FC2AE4CFCB28AA8A0 /* Resources */,
+				7183A8C0C5C54F79A2C33C2E /* App */,
+				A96867ED43FF456E8C9CBC92 /* Core */,
+				FCB7E1B3782940FE918FD48E /* Features */,
 			);
 			path = Lextures;
 			sourceTree = "<group>";
 		};
-		6A4A6A7437C442E582159C4F = {
+		7183A8C0C5C54F79A2C33C2E /* App */ = {
 			isa = PBXGroup;
 			children = (
-				564F1220D41B424C85BB83FB /* Lextures */,
-				BD52C146EA66449EAACF1394 /* Config */,
-				7202BE50B25146A9B10F1E6E /* Products */,
-			);
-			sourceTree = "<group>";
-		};
-		6F079D67B912406388F19CDA /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				9FA16F1B714D4D58BCE19915 /* Assets.xcassets */,
-				D0792B2CF8534C8B9D32B1F8 /* Info.plist */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		7202BE50B25146A9B10F1E6E /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				8FC8324422AE44CDA7A40993 /* Lextures.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		8425669E02D3410CB45639A3 /* App */ = {
-			isa = PBXGroup;
-			children = (
-				ED56AA5D5B79458D98C2BECA /* AppDelegate.swift */,
-				36607F9A72EC4C07BC51791F /* LexturesApp.swift */,
-				FC8CF7A84DC94363A73F8456 /* RootView.swift */,
+				1301A212010F4351854D97E2 /* AppDelegate.swift */,
+				0D415D032C1844FE8F45BEF8 /* LexturesApp.swift */,
+				A05C698800AC4B4982D29CB3 /* RootView.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
 		};
-		8B48816C2AAF4297ADBC6A6A /* Grading */ = {
+		A96867ED43FF456E8C9CBC92 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				EDA054AB3A094E1988E5022F /* GradingBacklogView.swift */,
+				394D09F44A4347B8BFF14205 /* Auth */,
+				BC52FB02985F4AF6B1EBA202 /* Config */,
+				12B39C9629E74E99A194D299 /* Design */,
+				5AD5C41C896E49D290A4239D /* LMS */,
+				AFA30B99D5E1476A85171AE3 /* Networking */,
+				C8C127479964405B8EFC1455 /* Notebook */,
 			);
-			path = Grading;
+			path = Core;
 			sourceTree = "<group>";
 		};
-		92062D83A33B4B6C92B4D1BD /* Profile */ = {
+		FCB7E1B3782940FE918FD48E /* Features */ = {
 			isa = PBXGroup;
 			children = (
-				19EF45568F604C7E8453AF99 /* NotificationsView.swift */,
-				39EA27A24AB547BDA105CB06 /* ProfileView.swift */,
+				72E33627E1C249E9AE85E3ED /* Auth */,
+				7675643BA72541F19D3FFDD6 /* Courses */,
+				B0681CA130754335868C3665 /* Dashboard */,
+				60857CE5780847E78E2E0FDB /* Grading */,
+				75DCE22BF6CB448EB44884D1 /* Home */,
+				496EF4A60F954C288B84726E /* Inbox */,
+				CD497CED663140BAB992D27B /* Notebooks */,
+				FDB20FAAEEBE480EB249DF7E /* Profile */,
+				311ED73FCE5B4516AE6BBF60 /* Splash */,
 			);
-			path = Profile;
+			path = Features;
 			sourceTree = "<group>";
 		};
-		9302FB656B1D499A84759E93 /* Notebook */ = {
+		879E070FC2AE4CFCB28AA8A0 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				5CAE14244332488E81018E1C /* NotebookDrawing.swift */,
-				35C672F5CEEC43E896E03582 /* NotebookMarkdown.swift */,
-				ACBFB4CD30C241AC9289EBF4 /* NotebookSlashCommands.swift */,
-				6619ACFC275F41938F4E1B97 /* NotebookStore.swift */,
-				89C0585A260648F4A02EB2C7 /* NotebookSync.swift */,
-				5F06B4482F7548C8A4CC6160 /* NotebookTree.swift */,
+				570B2FDFD3F84458BF4B2290 /* Assets.xcassets */,
+				CCCEE0D2EF1C437894E4B4CE /* Info.plist */,
 			);
-			path = Notebook;
+			path = Resources;
 			sourceTree = "<group>";
 		};
-		9644F06393DC47CC856D5B04 /* Notebooks */ = {
+		394D09F44A4347B8BFF14205 /* Auth */ = {
 			isa = PBXGroup;
 			children = (
-				F456288D9FFB41E4B3702CE3 /* NotebookDrawingViews.swift */,
-				A343609093054EA184419E0C /* NotebookEditorSupportViews.swift */,
-				D12D6FCA93BB4E949D2EE063 /* NotebookEditorView.swift */,
-				7E1A9C44B2D34F65A8E1C9D0 /* NotebookPagesView.swift */,
-				C0CC4CFA0F9B47E8AB3B663E /* NotebooksListView.swift */,
-			);
-			path = Notebooks;
-			sourceTree = "<group>";
-		};
-		966625AA644F492D9C65F86C /* Auth */ = {
-			isa = PBXGroup;
-			children = (
-				000A68AE1AAD401DAB85F224 /* AuthFlowView.swift */,
-				E99E27F3887C4B56AB4D4770 /* LoginView.swift */,
-				D06360273D8746FD83D7BA65 /* SignupView.swift */,
+				1D739C14D557424987C25589 /* AuthAPI.swift */,
+				AA6181CDF4144C6DA7F52348 /* AuthSession.swift */,
+				56C6051B7BF8414390521478 /* KeychainStore.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
 		};
-		A9CC0F11171E4F17928B6985 /* Splash */ = {
+		BC52FB02985F4AF6B1EBA202 /* Config */ = {
 			isa = PBXGroup;
 			children = (
-				8002F9C7CEBB408DB40A34CD /* SplashView.swift */,
-			);
-			path = Splash;
-			sourceTree = "<group>";
-		};
-		AF76197835F44EF8BDFD479B /* Home */ = {
-			isa = PBXGroup;
-			children = (
-				F2A38DE510264A5FBE3AC6A9 /* AnnouncementsViews.swift */,
-				ACDC70291C494F3490824596 /* MainTabView.swift */,
-			);
-			path = Home;
-			sourceTree = "<group>";
-		};
-		BD52C146EA66449EAACF1394 /* Config */ = {
-			isa = PBXGroup;
-			children = (
-				23E537FADE8F4B5E8A491A87 /* Development.xcconfig */,
+				AAD67529F427421A959CDE06 /* AppConfiguration.swift */,
 			);
 			path = Config;
 			sourceTree = "<group>";
 		};
-		C56D83944C4B46C0BADDE606 /* Design */ = {
+		12B39C9629E74E99A194D299 /* Design */ = {
 			isa = PBXGroup;
 			children = (
-				2470B77A957A41DF89F953F1 /* AuthFieldRepresentable.swift */,
-				953659958FBB407CBDC047CF /* BrandLogoView.swift */,
-				E4C113EBC16E44CCAABEBE21 /* LexturesTheme.swift */,
+				FB6FB1565C8C4741B4BDB608 /* AuthFieldRepresentable.swift */,
+				E0B7BF1060994AC5B0F29552 /* BrandLogoView.swift */,
+				F0B958A7508C42DC8E698769 /* LexturesTheme.swift */,
 			);
 			path = Design;
 			sourceTree = "<group>";
 		};
-		D247FBA9779B4BF1B3F86302 /* Courses */ = {
+		5AD5C41C896E49D290A4239D /* LMS */ = {
 			isa = PBXGroup;
 			children = (
-				F51F2F553BE742D9960B30B4 /* CourseAttendanceView.swift */,
-				219FBAE5655846D7B3A3F6E0 /* CourseDetailView.swift */,
-				93CFD443255C48F3845EF170 /* CourseGradesView.swift */,
-				01D5650BAD074CC1819B9AF4 /* CourseSyllabusView.swift */,
-				8A601CB268464C82BDF40DA7 /* CoursesListView.swift */,
-				30443FB933004FECBBA59B9D /* ItemDetailRows.swift */,
-				D469F06C9A22485794436C7D /* ItemDetailView.swift */,
-			);
-			path = Courses;
-			sourceTree = "<group>";
-		};
-		D9000027D86F4BBEA773CF67 /* LMS */ = {
-			isa = PBXGroup;
-			children = (
-				335FDBE756D94916BC24BD93 /* LMSAPI.swift */,
-				F80DC4827EA145A8AB99F667 /* LMSAPIFeatures.swift */,
-				0AAF108D251F4A5386FAF52B /* LMSFeatureModels.swift */,
-				D4A7771E217847828945B3E1 /* LMSModels.swift */,
+				3057DF4A62FB48B3B0E0F19D /* CourseHeroImage.swift */,
+				3E56F3D33F844AF2A9078879 /* LMSAPI.swift */,
+				783FB56FEA8646E493E1F892 /* LMSAPIFeatures.swift */,
+				A67EC2E472DF4AC496EE5228 /* LMSFeatureModels.swift */,
+				30950446704F46C39BC5C627 /* LMSModels.swift */,
 			);
 			path = LMS;
 			sourceTree = "<group>";
 		};
-		E4980B748EA14558B271A540 /* Auth */ = {
+		AFA30B99D5E1476A85171AE3 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
-				E381B02ECFC049589D2DC497 /* AuthAPI.swift */,
-				6A3941BAE0D344B68BF9E193 /* AuthSession.swift */,
-				A77F64B7E38D44B095C03DB2 /* KeychainStore.swift */,
+				2BCBFDA4B1F445E48F9384EB /* APIClient.swift */,
+				C81475601FE54C2396AFD164 /* APIError.swift */,
+				8A158EF966AA4F73BBA4DD3F /* NetworkBootstrap.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		C8C127479964405B8EFC1455 /* Notebook */ = {
+			isa = PBXGroup;
+			children = (
+				61CA06827D1441A39B9E9CB8 /* NotebookDrawing.swift */,
+				B470832CAE1B4390B7E1F400 /* NotebookMarkdown.swift */,
+				BEBB821FDA5141A090CF8ED1 /* NotebookSlashCommands.swift */,
+				18AB274F28DA4765B6936B7D /* NotebookStore.swift */,
+				0AFC6E7A1E8742C694CAE9D3 /* NotebookSync.swift */,
+				A7F690D75FCF4CAE9E31A8BE /* NotebookTree.swift */,
+			);
+			path = Notebook;
+			sourceTree = "<group>";
+		};
+		72E33627E1C249E9AE85E3ED /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				7CD2BF03169B40F8BB4603F9 /* AuthFlowView.swift */,
+				AA08181B1FD143698CFE9F1D /* LoginView.swift */,
+				158C7F82B9C44AAD9C19D313 /* SignupView.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
 		};
-		EBAE4996735E499690B16F07 /* Inbox */ = {
+		7675643BA72541F19D3FFDD6 /* Courses */ = {
 			isa = PBXGroup;
 			children = (
-				00371559A0064F3C8680FB17 /* ComposeMessageView.swift */,
-				8CB61B2251914FD5BEC68339 /* InboxView.swift */,
-				342A38D5616F47F7BDEB10A5 /* MessageDetailView.swift */,
+				0BD0FD4519034CFF87ACDD97 /* CourseAttendanceView.swift */,
+				83819D2C91854BAA87DD64C9 /* CourseDetailView.swift */,
+				CB0AD28460E743AF8914E93B /* CourseGradesView.swift */,
+				A6879EF8BB3B4773A6AB90B3 /* CourseSyllabusView.swift */,
+				6B4EA2DF1FEE40ED88024562 /* CoursesListView.swift */,
+				38E26170E6E246CDA60E2648 /* ItemDetailRows.swift */,
+				A66635F9C2404AEBB6C0D702 /* ItemDetailView.swift */,
+			);
+			path = Courses;
+			sourceTree = "<group>";
+		};
+		B0681CA130754335868C3665 /* Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+				7044CD091D4D44B29700AA65 /* DashboardView.swift */,
+			);
+			path = Dashboard;
+			sourceTree = "<group>";
+		};
+		60857CE5780847E78E2E0FDB /* Grading */ = {
+			isa = PBXGroup;
+			children = (
+				CA929DA3E86949FCA7458E25 /* GradingBacklogView.swift */,
+				A4C9DD73050B4C399A795450 /* SpeedGraderView.swift */,
+			);
+			path = Grading;
+			sourceTree = "<group>";
+		};
+		75DCE22BF6CB448EB44884D1 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				A62E6ECC3E1F485BABFD045C /* AnnouncementsViews.swift */,
+				3B217EF481094A78ABCE9D57 /* MainTabView.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		496EF4A60F954C288B84726E /* Inbox */ = {
+			isa = PBXGroup;
+			children = (
+				55F1EB560B414CE5BC72DEE6 /* ComposeMessageView.swift */,
+				AEB66BAF728D40CB940CE163 /* InboxView.swift */,
+				9C73DF511F2A44B59807813A /* MessageDetailView.swift */,
 			);
 			path = Inbox;
+			sourceTree = "<group>";
+		};
+		CD497CED663140BAB992D27B /* Notebooks */ = {
+			isa = PBXGroup;
+			children = (
+				A88989E14E9745ADB033A900 /* NotebookDrawingViews.swift */,
+				75620A8776714D22A8755B24 /* NotebookEditorSupportViews.swift */,
+				0039BFFD2DB74196B025B372 /* NotebookEditorView.swift */,
+				7226267AC7F04A61943EB563 /* NotebookPagesView.swift */,
+				47260659CDF34919A49376AD /* NotebooksListView.swift */,
+			);
+			path = Notebooks;
+			sourceTree = "<group>";
+		};
+		FDB20FAAEEBE480EB249DF7E /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+				9FD437F6AD0D46B49256D2F8 /* NotificationsView.swift */,
+				0560960CA0824DD4A44A525A /* ProfileView.swift */,
+			);
+			path = Profile;
+			sourceTree = "<group>";
+		};
+		311ED73FCE5B4516AE6BBF60 /* Splash */ = {
+			isa = PBXGroup;
+			children = (
+				9EECC55348A146E6A8930358 /* SplashView.swift */,
+			);
+			path = Splash;
+			sourceTree = "<group>";
+		};
+		EEA523EE34AD4DED8A7F8E1C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				254C11EEEC9D4475BD749587 /* Lextures.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		664E20BD81234DB98F5AA996 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				C69D6A1902944F5482EC8494 /* Development.xcconfig */,
+			);
+			path = Config;
+			sourceTree = "<group>";
+		};
+		77C73FBA6C6F4C09BF133922 = {
+			isa = PBXGroup;
+			children = (
+				5088BEAA630644AC80095F60 /* Lextures */,
+				664E20BD81234DB98F5AA996 /* Config */,
+				EEA523EE34AD4DED8A7F8E1C /* Products */,
+			);
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		40934B6DD44F4A9CB8AFA195 /* Lextures */ = {
+		F47E623D641A4B928ED3D17B /* Lextures */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 677D7E42FC574043937597E2 /* Build configuration list for PBXNativeTarget "Lextures" */;
+			buildConfigurationList = 188A05F6354847109CA41D7E /* Build configuration list for PBXNativeTarget "Lextures" */;
 			buildPhases = (
-				C78758AC0B464FBA8E345EFD /* Sources */,
-				C5A3C66FEAAB416CB9BB0223 /* Frameworks */,
-				0B7EEB792E864E4DBDAB4650 /* Resources */,
+				D372C888004B481BA6E7CD7F /* Sources */,
+				C7EC4AFCB13D433CBBF5F709 /* Frameworks */,
+				7086059935AA43199C065B9F /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = Lextures;
+			name = "Lextures";
 			productName = Lextures;
-			productReference = 8FC8324422AE44CDA7A40993 /* Lextures.app */;
+			productReference = 254C11EEEC9D4475BD749587 /* Lextures.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		7EF1CB4F0DC24A669B80DF3E /* Project object */ = {
+		836022E2E20A4C148F2405A9 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1600;
-				LastUpgradeCheck = 2650;
+				LastUpgradeCheck = 1600;
 				TargetAttributes = {
-					40934B6DD44F4A9CB8AFA195 = {
+					F47E623D641A4B928ED3D17B = {
 						CreatedOnToolsVersion = 16.0;
 					};
 				};
 			};
-			buildConfigurationList = 0EE568337B484F0C87A6B13C /* Build configuration list for PBXProject "Lextures" */;
+			buildConfigurationList = 2BFE7BD8F1244BBFA33C2BF0 /* Build configuration list for PBXProject "Lextures" */;
 			compatibilityVersion = "Xcode 15.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -401,171 +407,134 @@
 				en,
 				Base,
 			);
-			mainGroup = 6A4A6A7437C442E582159C4F;
-			productRefGroup = 7202BE50B25146A9B10F1E6E /* Products */;
+			mainGroup = 77C73FBA6C6F4C09BF133922;
+			productRefGroup = EEA523EE34AD4DED8A7F8E1C /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				40934B6DD44F4A9CB8AFA195 /* Lextures */,
+				F47E623D641A4B928ED3D17B /* Lextures */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		0B7EEB792E864E4DBDAB4650 /* Resources */ = {
+		7086059935AA43199C065B9F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
-			files = (
-				0C932BCA11A64A85835C8E11 /* Assets.xcassets in Resources */,
-			);
 			runOnlyForDeploymentPostprocessing = 0;
+			files = (
+				8295FCA9E58242AEBF0D6B24 /* Assets.xcassets in Resources */,
+			);
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		C78758AC0B464FBA8E345EFD /* Sources */ = {
+		D372C888004B481BA6E7CD7F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
-			files = (
-				98219FA136424EE98E2CCB96 /* AppDelegate.swift in Sources */,
-				250204AD53A545ECAE48AF36 /* LexturesApp.swift in Sources */,
-				0BE9D62E48EA4C629B1F40DD /* RootView.swift in Sources */,
-				A7696158D521432BBEBD7060 /* AuthAPI.swift in Sources */,
-				03F24D1C7C2F4D36B4A9974F /* AuthSession.swift in Sources */,
-				259B10F0F6F34A00853E6DE9 /* KeychainStore.swift in Sources */,
-				B57A14D017DD44ABBEC6B1C2 /* AppConfiguration.swift in Sources */,
-				1123E8C06A88423D9A7C4FC9 /* AuthFieldRepresentable.swift in Sources */,
-				0BAA37D85E8E4EDE9FFD08F2 /* BrandLogoView.swift in Sources */,
-				4FC39E85E000400A84539C68 /* LexturesTheme.swift in Sources */,
-				5EB87BB18EEF448DBA298195 /* LMSAPI.swift in Sources */,
-				0F71D9420CA1496A9052C76F /* LMSAPIFeatures.swift in Sources */,
-				6E09A7B233E34534949D4962 /* LMSFeatureModels.swift in Sources */,
-				63D7E5CF6E074933A11B7966 /* LMSModels.swift in Sources */,
-				7EF1B2948974453BA4281BAC /* APIClient.swift in Sources */,
-				0CA81952480A4469B881EA68 /* APIError.swift in Sources */,
-				154D39BCA6D0413690460016 /* NetworkBootstrap.swift in Sources */,
-				A92FFD7126524313B2CFA84C /* NotebookDrawing.swift in Sources */,
-				EAE21D487BD843B8B61AF258 /* NotebookMarkdown.swift in Sources */,
-				A12E78A380AF4D6A998B8505 /* NotebookSlashCommands.swift in Sources */,
-				73C9BB2170AE486F8AEBC7BD /* NotebookStore.swift in Sources */,
-				A325645C108543E3B6FA2855 /* NotebookSync.swift in Sources */,
-				1D4876D8A2864F01915DC900 /* NotebookTree.swift in Sources */,
-				B3ECEB502E794C60AC4A63E0 /* AuthFlowView.swift in Sources */,
-				E7DB3F2216844788863F034B /* LoginView.swift in Sources */,
-				2F6739E5496D46E08D307057 /* SignupView.swift in Sources */,
-				D465FEB62870425D94160B9C /* CourseAttendanceView.swift in Sources */,
-				2E4D4CC7DBAE477B849B34E6 /* CourseDetailView.swift in Sources */,
-				E126575B54E04CF2A499DD50 /* CourseGradesView.swift in Sources */,
-				47B7567DAEDA4C98B1DAAAC7 /* CourseSyllabusView.swift in Sources */,
-				DA48336D51074394A319EEB1 /* CoursesListView.swift in Sources */,
-				14B500CFD7E242ADAA4D83ED /* ItemDetailRows.swift in Sources */,
-				F1FE04A22BAF43DAB45741CA /* ItemDetailView.swift in Sources */,
-				DCE07FE1A75345BDB9A5DFD5 /* DashboardView.swift in Sources */,
-				D4F36BF7CA994F059B15D1A6 /* GradingBacklogView.swift in Sources */,
-				19F5F42A3DE740889E74539A /* AnnouncementsViews.swift in Sources */,
-				38B6DDE61E534BFAA25470A3 /* MainTabView.swift in Sources */,
-				B5057044BF7D4838BE865AD0 /* ComposeMessageView.swift in Sources */,
-				77BC611BB30E490E9E6AEFC0 /* InboxView.swift in Sources */,
-				F182B961441740608636D510 /* MessageDetailView.swift in Sources */,
-				4AB48FBB013B4D93BFFE082E /* NotebookDrawingViews.swift in Sources */,
-				0644413C280E461CA9E6706E /* NotebookEditorSupportViews.swift in Sources */,
-				32F3955E9F524838A2933774 /* NotebookEditorView.swift in Sources */,
-				8F2B0D55C3E45076B9F2DAE1 /* NotebookPagesView.swift in Sources */,
-				5FA504A6F2C24DB3A47DA51D /* NotebooksListView.swift in Sources */,
-				2386914D66FE44068A2F9D11 /* NotificationsView.swift in Sources */,
-				6432F2AE481E47B09FD6D673 /* ProfileView.swift in Sources */,
-				E5BA8E3802B8404BAE92B450 /* SplashView.swift in Sources */,
-			);
 			runOnlyForDeploymentPostprocessing = 0;
+			files = (
+				82F50A6D5D5E43828442CCBD /* AppDelegate.swift in Sources */,
+				784E0470C7624962A401A324 /* LexturesApp.swift in Sources */,
+				F8965C4982244EE78E5EE37C /* RootView.swift in Sources */,
+				7F15AC9A98B6416298F0E2E7 /* AuthAPI.swift in Sources */,
+				907C146ACDEB442EA8753A33 /* AuthSession.swift in Sources */,
+				1F5C1A2103634B1AA90F6FC7 /* KeychainStore.swift in Sources */,
+				5B469EA7D91B48A19F2E8B23 /* AppConfiguration.swift in Sources */,
+				A8355B9444DD4689B446E3C3 /* AuthFieldRepresentable.swift in Sources */,
+				E451AEA9FC0744499CB5C433 /* BrandLogoView.swift in Sources */,
+				702C67F952FC4D46AA84A8BC /* LexturesTheme.swift in Sources */,
+				0DDD0A011A774ACDA7D98719 /* CourseHeroImage.swift in Sources */,
+				45B8F60107DA4FB89F79ABD3 /* LMSAPI.swift in Sources */,
+				E432DCE16E254852AF729D02 /* LMSAPIFeatures.swift in Sources */,
+				C1BAFCCDB8774722A856622B /* LMSFeatureModels.swift in Sources */,
+				A2B6E36705424B8CA8A44435 /* LMSModels.swift in Sources */,
+				1FCD610119E1473CAC908160 /* APIClient.swift in Sources */,
+				14CE03443A8745428D2C58C0 /* APIError.swift in Sources */,
+				948089F4A7D94BA6B6B440B3 /* NetworkBootstrap.swift in Sources */,
+				FE442D38DF5943658F411B8C /* NotebookDrawing.swift in Sources */,
+				B8CB210AE90B4A6D89B78AAC /* NotebookMarkdown.swift in Sources */,
+				FA4D6C553EAC4506B9C6EC18 /* NotebookSlashCommands.swift in Sources */,
+				14ABFC0C18D4485380E22A6F /* NotebookStore.swift in Sources */,
+				67CBB3E91C854E7C8CBBCAD8 /* NotebookSync.swift in Sources */,
+				7336F2BDCAD344028E65F1C9 /* NotebookTree.swift in Sources */,
+				DC7055D49D6C4FBEA9CC12A6 /* AuthFlowView.swift in Sources */,
+				2146B0E97CB74C5C8D915307 /* LoginView.swift in Sources */,
+				BBD20591AAB84D09A1484AC4 /* SignupView.swift in Sources */,
+				9F5FA2B4FB834CB4BAF8B162 /* CourseAttendanceView.swift in Sources */,
+				24AFD590C4D448EEBC569D77 /* CourseDetailView.swift in Sources */,
+				A438FB26B7F0432490351D64 /* CourseGradesView.swift in Sources */,
+				5E1483A418784253841907CB /* CourseSyllabusView.swift in Sources */,
+				3971A8515B0F4D838E1A7640 /* CoursesListView.swift in Sources */,
+				758D9D32FFA44F0DB20E2769 /* ItemDetailRows.swift in Sources */,
+				2BC799521809413B8DC138DE /* ItemDetailView.swift in Sources */,
+				8F35B2C6D54048F1B527BE2C /* DashboardView.swift in Sources */,
+				43088A0355A74E9E9EAEC991 /* GradingBacklogView.swift in Sources */,
+				296E6CBE9A1B4B48B5C9228A /* SpeedGraderView.swift in Sources */,
+				AC1EDDCFE1F946999F54E5A0 /* AnnouncementsViews.swift in Sources */,
+				266BCB111888433A920A873F /* MainTabView.swift in Sources */,
+				F0A827C700444C738EBCDEBC /* ComposeMessageView.swift in Sources */,
+				1D2FC8DA7AE24011BC76220F /* InboxView.swift in Sources */,
+				EA17F526D17B4487B1EFCFE5 /* MessageDetailView.swift in Sources */,
+				A1DB372571294385BDCE6F00 /* NotebookDrawingViews.swift in Sources */,
+				8C87B19F5D184B45BF3B6562 /* NotebookEditorSupportViews.swift in Sources */,
+				325F0F9BFA324FCF9074196C /* NotebookEditorView.swift in Sources */,
+				BE3FBB94981149DE9DC6F9A2 /* NotebookPagesView.swift in Sources */,
+				5F02869576C64C3198D1981F /* NotebooksListView.swift in Sources */,
+				AA5F25AC893F4E8E8AA9A00B /* NotificationsView.swift in Sources */,
+				F9669A6F09A94BC998E3846F /* ProfileView.swift in Sources */,
+				1C871944AD4A4331BB1FDF04 /* SplashView.swift in Sources */,
+			);
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		4C702AD712A948C5BE4A48DA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 23E537FADE8F4B5E8A491A87 /* Development.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = Lextures/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 0.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.lextures.ios;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
-			};
-			name = Debug;
-		};
-		ABAF4C80B4D44A5DAE576E03 /* Debug */ = {
+		19929032AF6246888F9F9851 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = 8RF75885C9;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_OPTIMIZATION_LEVEL = -Onone;
 			};
 			name = Debug;
 		};
-		BCBAD85AE2154100AC38611C /* Release */ = {
+		16D90CC1A934482C91E3E5C6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 23E537FADE8F4B5E8A491A87 /* Development.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf-with-dsym;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = s;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				ONLY_ACTIVE_ARCH = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = -O;
+			};
+			name = Release;
+		};
+		32C52A445E6E40C292B116C7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C69D6A1902944F5482EC8494 /* Development.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Lextures/Resources/Info.plist;
@@ -582,78 +551,57 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
-			name = Release;
+			name = Debug;
 		};
-		F5D5D787E7F74A4B9849C42F /* Release */ = {
+		22C07234871740C79BE21C47 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C69D6A1902944F5482EC8494 /* Development.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 8RF75885C9;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = s;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				ONLY_ACTIVE_ARCH = NO;
-				SDKROOT = iphoneos;
-				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Lextures/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lextures.ios;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		0EE568337B484F0C87A6B13C /* Build configuration list for PBXProject "Lextures" */ = {
+		2BFE7BD8F1244BBFA33C2BF0 /* Build configuration list for PBXProject "Lextures" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				ABAF4C80B4D44A5DAE576E03 /* Debug */,
-				F5D5D787E7F74A4B9849C42F /* Release */,
+				19929032AF6246888F9F9851 /* Debug */,
+				16D90CC1A934482C91E3E5C6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		677D7E42FC574043937597E2 /* Build configuration list for PBXNativeTarget "Lextures" */ = {
+		188A05F6354847109CA41D7E /* Build configuration list for PBXNativeTarget "Lextures" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				4C702AD712A948C5BE4A48DA /* Debug */,
-				BCBAD85AE2154100AC38611C /* Release */,
+				32C52A445E6E40C292B116C7 /* Debug */,
+				22C07234871740C79BE21C47 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 7EF1CB4F0DC24A669B80DF3E /* Project object */;
+	rootObject = 836022E2E20A4C148F2405A9 /* Project object */;
 }

--- a/clients/ios/Lextures.xcodeproj/xcshareddata/xcschemes/Lextures-Device.xcscheme
+++ b/clients/ios/Lextures.xcodeproj/xcshareddata/xcschemes/Lextures-Device.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "40934B6DD44F4A9CB8AFA195"
+               BlueprintIdentifier = "F47E623D641A4B928ED3D17B"
                BuildableName = "Lextures.app"
                BlueprintName = "Lextures"
                ReferencedContainer = "container:Lextures.xcodeproj">
@@ -43,7 +43,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "40934B6DD44F4A9CB8AFA195"
+            BlueprintIdentifier = "F47E623D641A4B928ED3D17B"
             BuildableName = "Lextures.app"
             BlueprintName = "Lextures"
             ReferencedContainer = "container:Lextures.xcodeproj">

--- a/clients/ios/Lextures.xcodeproj/xcshareddata/xcschemes/Lextures.xcscheme
+++ b/clients/ios/Lextures.xcodeproj/xcshareddata/xcschemes/Lextures.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2650"
+   LastUpgradeVersion = "1600"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "40934B6DD44F4A9CB8AFA195"
+               BlueprintIdentifier = "F47E623D641A4B928ED3D17B"
                BuildableName = "Lextures.app"
                BlueprintName = "Lextures"
                ReferencedContainer = "container:Lextures.xcodeproj">
@@ -43,7 +43,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "40934B6DD44F4A9CB8AFA195"
+            BlueprintIdentifier = "F47E623D641A4B928ED3D17B"
             BuildableName = "Lextures.app"
             BlueprintName = "Lextures"
             ReferencedContainer = "container:Lextures.xcodeproj">

--- a/clients/ios/Lextures/Core/LMS/CourseHeroImage.swift
+++ b/clients/ios/Lextures/Core/LMS/CourseHeroImage.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// Course banner image with auth for `/course-files/.../content` URLs (parity with web).
+struct CourseHeroImage: View {
+    @Environment(AuthSession.self) private var session
+    let urlString: String?
+    let fallbackKey: String
+    var height: CGFloat = 84
+
+    @State private var image: UIImage?
+
+    private static let cache = NSCache<NSString, UIImage>()
+
+    var body: some View {
+        ZStack {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                LexturesTheme.coverGradient(for: fallbackKey)
+            }
+        }
+        .frame(height: height)
+        .frame(maxWidth: .infinity)
+        .clipped()
+        .accessibilityHidden(true)
+        .task(id: urlString) { await load() }
+    }
+
+    private func load() async {
+        guard let raw = urlString?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            image = nil
+            return
+        }
+        if let cached = Self.cache.object(forKey: raw as NSString) {
+            image = cached
+            return
+        }
+        guard let url = resolvedURL(raw) else { return }
+        var request = URLRequest(url: url)
+        if let token = session.accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        guard
+            let (data, response) = try? await URLSession.shared.data(for: request),
+            (response as? HTTPURLResponse).map({ (200 ... 299).contains($0.statusCode) }) != false,
+            let loaded = UIImage(data: data)
+        else { return }
+        Self.cache.setObject(loaded, forKey: raw as NSString)
+        image = loaded
+    }
+
+    private func resolvedURL(_ raw: String) -> URL? {
+        if raw.hasPrefix("/") {
+            return AppConfiguration.apiURL(path: raw)
+        }
+        if let parsed = URL(string: raw), parsed.scheme == "https" || parsed.scheme == "http" {
+            return parsed
+        }
+        return nil
+    }
+}

--- a/clients/ios/Lextures/Core/LMS/LMSAPIFeatures.swift
+++ b/clients/ios/Lextures/Core/LMS/LMSAPIFeatures.swift
@@ -115,6 +115,42 @@ extension LMSAPI {
         return try decode(SubmissionsListResponse.self, from: data).submissions
     }
 
+    static func fetchQuizAttempts(
+        courseCode: String,
+        itemId: String,
+        accessToken: String
+    ) async throws -> [QuizAttemptSummary] {
+        let (data, _) = try await client.request(
+            path: "/api/v1/courses/\(encodePath(courseCode))/quizzes/\(encodePath(itemId))/attempts",
+            authorized: true,
+            accessToken: accessToken
+        )
+        return try decode(QuizAttemptsListResponse.self, from: data).attempts
+    }
+
+    static func fetchGradingSubmissions(
+        courseCode: String,
+        backlogItem: GradingBacklogItem,
+        graded: String?,
+        accessToken: String
+    ) async throws -> [AssignmentSubmission] {
+        if backlogItem.isQuiz {
+            let attempts = try await fetchQuizAttempts(
+                courseCode: courseCode,
+                itemId: backlogItem.resolvedItemId,
+                accessToken: accessToken
+            )
+            let submissions = GradingSubmissionMapper.quizAttemptsToSubmissions(attempts)
+            return GradingSubmissionMapper.filterSubmissions(submissions, graded: graded ?? "all")
+        }
+        return try await fetchSubmissions(
+            courseCode: courseCode,
+            itemId: backlogItem.resolvedItemId,
+            graded: graded,
+            accessToken: accessToken
+        )
+    }
+
     static func fetchSubmissionGrade(
         courseCode: String,
         itemId: String,

--- a/clients/ios/Lextures/Core/LMS/LMSFeatureModels.swift
+++ b/clients/ios/Lextures/Core/LMS/LMSFeatureModels.swift
@@ -158,12 +158,16 @@ struct AssignmentSubmission: Decodable, Identifiable, Hashable {
     var submittedByDisplayName: String?
     var blindLabel: String?
     var attachmentFilename: String?
+    var attachmentMimeType: String?
+    var attachmentContentPath: String?
+    var bodyText: String?
     var submittedAt: String
     var updatedAt: String?
     var versionNumber: Int?
     var resubmissionRequested: Bool?
     var revisionDueAt: String?
     var revisionFeedback: String?
+    var isGraded: Bool?
 
     /// Name shown in staff lists; respects blind grading.
     var displayName: String {
@@ -179,6 +183,27 @@ struct MySubmissionResponse: Decodable {
 
 struct SubmissionsListResponse: Decodable {
     var submissions: [AssignmentSubmission]
+
+    enum CodingKeys: String, CodingKey { case submissions }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // The list endpoint returns a roster row for every enrolled student, including
+        // non-submitters that lack `id`/`submittedAt`. Decode leniently and keep only
+        // real submissions so one placeholder doesn't fail the whole list.
+        let rows = try container.decodeIfPresent([LossyDecodable<AssignmentSubmission>].self, forKey: .submissions) ?? []
+        submissions = rows.compactMap(\.value)
+    }
+}
+
+/// Decodes `T` if possible, otherwise yields `nil` without throwing — used to skip
+/// malformed/placeholder elements inside an array without failing the whole decode.
+struct LossyDecodable<T: Decodable>: Decodable {
+    let value: T?
+
+    init(from decoder: Decoder) throws {
+        value = try? T(from: decoder)
+    }
 }
 
 /// GET/PUT `.../submissions/{id}/grade`.
@@ -191,15 +216,86 @@ struct SubmissionGrade: Decodable {
     var excused: Bool?
 }
 
+// MARK: - Quiz attempts (staff)
+
+/// Row from GET `/quizzes/{item}/attempts`.
+struct QuizAttemptSummary: Decodable, Identifiable, Hashable {
+    var id: String
+    var studentUserId: String?
+    var attemptNumber: Int
+    var submittedAt: String
+    var scorePercent: Double?
+    var pointsEarned: Double
+    var pointsPossible: Double
+    var studentName: String?
+    var needsManualGrading: Bool?
+}
+
+struct QuizAttemptsListResponse: Decodable {
+    var attempts: [QuizAttemptSummary]
+}
+
 // MARK: - Grading backlog (staff)
 
 /// Row from GET `/courses/{code}/grading-backlog`.
 struct GradingBacklogItem: Decodable, Identifiable, Hashable {
+    var itemId: String?
+    var itemType: String? // "assignment" | "quiz"
     var assignmentId: String
     var assignmentTitle: String
     var ungradedCount: Int
 
-    var id: String { assignmentId }
+    var resolvedItemId: String { itemId ?? assignmentId }
+    var isQuiz: Bool { itemType == "quiz" }
+    var id: String { "\(itemType ?? "assignment")-\(resolvedItemId)" }
+}
+
+enum GradingSubmissionMapper {
+    static func quizAttemptsToSubmissions(_ attempts: [QuizAttemptSummary]) -> [AssignmentSubmission] {
+        var byStudent: [String: QuizAttemptSummary] = [:]
+        for attempt in attempts {
+            let key = attempt.studentUserId?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty ?? attempt.id
+            if let existing = byStudent[key] {
+                if attempt.attemptNumber >= existing.attemptNumber {
+                    byStudent[key] = attempt
+                }
+            } else {
+                byStudent[key] = attempt
+            }
+        }
+        return byStudent.values
+            .sorted { ($0.studentName ?? "") < ($1.studentName ?? "") }
+            .map { attempt in
+                AssignmentSubmission(
+                    id: attempt.id,
+                    submittedBy: attempt.studentUserId,
+                    submittedByDisplayName: attempt.studentName,
+                    blindLabel: nil,
+                    attachmentFilename: nil,
+                    submittedAt: attempt.submittedAt,
+                    updatedAt: nil,
+                    versionNumber: attempt.attemptNumber > 1 ? attempt.attemptNumber : nil,
+                    resubmissionRequested: nil,
+                    revisionDueAt: nil,
+                    revisionFeedback: nil,
+                    isGraded: attempt.needsManualGrading == false
+                )
+            }
+    }
+
+    static func filterSubmissions(_ submissions: [AssignmentSubmission], graded: String?) -> [AssignmentSubmission] {
+        guard let graded, graded != "all" else { return submissions }
+        if graded == "graded" {
+            return submissions.filter { $0.isGraded == true }
+        }
+        return submissions.filter { $0.isGraded != true }
+    }
+}
+
+private extension String {
+    var nonEmpty: String? {
+        isEmpty ? nil : self
+    }
 }
 
 struct GradingBacklogResponse: Decodable {

--- a/clients/ios/Lextures/Features/Dashboard/DashboardView.swift
+++ b/clients/ios/Lextures/Features/Dashboard/DashboardView.swift
@@ -166,6 +166,7 @@ struct DashboardView: View {
                         }
                     }
                     .padding(16)
+                    .padding(.bottom, 8)
                 }
                 .refreshable {
                     await model.load(accessToken: session.accessToken, force: true)
@@ -437,15 +438,18 @@ struct DashboardView: View {
                 .padding(.horizontal, 2)
             }
             .scrollClipDisabled()
+            .padding(.bottom, 4)
         }
     }
 
     private func courseCarouselCard(_ course: CourseSummary) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             ZStack(alignment: .topTrailing) {
-                RoundedRectangle(cornerRadius: 0)
-                    .fill(LexturesTheme.coverGradient(for: course.courseCode))
-                    .frame(height: 84)
+                CourseHeroImage(
+                    urlString: course.heroImageUrl,
+                    fallbackKey: course.courseCode,
+                    height: 84
+                )
                 Image(systemName: "book.fill")
                     .font(.title3)
                     .foregroundStyle(.white.opacity(0.5))

--- a/clients/ios/Lextures/Features/Grading/GradingBacklogView.swift
+++ b/clients/ios/Lextures/Features/Grading/GradingBacklogView.swift
@@ -47,9 +47,20 @@ struct GradingBacklogSection: View {
                     .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
 
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(item.assignmentTitle)
-                        .font(.subheadline.weight(.medium))
-                        .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                    HStack(spacing: 6) {
+                        Text(item.assignmentTitle)
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                        if item.isQuiz {
+                            Text("Quiz")
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(LexturesTheme.amber)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(LexturesTheme.amber.opacity(0.14))
+                                .clipShape(Capsule())
+                        }
+                    }
                     Text("\(item.ungradedCount) ungraded submission\(item.ungradedCount == 1 ? "" : "s")")
                         .font(.caption)
                         .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
@@ -177,12 +188,20 @@ struct SubmissionsListView: View {
         .task { await load() }
         .task(id: filter) { await load() }
         .sheet(item: $grading) { submission in
-            GradeSubmissionSheet(
-                course: course,
-                assignmentId: backlogItem.assignmentId,
-                submission: submission
-            ) {
-                Task { await load() }
+            if backlogItem.isQuiz {
+                QuizAttemptInfoSheet(
+                    backlogItem: backlogItem,
+                    submission: submission
+                )
+            } else {
+                SpeedGraderView(
+                    course: course,
+                    assignmentId: backlogItem.resolvedItemId,
+                    submissions: submissions,
+                    startIndex: submissions.firstIndex(of: submission) ?? 0
+                ) {
+                    Task { await load() }
+                }
             }
         }
     }
@@ -238,9 +257,9 @@ struct SubmissionsListView: View {
         errorMessage = nil
         defer { loading = false }
         do {
-            submissions = try await LMSAPI.fetchSubmissions(
+            submissions = try await LMSAPI.fetchGradingSubmissions(
                 courseCode: course.courseCode,
-                itemId: backlogItem.assignmentId,
+                backlogItem: backlogItem,
                 graded: filter.queryValue,
                 accessToken: token
             )
@@ -250,33 +269,13 @@ struct SubmissionsListView: View {
     }
 }
 
-/// Bottom sheet: enter points + comment for one submission.
-struct GradeSubmissionSheet: View {
-    @Environment(AuthSession.self) private var session
+/// Quiz attempts must be graded per question on web (mobile v1 is read-only).
+struct QuizAttemptInfoSheet: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dismiss) private var dismiss
 
-    let course: CourseSummary
-    let assignmentId: String
+    let backlogItem: GradingBacklogItem
     let submission: AssignmentSubmission
-    var onSaved: () -> Void = {}
-
-    @State private var pointsText = ""
-    @State private var comment = ""
-    @State private var maxPoints: Double?
-    @State private var errorMessage: String?
-    @State private var loading = true
-    @State private var saving = false
-
-    private var pointsValue: Double? {
-        Double(pointsText.replacingOccurrences(of: ",", with: "."))
-    }
-
-    private var pointsValid: Bool {
-        guard let value = pointsValue else { return false }
-        if let max = maxPoints { return value >= 0 && value <= max }
-        return value >= 0
-    }
 
     var body: some View {
         NavigationStack {
@@ -285,10 +284,6 @@ struct GradeSubmissionSheet: View {
 
                 ScrollView {
                     VStack(alignment: .leading, spacing: 14) {
-                        if let errorMessage {
-                            LMSErrorBanner(message: errorMessage)
-                        }
-
                         LMSCard {
                             Text(submission.displayName)
                                 .font(LexturesTheme.displayFont(18))
@@ -296,137 +291,33 @@ struct GradeSubmissionSheet: View {
                             Text("Submitted \(LMSDates.shortDateTime(submission.submittedAt))")
                                 .font(.caption)
                                 .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
-                            if let filename = submission.attachmentFilename, !filename.isEmpty {
-                                Label(filename, systemImage: "paperclip")
+                            if let version = submission.versionNumber, version > 1 {
+                                Text("Attempt \(version)")
                                     .font(.caption)
-                                    .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
-                                Text("Open the web app to review file submissions in full.")
-                                    .font(.caption2)
-                                    .italic()
                                     .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
                             }
                         }
 
                         LMSCard {
-                            Text("Score")
+                            Text("Grade on web")
                                 .font(LexturesTheme.displayFont(17))
                                 .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
-                            HStack(spacing: 10) {
-                                TextField("Points", text: $pointsText)
-                                    .keyboardType(.decimalPad)
-                                    .font(LexturesTheme.displayFont(22, weight: .bold))
-                                    .padding(.horizontal, 14)
-                                    .padding(.vertical, 10)
-                                    .frame(width: 120)
-                                    .background(LexturesTheme.sceneBackground(for: colorScheme).opacity(0.7))
-                                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                            .stroke(
-                                                pointsText.isEmpty || pointsValid
-                                                    ? LexturesTheme.fieldBorder(for: colorScheme)
-                                                    : LexturesTheme.error,
-                                                lineWidth: 1
-                                            )
-                                    )
-                                if let max = maxPoints {
-                                    Text("/ \(max.formatted()) pts")
-                                        .font(.subheadline.weight(.semibold))
-                                        .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
-                                }
-                            }
-                            if !pointsText.isEmpty && !pointsValid {
-                                Text(maxPoints.map { "Enter a number between 0 and \($0.formatted())." } ?? "Enter a valid number.")
-                                    .font(.caption)
-                                    .foregroundStyle(LexturesTheme.error)
-                            }
+                            Text("Quiz answers are graded question by question. Open the web app to review responses and enter scores for \(backlogItem.assignmentTitle).")
+                                .font(.subheadline)
+                                .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
                         }
-
-                        LMSCard {
-                            Text("Feedback")
-                                .font(LexturesTheme.displayFont(17))
-                                .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
-                            TextField("Comment for the student (optional)", text: $comment, axis: .vertical)
-                                .lineLimit(4 ... 8)
-                                .padding(12)
-                                .background(LexturesTheme.sceneBackground(for: colorScheme).opacity(0.7))
-                                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                        .stroke(LexturesTheme.fieldBorder(for: colorScheme), lineWidth: 1)
-                                )
-                        }
-
-                        Button {
-                            Task { await save() }
-                        } label: {
-                            if saving {
-                                ProgressView()
-                                    .frame(maxWidth: .infinity)
-                            } else {
-                                Text("Save grade")
-                            }
-                        }
-                        .buttonStyle(AuthPrimaryButtonStyle())
-                        .disabled(!pointsValid || saving || loading)
                     }
                     .padding(16)
                 }
             }
-            .navigationTitle("Grade submission")
+            .navigationTitle("Quiz attempt")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel") { dismiss() }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
                 }
             }
-            .task { await loadExisting() }
         }
-        .presentationDetents([.large])
-    }
-
-    private func loadExisting() async {
-        guard let token = session.accessToken else {
-            loading = false
-            return
-        }
-        loading = true
-        defer { loading = false }
-        // Pre-fill when a grade already exists; also learns maxPoints for validation.
-        if let grade = try? await LMSAPI.fetchSubmissionGrade(
-            courseCode: course.courseCode,
-            itemId: assignmentId,
-            submissionId: submission.id,
-            accessToken: token
-        ) {
-            maxPoints = grade.maxPoints
-            if let earned = grade.pointsEarned {
-                pointsText = earned.formatted()
-            }
-            comment = grade.instructorComment ?? ""
-        }
-    }
-
-    private func save() async {
-        guard let token = session.accessToken, let points = pointsValue else { return }
-        saving = true
-        errorMessage = nil
-        defer { saving = false }
-        do {
-            try await LMSAPI.putSubmissionGrade(
-                courseCode: course.courseCode,
-                itemId: assignmentId,
-                submissionId: submission.id,
-                body: .init(
-                    pointsEarned: points,
-                    instructorComment: comment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : comment
-                ),
-                accessToken: token
-            )
-            onSaved()
-            dismiss()
-        } catch {
-            errorMessage = (error as? LocalizedError)?.errorDescription ?? "Could not save the grade."
-        }
+        .presentationDetents([.medium, .large])
     }
 }

--- a/clients/ios/Lextures/Features/Grading/SpeedGraderView.swift
+++ b/clients/ios/Lextures/Features/Grading/SpeedGraderView.swift
@@ -1,0 +1,349 @@
+import SwiftUI
+
+/// SpeedGrader-style flow: page through an assignment's submissions, read each
+/// one, and enter a score/feedback without returning to the list. Seeded with the
+/// already-loaded submissions snapshot and the index of the tapped student.
+struct SpeedGraderView: View {
+    @Environment(AuthSession.self) private var session
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dismiss) private var dismiss
+
+    let course: CourseSummary
+    let assignmentId: String
+    let submissions: [AssignmentSubmission]
+    var onSaved: () -> Void = {}
+
+    @State private var index: Int
+    @State private var graded: Set<String>
+    @State private var pointsText = ""
+    @State private var comment = ""
+    @State private var maxPoints: Double?
+    @State private var loading = true
+    @State private var saving = false
+    @State private var errorMessage: String?
+
+    init(
+        course: CourseSummary,
+        assignmentId: String,
+        submissions: [AssignmentSubmission],
+        startIndex: Int,
+        onSaved: @escaping () -> Void = {}
+    ) {
+        self.course = course
+        self.assignmentId = assignmentId
+        self.submissions = submissions
+        self.onSaved = onSaved
+        _index = State(initialValue: min(max(startIndex, 0), max(submissions.count - 1, 0)))
+        _graded = State(initialValue: Set(submissions.filter { $0.isGraded == true }.map(\.id)))
+    }
+
+    private var current: AssignmentSubmission? {
+        submissions.indices.contains(index) ? submissions[index] : nil
+    }
+
+    private var remainingUngraded: Int {
+        submissions.filter { !graded.contains($0.id) }.count
+    }
+
+    private var pointsValue: Double? {
+        Double(pointsText.replacingOccurrences(of: ",", with: "."))
+    }
+
+    private var pointsValid: Bool {
+        guard let value = pointsValue else { return false }
+        if let max = maxPoints { return value >= 0 && value <= max }
+        return value >= 0
+    }
+
+    /// First ungraded index strictly after the current one; nil when none remain.
+    private func nextUngradedIndex(after start: Int) -> Int? {
+        guard !submissions.isEmpty else { return nil }
+        for offset in 1...submissions.count {
+            let candidate = (start + offset) % submissions.count
+            if candidate == start { break }
+            if !graded.contains(submissions[candidate].id) { return candidate }
+        }
+        return nil
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                LexturesTheme.sceneBackground(for: colorScheme).ignoresSafeArea()
+
+                if let submission = current {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 14) {
+                            progressCard
+                            if let errorMessage {
+                                LMSErrorBanner(message: errorMessage)
+                            }
+                            studentCard(submission)
+                            submissionCard(submission)
+                            scoreCard
+                            feedbackCard
+                            actionBar
+                        }
+                        .padding(16)
+                    }
+                } else {
+                    LMSEmptyState(
+                        systemImage: "checkmark.seal.fill",
+                        title: "Nothing to grade",
+                        message: "There are no submissions in this view."
+                    )
+                    .padding(24)
+                }
+            }
+            .navigationTitle("Speed grader")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .task(id: index) { await loadGrade() }
+        }
+    }
+
+    // MARK: - Cards
+
+    private var progressCard: some View {
+        HStack(spacing: 10) {
+            Text("\(index + 1) of \(submissions.count)")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+            Spacer(minLength: 0)
+            Text(remainingUngraded == 0 ? "All graded" : "\(remainingUngraded) ungraded")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(remainingUngraded == 0 ? LexturesTheme.accent(for: colorScheme) : LexturesTheme.amber)
+                .padding(.horizontal, 9)
+                .padding(.vertical, 3)
+                .background((remainingUngraded == 0 ? LexturesTheme.accent(for: colorScheme) : LexturesTheme.amber).opacity(0.14))
+                .clipShape(Capsule())
+        }
+    }
+
+    private func studentCard(_ submission: AssignmentSubmission) -> some View {
+        LMSCard {
+            HStack(spacing: 12) {
+                Circle()
+                    .fill(LexturesTheme.coverGradient(for: submission.displayName))
+                    .frame(width: 42, height: 42)
+                    .overlay(
+                        Text(String(submission.displayName.prefix(2)).uppercased())
+                            .font(.subheadline.weight(.bold))
+                            .foregroundStyle(.white)
+                    )
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(submission.displayName)
+                        .font(LexturesTheme.displayFont(18))
+                        .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                    HStack(spacing: 6) {
+                        Text("Submitted \(LMSDates.shortDateTime(submission.submittedAt))")
+                            .font(.caption)
+                            .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                        if let version = submission.versionNumber, version > 1 {
+                            Text("v\(version)")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(LexturesTheme.accent(for: colorScheme))
+                        }
+                    }
+                }
+                Spacer(minLength: 0)
+                if graded.contains(submission.id) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(LexturesTheme.accent(for: colorScheme))
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func submissionCard(_ submission: AssignmentSubmission) -> some View {
+        let body = submission.bodyText?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let filename = submission.attachmentFilename
+        if (body?.isEmpty == false) || (filename?.isEmpty == false) {
+            LMSCard {
+                Text("Submission")
+                    .font(LexturesTheme.displayFont(17))
+                    .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                if let body, !body.isEmpty {
+                    Text(body)
+                        .font(.subheadline)
+                        .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                        .textSelection(.enabled)
+                }
+                if let filename, !filename.isEmpty {
+                    Label(filename, systemImage: "paperclip")
+                        .font(.caption)
+                        .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                    Text("Open the web app to review file submissions in full.")
+                        .font(.caption2)
+                        .italic()
+                        .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                }
+            }
+        } else {
+            LMSCard {
+                Text("Submission")
+                    .font(LexturesTheme.displayFont(17))
+                    .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+                Text("No text or attachment was submitted.")
+                    .font(.subheadline)
+                    .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+            }
+        }
+    }
+
+    private var scoreCard: some View {
+        LMSCard {
+            Text("Score")
+                .font(LexturesTheme.displayFont(17))
+                .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+            HStack(spacing: 10) {
+                TextField("Points", text: $pointsText)
+                    .keyboardType(.decimalPad)
+                    .font(LexturesTheme.displayFont(22, weight: .bold))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .frame(width: 120)
+                    .background(LexturesTheme.sceneBackground(for: colorScheme).opacity(0.7))
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .stroke(
+                                pointsText.isEmpty || pointsValid
+                                    ? LexturesTheme.fieldBorder(for: colorScheme)
+                                    : LexturesTheme.error,
+                                lineWidth: 1
+                            )
+                    )
+                if let max = maxPoints {
+                    Text("/ \(max.formatted()) pts")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(LexturesTheme.textSecondary(for: colorScheme))
+                }
+            }
+            if !pointsText.isEmpty && !pointsValid {
+                Text(maxPoints.map { "Enter a number between 0 and \($0.formatted())." } ?? "Enter a valid number.")
+                    .font(.caption)
+                    .foregroundStyle(LexturesTheme.error)
+            }
+        }
+    }
+
+    private var feedbackCard: some View {
+        LMSCard {
+            Text("Feedback")
+                .font(LexturesTheme.displayFont(17))
+                .foregroundStyle(LexturesTheme.textPrimary(for: colorScheme))
+            TextField("Comment for the student (optional)", text: $comment, axis: .vertical)
+                .lineLimit(3 ... 6)
+                .padding(12)
+                .background(LexturesTheme.sceneBackground(for: colorScheme).opacity(0.7))
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(LexturesTheme.fieldBorder(for: colorScheme), lineWidth: 1)
+                )
+        }
+    }
+
+    private var actionBar: some View {
+        VStack(spacing: 10) {
+            Button {
+                Task { await save() }
+            } label: {
+                if saving {
+                    ProgressView().frame(maxWidth: .infinity)
+                } else {
+                    Text(remainingUngraded <= 1 && pointsValid ? "Save grade" : "Save & next")
+                }
+            }
+            .buttonStyle(AuthPrimaryButtonStyle())
+            .disabled(!pointsValid || saving || loading)
+
+            HStack(spacing: 12) {
+                navButton(title: "Previous", systemImage: "chevron.left", disabled: index == 0 || saving) {
+                    index = max(index - 1, 0)
+                }
+                navButton(title: "Next", systemImage: "chevron.right", disabled: index >= submissions.count - 1 || saving) {
+                    index = min(index + 1, submissions.count - 1)
+                }
+            }
+        }
+    }
+
+    private func navButton(title: String, systemImage: String, disabled: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: systemImage)
+                .font(.subheadline.weight(.semibold))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .foregroundStyle(disabled ? LexturesTheme.textSecondary(for: colorScheme).opacity(0.5) : LexturesTheme.accent(for: colorScheme))
+                .background(LexturesTheme.cardBackground(for: colorScheme))
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(LexturesTheme.fieldBorder(for: colorScheme), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+    }
+
+    // MARK: - Data
+
+    private func loadGrade() async {
+        guard let token = session.accessToken, let submission = current else {
+            loading = false
+            return
+        }
+        loading = true
+        errorMessage = nil
+        pointsText = ""
+        comment = ""
+        maxPoints = nil
+        defer { loading = false }
+        if let grade = try? await LMSAPI.fetchSubmissionGrade(
+            courseCode: course.courseCode,
+            itemId: assignmentId,
+            submissionId: submission.id,
+            accessToken: token
+        ) {
+            maxPoints = grade.maxPoints
+            if let earned = grade.pointsEarned {
+                pointsText = earned.formatted()
+                graded.insert(submission.id)
+            }
+            comment = grade.instructorComment ?? ""
+        }
+    }
+
+    private func save() async {
+        guard let token = session.accessToken, let points = pointsValue, let submission = current else { return }
+        saving = true
+        errorMessage = nil
+        defer { saving = false }
+        do {
+            try await LMSAPI.putSubmissionGrade(
+                courseCode: course.courseCode,
+                itemId: assignmentId,
+                submissionId: submission.id,
+                body: .init(
+                    pointsEarned: points,
+                    instructorComment: comment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : comment
+                ),
+                accessToken: token
+            )
+            graded.insert(submission.id)
+            onSaved()
+            if let next = nextUngradedIndex(after: index) {
+                index = next
+            }
+        } catch {
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? "Could not save the grade."
+        }
+    }
+}

--- a/clients/ios/Lextures/Features/Home/MainTabView.swift
+++ b/clients/ios/Lextures/Features/Home/MainTabView.swift
@@ -55,11 +55,13 @@ struct MainTabView: View {
     @State private var shell = AppShellModel()
 
     var body: some View {
-        ZStack(alignment: .bottom) {
+        VStack(spacing: 0) {
             tabContent
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             LexturesTabBar(shell: shell)
                 .padding(.horizontal, 24)
-                .padding(.bottom, 4)
+                .padding(.top, 8)
+                .padding(.bottom, 6)
         }
         .environment(shell)
         .task {
@@ -81,9 +83,6 @@ struct MainTabView: View {
 
     private func pane<Content: View>(_ tab: AppTab, @ViewBuilder content: () -> Content) -> some View {
         content()
-            .safeAreaInset(edge: .bottom) {
-                Color.clear.frame(height: 70)
-            }
             .opacity(shell.selectedTab == tab ? 1 : 0)
             .allowsHitTesting(shell.selectedTab == tab)
             .accessibilityHidden(shell.selectedTab != tab)

--- a/clients/ios/Lextures/Features/Notebooks/NotebookPagesView.swift
+++ b/clients/ios/Lextures/Features/Notebooks/NotebookPagesView.swift
@@ -317,8 +317,7 @@ struct NotebookPagesView: View {
         .buttonStyle(.plain)
         .padding(.horizontal, 20)
         .padding(.top, 20)
-        // Navigation destinations don't inherit MainTabView's bottom inset (70pt).
-        .padding(.bottom, 20 + 70)
+        .padding(.bottom, 20)
         .accessibilityLabel("New page")
     }
 

--- a/docs/plan/speed-grader-mobile.md
+++ b/docs/plan/speed-grader-mobile.md
@@ -1,0 +1,200 @@
+# Speed Grader — Mobile (iOS + Android)
+
+> Implementation plan for a SpeedGrader-style grading flow in the Lextures mobile
+> apps. Lets staff with grading permission pick an assignment, page through
+> students, read each submission, and enter a grade/feedback without bouncing
+> back to a list between students.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature** | Speed Grader (mobile) |
+| **Section** | 21 — Mobile / Cross-platform |
+| **Severity** | MAJOR |
+| **Status (today)** | PARTIAL — backlog → submissions list → single grade sheet exists; no per-student paging, text submissions are "open the web app" |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes required — endpoints already return everything we need |
+
+---
+
+## 1. Problem Statement
+
+Mobile graders today can open a course's grading backlog, drill into one
+assignment, see its submissions, and tap a single submission to open a grade
+sheet (points + comment). That sheet is a dead end: after saving you return to
+the list and must re-tap the next student. Text submissions show only the
+filename with a "open the web app to review" note, so the grader can't actually
+read the work on device. The result is that real grading still has to happen on
+the web. A SpeedGrader-style flow — pick assignment, pick a starting student,
+then swipe/Next through the roster grading each one inline — makes mobile a
+first-class grading surface.
+
+## 2. Goals
+
+- Staff with grading permission can grade an assignment's submissions end to end
+  on mobile, paging student-to-student without returning to the list.
+- The submission content (text body + attachment metadata) is visible inline so
+  the grader has context for the score.
+- Saving a grade advances to the next ungraded student automatically (with the
+  option to go back/forward manually).
+- Progress is visible ("3 of 12", count remaining) so the grader knows how much
+  is left.
+- Reuse the existing backlog/submissions/grade endpoints and the existing entry
+  points (course-detail Grading section + dashboard teacher snapshot). No new
+  backend work.
+
+## 3. Non-Goals
+
+- Quiz / per-question grading stays read-only on mobile (unchanged: keep the
+  existing "grade on web" info screen). Speed Grader covers assignment
+  submissions only in v1.
+- No inline file/PDF/image rendering of attachments in v1 — show filename, type,
+  and (optionally) a "view attachment" affordance. Text bodies ARE rendered.
+- No rubric grading, no SpeedGrader-style annotation/markup, no offline queueing.
+- No new permissions model — reuse whatever already gates the backlog/grade
+  endpoints server-side.
+
+## 4. User Stories
+
+- **As an instructor**, I open an assignment from the grading backlog, tap a
+  student, and land in a grader where I can read their submission and enter a
+  score, then advance to the next student with one tap.
+- **As a TA**, I want to see how many submissions remain ungraded so I can pace
+  a grading session.
+- **As a grader**, I can jump backward to a student I already graded to fix a
+  score.
+
+## 5. What Already Exists (reuse)
+
+Backlog → list → single grade sheet is implemented on both platforms:
+
+- iOS: `clients/ios/Lextures/Features/Grading/GradingBacklogView.swift`
+  (`GradingBacklogSection`, `SubmissionsListView`, `GradeSubmissionSheet`,
+  `QuizAttemptInfoSheet`).
+- Android:
+  `clients/android/app/src/main/kotlin/com/lextures/android/features/grading/GradingScreens.kt`
+  (`GradingBacklogScreen`, `SubmissionsListScreen`, `GradeSubmissionScreen`,
+  `QuizAttemptInfoScreen`).
+
+API + models already present:
+
+- iOS `LMSAPI.fetchGradingSubmissions / fetchSubmissionGrade / putSubmissionGrade`
+  in `Core/LMS/LMSAPIFeatures.swift`; models in `Core/LMS/LMSFeatureModels.swift`.
+- Android `LmsApi.fetchGradingSubmissions / fetchSubmissionGrade / putSubmissionGrade`;
+  models in `core/lms/LmsFeatureModels.kt`.
+
+Backend response (`submissionToJSON` in
+`server/internal/httpserver/assignment_submissions_http.go`) already returns:
+`bodyText`, `attachmentFilename`, `attachmentMimeType`, `attachmentContentPath`,
+`attachments[]`, `versionNumber`, plus grading state. The clients currently
+decode only a subset — they drop `bodyText`, `attachmentMimeType`, and
+`attachmentContentPath`.
+
+## 6. Functional Requirements
+
+- **FR-1.** Tapping a (non-quiz) submission in the submissions list MUST open a
+  **Speed Grader** screen positioned on that student instead of the current
+  single-student sheet.
+- **FR-2.** The Speed Grader MUST present, for the current student: display name
+  (respecting blind-grading `blindLabel`), submitted-at, attempt/version,
+  submission **text body** (rendered) when present, and attachment filename +
+  type when present.
+- **FR-3.** The Speed Grader MUST provide a points field (validated `0…maxPoints`)
+  and an optional feedback comment, pre-filled from the existing grade via
+  `fetchSubmissionGrade`, and save via `putSubmissionGrade` — identical
+  semantics to today's sheet.
+- **FR-4.** The grader MUST be able to move to the previous / next submission in
+  the loaded list. Saving SHOULD advance to the next **ungraded** student in the
+  list; if none remain, show a "done" state.
+- **FR-5.** The grader MUST show progress: current index, total, and remaining
+  ungraded count.
+- **FR-6.** Per-student grade/comment/maxPoints MUST load when that student
+  becomes current (lazy per-student fetch), and unsaved edits MUST NOT leak
+  between students.
+- **FR-7.** Quiz items MUST keep the existing read-only "grade on web" behavior
+  (no Speed Grader).
+- **FR-8.** The grading-backlog and submissions-list entry points and their
+  navigation MUST remain functional; Speed Grader replaces only the leaf grade
+  sheet for assignments.
+
+## 7. Non-Functional
+
+- **Permissions** — unchanged; server already authorizes backlog/grade calls.
+- **Blind grading** — keep honoring `blindLabel`; never reveal identity the API
+  redacted.
+- **Accessibility** — fields labelled; Prev/Next reachable via VoiceOver /
+  TalkBack; respect Dynamic Type / font scaling (use existing `LexturesTheme` /
+  `LexturesType`).
+- **Resilience** — a failed save keeps the grader on the current student and
+  surfaces the error (reuse `session.mapError` / `LMSErrorBanner`); navigating
+  away from an unsaved edit is allowed (auto-advance only after a successful save).
+
+## 8. Design / Approach
+
+Keep the backlog and submissions list exactly as-is. Replace the leaf:
+
+- **iOS:** `SubmissionsListView`'s `.sheet(item: $grading)` for the non-quiz
+  branch opens a new `SpeedGraderView` (full-screen `NavigationLink`/sheet)
+  seeded with the loaded `[AssignmentSubmission]` and the tapped index, plus
+  `course` and `assignmentId`. `SpeedGraderView` owns: current index, a per-index
+  cache of `SubmissionGrade` (points/comment/maxPoints), header card,
+  body/attachment card, score + feedback cards (lifted from `GradeSubmissionSheet`),
+  a progress chip, and a Prev / Save & Next bar. On successful save, mark the
+  student graded locally, recompute remaining, and advance to the next ungraded
+  index. New file: `Features/Grading/SpeedGraderView.swift` (added to
+  `project.pbxproj`). `GradeSubmissionSheet` stays for any single-shot callers but
+  the list now routes to the grader.
+- **Android:** `SubmissionsListScreen`'s non-quiz tap sets a
+  `speedGrader = (submissions, index)` state and renders a new
+  `SpeedGraderScreen` (same back-stack-as-composable pattern already used for
+  `GradeSubmissionScreen`). It holds index + a `Map<submissionId, SubmissionGrade>`
+  cache and mirrors the iOS layout. New file:
+  `features/grading/SpeedGraderScreen.kt`. Reuse `formatPoints`, `LmsCard`,
+  `LmsErrorBanner`.
+
+Shared submission-content surfacing (small, additive):
+
+- Add `bodyText`, `attachmentMimeType`, `attachmentContentPath` to the
+  `AssignmentSubmission` model on both platforms (iOS `LMSFeatureModels.swift`,
+  Android `LmsFeatureModels.kt`). All optional/defaulted → backward compatible.
+- Quiz-mapped submissions leave these nil (already the case).
+
+## 9. Files to Touch
+
+**iOS**
+- `clients/ios/Lextures/Features/Grading/SpeedGraderView.swift` *(new)* — grader UI + paging/state.
+- `clients/ios/Lextures/Features/Grading/GradingBacklogView.swift` — route non-quiz taps to the grader.
+- `clients/ios/Lextures/Core/LMS/LMSFeatureModels.swift` — add `bodyText` / attachment fields to `AssignmentSubmission`.
+- `clients/ios/Lextures.xcodeproj/project.pbxproj` — register the new file.
+
+**Android**
+- `.../features/grading/SpeedGraderScreen.kt` *(new)* — grader UI + paging/state.
+- `.../features/grading/GradingScreens.kt` — route non-quiz taps to the grader.
+- `.../core/lms/LmsFeatureModels.kt` — add `bodyText` / attachment fields to `AssignmentSubmission`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. From a course's Grading section (or dashboard teacher snapshot), opening an
+   assignment and tapping a student opens the Speed Grader on that student.
+2. The grader shows name, submitted time, attempt, and the submission's text body
+   (when present) plus attachment info; quizzes still show the read-only web note.
+3. Entering valid points + optional comment and tapping Save persists the grade
+   (verified by reopening) and auto-advances to the next ungraded student.
+4. Prev/Next move between students; previously-graded students show their saved
+   score pre-filled; edits don't bleed across students.
+5. Progress indicator reflects index/total and remaining ungraded; reaching the
+   end shows a "caught up" state.
+6. Blind-graded assignments still show only the blind label.
+7. Both apps build; existing backlog/list flows and quiz read-only flow unchanged.
+
+## 11. Phasing
+
+1. Model fields (`bodyText` + attachment) on both platforms.
+2. iOS `SpeedGraderView` + routing.
+3. Android `SpeedGraderScreen` + routing.
+4. Progress/auto-advance polish + empty/done states.
+5. Manual verification on each platform; update this doc with any deltas.


### PR DESCRIPTION
## Summary

- Adds a Speed Grader flow on iOS and Android so staff can page through assignment submissions, read inline text bodies, enter scores/feedback, and advance to the next student without returning to the list.
- Extends grading backlog and API models to support quiz items (with read-only "grade on web" for quiz attempts) and filters out roster placeholder rows that have no gradeable submission id.
- Shows course hero images on dashboard course cards via a shared `CourseHeroImage` component, and adjusts home tab layout so content sits above the floating nav bar.
- Includes implementation plan at `docs/plan/speed-grader-mobile.md`.

## Test plan

- [ ] iOS: Open grading backlog → assignment → Speed Grader; verify prev/next paging, inline text submission, save grade advances to next ungraded student
- [ ] iOS: Quiz backlog item shows "Quiz" badge and opens read-only quiz attempt info (grade on web)
- [ ] iOS: Dashboard course carousel shows hero image when `heroImageUrl` is set
- [ ] Android: Same Speed Grader flow as iOS (paging, grading, auto-advance)
- [ ] Android: Quiz items in backlog route to quiz info screen, not assignment grader
- [ ] Android: Course hero images render on dashboard cards with auth token
- [ ] Verify home tab content is not obscured by the floating bottom nav on both platforms


Made with [Cursor](https://cursor.com)