### PR TITLE
feat(lms): pinned course row layout, hero thumbnails, and local WS proxy

### DIFF
--- a/clients/web/src/components/course-hero-image.tsx
+++ b/clients/web/src/components/course-hero-image.tsx
@@ -1,23 +1,29 @@
 import { type ComponentPropsWithoutRef, useEffect, useState } from 'react'
 import { authorizedFetch } from '../lib/api'
 import { needsAuthenticatedCourseImageSrc, resolveAuthorizedFetchPath } from '../lib/course-file-image'
+import { courseHeroImageSrc, type CourseHeroImageSize } from '../lib/course-hero-image-url'
 
-type Props = ComponentPropsWithoutRef<'img'>
+type Props = ComponentPropsWithoutRef<'img'> & {
+  /** `full` preserves original quality (course dashboard); catalog sizes request smaller thumbnails. */
+  size?: CourseHeroImageSize
+}
 
 /** Renders a hero image, fetching with auth when src is a course-files content URL. */
-export function CourseHeroImage({ src, className, alt = '', ...props }: Props) {
+export function CourseHeroImage({ src, size = 'full', className, alt = '', ...props }: Props) {
+  const fetchSrc = courseHeroImageSrc(src, size)
+
   const [resolvedSrc, setResolvedSrc] = useState<string | undefined>(() =>
-    src && !needsAuthenticatedCourseImageSrc(src) ? src : undefined,
+    fetchSrc && !needsAuthenticatedCourseImageSrc(fetchSrc) ? fetchSrc : undefined,
   )
 
   useEffect(() => {
     let cancelled = false
     let blobUrl: string | null = null
-    if (!src || !needsAuthenticatedCourseImageSrc(src)) {
-      setResolvedSrc(src ?? undefined)
+    if (!fetchSrc || !needsAuthenticatedCourseImageSrc(fetchSrc)) {
+      setResolvedSrc(fetchSrc ?? undefined)
       return
     }
-    void authorizedFetch(resolveAuthorizedFetchPath(src))
+    void authorizedFetch(resolveAuthorizedFetchPath(fetchSrc))
       .then((r) => {
         if (!r.ok) throw new Error(String(r.status))
         return r.blob()
@@ -34,7 +40,7 @@ export function CourseHeroImage({ src, className, alt = '', ...props }: Props) {
       cancelled = true
       if (blobUrl) URL.revokeObjectURL(blobUrl)
     }
-  }, [src])
+  }, [fetchSrc])
 
   return (
     <img

--- a/clients/web/src/components/layout/side-nav-pinned-courses.tsx
+++ b/clients/web/src/components/layout/side-nav-pinned-courses.tsx
@@ -1,7 +1,34 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import { NavLink, useLocation } from 'react-router-dom'
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  closestCorners,
+  defaultDropAnimation,
+  pointerWithin,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type DragCancelEvent,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import { SortableContext, rectSortingStrategy, useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import { useCoursePins } from '../../context/course-pinned-context'
 import { heroImageObjectStyle } from '../../lib/hero-image-position'
 import type { PinnedCourseSummary } from '../../lib/course-catalog-settings-api'
+import {
+  computeNextPinRows,
+  flatPinnedRows,
+  newRowDropId,
+  pinRowsEqual,
+  resolvePinDropTarget,
+  rowDropId,
+} from '../../lib/pinned-courses-layout'
 import { useShellNav } from './use-shell-nav'
 import { SideNavTooltip } from './side-nav-tooltip'
 import { CourseHeroImage } from '../course-hero-image'
@@ -17,68 +44,431 @@ const gridColsMap: Record<number, string> = {
   4: 'grid-cols-4',
 }
 
-export function SideNavPinnedCourses() {
-  const { pinnedCourses, loading, flashPinnedCourseId } = useCoursePins()
-  const { sideNavCollapsed } = useShellNav()
-  const location = useLocation()
+const iosDropAnimation = {
+  ...defaultDropAnimation,
+  duration: 220,
+  easing: 'cubic-bezier(0.2, 0, 0, 1)',
+}
 
-  if (loading || pinnedCourses.length === 0) return null
+const NEW_ROW_DROP_ID = newRowDropId()
 
-  const cols = Math.min(pinnedCourses.length, 4)
+/** Prefer the new-row slot and row gutters over sortable tile collisions. */
+const pinCollisionDetection: CollisionDetection = (args) => {
+  const pointerHits = pointerWithin(args)
+  const newRowHit = pointerHits.find((collision) => collision.id === NEW_ROW_DROP_ID)
+  if (newRowHit) return [newRowHit]
+
+  const cornerHits = closestCorners(args)
+  const sortableHit = cornerHits.find((collision) => !String(collision.id).startsWith('row:'))
+  if (sortableHit) return [sortableHit]
+
+  const rowHit = pointerHits.find(
+    (collision) => String(collision.id).startsWith('row:') && collision.id !== NEW_ROW_DROP_ID,
+  )
+  if (rowHit) return [rowHit]
+
+  return cornerHits
+}
+
+type PinnedCourseTileVisualProps = {
+  course: PinnedCourseSummary
+  active: boolean
+  sideNavCollapsed: boolean
+  overlay?: boolean
+  isPlaceholder?: boolean
+  isDragActive?: boolean
+  onSuppressNavClick?: () => boolean
+  onConsumeNavSuppress?: () => void
+}
+
+function PinnedCourseTileVisual({
+  course,
+  active,
+  sideNavCollapsed,
+  overlay = false,
+  isPlaceholder = false,
+  isDragActive = false,
+  onSuppressNavClick,
+  onConsumeNavSuppress,
+}: PinnedCourseTileVisualProps) {
+  const href = `/courses/${encodeURIComponent(course.courseCode)}`
+  const title = pinnedCourseTitle(course)
+
+  return (
+    <div
+      className={[
+        isPlaceholder ? 'pointer-events-none' : '',
+        overlay ? 'scale-[1.06]' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <NavLink
+        to={href}
+        aria-label={title}
+        aria-current={active ? 'page' : undefined}
+        draggable={false}
+        tabIndex={isPlaceholder ? -1 : undefined}
+        onClick={(event) => {
+          if (onSuppressNavClick?.()) {
+            event.preventDefault()
+            onConsumeNavSuppress?.()
+          }
+        }}
+        className={[
+          'group relative block overflow-hidden rounded-xl ring-1 ring-black/[0.06] hover:ring-indigo-400/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:ring-white/10 dark:hover:ring-indigo-400/40',
+          sideNavCollapsed ? 'h-9 w-9' : 'h-10 w-full',
+          active ? 'ring-2 ring-indigo-500 dark:ring-indigo-400' : '',
+          !sideNavCollapsed && !overlay && !isPlaceholder
+            ? 'cursor-grab touch-none active:cursor-grabbing'
+            : '',
+          overlay
+            ? 'cursor-grabbing shadow-lg shadow-black/20 ring-2 ring-indigo-400/50'
+            : '',
+          isDragActive && !overlay ? 'pointer-events-none' : '',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        <CourseHeroImage
+          src={course.heroImageUrl ?? '/course-card-hero.png'}
+          size="catalog-thumb"
+          alt=""
+          draggable={false}
+          loading="lazy"
+          decoding="async"
+          className="h-full w-full object-cover"
+          style={heroImageObjectStyle(course.heroImageObjectPosition)}
+        />
+        <span
+          className={[
+            'pointer-events-none absolute inset-0 bg-gradient-to-t from-black/35 to-transparent opacity-0 transition-opacity group-hover:opacity-100',
+            active ? 'opacity-100' : '',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+          aria-hidden
+        />
+      </NavLink>
+    </div>
+  )
+}
+
+type SortablePinnedCourseTileProps = {
+  course: PinnedCourseSummary
+  active: boolean
+  flashPinnedCourseId: string | null
+  sideNavCollapsed: boolean
+  isDragActive: boolean
+}
+
+function SortablePinnedCourseTile({
+  course,
+  active,
+  flashPinnedCourseId,
+  sideNavCollapsed,
+  isDragActive,
+}: SortablePinnedCourseTileProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: course.id,
+    disabled: sideNavCollapsed,
+  })
+  const suppressNavRef = useRef(false)
+  const wasDraggingRef = useRef(false)
+
+  useEffect(() => {
+    if (wasDraggingRef.current && !isDragging) {
+      suppressNavRef.current = true
+    }
+    wasDraggingRef.current = isDragging
+  }, [isDragging])
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition: transition ?? 'transform 200ms cubic-bezier(0.2, 0, 0, 1)',
+    opacity: isDragging ? 0 : 1,
+    zIndex: isDragging ? 0 : undefined,
+  }
+
+  const title = pinnedCourseTitle(course)
+
+  return (
+    <SideNavTooltip content={title} hoverWhenExpanded instant={flashPinnedCourseId === course.id}>
+      <div ref={setNodeRef} className="min-w-0" style={style} {...listeners} {...attributes}>
+        <PinnedCourseTileVisual
+          course={course}
+          active={active}
+          sideNavCollapsed={sideNavCollapsed}
+          isPlaceholder={isDragging}
+          isDragActive={isDragActive}
+          onSuppressNavClick={() => isDragActive || isDragging || suppressNavRef.current}
+          onConsumeNavSuppress={() => {
+            suppressNavRef.current = false
+          }}
+        />
+      </div>
+    </SideNavTooltip>
+  )
+}
+
+function PinnedCourseRow({
+  rowIndex,
+  courses,
+  sideNavCollapsed,
+  flashPinnedCourseId,
+  activeCourseIds,
+  isDragActive,
+}: {
+  rowIndex: number
+  courses: PinnedCourseSummary[]
+  sideNavCollapsed: boolean
+  flashPinnedCourseId: string | null
+  activeCourseIds: Set<string>
+  isDragActive: boolean
+}) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: rowDropId(rowIndex),
+    disabled: sideNavCollapsed,
+  })
+  const cols = Math.min(Math.max(courses.length, 1), 4)
   const gridColsClass = gridColsMap[cols] ?? 'grid-cols-4'
 
   return (
     <div
-      className={`shrink-0 px-3 py-3 ${sideNavCollapsed ? 'flex flex-col items-center gap-1.5' : `grid ${gridColsClass} gap-1.5`}`}
+      ref={setNodeRef}
+      className={[
+        sideNavCollapsed ? 'flex flex-col items-center gap-1.5' : `grid ${gridColsClass} gap-1.5`,
+        isOver && isDragActive ? 'rounded-xl bg-indigo-50/70 ring-1 ring-indigo-300/50 dark:bg-indigo-950/20 dark:ring-indigo-500/30' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      {courses.map((course) => (
+        <SortablePinnedCourseTile
+          key={course.id}
+          course={course}
+          active={activeCourseIds.has(course.id)}
+          flashPinnedCourseId={flashPinnedCourseId}
+          sideNavCollapsed={sideNavCollapsed}
+          isDragActive={isDragActive}
+        />
+      ))}
+    </div>
+  )
+}
+
+/** Invisible hit area below the grid — no visible chrome. */
+function NewPinnedRowDropZone() {
+  const { setNodeRef } = useDroppable({ id: NEW_ROW_DROP_ID })
+  return <div ref={setNodeRef} className="h-12 w-full" aria-hidden />
+}
+
+function NewRowPlaceholder() {
+  return (
+    <div
+      className="h-10 w-full rounded-xl bg-indigo-500/5 transition-[height,opacity] duration-200 ease-out dark:bg-indigo-400/5"
+      aria-hidden
+    />
+  )
+}
+
+export function SideNavPinnedCourses() {
+  const { pinnedRows, loading, flashPinnedCourseId, reorderPinnedRows } = useCoursePins()
+  const { sideNavCollapsed } = useShellNav()
+  const location = useLocation()
+  const [activeDragId, setActiveDragId] = useState<string | null>(null)
+  const [hoveringNewRow, setHoveringNewRow] = useState(false)
+  const [localRows, setLocalRows] = useState<PinnedCourseSummary[][]>([])
+  const localRowsRef = useRef(localRows)
+  const hoveringNewRowRef = useRef(false)
+  const activeDragIdRef = useRef<string | null>(null)
+  const saveTimeoutRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    localRowsRef.current = localRows
+  }, [localRows])
+
+  useEffect(() => {
+    hoveringNewRowRef.current = hoveringNewRow
+  }, [hoveringNewRow])
+
+  useEffect(() => {
+    activeDragIdRef.current = activeDragId
+  }, [activeDragId])
+
+  useEffect(() => {
+    if (activeDragId) return
+    setLocalRows(pinnedRows)
+  }, [pinnedRows, activeDragId])
+
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current !== null) {
+        window.clearTimeout(saveTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 6 },
+    }),
+  )
+
+  const sortableIds = useMemo(() => flatPinnedRows(localRows).map((course) => course.id), [localRows])
+
+  const activeCourseIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const row of localRows) {
+      for (const course of row) {
+        const href = `/courses/${encodeURIComponent(course.courseCode)}`
+        if (location.pathname === href || location.pathname.startsWith(`${href}/`)) {
+          ids.add(course.id)
+        }
+      }
+    }
+    return ids
+  }, [localRows, location.pathname])
+
+  const activeCourse = useMemo(() => {
+    if (!activeDragId) return null
+    for (const row of localRows) {
+      const found = row.find((course) => course.id === activeDragId)
+      if (found) return found
+    }
+    return null
+  }, [activeDragId, localRows])
+
+  const queueSave = useCallback(
+    (rows: PinnedCourseSummary[][]) => {
+      if (saveTimeoutRef.current !== null) {
+        window.clearTimeout(saveTimeoutRef.current)
+      }
+      saveTimeoutRef.current = window.setTimeout(() => {
+        saveTimeoutRef.current = null
+        void reorderPinnedRows(rows).catch(() => {
+          setLocalRows(pinnedRows)
+        })
+      }, 250)
+    },
+    [pinnedRows, reorderPinnedRows],
+  )
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveDragId(String(event.active.id))
+    setHoveringNewRow(false)
+  }, [])
+
+  const handleDragOver = useCallback(
+    (event: DragOverEvent) => {
+      const { active, over } = event
+      if (!over) {
+        setHoveringNewRow(false)
+        return
+      }
+
+      const overId = String(over.id)
+      if (overId === NEW_ROW_DROP_ID) {
+        setHoveringNewRow(true)
+        return
+      }
+
+      setHoveringNewRow(false)
+      if (active.id === over.id) return
+
+      const courseId = String(active.id)
+      setLocalRows((current) => {
+        const target = resolvePinDropTarget(current, overId)
+        if (!target || target.kind === 'new-row') return current
+        const next = computeNextPinRows(current, courseId, target)
+        return pinRowsEqual(current, next) ? current : next
+      })
+    },
+    [],
+  )
+
+  const handleDragEnd = useCallback(
+    (_event: DragEndEvent) => {
+      const draggedId = activeDragIdRef.current
+      let finalRows = localRowsRef.current
+
+      if (hoveringNewRowRef.current && draggedId) {
+        finalRows = computeNextPinRows(finalRows, draggedId, { kind: 'new-row' })
+        setLocalRows(finalRows)
+      }
+
+      setActiveDragId(null)
+      setHoveringNewRow(false)
+
+      if (!pinRowsEqual(finalRows, pinnedRows)) {
+        queueSave(finalRows)
+      }
+    },
+    [pinnedRows, queueSave],
+  )
+
+  const handleDragCancel = useCallback((_event: DragCancelEvent) => {
+    setActiveDragId(null)
+    setHoveringNewRow(false)
+    setLocalRows(pinnedRows)
+  }, [pinnedRows])
+
+  if (loading || localRows.length === 0) return null
+
+  const isDragging = activeDragId !== null
+
+  const rowsContent = (
+    <div
+      className={[
+        'shrink-0 px-3 py-3',
+        sideNavCollapsed ? 'flex flex-col items-center gap-1.5' : 'flex flex-col gap-1.5',
+      ].join(' ')}
       aria-label="Pinned courses"
     >
-      {pinnedCourses.map((course) => {
-        const href = `/courses/${encodeURIComponent(course.courseCode)}`
-        const active =
-          location.pathname === href || location.pathname.startsWith(`${href}/`)
-        const title = pinnedCourseTitle(course)
-
-        return (
-          <SideNavTooltip
-            key={course.id}
-            content={title}
-            hoverWhenExpanded
-            instant={flashPinnedCourseId === course.id}
-          >
-            <NavLink
-              to={href}
-              aria-label={title}
-              aria-current={active ? 'page' : undefined}
-              className={[
-                'group relative block overflow-hidden rounded-xl ring-1 ring-black/[0.06] transition-[background-color,color,border-color] hover:ring-indigo-400/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:ring-white/10 dark:hover:ring-indigo-400/40',
-                sideNavCollapsed ? 'h-9 w-9' : 'h-10 w-full',
-                active ? 'ring-2 ring-indigo-500 dark:ring-indigo-400' : '',
-              ]
-                .filter(Boolean)
-                .join(' ')}
-            >
-              <CourseHeroImage
-                src={course.heroImageUrl ?? '/course-card-hero.png'}
-                alt=""
-                draggable={false}
-                loading="lazy"
-                decoding="async"
-                className="h-full w-full object-cover"
-                style={heroImageObjectStyle(course.heroImageObjectPosition)}
-              />
-              <span
-                className={[
-                  'pointer-events-none absolute inset-0 bg-gradient-to-t from-black/35 to-transparent opacity-0 transition-[opacity,background-color,color,border-color] group-hover:opacity-100',
-                  active ? 'opacity-100' : '',
-                ]
-                  .filter(Boolean)
-                  .join(' ')}
-                aria-hidden
-              />
-            </NavLink>
-          </SideNavTooltip>
-        )
-      })}
+      {localRows.map((row, rowIndex) => (
+        <PinnedCourseRow
+          key={`pin-row-${rowIndex}`}
+          rowIndex={rowIndex}
+          courses={row}
+          sideNavCollapsed={sideNavCollapsed}
+          flashPinnedCourseId={flashPinnedCourseId}
+          activeCourseIds={activeCourseIds}
+          isDragActive={isDragging}
+        />
+      ))}
+      {hoveringNewRow ? <NewRowPlaceholder /> : null}
     </div>
+  )
+
+  if (sideNavCollapsed) return rowsContent
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={pinCollisionDetection}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <SortableContext items={sortableIds} strategy={rectSortingStrategy}>
+        {rowsContent}
+      </SortableContext>
+      {isDragging ? (
+        <div className="shrink-0 px-3">
+          <NewPinnedRowDropZone />
+        </div>
+      ) : null}
+      <DragOverlay dropAnimation={iosDropAnimation}>
+        {activeCourse ? (
+          <PinnedCourseTileVisual
+            course={activeCourse}
+            active={activeCourseIds.has(activeCourse.id)}
+            sideNavCollapsed={false}
+            overlay
+          />
+        ) : null}
+      </DragOverlay>
+    </DndContext>
   )
 }

--- a/clients/web/src/components/layout/side-nav.tsx
+++ b/clients/web/src/components/layout/side-nav.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { lazy, Suspense, useEffect } from 'react'
 import { matchPath, NavLink, useLocation } from 'react-router-dom'
 import { BrandLogo } from '../brand-logo'
 import { useShellNav } from './use-shell-nav'
@@ -8,7 +8,9 @@ import { SideNavMainLinks } from './side-nav-main-links'
 import { SideNavFooter } from './side-nav-footer'
 import { SideNavSettingsLinks } from './side-nav-settings-links'
 import { SideNavCommandPaletteTrigger } from './side-nav-command-palette'
-import { SideNavPinnedCourses } from './side-nav-pinned-courses'
+const SideNavPinnedCourses = lazy(() =>
+  import('./side-nav-pinned-courses').then((m) => ({ default: m.SideNavPinnedCourses })),
+)
 import { SideNavTooltip } from './side-nav-tooltip'
 import { isSettingsShellRoute } from './side-nav-path-utils'
 
@@ -104,7 +106,9 @@ export function SideNav() {
           </SideNavTooltip>
         </div>
         <SideNavCommandPaletteTrigger />
-        <SideNavPinnedCourses />
+        <Suspense fallback={null}>
+          <SideNavPinnedCourses />
+        </Suspense>
         <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
           <nav
             className={`absolute inset-0 flex flex-col gap-1 overflow-y-auto px-3 pb-3 pt-0 transition-[opacity,transform] duration-300 ease-out ${

--- a/clients/web/src/context/course-pinned-context.tsx
+++ b/clients/web/src/context/course-pinned-context.tsx
@@ -13,14 +13,22 @@ import { getAccessToken } from '../lib/auth'
 import {
   fetchPinnedCourses,
   putCourseCatalogPin,
+  putCourseCatalogPinLayout,
   type PinnedCourseSummary,
 } from '../lib/course-catalog-settings-api'
+import {
+  flatPinnedRows,
+  normalizePinRows,
+  rowsFromFlatCourses,
+  rowsToCourseIds,
+} from '../lib/pinned-courses-layout'
 import { useCoursesRevision } from './use-inbox-unread'
 
 const PINNED_TOOLTIP_FLASH_MS = 2600
 
 type CoursePinnedContextValue = {
   pinnedCourses: PinnedCourseSummary[]
+  pinnedRows: PinnedCourseSummary[][]
   pinnedCourseIds: Set<string>
   /** Course id that should show an instant sidebar title tooltip after pinning. */
   flashPinnedCourseId: string | null
@@ -32,6 +40,7 @@ type CoursePinnedContextValue = {
     pinned: boolean,
     optimisticCourse?: PinnedCourseSummary,
   ) => Promise<void>
+  reorderPinnedRows: (rows: PinnedCourseSummary[][]) => Promise<void>
 }
 
 const CoursePinnedContext = createContext<CoursePinnedContextValue | null>(null)
@@ -54,14 +63,24 @@ function toPinnedSummary(course: {
   }
 }
 
+function resolvePinnedRows(
+  courses: PinnedCourseSummary[],
+  rows: PinnedCourseSummary[][],
+): PinnedCourseSummary[][] {
+  if (rows.length > 0) return rows
+  return rowsFromFlatCourses(courses)
+}
+
 export function CoursePinnedProvider({ children }: { children: ReactNode }) {
   const coursesRevision = useCoursesRevision()
-  const [pinnedCourses, setPinnedCourses] = useState<PinnedCourseSummary[]>([])
+  const [pinnedRows, setPinnedRows] = useState<PinnedCourseSummary[][]>([])
   const [loading, setLoading] = useState(true)
   const [togglingCourseId, setTogglingCourseId] = useState<string | null>(null)
   const [flashPinnedCourseId, setFlashPinnedCourseId] = useState<string | null>(null)
   const flashTimeoutRef = useRef<number | null>(null)
   const flashRafRef = useRef<number | null>(null)
+
+  const pinnedCourses = useMemo(() => flatPinnedRows(pinnedRows), [pinnedRows])
 
   const flashPinnedTooltip = useCallback((courseId: string) => {
     if (flashTimeoutRef.current !== null) {
@@ -85,37 +104,41 @@ export function CoursePinnedProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
+  const applyPinnedPayload = useCallback((courses: PinnedCourseSummary[], rows: PinnedCourseSummary[][]) => {
+    setPinnedRows(resolvePinnedRows(courses, rows))
+  }, [])
+
   const refreshPinned = useCallback(async () => {
     if (!getAccessToken()) {
-      setPinnedCourses([])
+      setPinnedRows([])
       setLoading(false)
       return
     }
     try {
-      const courses = await fetchPinnedCourses()
-      setPinnedCourses(courses)
+      const payload = await fetchPinnedCourses()
+      applyPinnedPayload(payload.courses, payload.rows)
     } catch {
       /* keep previous list */
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [applyPinnedPayload])
 
   useEffect(() => {
     let cancelled = false
     void (async () => {
       if (!getAccessToken()) {
         if (!cancelled) {
-          setPinnedCourses([])
+          setPinnedRows([])
           setLoading(false)
         }
         return
       }
       try {
-        const courses = await fetchPinnedCourses()
-        if (!cancelled) setPinnedCourses(courses)
+        const payload = await fetchPinnedCourses()
+        if (!cancelled) applyPinnedPayload(payload.courses, payload.rows)
       } catch {
-        if (!cancelled) setPinnedCourses([])
+        if (!cancelled) setPinnedRows([])
       } finally {
         if (!cancelled) setLoading(false)
       }
@@ -123,17 +146,41 @@ export function CoursePinnedProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true
     }
-  }, [coursesRevision, refreshPinned])
+  }, [coursesRevision, refreshPinned, applyPinnedPayload])
+
+  const reorderPinnedRows = useCallback(
+    async (rows: PinnedCourseSummary[][]) => {
+      const normalized = normalizePinRows(rows.filter((row) => row.length > 0))
+      const previous = pinnedRows
+      setPinnedRows(normalized)
+      try {
+        await putCourseCatalogPinLayout(rowsToCourseIds(normalized))
+      } catch (err) {
+        setPinnedRows(previous)
+        throw err
+      }
+    },
+    [pinnedRows],
+  )
 
   const togglePin = useCallback(
     async (courseId: string, pinned: boolean, optimisticCourse?: PinnedCourseSummary) => {
-      const previous = pinnedCourses
+      const previous = pinnedRows
       setTogglingCourseId(courseId)
-      setPinnedCourses((current) => {
-        if (!pinned) return current.filter((course) => course.id !== courseId)
-        if (current.some((course) => course.id === courseId)) return current
+      setPinnedRows((current) => {
+        if (!pinned) {
+          return normalizePinRows(current.map((row) => row.filter((course) => course.id !== courseId)))
+        }
+        if (current.some((row) => row.some((course) => course.id === courseId))) return current
         if (!optimisticCourse) return current
-        return [...current, optimisticCourse]
+        const next = current.map((row) => [...row])
+        const lastRow = next[next.length - 1]
+        if (lastRow && lastRow.length < 4) {
+          lastRow.push(optimisticCourse)
+        } else {
+          next.push([optimisticCourse])
+        }
+        return next
       })
       const clearFlash = () => {
         setFlashPinnedCourseId(null)
@@ -160,14 +207,14 @@ export function CoursePinnedProvider({ children }: { children: ReactNode }) {
         await putCourseCatalogPin(courseId, pinned)
         await refreshPinned()
       } catch (err) {
-        setPinnedCourses(previous)
+        setPinnedRows(previous)
         if (pinned) clearFlash()
         throw err
       } finally {
         setTogglingCourseId(null)
       }
     },
-    [pinnedCourses, refreshPinned, flashPinnedCourseId, flashPinnedTooltip],
+    [pinnedRows, refreshPinned, flashPinnedCourseId, flashPinnedTooltip],
   )
 
   const pinnedCourseIds = useMemo(
@@ -178,14 +225,26 @@ export function CoursePinnedProvider({ children }: { children: ReactNode }) {
   const value = useMemo(
     () => ({
       pinnedCourses,
+      pinnedRows,
       pinnedCourseIds,
       flashPinnedCourseId,
       loading,
       togglingCourseId,
       refreshPinned,
       togglePin,
+      reorderPinnedRows,
     }),
-    [pinnedCourses, pinnedCourseIds, flashPinnedCourseId, loading, togglingCourseId, refreshPinned, togglePin],
+    [
+      pinnedCourses,
+      pinnedRows,
+      pinnedCourseIds,
+      flashPinnedCourseId,
+      loading,
+      togglingCourseId,
+      refreshPinned,
+      togglePin,
+      reorderPinnedRows,
+    ],
   )
 
   return <CoursePinnedContext.Provider value={value}>{children}</CoursePinnedContext.Provider>

--- a/clients/web/src/lib/__tests__/api.test.ts
+++ b/clients/web/src/lib/__tests__/api.test.ts
@@ -6,7 +6,7 @@ import {
   getRefreshToken,
   setRefreshToken,
 } from '../session-tokens'
-import { apiBaseUrl, apiUrl, authorizedFetch, backoffWithJitterMs, joinApiBase } from '../api'
+import { apiBaseUrl, apiUrl, authorizedFetch, backoffWithJitterMs, joinApiBase, wsUrl } from '../api'
 import { server } from '../../test/mocks/server'
 
 describe('joinApiBase', () => {
@@ -35,6 +35,24 @@ describe('apiUrl', () => {
     vi.stubEnv('VITE_API_URL', '')
     expect(apiBaseUrl()).toBe('http://localhost:8080')
     expect(apiUrl('/api/v1/x')).toBe('http://localhost:8080/api/v1/x')
+  })
+})
+
+describe('wsUrl', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('uses the API host when the API is not on localhost', () => {
+    vi.stubEnv('VITE_API_URL', 'https://api.example.com')
+    expect(wsUrl('/api/v1/ws/notifications')).toBe('wss://api.example.com/api/v1/ws/notifications')
+  })
+
+  it('routes through the page origin in local dev when API is on another port', () => {
+    vi.stubEnv('VITE_API_URL', 'http://localhost:8080')
+    expect(wsUrl('/api/v1/communication/ws')).toBe(
+      `ws://${window.location.host}/api/v1/communication/ws`,
+    )
   })
 })
 

--- a/clients/web/src/lib/__tests__/course-hero-image-url.test.ts
+++ b/clients/web/src/lib/__tests__/course-hero-image-url.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { courseHeroImageSrc } from '../course-hero-image-url'
+
+describe('courseHeroImageSrc', () => {
+  const courseFile =
+    '/api/v1/courses/C-ABC/course-files/550e8400-e29b-41d4-a716-446655440000/content'
+
+  it('returns undefined for empty src', () => {
+    expect(courseHeroImageSrc(null)).toBeUndefined()
+    expect(courseHeroImageSrc(undefined)).toBeUndefined()
+  })
+
+  it('passes through full-size course file URLs', () => {
+    expect(courseHeroImageSrc(courseFile, 'full')).toBe(courseFile)
+  })
+
+  it('appends resize params for catalog list thumbnails', () => {
+    expect(courseHeroImageSrc(courseFile, 'catalog-list')).toBe(
+      `${courseFile}?w=224&h=160&q=82`,
+    )
+  })
+
+  it('preserves display-size fragments on the base URL', () => {
+    const withFragment = `${courseFile}#w=1200&h=600`
+    expect(courseHeroImageSrc(withFragment, 'catalog-card')).toBe(
+      `${courseFile}?w=640&h=320&q=85`,
+    )
+  })
+
+  it('leaves external URLs unchanged', () => {
+    const external = 'https://cdn.example.com/banner.jpg'
+    expect(courseHeroImageSrc(external, 'catalog-card')).toBe(external)
+  })
+
+  it('leaves static asset paths unchanged', () => {
+    expect(courseHeroImageSrc('/course-card-hero.png', 'catalog-card')).toBe('/course-card-hero.png')
+  })
+})

--- a/clients/web/src/lib/__tests__/pinned-courses-layout.test.ts
+++ b/clients/web/src/lib/__tests__/pinned-courses-layout.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeNextPinRows,
+  flatPinnedRows,
+  MAX_PINS_PER_ROW,
+  resolvePinDropTarget,
+  rowsFromFlatCourses,
+  rowsToCourseIds,
+} from '../pinned-courses-layout'
+import type { PinnedCourseSummary } from '../course-catalog-settings-api'
+
+function course(id: string): PinnedCourseSummary {
+  return {
+    id,
+    courseCode: id,
+    title: id,
+    heroImageUrl: null,
+    heroImageObjectPosition: null,
+  }
+}
+
+describe('pinned-courses-layout', () => {
+  it('chunks flat courses into rows of four', () => {
+    const rows = rowsFromFlatCourses(['a', 'b', 'c', 'd', 'e'].map(course))
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toHaveLength(MAX_PINS_PER_ROW)
+    expect(rows[1]).toHaveLength(1)
+  })
+
+  it('moves a course into a new row', () => {
+    const rows = [[course('a'), course('b')], [course('c')]]
+    const next = computeNextPinRows(rows, 'a', { kind: 'new-row' })
+    expect(rowsToCourseIds(next)).toEqual([['b'], ['c'], ['a']])
+  })
+
+  it('resolves the new-row drop target id', () => {
+    const rows = [[course('a')]]
+    expect(resolvePinDropTarget(rows, 'row:new')).toEqual({ kind: 'new-row' })
+  })
+
+  it('inserts before another course in the same row', () => {
+    const rows = [[course('a'), course('c')], [course('b')]]
+    const next = computeNextPinRows(rows, 'b', { kind: 'row', rowIndex: 0, index: 1 })
+    expect(rowsToCourseIds(next)).toEqual([['a', 'b', 'c']])
+  })
+
+  it('spills overflow to the next row', () => {
+    const rows = [[course('a'), course('b'), course('c'), course('d')], [course('e')]]
+    const next = computeNextPinRows(rows, 'e', { kind: 'row', rowIndex: 0, index: 0 })
+    expect(rowsToCourseIds(next)).toEqual([
+      ['e', 'a', 'b', 'c'],
+      ['d'],
+    ])
+    expect(flatPinnedRows(next)).toHaveLength(5)
+  })
+})

--- a/clients/web/src/lib/api.ts
+++ b/clients/web/src/lib/api.ts
@@ -41,8 +41,30 @@ export function apiUrl(path: string): string {
   return joinApiBase(apiBaseUrl(), path)
 }
 
-/** WebSocket URL for the same API host as {@link apiUrl}. */
+function shouldProxyWebSocketViaPageOrigin(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  const api = new URL(apiBaseUrl())
+  if (api.host === window.location.host) {
+    return false
+  }
+  // Local dev: Vite on :5173 proxying to Go API on :8080 (direct ws://localhost:8080
+  // fails when port 8080 is SSH-tunneled without WebSocket upgrade support).
+  return api.hostname === 'localhost' || api.hostname === '127.0.0.1'
+}
+
+/**
+ * WebSocket URL for the same API host as {@link apiUrl}.
+ * In local dev, when the SPA and API run on different ports, route through the page
+ * origin so Vite's `/api` proxy handles the upgrade.
+ */
 export function wsUrl(path: string): string {
+  const p = path.startsWith('/') ? path : `/${path}`
+  if (shouldProxyWebSocketViaPageOrigin()) {
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    return `${proto}//${window.location.host}${p}`
+  }
   return apiUrl(path).replace(/^http/, 'ws')
 }
 

--- a/clients/web/src/lib/communication-api.ts
+++ b/clients/web/src/lib/communication-api.ts
@@ -1,4 +1,4 @@
-import { apiBaseUrl, authorizedFetch } from './api'
+import { authorizedFetch, wsUrl } from './api'
 import { getAccessToken } from './auth'
 
 export type MailboxParty = {
@@ -112,10 +112,7 @@ export async function sendMessage(
 /** WebSocket URL for mailbox notifications (auth is sent in first WS message). */
 export function mailboxWebSocketUrl(): string | null {
   if (!getAccessToken()) return null
-  const base = apiBaseUrl()
-  const u = new URL(base)
-  u.protocol = u.protocol === 'https:' ? 'wss:' : 'ws:'
-  return `${u.origin}/api/v1/communication/ws`
+  return wsUrl('/api/v1/communication/ws')
 }
 
 export type MailboxWsMessage = {

--- a/clients/web/src/lib/course-catalog-settings-api.ts
+++ b/clients/web/src/lib/course-catalog-settings-api.ts
@@ -89,12 +89,30 @@ export async function putCourseCatalogNickname(courseId: string, nickname: strin
   throw new Error(readApiErrorMessage(raw))
 }
 
-export async function fetchPinnedCourses(): Promise<PinnedCourseSummary[]> {
+export type PinnedCoursesPayload = {
+  courses: PinnedCourseSummary[]
+  rows: PinnedCourseSummary[][]
+}
+
+export async function fetchPinnedCourses(): Promise<PinnedCoursesPayload> {
   const res = await authorizedFetch('/api/v1/courses/catalog-pins')
   const raw: unknown = await res.json().catch(() => ({}))
   if (!res.ok) throw new Error(readApiErrorMessage(raw))
-  const data = raw as { courses?: PinnedCourseSummary[] }
-  return data.courses ?? []
+  const data = raw as { courses?: PinnedCourseSummary[]; rows?: PinnedCourseSummary[][] }
+  const courses = data.courses ?? []
+  const rows = data.rows ?? []
+  return { courses, rows }
+}
+
+export async function putCourseCatalogPinLayout(rows: string[][]): Promise<void> {
+  const res = await authorizedFetch('/api/v1/courses/catalog-pins/layout', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ rows }),
+  })
+  if (res.ok) return
+  const raw: unknown = await res.json().catch(() => ({}))
+  throw new Error(readApiErrorMessage(raw))
 }
 
 export async function putCourseCatalogPin(courseId: string, pinned: boolean): Promise<void> {

--- a/clients/web/src/lib/course-hero-image-url.ts
+++ b/clients/web/src/lib/course-hero-image-url.ts
@@ -1,0 +1,38 @@
+import { stripImageDisplayFragment } from './course-file-image'
+
+/** Display context for course hero banners; catalog variants request smaller server thumbnails. */
+export type CourseHeroImageSize = 'full' | 'catalog-card' | 'catalog-list' | 'catalog-gallery' | 'catalog-thumb'
+
+type SizeSpec = { w: number; h: number; q: number }
+
+const SIZE_SPECS: Record<Exclude<CourseHeroImageSize, 'full'>, SizeSpec> = {
+  'catalog-thumb': { w: 80, h: 80, q: 80 },
+  'catalog-list': { w: 224, h: 160, q: 82 },
+  'catalog-gallery': { w: 480, h: 360, q: 82 },
+  'catalog-card': { w: 640, h: 320, q: 85 },
+}
+
+function isResizableCourseFileContentURL(base: string): boolean {
+  return (
+    (base.includes('/course-files/') || base.includes('/files/items/')) && base.endsWith('/content')
+  )
+}
+
+/** Resolve the image URL to fetch, appending resize query params for catalog thumbnails. */
+export function courseHeroImageSrc(
+  src: string | null | undefined,
+  size: CourseHeroImageSize = 'full',
+): string | undefined {
+  if (!src) return undefined
+  if (size === 'full') return src
+
+  const { base } = stripImageDisplayFragment(src)
+  if (!isResizableCourseFileContentURL(base)) return src
+
+  const spec = SIZE_SPECS[size]
+  const url = new URL(base, 'http://local')
+  url.searchParams.set('w', String(spec.w))
+  url.searchParams.set('h', String(spec.h))
+  url.searchParams.set('q', String(spec.q))
+  return `${url.pathname}${url.search}`
+}

--- a/clients/web/src/lib/notifications-realtime.ts
+++ b/clients/web/src/lib/notifications-realtime.ts
@@ -1,13 +1,10 @@
-import { apiBaseUrl } from './api'
+import { wsUrl } from './api'
 import { getAccessToken } from './auth'
 
 /** WebSocket URL for in-app bell notification updates (auth is sent in first WS message). */
 export function notificationsWebSocketUrl(): string | null {
   if (!getAccessToken()) return null
-  const base = apiBaseUrl()
-  const u = new URL(base)
-  u.protocol = u.protocol === 'https:' ? 'wss:' : 'ws:'
-  return `${u.origin}/api/v1/ws/notifications`
+  return wsUrl('/api/v1/ws/notifications')
 }
 
 export type NotificationsWsMessage = {

--- a/clients/web/src/lib/pinned-courses-layout.ts
+++ b/clients/web/src/lib/pinned-courses-layout.ts
@@ -1,0 +1,122 @@
+import type { PinnedCourseSummary } from './course-catalog-settings-api'
+
+export const MAX_PINS_PER_ROW = 4
+
+export function flatPinnedRows(rows: PinnedCourseSummary[][]): PinnedCourseSummary[] {
+  return rows.flat()
+}
+
+/** Fallback when the API returns only a flat course list. */
+export function rowsFromFlatCourses(courses: PinnedCourseSummary[]): PinnedCourseSummary[][] {
+  if (courses.length === 0) return []
+  const rows: PinnedCourseSummary[][] = []
+  for (let i = 0; i < courses.length; i += MAX_PINS_PER_ROW) {
+    rows.push(courses.slice(i, i + MAX_PINS_PER_ROW))
+  }
+  return rows
+}
+
+export function rowDropId(rowIndex: number): string {
+  return `row:${rowIndex}`
+}
+
+export function newRowDropId(): string {
+  return 'row:new'
+}
+
+export function parseRowDropId(id: string): { kind: 'row'; rowIndex: number } | { kind: 'new' } | null {
+  if (id === 'row:new') return { kind: 'new' }
+  if (!id.startsWith('row:')) return null
+  const rowIndex = Number(id.slice('row:'.length))
+  if (!Number.isInteger(rowIndex) || rowIndex < 0) return null
+  return { kind: 'row', rowIndex }
+}
+
+export function rowsToCourseIds(rows: PinnedCourseSummary[][]): string[][] {
+  return rows.map((row) => row.map((course) => course.id))
+}
+
+export function pinRowsEqual(
+  left: PinnedCourseSummary[][],
+  right: PinnedCourseSummary[][],
+): boolean {
+  return rowsToCourseIds(left).flat().join('|') === rowsToCourseIds(right).flat().join('|')
+}
+
+export function normalizePinRows(rows: PinnedCourseSummary[][]): PinnedCourseSummary[][] {
+  const out: PinnedCourseSummary[][] = []
+  let overflow: PinnedCourseSummary[] = []
+
+  for (const row of rows) {
+    const combined = [...overflow, ...row]
+    overflow = []
+    if (combined.length > MAX_PINS_PER_ROW) {
+      out.push(combined.slice(0, MAX_PINS_PER_ROW))
+      overflow = combined.slice(MAX_PINS_PER_ROW)
+    } else if (combined.length > 0) {
+      out.push(combined)
+    }
+  }
+
+  if (overflow.length > 0) {
+    for (let i = 0; i < overflow.length; i += MAX_PINS_PER_ROW) {
+      out.push(overflow.slice(i, i + MAX_PINS_PER_ROW))
+    }
+  }
+
+  return out
+}
+
+export type PinDropTarget =
+  | { kind: 'row'; rowIndex: number; index?: number }
+  | { kind: 'new-row' }
+
+export function resolvePinDropTarget(
+  rows: PinnedCourseSummary[][],
+  overId: string,
+): PinDropTarget | null {
+  const parsed = parseRowDropId(overId)
+  if (parsed?.kind === 'new') return { kind: 'new-row' }
+  if (parsed?.kind === 'row') return { kind: 'row', rowIndex: parsed.rowIndex }
+
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const index = rows[rowIndex].findIndex((course) => course.id === overId)
+    if (index >= 0) return { kind: 'row', rowIndex, index }
+  }
+  return null
+}
+
+export function computeNextPinRows(
+  rows: PinnedCourseSummary[][],
+  courseId: string,
+  target: PinDropTarget,
+): PinnedCourseSummary[][] {
+  const next = rows.map((row) => [...row])
+  let moving: PinnedCourseSummary | undefined
+
+  for (const row of next) {
+    const index = row.findIndex((course) => course.id === courseId)
+    if (index >= 0) {
+      moving = row[index]
+      row.splice(index, 1)
+      break
+    }
+  }
+  if (!moving) return rows
+
+  if (target.kind === 'new-row') {
+    next.push([moving])
+    return normalizePinRows(next.filter((row) => row.length > 0))
+  }
+
+  while (next.length <= target.rowIndex) {
+    next.push([])
+  }
+
+  const row = next[target.rowIndex]
+  const insertAt =
+    target.index == null || target.index < 0 || target.index > row.length ? row.length : target.index
+  row.splice(insertAt, 0, moving)
+
+  return normalizePinRows(next.filter((row) => row.length > 0))
+}

--- a/clients/web/src/pages/lms/courses.tsx
+++ b/clients/web/src/pages/lms/courses.tsx
@@ -1,4 +1,15 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type MutableRefObject, type SVGProps } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
+  type MutableRefObject,
+  type PointerEvent as ReactPointerEvent,
+  type SVGProps,
+} from 'react'
 import { Link } from 'react-router-dom'
 import {
   closestCorners,
@@ -7,6 +18,7 @@ import {
   useSensor,
   useSensors,
   type DragEndEvent,
+  type DragStartEvent,
 } from '@dnd-kit/core'
 import {
   arrayMove,
@@ -53,6 +65,7 @@ import { formatRelativeCompact } from '../../lib/format-datetime'
 import { CourseCatalogStatusPill } from '../../components/ui/status-vocabulary'
 import { canCreateCourses } from '../../lib/rbac-api'
 import { CourseHeroImage } from '../../components/course-hero-image'
+import type { CourseHeroImageSize } from '../../lib/course-hero-image-url'
 import { CourseEnrollmentInvitationActions } from '../../components/enrollment/course-enrollment-invitation-actions'
 
 export type { CoursePublic } from '../../lib/courses-api'
@@ -98,6 +111,92 @@ function CreateCourseIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
 }
 
 const COURSE_GRID_SORT_ID = 'course-catalog-grid'
+const CATALOG_DRAG_ACTIVATION_DISTANCE_SQ = 8 * 8
+
+type CatalogPointerDragGuard = {
+  x: number
+  y: number
+  moved: boolean
+}
+
+function catalogCardPointerDownCapture(
+  guard: MutableRefObject<CatalogPointerDragGuard>,
+  e: ReactPointerEvent<HTMLElement>,
+) {
+  guard.current = { x: e.clientX, y: e.clientY, moved: false }
+}
+
+function shouldSuppressCatalogLinkClick(opts: {
+  pointerGuard?: MutableRefObject<CatalogPointerDragGuard>
+  justFinishedDraggingRef?: MutableRefObject<boolean>
+  isDragging?: boolean
+  catalogDragActive?: boolean
+  suppressAfterDragRef?: MutableRefObject<boolean>
+}): boolean {
+  return Boolean(
+    opts.isDragging ||
+      opts.catalogDragActive ||
+      opts.suppressAfterDragRef?.current ||
+      opts.justFinishedDraggingRef?.current ||
+      opts.pointerGuard?.current.moved,
+  )
+}
+
+function consumeCatalogLinkClickSuppress(opts: {
+  pointerGuard?: MutableRefObject<CatalogPointerDragGuard>
+  justFinishedDraggingRef?: MutableRefObject<boolean>
+  suppressAfterDragRef?: MutableRefObject<boolean>
+}) {
+  if (opts.pointerGuard) opts.pointerGuard.current.moved = false
+  if (opts.justFinishedDraggingRef) opts.justFinishedDraggingRef.current = false
+  if (opts.suppressAfterDragRef) opts.suppressAfterDragRef.current = false
+}
+
+function useCatalogSortablePointerGuard(isDragging: boolean) {
+  const pointerGuardRef = useRef<CatalogPointerDragGuard>({ x: 0, y: 0, moved: false })
+  const justFinishedDraggingRef = useRef(false)
+  const wasDraggingRef = useRef(false)
+
+  useEffect(() => {
+    if (isDragging) {
+      pointerGuardRef.current.moved = true
+      justFinishedDraggingRef.current = false
+    } else if (wasDraggingRef.current) {
+      pointerGuardRef.current.moved = true
+      justFinishedDraggingRef.current = true
+    }
+    wasDraggingRef.current = isDragging
+  }, [isDragging])
+
+  const onPointerDownCapture = useCallback((e: ReactPointerEvent<HTMLElement>) => {
+    justFinishedDraggingRef.current = false
+    catalogCardPointerDownCapture(pointerGuardRef, e)
+    const pointerId = e.pointerId
+
+    const onWindowPointerMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return
+      if (pointerGuardRef.current.moved) return
+      const dx = ev.clientX - pointerGuardRef.current.x
+      const dy = ev.clientY - pointerGuardRef.current.y
+      if (dx * dx + dy * dy >= CATALOG_DRAG_ACTIVATION_DISTANCE_SQ) {
+        pointerGuardRef.current.moved = true
+      }
+    }
+
+    const endWindowTracking = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return
+      window.removeEventListener('pointermove', onWindowPointerMove)
+      window.removeEventListener('pointerup', endWindowTracking)
+      window.removeEventListener('pointercancel', endWindowTracking)
+    }
+
+    window.addEventListener('pointermove', onWindowPointerMove)
+    window.addEventListener('pointerup', endWindowTracking)
+    window.addEventListener('pointercancel', endWindowTracking)
+  }, [])
+
+  return { pointerGuardRef, justFinishedDraggingRef, onPointerDownCapture }
+}
 
 type CatalogSection = {
   key: string
@@ -110,6 +209,14 @@ type SortableCourseProps = {
   setNodeRef: (node: HTMLElement | null) => void
   style: CSSProperties
   isDragging: boolean
+  pointerGuardRef: MutableRefObject<CatalogPointerDragGuard>
+  justFinishedDraggingRef: MutableRefObject<boolean>
+  onPointerDownCapture: (e: ReactPointerEvent<HTMLElement>) => void
+}
+
+type CatalogCourseDragProps = {
+  catalogDragActive: boolean
+  suppressNavigateAfterDragRef: MutableRefObject<boolean>
 }
 
 function formatEditedAgo(iso: string): string {
@@ -120,6 +227,33 @@ function formatCourseTermLabel(course: CoursePublic): string {
   return course.term?.name?.trim() || '—'
 }
 
+const CATALOG_LIST_HERO_FRAME =
+  'relative aspect-[7/5] w-28 shrink-0 overflow-hidden rounded-lg bg-slate-100 dark:bg-neutral-800'
+
+function CatalogCourseHero({
+  course,
+  size,
+  className,
+}: {
+  course: CoursePublic
+  size: CourseHeroImageSize
+  className: string
+}) {
+  return (
+    <CourseHeroImage
+      data-lex-hero
+      src={course.heroImageUrl ?? '/course-card-hero.png'}
+      size={size}
+      alt=""
+      draggable={false}
+      loading="lazy"
+      decoding="async"
+      className={className}
+      style={heroImageObjectStyle(course.heroImageObjectPosition)}
+    />
+  )
+}
+
 function catalogViewUsesGrid(view: CourseCatalogView): boolean {
   return view === 'cards' || view === 'gallery'
 }
@@ -127,22 +261,19 @@ function catalogViewUsesGrid(view: CourseCatalogView): boolean {
 function CourseCard({
   course,
   sortable,
+  catalogDragActive,
   suppressNavigateAfterDragRef,
   onNicknameChange,
   onPinnedChange,
   onInvitationResolved,
 }: {
   course: CoursePublic
-  suppressNavigateAfterDragRef?: MutableRefObject<boolean>
+  catalogDragActive: boolean
+  suppressNavigateAfterDragRef: MutableRefObject<boolean>
   onNicknameChange: CatalogNicknameChangeHandler
   onPinnedChange: CatalogPinnedChangeHandler
   onInvitationResolved?: CatalogInvitationResolvedHandler
-  sortable?: {
-    listeners: Record<string, unknown>
-    setNodeRef: (node: HTMLElement | null) => void
-    style: CSSProperties
-    isDragging: boolean
-  }
+  sortable?: SortableCourseProps
 }) {
   const courseHref = `/courses/${encodeURIComponent(course.courseCode)}`
   const badgeLabel = courseCatalogStatusLabel(course)
@@ -152,16 +283,7 @@ function CourseCard({
 
   const heroBlock = (
     <>
-      <CourseHeroImage
-        data-lex-hero
-        src={course.heroImageUrl ?? '/course-card-hero.png'}
-        alt=""
-        draggable={false}
-        loading="lazy"
-        decoding="async"
-        className="h-40 w-full object-cover"
-        style={heroImageObjectStyle(course.heroImageObjectPosition)}
-      />
+      <CatalogCourseHero course={course} size="catalog-card" className="h-40 w-full object-cover" />
       <div
         className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/80 via-black/25 to-transparent"
         aria-hidden
@@ -184,6 +306,26 @@ function CourseCard({
 
   const invitationMutedClass = invitationPending ? 'opacity-60 grayscale' : ''
 
+  const suppressLinkClick = () =>
+    shouldSuppressCatalogLinkClick({
+      pointerGuard: sortable?.pointerGuardRef,
+      justFinishedDraggingRef: sortable?.justFinishedDraggingRef,
+      isDragging: sortable?.isDragging,
+      catalogDragActive,
+      suppressAfterDragRef: suppressNavigateAfterDragRef,
+    })
+
+  const onCatalogLinkClick = (e: ReactMouseEvent<HTMLAnchorElement>) => {
+    if (!suppressLinkClick()) return
+    e.preventDefault()
+    e.stopPropagation()
+    consumeCatalogLinkClickSuppress({
+      pointerGuard: sortable?.pointerGuardRef,
+      justFinishedDraggingRef: sortable?.justFinishedDraggingRef,
+      suppressAfterDragRef: suppressNavigateAfterDragRef,
+    })
+  }
+
   return (
     <article
       ref={sortable?.setNodeRef}
@@ -195,6 +337,7 @@ function CourseCard({
       ]
         .filter(Boolean)
         .join(' ')}
+      onPointerDownCapture={sortable?.onPointerDownCapture}
       {...(sortable ? sortable.listeners : {})}
     >
       <div className={invitationMutedClass}>
@@ -207,12 +350,7 @@ function CourseCard({
             to={courseHref}
             className="relative block focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500"
             aria-label={`Open ${displayTitle}`}
-            onClick={(e) => {
-              if (!suppressNavigateAfterDragRef?.current) return
-              e.preventDefault()
-              e.stopPropagation()
-              suppressNavigateAfterDragRef.current = false
-            }}
+            onClick={onCatalogLinkClick}
           >
             {heroBlock}
           </Link>
@@ -257,13 +395,14 @@ function CourseCard({
 
 function SortableCourseCard({
   course,
+  catalogDragActive,
   suppressNavigateAfterDragRef,
   onNicknameChange,
   onPinnedChange,
   onInvitationResolved,
 }: {
   course: CoursePublic
-  suppressNavigateAfterDragRef: MutableRefObject<boolean>
+} & CatalogCourseDragProps & {
   onNicknameChange: CatalogNicknameChangeHandler
   onPinnedChange: CatalogPinnedChangeHandler
   onInvitationResolved?: CatalogInvitationResolvedHandler
@@ -271,6 +410,8 @@ function SortableCourseCard({
   const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: course.id,
   })
+  const { pointerGuardRef, justFinishedDraggingRef, onPointerDownCapture } =
+    useCatalogSortablePointerGuard(isDragging)
   const style: CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -282,6 +423,7 @@ function SortableCourseCard({
     <div className="h-full min-h-0">
       <CourseCard
         course={course}
+        catalogDragActive={catalogDragActive}
         suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
         onNicknameChange={onNicknameChange}
         onPinnedChange={onPinnedChange}
@@ -291,6 +433,9 @@ function SortableCourseCard({
           setNodeRef,
           style,
           isDragging,
+          pointerGuardRef,
+          justFinishedDraggingRef,
+          onPointerDownCapture,
         }}
       />
     </div>
@@ -300,13 +445,15 @@ function SortableCourseCard({
 function CourseListRow({
   course,
   sortable,
+  catalogDragActive,
   suppressNavigateAfterDragRef,
   onNicknameChange,
   onPinnedChange,
   onInvitationResolved,
 }: {
   course: CoursePublic
-  suppressNavigateAfterDragRef?: MutableRefObject<boolean>
+  catalogDragActive: boolean
+  suppressNavigateAfterDragRef: MutableRefObject<boolean>
   onNicknameChange: CatalogNicknameChangeHandler
   onPinnedChange: CatalogPinnedChangeHandler
   onInvitationResolved?: CatalogInvitationResolvedHandler
@@ -319,6 +466,26 @@ function CourseListRow({
   const invitationPending = courseInvitationPending(course)
   const invitationMutedClass = invitationPending ? 'opacity-60 grayscale' : ''
 
+  const suppressLinkClick = () =>
+    shouldSuppressCatalogLinkClick({
+      pointerGuard: sortable?.pointerGuardRef,
+      justFinishedDraggingRef: sortable?.justFinishedDraggingRef,
+      isDragging: sortable?.isDragging,
+      catalogDragActive,
+      suppressAfterDragRef: suppressNavigateAfterDragRef,
+    })
+
+  const onCatalogLinkClick = (e: ReactMouseEvent<HTMLAnchorElement>) => {
+    if (!suppressLinkClick()) return
+    e.preventDefault()
+    e.stopPropagation()
+    consumeCatalogLinkClickSuppress({
+      pointerGuard: sortable?.pointerGuardRef,
+      justFinishedDraggingRef: sortable?.justFinishedDraggingRef,
+      suppressAfterDragRef: suppressNavigateAfterDragRef,
+    })
+  }
+
   return (
     <article
       ref={sortable?.setNodeRef}
@@ -330,44 +497,30 @@ function CourseListRow({
       ]
         .filter(Boolean)
         .join(' ')}
+      onPointerDownCapture={sortable?.onPointerDownCapture}
       {...(sortable ? sortable.listeners : {})}
     >
       <div className="flex min-w-0 flex-1 items-stretch gap-4 p-3 sm:p-4">
         <div className={invitationMutedClass}>
         {invitationPending ? (
-          <div className="relative h-16 w-24 shrink-0 overflow-hidden rounded-lg sm:h-20 sm:w-28" aria-hidden>
-            <CourseHeroImage
-              data-lex-hero
-              src={course.heroImageUrl ?? '/course-card-hero.png'}
-              alt=""
-              draggable={false}
-              loading="lazy"
-              decoding="async"
-              className="h-full w-full object-cover"
-              style={heroImageObjectStyle(course.heroImageObjectPosition)}
+          <div className={CATALOG_LIST_HERO_FRAME} aria-hidden>
+            <CatalogCourseHero
+              course={course}
+              size="catalog-list"
+              className="absolute inset-0 h-full w-full object-cover"
             />
           </div>
         ) : (
           <Link
             to={courseHref}
-            className="relative h-16 w-24 shrink-0 overflow-hidden rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 sm:h-20 sm:w-28"
+            className={`${CATALOG_LIST_HERO_FRAME} focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500`}
             aria-label={`Open ${displayTitle}`}
-            onClick={(e) => {
-              if (!suppressNavigateAfterDragRef?.current) return
-              e.preventDefault()
-              e.stopPropagation()
-              suppressNavigateAfterDragRef.current = false
-            }}
+            onClick={onCatalogLinkClick}
           >
-            <CourseHeroImage
-              data-lex-hero
-              src={course.heroImageUrl ?? '/course-card-hero.png'}
-              alt=""
-              draggable={false}
-              loading="lazy"
-              decoding="async"
-              className="h-full w-full object-cover"
-              style={heroImageObjectStyle(course.heroImageObjectPosition)}
+            <CatalogCourseHero
+              course={course}
+              size="catalog-list"
+              className="absolute inset-0 h-full w-full object-cover"
             />
           </Link>
         )}
@@ -392,12 +545,7 @@ function CourseListRow({
             <Link
               to={courseHref}
               className="text-start text-sm leading-snug text-slate-600 line-clamp-2 hover:text-indigo-600 dark:text-neutral-400 dark:hover:text-indigo-300"
-              onClick={(e) => {
-                if (!suppressNavigateAfterDragRef?.current) return
-                e.preventDefault()
-                e.stopPropagation()
-                suppressNavigateAfterDragRef.current = false
-              }}
+              onClick={onCatalogLinkClick}
             >
               {descriptionBlurb}
             </Link>
@@ -418,13 +566,14 @@ function CourseListRow({
 
 function SortableCourseListRow({
   course,
+  catalogDragActive,
   suppressNavigateAfterDragRef,
   onNicknameChange,
   onPinnedChange,
   onInvitationResolved,
 }: {
   course: CoursePublic
-  suppressNavigateAfterDragRef: MutableRefObject<boolean>
+} & CatalogCourseDragProps & {
   onNicknameChange: CatalogNicknameChangeHandler
   onPinnedChange: CatalogPinnedChangeHandler
   onInvitationResolved?: CatalogInvitationResolvedHandler
@@ -432,6 +581,8 @@ function SortableCourseListRow({
   const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: course.id,
   })
+  const { pointerGuardRef, justFinishedDraggingRef, onPointerDownCapture } =
+    useCatalogSortablePointerGuard(isDragging)
   const style: CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -442,6 +593,7 @@ function SortableCourseListRow({
   return (
     <CourseListRow
       course={course}
+      catalogDragActive={catalogDragActive}
       suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
       onNicknameChange={onNicknameChange}
       onPinnedChange={onPinnedChange}
@@ -451,6 +603,9 @@ function SortableCourseListRow({
         setNodeRef,
         style,
         isDragging,
+        pointerGuardRef,
+        justFinishedDraggingRef,
+        onPointerDownCapture,
       }}
     />
   )
@@ -459,13 +614,15 @@ function SortableCourseListRow({
 function CourseGalleryTile({
   course,
   sortable,
+  catalogDragActive,
   suppressNavigateAfterDragRef,
   onNicknameChange,
   onPinnedChange,
   onInvitationResolved,
 }: {
   course: CoursePublic
-  suppressNavigateAfterDragRef?: MutableRefObject<boolean>
+  catalogDragActive: boolean
+  suppressNavigateAfterDragRef: MutableRefObject<boolean>
   onNicknameChange: CatalogNicknameChangeHandler
   onPinnedChange: CatalogPinnedChangeHandler
   onInvitationResolved?: CatalogInvitationResolvedHandler
@@ -476,6 +633,26 @@ function CourseGalleryTile({
   const displayTitle = courseCatalogDisplayTitle(course)
   const invitationPending = courseInvitationPending(course)
   const invitationMutedClass = invitationPending ? 'opacity-60 grayscale' : ''
+
+  const suppressLinkClick = () =>
+    shouldSuppressCatalogLinkClick({
+      pointerGuard: sortable?.pointerGuardRef,
+      justFinishedDraggingRef: sortable?.justFinishedDraggingRef,
+      isDragging: sortable?.isDragging,
+      catalogDragActive,
+      suppressAfterDragRef: suppressNavigateAfterDragRef,
+    })
+
+  const onCatalogLinkClick = (e: ReactMouseEvent<HTMLAnchorElement>) => {
+    if (!suppressLinkClick()) return
+    e.preventDefault()
+    e.stopPropagation()
+    consumeCatalogLinkClickSuppress({
+      pointerGuard: sortable?.pointerGuardRef,
+      justFinishedDraggingRef: sortable?.justFinishedDraggingRef,
+      suppressAfterDragRef: suppressNavigateAfterDragRef,
+    })
+  }
 
   return (
     <article
@@ -488,20 +665,16 @@ function CourseGalleryTile({
       ]
         .filter(Boolean)
         .join(' ')}
+      onPointerDownCapture={sortable?.onPointerDownCapture}
       {...(sortable ? sortable.listeners : {})}
     >
       <div className={invitationMutedClass}>
       {invitationPending ? (
         <div className="relative block aspect-[4/3]" aria-hidden>
-          <CourseHeroImage
-            data-lex-hero
-            src={course.heroImageUrl ?? '/course-card-hero.png'}
-            alt=""
-            draggable={false}
-            loading="lazy"
-            decoding="async"
+          <CatalogCourseHero
+            course={course}
+            size="catalog-gallery"
             className="absolute inset-0 h-full w-full object-cover"
-            style={heroImageObjectStyle(course.heroImageObjectPosition)}
           />
         </div>
       ) : (
@@ -509,22 +682,12 @@ function CourseGalleryTile({
         to={courseHref}
         className="relative block aspect-[4/3] focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500"
         aria-label={`Open ${displayTitle}`}
-        onClick={(e) => {
-          if (!suppressNavigateAfterDragRef?.current) return
-          e.preventDefault()
-          e.stopPropagation()
-          suppressNavigateAfterDragRef.current = false
-        }}
+        onClick={onCatalogLinkClick}
       >
-        <CourseHeroImage
-          data-lex-hero
-          src={course.heroImageUrl ?? '/course-card-hero.png'}
-          alt=""
-          draggable={false}
-          loading="lazy"
-          decoding="async"
+        <CatalogCourseHero
+          course={course}
+          size="catalog-gallery"
           className="absolute inset-0 h-full w-full object-cover"
-          style={heroImageObjectStyle(course.heroImageObjectPosition)}
         />
         <div
           className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent"
@@ -563,13 +726,14 @@ function CourseGalleryTile({
 
 function SortableCourseGalleryTile({
   course,
+  catalogDragActive,
   suppressNavigateAfterDragRef,
   onNicknameChange,
   onPinnedChange,
   onInvitationResolved,
 }: {
   course: CoursePublic
-  suppressNavigateAfterDragRef: MutableRefObject<boolean>
+} & CatalogCourseDragProps & {
   onNicknameChange: CatalogNicknameChangeHandler
   onPinnedChange: CatalogPinnedChangeHandler
   onInvitationResolved?: CatalogInvitationResolvedHandler
@@ -577,6 +741,8 @@ function SortableCourseGalleryTile({
   const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: course.id,
   })
+  const { pointerGuardRef, justFinishedDraggingRef, onPointerDownCapture } =
+    useCatalogSortablePointerGuard(isDragging)
   const style: CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -587,6 +753,7 @@ function SortableCourseGalleryTile({
   return (
     <CourseGalleryTile
       course={course}
+      catalogDragActive={catalogDragActive}
       suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
       onNicknameChange={onNicknameChange}
       onPinnedChange={onPinnedChange}
@@ -596,6 +763,9 @@ function SortableCourseGalleryTile({
         setNodeRef,
         style,
         isDragging,
+        pointerGuardRef,
+        justFinishedDraggingRef,
+        onPointerDownCapture,
       }}
     />
   )
@@ -619,13 +789,15 @@ function CourseCatalogTableHeader() {
 function CourseTableRow({
   course,
   sortable,
+  catalogDragActive,
   suppressNavigateAfterDragRef,
   onNicknameChange,
   onPinnedChange,
   onInvitationResolved,
 }: {
   course: CoursePublic
-  suppressNavigateAfterDragRef?: MutableRefObject<boolean>
+  catalogDragActive: boolean
+  suppressNavigateAfterDragRef: MutableRefObject<boolean>
   onNicknameChange: CatalogNicknameChangeHandler
   onPinnedChange: CatalogPinnedChangeHandler
   onInvitationResolved?: CatalogInvitationResolvedHandler
@@ -635,6 +807,26 @@ function CourseTableRow({
   const badgeLabel = courseCatalogStatusLabel(course)
   const invitationPending = courseInvitationPending(course)
   const invitationMutedClass = invitationPending ? 'opacity-60 grayscale' : ''
+
+  const suppressLinkClick = () =>
+    shouldSuppressCatalogLinkClick({
+      pointerGuard: sortable?.pointerGuardRef,
+      justFinishedDraggingRef: sortable?.justFinishedDraggingRef,
+      isDragging: sortable?.isDragging,
+      catalogDragActive,
+      suppressAfterDragRef: suppressNavigateAfterDragRef,
+    })
+
+  const onCatalogLinkClick = (e: ReactMouseEvent<HTMLAnchorElement>) => {
+    if (!suppressLinkClick()) return
+    e.preventDefault()
+    e.stopPropagation()
+    consumeCatalogLinkClickSuppress({
+      pointerGuard: sortable?.pointerGuardRef,
+      justFinishedDraggingRef: sortable?.justFinishedDraggingRef,
+      suppressAfterDragRef: suppressNavigateAfterDragRef,
+    })
+  }
 
   return (
     <article
@@ -647,6 +839,7 @@ function CourseTableRow({
       ]
         .filter(Boolean)
         .join(' ')}
+      onPointerDownCapture={sortable?.onPointerDownCapture}
       {...(sortable ? sortable.listeners : {})}
     >
       <div className="flex min-w-0 items-start gap-2">
@@ -669,12 +862,7 @@ function CourseTableRow({
             <Link
               to={courseHref}
               className={`mt-1 inline-block text-xs font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-300 dark:hover:text-indigo-200 ${invitationMutedClass}`}
-              onClick={(e) => {
-                if (!suppressNavigateAfterDragRef?.current) return
-                e.preventDefault()
-                e.stopPropagation()
-                suppressNavigateAfterDragRef.current = false
-              }}
+              onClick={onCatalogLinkClick}
             >
               Open course
             </Link>
@@ -702,13 +890,14 @@ function CourseTableRow({
 
 function SortableCourseTableRow({
   course,
+  catalogDragActive,
   suppressNavigateAfterDragRef,
   onNicknameChange,
   onPinnedChange,
   onInvitationResolved,
 }: {
   course: CoursePublic
-  suppressNavigateAfterDragRef: MutableRefObject<boolean>
+} & CatalogCourseDragProps & {
   onNicknameChange: CatalogNicknameChangeHandler
   onPinnedChange: CatalogPinnedChangeHandler
   onInvitationResolved?: CatalogInvitationResolvedHandler
@@ -716,6 +905,8 @@ function SortableCourseTableRow({
   const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: course.id,
   })
+  const { pointerGuardRef, justFinishedDraggingRef, onPointerDownCapture } =
+    useCatalogSortablePointerGuard(isDragging)
   const style: CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -726,6 +917,7 @@ function SortableCourseTableRow({
   return (
     <CourseTableRow
       course={course}
+      catalogDragActive={catalogDragActive}
       suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
       onNicknameChange={onNicknameChange}
       onPinnedChange={onPinnedChange}
@@ -735,6 +927,9 @@ function SortableCourseTableRow({
         setNodeRef,
         style,
         isDragging,
+        pointerGuardRef,
+        justFinishedDraggingRef,
+        onPointerDownCapture,
       }}
     />
   )
@@ -787,6 +982,7 @@ export default function Courses() {
   }, [orgId])
   /** After a catalog drag, the browser may emit a click on the card link; block that navigation. */
   const suppressNavigateAfterDragRef = useRef(false)
+  const [catalogDragActive, setCatalogDragActive] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -955,17 +1151,26 @@ export default function Courses() {
   const clearSuppressNavigateAfterDragSoon = useCallback(() => {
     window.setTimeout(() => {
       suppressNavigateAfterDragRef.current = false
-    }, 200)
+    }, 300)
   }, [])
 
-  const handleDragStart = useCallback(() => {
+  const finishCatalogDrag = useCallback(() => {
     suppressNavigateAfterDragRef.current = true
+    clearSuppressNavigateAfterDragSoon()
+    window.setTimeout(() => {
+      setCatalogDragActive(false)
+    }, 0)
+  }, [clearSuppressNavigateAfterDragSoon])
+
+  const handleDragStart = useCallback((_event: DragStartEvent) => {
+    suppressNavigateAfterDragRef.current = true
+    setCatalogDragActive(true)
   }, [])
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event
-      clearSuppressNavigateAfterDragSoon()
+      finishCatalogDrag()
       if (!over || active.id === over.id || !courses?.length) return
       setError(null)
       const oldIndex = courses.findIndex((c) => c.id === active.id)
@@ -979,12 +1184,12 @@ export default function Courses() {
         setError('Could not save course order. Try again.')
       })
     },
-    [courses, clearSuppressNavigateAfterDragSoon],
+    [courses, finishCatalogDrag],
   )
 
   const handleDragCancel = useCallback(() => {
-    clearSuppressNavigateAfterDragSoon()
-  }, [clearSuppressNavigateAfterDragSoon])
+    finishCatalogDrag()
+  }, [finishCatalogDrag])
 
   const sortStrategy = catalogViewUsesGrid(catalogView) ? rectSortingStrategy : verticalListSortingStrategy
 
@@ -996,6 +1201,7 @@ export default function Courses() {
             <SortableCourseCard
               key={course.id}
               course={course}
+              catalogDragActive={catalogDragActive}
               suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
               onNicknameChange={handleNicknameChange}
               onPinnedChange={handlePinnedChange}
@@ -1007,6 +1213,7 @@ export default function Courses() {
             <SortableCourseGalleryTile
               key={course.id}
               course={course}
+              catalogDragActive={catalogDragActive}
               suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
               onNicknameChange={handleNicknameChange}
               onPinnedChange={handlePinnedChange}
@@ -1018,6 +1225,7 @@ export default function Courses() {
             <SortableCourseTableRow
               key={course.id}
               course={course}
+              catalogDragActive={catalogDragActive}
               suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
               onNicknameChange={handleNicknameChange}
               onPinnedChange={handlePinnedChange}
@@ -1029,6 +1237,7 @@ export default function Courses() {
             <SortableCourseListRow
               key={course.id}
               course={course}
+              catalogDragActive={catalogDragActive}
               suppressNavigateAfterDragRef={suppressNavigateAfterDragRef}
               onNicknameChange={handleNicknameChange}
               onPinnedChange={handlePinnedChange}
@@ -1043,7 +1252,7 @@ export default function Courses() {
         }
       }
     },
-    [catalogView, handleInvitationResolved, handleNicknameChange, handlePinnedChange],
+    [catalogDragActive, catalogView, handleInvitationResolved, handleNicknameChange, handlePinnedChange],
   )
 
   const renderCourseItems = useCallback(

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -90,6 +90,7 @@ export default defineConfig({
       '/api': {
         target: process.env.VITE_DEV_API_PROXY ?? 'http://127.0.0.1:8080',
         changeOrigin: true,
+        ws: true,
       },
     },
   },

--- a/docs/plan/mobile/M0.1-push-deep-links.md
+++ b/docs/plan/mobile/M0.1-push-deep-links.md
@@ -1,0 +1,157 @@
+# M0.1 — Native Push Notifications & Deep Links (Mobile)
+
+> Register APNs (iOS) / FCM (Android) device tokens, receive push for the events the
+> student cares about (grade posted, due-soon, announcement, discussion reply,
+> message), and **deep-link** a tapped notification straight to the relevant screen.
+> Source: 6.3 push notifications, 21.5 APNs/FCM push service.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M0 — Foundation & Platform |
+| **Severity** | BLOCKER (platform) — without push, a phone-first student must keep checking manually; it's table stakes and a top retention lever |
+| **Status (today)** | MISSING on device — server `push_http.go` exists; mobile registers no token and handles no notification |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI + APNs), Android (Compose + FCM) |
+| **Backend** | Minimal — `push_http.go` exists (device tokens + SSE). Confirm/extend a `device_push_tokens` registration endpoint + APNs/FCM dispatch (per 21.5) if not already wired for native tokens |
+| **Depends on** | Auth session (built) · **Unblocks** reminders/notify hooks across M2.1, M4.1, M6.1, M7.1, M8.1 |
+
+---
+
+## 1. Problem Statement
+
+A student should learn that a grade posted, an assignment is due tonight, or a
+classmate replied — without opening the app and hunting. Today there's no native
+push and no deep linking, so the app is purely pull-based. Push + deep links turn it
+into a timely, glanceable companion and materially lift engagement and on-time
+submissions.
+
+## 2. Goals
+
+- Register the device's **APNs/FCM token** with the backend, tied to the logged-in
+  user + platform + app version, and deregister on logout.
+- Receive and present push for: **grade posted, due-soon reminder, new announcement,
+  discussion reply, new message** (respecting per-user notification preferences).
+- **Deep-link**: tapping a notification opens the exact screen (assignment, grade,
+  thread, message, course).
+- A consistent in-app **notification center** ties to the existing notifications list.
+- Permission priming that follows platform best practice (ask in context, not at
+  cold launch).
+
+## 3. Non-Goals
+
+- Building the server push **dispatch** pipeline from scratch — 21.5 owns that; this
+  story consumes/validates it and adds device registration if missing.
+- Rich notification UI (images/actions) beyond a title/body + deep link in v1
+  (quick-reply actions are a fast-follow).
+- In-app messaging real-time transport changes (SSE already exists server-side).
+
+## 4. User Stories
+
+- **As a student**, I get a push the moment my essay grade is posted and tap it to see
+  the feedback.
+- **As a student**, I get a reminder that a quiz is due in 2 hours.
+- **As a student**, tapping a "new reply" push drops me right into the thread.
+- **As a student**, I can turn categories of notifications on/off.
+
+## 5. What already exists (reuse)
+
+- **Server**: `push_http.go` (+ `push_sse.go`, `push_http_db_test.go`) and the 21.5
+  plan define device-token storage and dispatch. `notification_preferences_http.go`
+  governs per-category opt-in. Confirm a native-token registration route
+  (`POST /api/.../device-tokens`) + APNs/FCM send; add if absent (minimal).
+- **Mobile**: auth session + secure store (built); existing notifications list
+  (`NotificationsView`/`NotificationsScreen`) becomes the in-app center; nav shell to
+  route into.
+
+## 6. Functional Requirements
+
+- **FR-1.** On login (and on token refresh), the app MUST obtain the platform push
+  token and **register** it with the backend along with `X-Platform` and app version;
+  on logout it MUST **deregister** that token.
+- **FR-2.** The app MUST request notification permission **in context** (e.g., after
+  the first meaningful action or from a settings prompt), not at first launch, and
+  handle denial gracefully (in-app center still works).
+- **FR-3.** The app MUST display foreground and background notifications for the
+  supported event types, honoring the user's **notification preferences**
+  (`notification_preferences_http.go`).
+- **FR-4.** Each notification MUST carry a **deep-link payload** (type + ids) that,
+  on tap, routes to the correct native screen: grade → [M6.1](M6.1-grades-feedback.md),
+  due-soon → the item ([M4.1](M4.1-quiz-taker.md)/[M5.1](M5.1-assignment-submission.md)),
+  announcement → course feed, discussion reply → [M7.1](M7.1-discussions.md) thread,
+  message → Inbox thread.
+- **FR-5.** A central **deep-link router** MUST resolve a route from either a push tap
+  or a universal/app link URL, with safe fallback (open the app home if the target is
+  unavailable/forbidden).
+- **FR-6.** The in-app **notification center** MUST list recent notifications (reuse
+  existing list), mark read/unread, and tap-through using the same router; a badge MUST
+  reflect unread count.
+- **FR-7.** Universal Links (iOS) / App Links (Android) for `lextures` URLs SHOULD open
+  the app to the mapped screen when installed.
+
+## 7. Non-Functional
+
+- **Privacy/Compliance**: notification content MUST avoid sensitive detail on the lock
+  screen where policy requires (configurable); respect minor-account constraints;
+  tokens stored/transmitted securely.
+- **Reliability**: token re-registration on app update / OS token rotation; idempotent
+  registration; dispatch failures don't crash.
+- **Accessibility**: notification center rows labelled; badge state exposed.
+- **Observability**: log push delivery/open with app version (per 17.7) without PII.
+
+## 8. Design / Approach
+
+- **iOS**: `Core/Push/PushManager.swift` (UNUserNotificationCenter delegate, APNs
+  registration, permission priming), `Core/Routing/DeepLinkRouter.swift` (maps
+  payload/URL → a navigation intent consumed by `MainTabView`/`AppShell`). Register
+  Universal Links (apple-app-site-association) + push entitlement. Token register/
+  deregister calls in `Core/Auth`/`LMSAPIFeatures.swift`.
+- **Android**: `core/push/PushService.kt` (FirebaseMessagingService),
+  `core/routing/DeepLinkRouter.kt`, intent-filters for App Links, `POST_NOTIFICATIONS`
+  permission flow (Android 13+). Token register/deregister in `core/auth` / `LmsApi.kt`.
+- **Router** is the single source of truth so push, app links, and in-app taps share
+  one resolution path. Notification preferences screen extends the existing settings.
+
+## 9. Files to touch
+
+**iOS**
+- `clients/ios/Lextures/Core/Push/PushManager.swift` *(new)*
+- `clients/ios/Lextures/Core/Routing/DeepLinkRouter.swift` *(new)*
+- `clients/ios/Lextures/Features/Home/MainTabView.swift` — consume navigation intents
+- `clients/ios/Lextures/Features/Profile/NotificationsView.swift` — center + router taps + prefs
+- `clients/ios/Lextures/Core/LMS/LMSAPIFeatures.swift` — device-token register/deregister
+- `clients/ios/Lextures/App/*` + entitlements + AASA — push + Universal Links
+- `clients/ios/Lextures.xcodeproj/project.pbxproj`
+
+**Android**
+- `.../core/push/PushService.kt` *(new — FirebaseMessagingService)*
+- `.../core/routing/DeepLinkRouter.kt` *(new)*
+- `.../app/MainActivity.kt` / `RootScreen.kt` — intent handling + App Links
+- `.../features/profile/NotificationsScreen.kt` — center + prefs
+- `.../core/lms/LmsApi.kt` — token register/deregister
+- `AndroidManifest.xml` — FCM service, intent-filters, `POST_NOTIFICATIONS`
+
+**Backend** — confirm/add device-token registration + APNs/FCM dispatch per 21.5 (minimal if `push_http.go` already covers it).
+
+## 10. Acceptance Criteria
+
+1. Logging in registers a device token server-side; logging out removes it.
+2. Permission is requested in context; denying still leaves the in-app center working.
+3. A posted grade produces a push (when that preference is on) that, tapped, opens the
+   grade feedback screen; turning that preference off stops it.
+4. Pushes for due-soon, announcement, discussion reply, and message each deep-link to
+   the correct screen.
+5. A `lextures` universal/app link opens the installed app to the mapped screen.
+6. The notification center lists recent items with read/unread and a correct badge.
+7. Both apps build; token survives an app update / OS token rotation.
+
+## 11. Phasing
+
+1. Confirm/extend server device-token + dispatch (21.5).
+2. iOS APNs registration + permission priming + token register/deregister.
+3. Deep-link router + Universal Links + notification center taps.
+4. Android FCM parity + App Links + `POST_NOTIFICATIONS`.
+5. Wire notify hooks from M2.1/M4.1/M6.1/M7.1/M8.1; preference enforcement.
+6. Observability + on-device verification across event types.
+</content>

--- a/docs/plan/mobile/M0.2-offline-sync.md
+++ b/docs/plan/mobile/M0.2-offline-sync.md
@@ -1,0 +1,162 @@
+# M0.2 — Offline Mode & Sync (Mobile)
+
+> A shared offline layer: read screens render last-cached data with a staleness
+> indicator, downloaded content is available without signal, and writes (submissions,
+> quiz answers, discussion posts, review ratings, progress) queue in an outbox and
+> sync — idempotently — on reconnect. Source: 7.3 offline PWA (web analogue),
+> 21.x offline mode.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M0 — Foundation & Platform |
+| **Severity** | BLOCKER (platform) — phone-first/commuter students lose signal constantly; "useful without a computer" implies "useful without a connection" |
+| **Status (today)** | MISSING — apps are online-only; no cache or outbox |
+| **Estimated effort** | L |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — reuses existing endpoints; relies on idempotency keys the client supplies |
+| **Depends on** | Foundation for M3.x reads, M4.1 answers, M5.1 submissions, M7.1 posts, M8.1 ratings, M2.1 reads |
+
+---
+
+## 1. Problem Statement
+
+Students study on buses, in basements, between class buildings — places with no
+signal. An online-only app is unusable there. We need a consistent offline layer so
+every screen degrades to cached reads and every write survives a dead connection and
+syncs later, without the student babysitting it or fearing lost work. This is shared
+infrastructure many other stories hook into rather than each reinventing.
+
+## 2. Goals
+
+- A **read cache**: list/detail responses persist locally; screens render the last
+  cached value instantly and show a **staleness** indicator when offline/old.
+- A **download** path for content (files, content pages, prefetched review/quiz items)
+  to use fully offline.
+- A **write outbox**: mutations (submit, answer autosave, post, rating, progress)
+  enqueue when offline and **replay in order** on reconnect, with **idempotency keys**
+  so retries never double-apply.
+- Clear, honest UI: "offline," "saved locally — will sync," "synced," "sync failed —
+  retry," and conflict surfacing.
+
+## 3. Non-Goals
+
+- Full peer-to-peer or CRDT collaborative offline editing (notebooks already have
+  their own sync; collab docs stay online).
+- Offline for inherently online features (AI tutor generation, live video, payments).
+- A general-purpose local database product — a focused, typed cache + outbox is enough.
+
+## 4. User Stories
+
+- **As a student on the subway**, I open a downloaded reading and a prefetched review
+  deck and study with no signal.
+- **As a student**, I submit a typed assignment in airplane mode; it shows "will
+  submit when online" and goes through automatically later.
+- **As a student**, my quiz answers save locally when signal drops and reconcile when
+  it returns, with nothing lost or duplicated.
+
+## 5. What already exists (reuse)
+
+- **Mobile**: the notebooks feature already implements a **sync** pattern
+  (`Core/Notebook/NotebookSync.*`, `NotebookStore.*`) — generalize its offline/queue
+  approach into a shared layer instead of a per-feature one. Networking client +
+  auth session are in place.
+- **Server**: existing endpoints; many writes already tolerate retries — this story
+  formalizes client idempotency keys (e.g. a client-generated request id) so replays
+  are safe.
+
+## 6. Functional Requirements
+
+- **FR-1.** A reusable **cache store** MUST persist typed read responses (courses,
+  modules, content pages, grades, to-dos, threads, review queue) keyed by
+  resource+params, with timestamps and an eviction budget (LRU) shared with M3.2 file
+  downloads.
+- **FR-2.** Read screens MUST render the **last cached value immediately** and fetch
+  fresh in the background; when offline or data is stale, a non-blocking **staleness
+  indicator** MUST show "last updated X."
+- **FR-3.** A **download manager** MUST let content be saved for offline (course files
+  via M3.2, content pages, prefetched review/quiz items) and reflect saved/available
+  state; offline opens read from local storage.
+- **FR-4.** A **write outbox** MUST enqueue mutations made offline (assignment submit
+  text/draft, quiz `advance` answers, discussion post, review rating, module progress)
+  with a **client idempotency key** and replay them **in order** on reconnect.
+- **FR-5.** Replays MUST be **idempotent**: the server (or client de-dupe) MUST not
+  double-apply a mutation retried after a partial success. Each outbox item carries a
+  stable id; success/failure is tracked per item.
+- **FR-6.** The UI MUST clearly convey per-item sync state (queued / syncing / synced /
+  failed) and offer **retry**; a global "X pending changes" affordance MUST be
+  discoverable. **Conflicts** (server rejects a stale write) MUST surface rather than
+  silently drop.
+- **FR-7.** Connectivity changes MUST trigger automatic sync; sync MUST also run on app
+  foreground and be resilient to mid-sync interruption.
+
+## 7. Non-Functional
+
+- **Data integrity**: never lose a queued write; never double-submit; ordering
+  preserved per resource.
+- **Storage**: respect a configurable budget; LRU eviction of read cache and
+  downloads; user-visible cache size + clear (shared with M3.2).
+- **Security**: cached data + outbox stored in app-private storage; sensitive payloads
+  encrypted at rest where the platform supports it; cleared on logout.
+- **Performance**: cache reads are synchronous-fast; sync runs off the main thread;
+  battery-friendly (coalesce, backoff).
+- **Observability**: sync success/failure counts + queue depth logged (no PII) for
+  diagnostics (17.7).
+
+## 8. Design / Approach
+
+- **iOS** (`Core/Offline/`): `CacheStore` (typed on-disk cache, e.g. file/SQLite or
+  Core Data), `OutboxStore` + `SyncEngine` (ordered queue, reachability via
+  `NWPathMonitor`, backoff, idempotency keys), `DownloadStore` (shared with M3.2). A
+  small `Cached<T>` wrapper exposes value + freshness to views; a `SyncStatusView`
+  badge surfaces state. Generalize from `NotebookSync`.
+- **Android** (`core/offline/`): `CacheStore` (Room/SQLite or DataStore),
+  `OutboxStore` + `SyncWorker` (WorkManager for reliable background sync +
+  connectivity triggers), `DownloadStore`. `Cached<T>` + `SyncStatus` composable.
+- **Idempotency**: every queued mutation generates a UUID request id sent as a header;
+  the client also de-dupes locally on success. Document the header so server handlers
+  can de-dupe where needed (minimal/no server change for already-idempotent routes).
+- **Adoption**: M3.x reads, M2.1, M6.1, M7.1 wrap fetches in `CacheStore`; M4.1, M5.1,
+  M7.1, M8.1 route writes through the outbox.
+
+## 9. Files to touch
+
+**iOS**
+- `clients/ios/Lextures/Core/Offline/CacheStore.swift` *(new)*
+- `clients/ios/Lextures/Core/Offline/OutboxStore.swift` *(new)*
+- `clients/ios/Lextures/Core/Offline/SyncEngine.swift` *(new)*
+- `clients/ios/Lextures/Core/Offline/DownloadStore.swift` *(new — shared with M3.2)*
+- `clients/ios/Lextures/Core/Networking/APIClient.swift` — idempotency header + reachability hook
+- `clients/ios/Lextures/Core/Design/SyncStatusView.swift` *(new)*
+- `clients/ios/Lextures.xcodeproj/project.pbxproj`
+
+**Android**
+- `.../core/offline/CacheStore.kt`, `OutboxStore.kt`, `SyncWorker.kt`, `DownloadStore.kt` *(new)*
+- `.../core/network/ApiClient.kt` — idempotency header + connectivity
+- `.../core/design/SyncStatus.kt` *(new)*
+
+**Backend** — none required; document the client idempotency header for handler de-dupe.
+
+## 10. Acceptance Criteria
+
+1. Re-opening a previously loaded course/module/grades screen while offline renders
+   cached data with a "last updated" indicator.
+2. A downloaded file and a prefetched review deck open and complete fully offline.
+3. Submitting an assignment, answering quiz questions, posting a discussion reply, and
+   rating a review while offline all queue with a visible "will sync" state.
+4. On reconnect, queued writes replay in order and the server reflects each exactly
+   once (no duplicates), verified by re-fetch.
+5. A forced retry of an already-applied write does not double-apply (idempotency).
+6. Cache size is visible and clearable; logout clears cache + outbox.
+7. A rejected stale write surfaces a conflict rather than disappearing. Both apps build.
+
+## 11. Phasing
+
+1. `CacheStore` + `Cached<T>` wrapper; wrap M3.1/M2.1/M6.1 reads (read-only offline).
+2. `DownloadStore` shared with M3.2 (offline files + content pages).
+3. `OutboxStore` + `SyncEngine`/`SyncWorker` + idempotency header; wire M5.1 submit.
+4. Wire M4.1 answers, M7.1 posts, M8.1 ratings, module progress through the outbox.
+5. Sync-status UI, conflict surfacing, storage budget/clear.
+6. Android parity; observability; on-device verification (airplane-mode flows).
+</content>

--- a/docs/plan/mobile/M0.3-accessibility.md
+++ b/docs/plan/mobile/M0.3-accessibility.md
@@ -1,0 +1,108 @@
+# M0.3 — Accessibility: VoiceOver/TalkBack, Dynamic Type & Read-Aloud (Mobile)
+
+> A cross-cutting accessibility program so every native screen is usable with a screen
+> reader, scalable text, sufficient contrast, and read-aloud/dyslexia supports.
+> Source: 12.1 screen-reader audit, 12.2 keyboard/focus, 12.3 contrast, 12.6 dyslexia,
+> 12.7 high-contrast/reduced-motion, 12.8 text-to-speech, 12.9 speech-to-text.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M0 — Foundation & Platform |
+| **Severity** | MAJOR — legal/ethical requirement (WCAG/ADA/Section 508) and core to inclusive K-12/HE adoption |
+| **Status (today)** | PARTIAL — some screens use accessibility labels; no program-level guarantee, audit, or read-aloud |
+| **Estimated effort** | M (ongoing) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None |
+| **Depends on** | Cross-cuts every feature story |
+
+---
+
+## 1. Problem Statement
+
+Students with disabilities must be able to use the app fully. Native accessibility can
+regress silently per screen. We need a baseline standard, an audit, fixes, and reusable
+supports (read-aloud, dyslexia-friendly display, speech input) so accessibility is a
+guarantee, not an afterthought — and every other story inherits it.
+
+## 2. Goals
+
+- All native screens fully operable with **VoiceOver/TalkBack** (labels, traits, order,
+  grouping, announcements).
+- **Dynamic Type / font scaling** support everywhere without clipping.
+- **Contrast** + **high-contrast** + **reduced-motion** honored; never color-only.
+- **Read-aloud** (text-to-speech) for content; **dyslexia-friendly** display option;
+  **speech-to-text** input where typing is heavy.
+- An **audit checklist** + automated checks wired into CI where possible.
+
+## 3. Non-Goals
+
+- Web accessibility (covered by 12.x web work). Third-party embedded content (H5P/LTI)
+  beyond exposing native controls around it.
+
+## 4. User Stories
+
+- **As a blind student**, I navigate the whole quiz flow with VoiceOver.
+- **As a low-vision student**, I crank text size and nothing breaks.
+- **As a dyslexic student**, I turn on a readable font and have content read aloud.
+
+## 5. What already exists (reuse)
+
+- **Mobile**: existing accessibility labels in `MainTabView` etc.; `LexturesTheme`/
+  `LexturesType` (extend for scaling/contrast/dyslexia variants); platform TTS/STT
+  (AVSpeechSynthesizer / SFSpeechRecognizer; Android TextToSpeech / SpeechRecognizer).
+
+## 6. Functional Requirements
+
+- **FR-1.** Every interactive element MUST have an accessible **label/role/value**; focus
+  order MUST be logical; decorative items hidden; dynamic changes **announced** politely.
+- **FR-2.** All text/layout MUST support **Dynamic Type / large font scale** to platform
+  max without truncation/overlap; tap targets ≥44×44pt.
+- **FR-3.** Color use MUST meet **WCAG 2.1 AA** contrast, honor **high-contrast** and
+  **reduced-motion** system settings, and never rely on color alone.
+- **FR-4.** A **read-aloud** control MUST be available on content pages/readings (TTS),
+  and a **dyslexia-friendly** display toggle (font/spacing) MUST be available app-wide.
+- **FR-5.** **Speech-to-text** input SHOULD be available for long text fields
+  (discussion/assignment/tutor) using platform dictation.
+- **FR-6.** An **accessibility audit checklist** MUST exist per screen; automated checks
+  (Accessibility Scanner / XCUITest audits) SHOULD run in CI for key flows.
+
+## 7. Non-Functional
+
+- **Standard**: WCAG 2.1 AA as the bar (informs VPAT 12.8 / 10.8). **Performance**: TTS
+  off main thread. **Consistency**: supports live in shared theme/components so new
+  screens inherit them.
+
+## 8. Design / Approach
+
+Add accessibility primitives to `Core/Design`: scaling-aware type, contrast/high-contrast
+palettes, dyslexia font option, a reusable `ReadAloudButton`, and a `DictationField`.
+Establish a per-screen checklist; add automated audit hooks in CI. Retrofit existing
+screens; new stories adopt the components by default.
+
+## 9. Files to touch
+
+**iOS** — `Core/Design/LexturesTheme.swift`/`LexturesType.swift` (scaling/contrast/dyslexia), `Core/Accessibility/ReadAloud.swift`, `DictationField.swift` *(new)*, audit notes, `project.pbxproj`; retrofit feature views.
+
+**Android** — `core/design/LexturesTheme.kt` (scaling/contrast/dyslexia), `core/accessibility/ReadAloud.kt`, `DictationField.kt` *(new)*; retrofit screens.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. Core flows (login, dashboard, module, quiz, submission, grades, discussions) pass a
+   VoiceOver/TalkBack walkthrough with correct labels/order/announcements.
+2. Max font scale shows no clipping/overlap on those flows; targets ≥44pt.
+3. Contrast meets AA; high-contrast + reduced-motion honored; no color-only signals.
+4. Read-aloud works on a content page; dyslexia display toggles app-wide; dictation works
+   in a long field.
+5. Automated accessibility checks run in CI for key flows. Both apps build.
+
+## 11. Phasing
+
+1. Theme primitives (scaling/contrast/dyslexia) + audit checklist.
+2. Retrofit core flows; fix labels/order/targets.
+3. Read-aloud + dictation components.
+4. CI audit hooks; ongoing per-story adoption.
+</content>

--- a/docs/plan/mobile/M0.4-i18n-rtl.md
+++ b/docs/plan/mobile/M0.4-i18n-rtl.md
@@ -1,0 +1,97 @@
+# M0.4 — Internationalization, Locale & RTL (Mobile)
+
+> Localize the native apps, follow the device locale, render right-to-left correctly,
+> and handle dates/numbers/timezones per locale. Source: 11.1 i18n framework,
+> 11.2 RTL, 11.3 locale-aware dates/numbers, 11.4 time zones.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M0 — Foundation & Platform |
+| **Severity** | MAJOR — required for non-English markets; correct timezones prevent missed deadlines |
+| **Status (today)** | MISSING — UI strings hardcoded; no RTL/locale handling verified |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — server already localizes content (11.x); app consumes locale + translated content |
+| **Depends on** | Cross-cuts every feature (esp. M2.1 dates/timezones) |
+
+---
+
+## 1. Problem Statement
+
+Hardcoded English strings and untested RTL/locale handling block non-English users and
+risk wrong due-date times across timezones — a correctness bug, not just polish. The
+app must externalize strings, follow device locale, mirror for RTL, and format
+dates/numbers/times correctly.
+
+## 2. Goals
+
+- **Externalize** all UI strings into platform localization resources; reuse web i18n
+  keys where practical.
+- Follow **device locale** (with an in-app override) and load matching translations.
+- Correct **RTL** mirroring for Arabic/Hebrew etc.
+- **Locale-aware** dates/numbers and **timezone-correct** due dates/events.
+
+## 3. Non-Goals
+
+- Producing translations (localization vendor/process). Translating user-generated
+  content (server 11.5 handles content translation).
+
+## 4. User Stories
+
+- **As an Arabic-speaking student**, the app is in Arabic and laid out right-to-left.
+- **As a student traveling**, "due 11:59 PM" shows in the correct course/local timezone.
+
+## 5. What already exists (reuse)
+
+- **Server**: localized content + locale-aware APIs (11.x). **Mobile**: theme/components
+  to make direction-aware; date formatting helpers to centralize.
+
+## 6. Functional Requirements
+
+- **FR-1.** All user-facing strings MUST come from **localized resources** (iOS String
+  Catalog / `.strings`; Android `strings.xml`); no hardcoded display text.
+- **FR-2.** The app MUST follow the **device locale** by default with an in-app language
+  override, loading the matching translations and requesting localized content from the API.
+- **FR-3.** Layout MUST **mirror for RTL** (leading/trailing, not left/right; icons/chevrons
+  flipped where semantic).
+- **FR-4.** Dates, times, and numbers MUST use **locale-aware** formatting; due
+  dates/events MUST render in the correct **timezone** (course/user) consistently with M2.1.
+- **FR-5.** Pluralization/gender MUST use platform plural resources.
+
+## 7. Non-Functional
+
+- **Maintainability**: a key-coverage check flags missing translations; pseudo-locale
+  for layout testing. **Accessibility**: localized strings reach VoiceOver/TalkBack.
+
+## 8. Design / Approach
+
+Centralize strings into resources and replace literals; add a `Localized`/`L` accessor;
+make `Core/Design` direction-aware; centralize date/number/timezone formatting in one
+helper used everywhere (esp. M2.1). Add pseudo-locale + missing-key lint.
+
+## 9. Files to touch
+
+**iOS** — String Catalog / `Localizable.strings`, `Core/I18n/Localized.swift`, `Core/I18n/DateFormatting.swift` *(new)*, direction-aware `Core/Design/*`; replace literals across feature views; `project.pbxproj`.
+
+**Android** — `res/values*/strings.xml`, `core/i18n/*` *(new)*, RTL-aware layouts (`supportsRtl`), centralized formatters; replace literals.
+
+**Backend** — none (consume locale params).
+
+## 10. Acceptance Criteria
+
+1. No hardcoded display strings remain on core flows; switching device/app language
+   changes the UI and requested content.
+2. An RTL language mirrors layout correctly across core flows.
+3. Dates/numbers format per locale; a due date shows the correct time across two device
+   timezones, matching web/M2.1.
+4. Missing-translation check + pseudo-locale exist. Both apps build.
+
+## 11. Phasing
+
+1. Externalize strings + locale loading + override.
+2. Centralized locale/timezone date formatting (wire M2.1).
+3. RTL mirroring across core flows.
+4. Pluralization + missing-key lint + pseudo-locale; verification.
+</content>

--- a/docs/plan/mobile/M1.1-sso-mfa-magic-link.md
+++ b/docs/plan/mobile/M1.1-sso-mfa-magic-link.md
@@ -1,0 +1,116 @@
+# M1.1 — SSO, MFA & Magic Link (Mobile)
+
+> Let students sign in the way their school/account actually works: SAML/OIDC SSO via
+> the system browser, TOTP/WebAuthn MFA, and passwordless magic link. Source:
+> 4.1 SAML, 4.2 OIDC, 4.6 MFA (TOTP/WebAuthn/passkeys), 4.7 magic link.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M1 — Auth & Onboarding |
+| **Severity** | MAJOR — many institutions mandate SSO/MFA; password-only login locks those users out |
+| **Status (today)** | PARTIAL — mobile has email/password + secure token store; no SSO, MFA, or magic link |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — `saml-callback`, `oidc`, `mfa-login`, `magic-link` flows exist server-side |
+| **Depends on** | Auth session (built) · pairs with [M1.2](M1.2-biometric-sessions.md) |
+
+---
+
+## 1. Problem Statement
+
+Institutional users almost never log in with a local password — they use SSO and are
+often required to complete MFA. Self-learners increasingly prefer magic links. Mobile
+only supports email/password today, so a large share of real users simply cannot sign
+in on their phone.
+
+## 2. Goals
+
+- **SSO** (SAML 2.0 / OIDC) login via a secure system browser session (ASWebAuthenticationSession /
+  Custom Tabs) that returns a token to the app.
+- **MFA**: complete a TOTP or WebAuthn/passkey challenge after primary auth.
+- **Magic link**: request a link and resume the session when the link opens the app
+  (via the deep-link router from [M0.1](M0.1-push-deep-links.md)).
+- Discover the right method per email/org (SSO-redirect vs. password).
+
+## 3. Non-Goals
+
+- Identity provisioning (SCIM/OneRoster/Clever) — admin/server, web-only.
+- Building MFA enrollment management UI beyond completing a challenge + minimal
+  enrollment (full device management is [M1.2](M1.2-biometric-sessions.md)/web).
+
+## 4. User Stories
+
+- **As a university student**, I tap "Sign in with my school," authenticate in the
+  secure browser, and land in the app.
+- **As a student with MFA**, I enter my authenticator code (or use a passkey) and I'm in.
+- **As a self-learner**, I request a magic link, tap it in my email, and the app opens
+  signed in.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: `saml-callback`, OIDC, `mfa-login`, `magic-link` routes
+  back the web flows. The mobile app receives the resulting JWT and stores it in the
+  existing secure store.
+- **Mobile**: `Core/Auth` (session, `KeychainStore`/`TokenStore`), the M0.1 deep-link
+  router (for magic-link/SSO callback URLs), existing login UI to extend.
+
+## 6. Functional Requirements
+
+- **FR-1.** The login screen MUST offer SSO entry; selecting it MUST open the IdP flow
+  in a **secure system browser** session and capture the returned auth token via a
+  registered callback (Universal/App Link), then store it securely.
+- **FR-2.** When the server signals an **MFA** challenge after primary auth, the app
+  MUST present the appropriate challenge UI (TOTP code entry; WebAuthn/passkey via
+  ASAuthorization / Credential Manager) and complete it before establishing the session.
+- **FR-3.** The app MUST support **magic-link**: request from the login screen, and
+  when the emailed link opens the app, resume/establish the session via the deep-link
+  router.
+- **FR-4.** The app SHOULD detect the correct method by email/org (password vs.
+  SSO-required) and route accordingly, with a clear fallback.
+- **FR-5.** All resulting tokens MUST land in the existing **secure store**; refresh
+  and revocation behave as in [M1.2](M1.2-biometric-sessions.md).
+- **FR-6.** Failures (cancelled SSO, wrong code, expired link) MUST show clear,
+  recoverable errors.
+
+## 7. Non-Functional
+
+- **Security**: use the OS secure web-auth session (no embedded WebView for SSO
+  credentials); PKCE for OIDC; tokens only in secure storage; no token in logs.
+- **Accessibility**: challenge inputs labelled; passkey prompts use native APIs.
+- **Reliability**: callback handling robust to app-switch/backgrounding.
+
+## 8. Design / Approach
+
+- **iOS**: `Features/Auth/SSOAuthController.swift` (ASWebAuthenticationSession),
+  `MFAChallengeView` (TOTP + ASAuthorization passkey), magic-link handled by the M0.1
+  router. Extend `LoginView`/`AuthFlowView`; auth calls in `Core/Auth/AuthAPI.swift`.
+- **Android**: Custom Tabs for SSO, `MfaChallengeScreen` (TOTP + Credential Manager
+  passkey), App Link for magic link. Extend `LoginScreen`/`AuthFlowScreen`;
+  `core/auth/AuthApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Auth/SSOAuthController.swift` *(new)*, `Features/Auth/MFAChallengeView.swift` *(new)*, `Features/Auth/LoginView.swift`, `Features/Auth/AuthFlowView.swift`, `Core/Auth/AuthAPI.swift`, `Core/Routing/DeepLinkRouter.swift` (magic link), `project.pbxproj`.
+
+**Android** — `features/auth/SsoAuth.kt` *(new)*, `features/auth/MfaChallengeScreen.kt` *(new)*, `features/auth/LoginScreen.kt`, `features/auth/AuthFlowScreen.kt`, `core/auth/AuthApi.kt`, `core/routing/DeepLinkRouter.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. SSO login opens the IdP in a secure system browser and returns a working session
+   stored securely.
+2. An MFA-required account presents a TOTP/passkey challenge and only signs in on success.
+3. A magic-link email opens the app already signed in.
+4. Email-based method detection routes SSO-required users to SSO and others to password.
+5. Cancelled/failed flows show recoverable errors; no token appears in logs. Both apps build.
+
+## 11. Phasing
+
+1. SSO via system browser + secure callback (both platforms).
+2. MFA challenge (TOTP) → add WebAuthn/passkey.
+3. Magic link via M0.1 router.
+4. Method detection + polish; verification.
+</content>

--- a/docs/plan/mobile/M1.2-biometric-sessions.md
+++ b/docs/plan/mobile/M1.2-biometric-sessions.md
@@ -1,0 +1,100 @@
+# M1.2 — Biometric Unlock & Session Management (Mobile)
+
+> Face ID / Touch ID / fingerprint to re-enter the app after backgrounding, with
+> token refresh/revocation and a view of active device sessions. Source:
+> 4.8 JWT refresh/revocation, 4.9 device/session management.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M1 — Auth & Onboarding |
+| **Severity** | MAJOR — biometric gate is expected for an app holding grades/PII; refresh/revocation keeps sessions safe |
+| **Status (today)** | PARTIAL — secure token store exists; no biometric gate, no explicit refresh/revocation or session UI |
+| **Estimated effort** | S |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — `jwt-refresh`, revocation, and device-session endpoints exist (4.8/4.9) |
+| **Depends on** | Auth session (built) · pairs with [M1.1](M1.1-sso-mfa-magic-link.md) |
+
+---
+
+## 1. Problem Statement
+
+The app holds grades and personal data, so it should lock behind biometrics like any
+serious account app. It also needs to silently refresh tokens, honor server-side
+revocation (so a remote sign-out actually signs the device out), and let a student see
+and revoke their active devices.
+
+## 2. Goals
+
+- Optional **biometric lock** that gates the app after a configurable background timeout.
+- Transparent **token refresh**; honor server **revocation** (force re-auth).
+- A **device/session** screen: list active sessions, sign out others, sign out everywhere.
+
+## 3. Non-Goals
+
+- Re-implementing primary auth (M1.1) or MFA enrollment management.
+
+## 4. User Stories
+
+- **As a student**, after my phone locks I unlock the app with Face ID instead of
+  retyping a password.
+- **As a student**, signing out on the web ends my phone session too.
+- **As a student**, I review my logged-in devices and sign out a lost one.
+
+## 5. What already exists (reuse)
+
+- **Mobile**: `Core/Auth` session + `KeychainStore`/`TokenStore`; biometric APIs
+  (LocalAuthentication / BiometricPrompt). Profile/Settings to host the toggle + session list.
+- **Server (no changes)**: refresh + revocation + device-session list/revoke endpoints (4.8/4.9).
+
+## 6. Functional Requirements
+
+- **FR-1.** A settings toggle MUST enable **biometric lock**; when on, returning to the
+  app after a configurable timeout MUST require Face ID/Touch ID/fingerprint, with a
+  passcode fallback.
+- **FR-2.** The app MUST **refresh** the access token using the refresh token before
+  expiry and on 401; refresh tokens stay in secure storage only.
+- **FR-3.** On a **revoked**/invalid session, the app MUST clear local tokens and route
+  to login (force re-auth), surfacing a clear reason.
+- **FR-4.** A **device sessions** screen MUST list active sessions (device, last seen)
+  and allow **sign out other** / **sign out everywhere**.
+- **FR-5.** Logout MUST clear tokens, biometric-gated cache, and the offline
+  cache/outbox ([M0.2](M0.2-offline-sync.md)) and deregister the push token ([M0.1](M0.1-push-deep-links.md)).
+
+## 7. Non-Functional
+
+- **Security**: biometric protects local access only (server auth unchanged); tokens
+  never logged; refresh races handled (single-flight).
+- **Accessibility**: biometric prompt + fallback reachable; session rows labelled.
+
+## 8. Design / Approach
+
+- **iOS**: `Core/Auth/BiometricGate.swift` (LocalAuthentication + scene-phase timeout),
+  refresh interceptor in `Core/Networking/APIClient.swift`, `Features/Profile/DeviceSessionsView.swift`.
+- **Android**: `core/auth/BiometricGate.kt` (BiometricPrompt + lifecycle timeout),
+  refresh interceptor in `core/network/ApiClient.kt`, `features/profile/DeviceSessionsScreen.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Core/Auth/BiometricGate.swift` *(new)*, `Core/Networking/APIClient.swift` (refresh/401), `Features/Profile/DeviceSessionsView.swift` *(new)*, `Features/Profile/ProfileView.swift` (toggle), `project.pbxproj`.
+
+**Android** — `core/auth/BiometricGate.kt` *(new)*, `core/network/ApiClient.kt`, `features/profile/DeviceSessionsScreen.kt` *(new)*, `features/profile/ProfileTab.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. With biometric lock on, returning after the timeout requires biometrics (passcode fallback).
+2. An expiring token refreshes transparently; concurrent calls don't double-refresh.
+3. Revoking the session server-side forces the device back to login next request.
+4. The sessions screen lists devices and can sign out others / everywhere.
+5. Logout clears tokens, cache/outbox, and deregisters push. Both apps build.
+
+## 11. Phasing
+
+1. Refresh/401 interceptor + revocation handling.
+2. Biometric gate + settings toggle.
+3. Device sessions screen.
+4. Logout teardown (cache/outbox/push); verification.
+</content>

--- a/docs/plan/mobile/M1.3-onboarding-diagnostic.md
+++ b/docs/plan/mobile/M1.3-onboarding-diagnostic.md
@@ -1,0 +1,94 @@
+# M1.3 — Onboarding & Placement Diagnostic (Mobile)
+
+> A first-run onboarding that gets a new student productive fast, plus the optional
+> placement/diagnostic that calibrates where to start. Source: `onboarding-page`,
+> 1.7 diagnostic/placement assessments, 15.11 onboarding diagnostic.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M1 — Auth & Onboarding |
+| **Severity** | MAJOR (SL) — first-run quality drives self-learner activation/retention |
+| **Status (today)** | MISSING — no native onboarding or diagnostic |
+| **Estimated effort** | S |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — onboarding + `diagnostic-attempts/{id}/respond` endpoints exist |
+| **Depends on** | M4.1 (diagnostic reuses question rendering) · M8.2 (placement feeds paths) |
+
+---
+
+## 1. Problem Statement
+
+A new student's first minutes decide whether they stick. Web has onboarding and a
+placement diagnostic; mobile drops new users straight into a cold dashboard. A guided
+first run plus an optional diagnostic that "starts you in the right place" raises
+activation, especially for self-learners.
+
+## 2. Goals
+
+- A short, skippable **onboarding** (goals/role, notifications opt-in, key actions).
+- An optional **placement diagnostic** that adapts and produces a recommended starting
+  point/path.
+- Smooth handoff into the dashboard / recommended path.
+
+## 3. Non-Goals
+
+- Authoring diagnostics (server/instructor). Account creation is M1.1/signup (built).
+
+## 4. User Stories
+
+- **As a new self-learner**, I answer a few questions about my goal and get pointed at
+  the right course/path.
+- **As a new student**, onboarding asks to enable notifications at the right moment.
+- **As a returning user**, I never see onboarding again.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: onboarding state + `POST /api/v1/diagnostic-attempts/{attemptID}/respond`
+  (adaptive diagnostic). **Mobile**: signup/auth flow, M4.1 question renderers,
+  recommendations API (M8.2), notification priming (M0.1).
+
+## 6. Functional Requirements
+
+- **FR-1.** First run after signup MUST show a brief onboarding (role/goal, optional
+  profile bits, notification opt-in via M0.1), fully **skippable**, shown once.
+- **FR-2.** The app MUST offer an optional **placement diagnostic** that delivers
+  adaptive items (reuse M4.1 renderers), submitting each via the respond endpoint.
+- **FR-3.** On completion, the app MUST present the **result/recommendation** (starting
+  level/course/path) and hand off into it (M8.2) or the dashboard.
+- **FR-4.** Onboarding/diagnostic completion state MUST persist server-side so it's not
+  repeated across devices.
+
+## 7. Non-Functional
+
+- **Accessibility**: progress + items fully accessible; skip always reachable.
+- **Performance**: snappy transitions; diagnostic items prefetch.
+
+## 8. Design / Approach
+
+- **iOS** `Features/Onboarding/` (`OnboardingFlowView`, `DiagnosticView` reusing
+  `QuizQuestionViews`); gate on a first-run/onboarding-complete flag.
+- **Android** `features/onboarding/` (`OnboardingFlowScreen`, `DiagnosticScreen`).
+
+## 9. Files to touch
+
+**iOS** — `Features/Onboarding/OnboardingFlowView.swift` *(new)*, `Features/Onboarding/DiagnosticView.swift` *(new)*, `Features/Auth/AuthFlowView.swift` (route post-signup), `Core/LMS/LMSAPIFeatures.swift`, `project.pbxproj`.
+
+**Android** — `features/onboarding/OnboardingFlowScreen.kt` *(new)*, `features/onboarding/DiagnosticScreen.kt` *(new)*, `features/auth/AuthFlowScreen.kt`, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A new account sees onboarding once; it's skippable and not shown again (cross-device).
+2. The optional diagnostic delivers adaptive items and submits responses.
+3. Completion shows a recommendation and hands off to a path/dashboard.
+4. Notification opt-in is offered in context. Both apps build.
+
+## 11. Phasing
+
+1. Onboarding flow + first-run gating + notification opt-in.
+2. Diagnostic delivery via M4.1 renderers + respond submission.
+3. Result/recommendation handoff (M8.2); Android parity; verification.
+</content>

--- a/docs/plan/mobile/M1.4-settings-accommodations.md
+++ b/docs/plan/mobile/M1.4-settings-accommodations.md
@@ -1,0 +1,104 @@
+# M1.4 — Profile, Settings & Accommodations (Mobile)
+
+> A real settings surface: edit profile, manage app preferences (theme, language,
+> biometric, notifications), and view/activate the student's approved accommodations.
+> Source: `settings`, `MyProfile`, `my-accommodations`, 12.10 accommodations engine.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M1 — Auth & Onboarding |
+| **Severity** | MAJOR — settings is table stakes; accommodations are a legal/equity requirement |
+| **Status (today)** | PARTIAL — a basic Profile + notifications list exists; no settings depth or accommodations |
+| **Estimated effort** | S |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — profile, settings, accommodations endpoints exist |
+| **Depends on** | [M1.2](M1.2-biometric-sessions.md) (biometric toggle), [M2.2](M2.2-notification-center.md) (notif prefs), [M0.3](M0.3-accessibility.md)/[M0.4](M0.4-i18n-rtl.md) (a11y/language toggles) |
+
+---
+
+## 1. Problem Statement
+
+The current profile is thin. Students need to edit their profile, control app behavior
+(theme, language, biometric, notifications, dyslexia/read-aloud), and — importantly —
+see and use their **approved accommodations** (extra time, etc.), which must be visible
+and honored on mobile too.
+
+## 2. Goals
+
+- Edit **profile** (name, avatar, contact, pronouns where applicable).
+- **Preferences**: theme, language override (M0.4), biometric (M1.2), notifications
+  (M2.2), accessibility toggles (M0.3).
+- View **my accommodations** (approved supports) and confirm they're applied (e.g.,
+  extended quiz time reflected in M4.1).
+
+## 3. Non-Goals
+
+- Approving/granting accommodations (staff/admin/web). Account deletion flows beyond
+  linking to the privacy center.
+
+## 4. User Stories
+
+- **As a student**, I update my display name and avatar.
+- **As a student**, I switch to dark mode and Spanish.
+- **As a student with extended time**, I confirm my accommodation is active and see the
+  extra time in quizzes.
+
+## 5. What already exists (reuse)
+
+- **Mobile**: `ProfileView`/`ProfileTab`, notifications list, theme; M1.2/M2.2/M0.3/M0.4
+  toggles. **Server (no changes)**: profile/settings + accommodations endpoints; the
+  engine (12.10) already enforces accommodations server-side.
+
+## 6. Functional Requirements
+
+- **FR-1.** A **Profile** screen MUST allow editing name, avatar, and permitted contact
+  fields, persisted server-side.
+- **FR-2.** A **Settings** screen MUST expose: theme (system/light/dark), **language**
+  override (M0.4), **biometric lock** (M1.2), **notification preferences** (M2.2), and
+  **accessibility** toggles (dyslexia font, read-aloud defaults — M0.3), plus links to
+  privacy center / trust center / about / sign out.
+- **FR-3.** A **My Accommodations** view MUST list the student's approved accommodations
+  with plain-language descriptions and where each applies.
+- **FR-4.** Accommodations affecting timed activities (e.g., extended time) MUST be
+  reflected in the relevant flow (M4.1 reads the server-applied limit — verify it shows
+  the accommodated time).
+- **FR-5.** Settings MUST persist across devices where server-backed; device-only prefs
+  stored locally.
+
+## 7. Non-Functional
+
+- **Privacy**: accommodations are sensitive — display only to the student; respect minor
+  policy. **Accessibility**: the settings screen itself is a model of M0.3 compliance.
+  **Offline**: read cached; edits queue.
+
+## 8. Design / Approach
+
+Extend `Features/Profile/`: `SettingsView` (sectioned toggles + links), `EditProfileView`,
+`MyAccommodationsView`. Wire toggles to M1.2/M2.2/M0.3/M0.4. Calls in `LMSAPIFeatures.swift`/
+`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Profile/SettingsView.swift`, `EditProfileView.swift`, `MyAccommodationsView.swift` *(new)*, `Features/Profile/ProfileView.swift` (entry), `Core/LMS/LMSAPIFeatures.swift`, `project.pbxproj`.
+
+**Android** — `features/profile/SettingsScreen.kt`, `EditProfileScreen.kt`, `MyAccommodationsScreen.kt` *(new)*, `features/profile/ProfileTab.kt`, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. Editing profile (name/avatar/contact) persists server-side.
+2. Settings toggles for theme, language, biometric, notifications, and accessibility all
+   work and persist appropriately.
+3. My Accommodations lists approved supports in plain language.
+4. An extended-time accommodation is reflected in a quiz's allowed time (M4.1). Both apps build.
+
+## 11. Phasing
+
+1. Settings screen aggregating existing toggles (theme/biometric/notifications/language/a11y).
+2. Edit profile.
+3. My Accommodations view + verify M4.1 timed reflection.
+4. Android parity; offline; verification.
+</content>

--- a/docs/plan/mobile/M10.1-parent-portal.md
+++ b/docs/plan/mobile/M10.1-parent-portal.md
@@ -1,0 +1,100 @@
+# M10.1 — Parent Portal (Mobile)
+
+> A parent/guardian experience: link to their child(ren), see grades, attendance,
+> assignments, announcements, and behavior at a glance, and receive relevant
+> notifications. Source: 13.1 parent portal, 5.10 parent/guardian role,
+> `parent/parent-dashboard`, `parent/conference-booking`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M10 — K-12 & Parent |
+| **Severity** | MAJOR (K12) — parents are phone-first and rarely log into the web LMS; mobile is *the* parent surface |
+| **Status (today)** | MISSING — no parent role experience on mobile |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — parent role + observer endpoints (grades/attendance/announcements) exist |
+| **Depends on** | [M0.1](M0.1-push-deep-links.md) (parent notifications), [M10.2](M10.2-conference-booking.md) (conferences) |
+
+---
+
+## 1. Problem Statement
+
+Parents check on their kids from their phones, not a desktop LMS. Without a parent
+mobile experience, guardians can't see grades, attendance, or announcements — a major
+gap for K-12 adoption where parent engagement is a selling point.
+
+## 2. Goals
+
+- **Link** a parent to one or more children (observer relationship) and switch between them.
+- A **parent dashboard**: recent grades, attendance, upcoming assignments, announcements,
+  behavior summary — read-only, per child.
+- Parent-scoped **notifications** (M0.1) and conference booking (M10.2).
+
+## 3. Non-Goals
+
+- Parents acting as the student (submitting work). Managing guardian links/approval (admin/web).
+
+## 4. User Stories
+
+- **As a parent**, I open the app, pick my daughter, and see her grades and that she
+  was marked absent Tuesday.
+- **As a parent**, I get a push when a low grade posts.
+- **As a parent with two kids**, I switch between them easily.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: parent/observer role + child grades/attendance/announcements/
+  behavior endpoints; parent dashboard data. **Mobile**: course/grades/attendance views to
+  reuse in read-only observer mode; M0.1; M10.2.
+
+## 6. Functional Requirements
+
+- **FR-1.** A parent account MUST see a **child switcher** and a per-child **dashboard**:
+  recent grades, attendance summary, upcoming assignments/due dates, announcements, and
+  behavior summary — all **read-only**.
+- **FR-2.** The parent MUST be able to drill into a child's **course grades** and
+  **attendance** detail (reuse student views in observer mode).
+- **FR-3.** Parent **notifications** (grade posted, absence, announcement, low-grade
+  alert) MUST be supported via M0.1 with per-child/per-category preferences.
+- **FR-4.** **Conference booking** (M10.2) MUST be reachable from the parent experience.
+- **FR-5.** Role-appropriate UI: the app MUST detect the parent role and present the
+  parent shell (not the student shell).
+
+## 7. Non-Functional
+
+- **Privacy/FERPA**: a parent sees only linked children's data; respect access scope
+  strictly. **Accessibility**: dashboard labelled; child switcher accessible. **Offline**:
+  cached read.
+
+## 8. Design / Approach
+
+`Features/Parent/` (iOS) / `features/parent/` (Android): `ParentDashboardView` (child
+switcher + summary cards), reuse `CourseGradesView`/`CourseAttendanceView` in observer
+mode. Role detection in the app shell selects the parent tab set. Calls in
+`LMSAPIFeatures.swift`/`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Parent/ParentDashboardView.swift` *(new)*, `Features/Home/MainTabView.swift` (role-based shell), reuse grades/attendance, `Core/LMS/LMSAPIFeatures.swift`, `project.pbxproj`.
+
+**Android** — `features/parent/ParentDashboardScreen.kt` *(new)*, `app/RootScreen.kt` (role shell), reuse grades/attendance, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A parent account shows a child switcher and per-child dashboard (grades, attendance,
+   upcoming, announcements, behavior), read-only, scoped to linked children only.
+2. Drilling into grades/attendance reuses student views correctly.
+3. Parent notifications fire per preference and deep-link to the child's relevant screen.
+4. Conference booking (M10.2) is reachable. Both apps build.
+
+## 11. Phasing
+
+1. Role detection + parent shell + child switcher.
+2. Per-child dashboard (reuse grades/attendance read).
+3. Parent notifications (M0.1) + preferences.
+4. Conference booking link (M10.2); Android parity; verification.
+</content>

--- a/docs/plan/mobile/M10.2-conference-booking.md
+++ b/docs/plan/mobile/M10.2-conference-booking.md
@@ -1,0 +1,82 @@
+# M10.2 — Parent–Teacher Conference Booking (Mobile)
+
+> Parents book parent–teacher conference slots from the phone. Source: 13.12
+> parent–teacher conference scheduling, `parent/conference-booking`,
+> `conference-schedule-grid`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M10 — K-12 & Parent |
+| **Severity** | MAJOR (K12) — conference sign-ups are time-boxed and parents do them on phones |
+| **Status (today)** | MISSING |
+| **Estimated effort** | S |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — conference availability/booking endpoints exist |
+| **Depends on** | [M10.1](M10.1-parent-portal.md) (parent shell), [M2.1](M2.1-calendar-todos.md)/M0.1 (calendar + reminders) |
+
+---
+
+## 1. Problem Statement
+
+Conference scheduling opens for a short window and fills fast; parents need to grab a
+slot from their phone the moment it opens. No mobile booking means missed conferences.
+
+## 2. Goals
+
+- View available conference slots per teacher/child.
+- Book, reschedule, cancel; see confirmed bookings; reminders + calendar add.
+
+## 3. Non-Goals
+
+- Teachers configuring availability (web).
+
+## 4. User Stories
+
+- **As a parent**, I book a 4:10pm slot with Ms. Lee for my son and get a reminder.
+- **As a parent**, I reschedule when work runs late.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: conference availability + booking + cancel. **Mobile**: M7.3
+  office-hours booking pattern (reuse), M10.1 parent shell, M2.1 calendar, M0.1 reminders.
+
+## 6. Functional Requirements
+
+- **FR-1.** Show **available** conference slots per teacher/child with correct local times.
+- **FR-2.** **Book** a slot (child + optional topic), with confirmation; conflicts surface.
+- **FR-3.** **Reschedule/cancel** within policy; list confirmed bookings.
+- **FR-4.** Add to **calendar** (M2.1) and set a **reminder** (M0.1); meeting link opens at time.
+
+## 7. Non-Functional
+
+- **Timezone** correct (M0.4). **Accessibility**: slots/booking labelled. **Offline**: read
+  cached; booking needs connection.
+
+## 8. Design / Approach
+
+Reuse M7.3 booking components in a conference context under `Features/Parent/` /
+`features/parent/`: `ConferenceBookingView`, `MyConferencesView`. Calls in
+`LMSAPIFeatures.swift`/`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Parent/ConferenceBookingView.swift`, `MyConferencesView.swift` *(new)*, reuse M7.3, `Core/LMS/LMSAPIFeatures.swift`, parent entry, `project.pbxproj`.
+
+**Android** — `features/parent/Conference*.kt` *(new)*, reuse M7.3, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. Available conference slots show per teacher/child at correct local times.
+2. Booking persists with confirmation; conflicts surface; it appears on the calendar.
+3. Reschedule/cancel works; reminders fire. Both apps build.
+
+## 11. Phasing
+
+1. Slots + book (reuse M7.3).
+2. Reschedule/cancel + my conferences + calendar/reminder.
+3. Android parity; verification.
+</content>

--- a/docs/plan/mobile/M10.3-behavior-hallpass.md
+++ b/docs/plan/mobile/M10.3-behavior-hallpass.md
@@ -1,0 +1,88 @@
+# M10.3 — Behavior / PBIS & Hall Pass (Mobile)
+
+> Classroom-management tools on the phone: log PBIS behavior points/incidents, and
+> issue/track digital hall passes. Source: 13.3 behavior/PBIS tracking, 13.9 hall pass
+> / classroom management, `CourseBehavior`/`BehaviorDashboard`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M10 — K-12 & Parent |
+| **Severity** | MINOR — valuable for K-12 teachers; phone-natural |
+| **Status (today)** | MISSING |
+| **Estimated effort** | S |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — behavior + hall-pass endpoints exist |
+| **Depends on** | M11.x (instructor shell), [M10.1](M10.1-parent-portal.md) (parent visibility) |
+
+---
+
+## 1. Problem Statement
+
+Behavior tracking and hall passes happen in the moment, in the room — phone tasks. No
+mobile support means teachers use paper or a laptop. A quick mobile flow fits the
+classroom reality and feeds parent visibility (M10.1).
+
+## 2. Goals
+
+- **Teacher**: award/deduct PBIS points and log incidents quickly per student/class.
+- **Hall pass**: issue a timed digital pass; track active passes; student sees their pass.
+- Roll up to behavior dashboard + parent view (read).
+
+## 3. Non-Goals
+
+- Configuring PBIS frameworks/point systems (admin/web).
+
+## 4. User Stories
+
+- **As a teacher**, I tap a student and give a "respect" point, or log a tardy.
+- **As a teacher**, I issue a 5-minute restroom pass and see it count down.
+- **As a student**, I show my active hall pass on my phone.
+- **As a parent**, I see behavior notes (M10.1).
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: behavior award/log + dashboard, hall-pass issue/track.
+  **Mobile**: roster from course, M11 instructor shell, M10.1 parent read.
+
+## 6. Functional Requirements
+
+- **FR-1.** A teacher MUST quickly **award/deduct** behavior points and **log incidents**
+  per student (and bulk per class), with reason/category.
+- **FR-2.** A teacher MUST **issue a hall pass** (student + duration + reason) and see
+  **active passes** with countdown; passes auto-expire and are returnable early.
+- **FR-3.** A student MUST be able to **view their active pass**.
+- **FR-4.** Behavior data MUST roll up to the dashboard and be visible to parents (M10.1) per policy.
+
+## 7. Non-Functional
+
+- **Privacy**: behavior data sensitive; minor policy + scope. **Offline**: log/queue (M0.2).
+  **Speed**: minimal taps. **Accessibility**: labelled.
+
+## 8. Design / Approach
+
+`Features/Behavior/` (iOS) / `features/behavior/` (Android): `BehaviorRosterView`
+(quick award/log), `HallPassView` (issue + active list), student `MyHallPassView`. Calls
+in `LMSAPIFeatures.swift`/`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Behavior/BehaviorRosterView.swift`, `HallPassView.swift`, `MyHallPassView.swift` *(new)*, course entry, `Core/LMS/LMSAPIFeatures.swift`, `project.pbxproj`.
+
+**Android** — `features/behavior/*` *(new)*, course entry, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A teacher awards/deducts points and logs an incident per student and in bulk.
+2. A hall pass issues with duration, shows active with countdown, and auto-expires; early return works.
+3. A student sees their active pass; parents see behavior per policy. Both apps build.
+
+## 11. Phasing
+
+1. Behavior quick award/log + dashboard read.
+2. Hall pass issue/track + student view.
+3. Parent visibility (M10.1); offline (M0.2); Android parity; verification.
+</content>

--- a/docs/plan/mobile/M10.4-age-appropriate-ui.md
+++ b/docs/plan/mobile/M10.4-age-appropriate-ui.md
@@ -1,0 +1,89 @@
+# M10.4 — Age-Appropriate UI Mode (Mobile)
+
+> A simplified, larger, friendlier UI mode for younger (elementary) students: bigger
+> targets, simpler language/navigation, more icons, fewer choices. Source: 13.11
+> age-appropriate UI mode.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M10 — K-12 & Parent |
+| **Severity** | MINOR–MAJOR (K12 elementary) — young students can't use a dense adult UI |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — grade-level/age signal already exists (13.6/13.11) |
+| **Depends on** | [M0.3](M0.3-accessibility.md) (shared scaling), [M0.4](M0.4-i18n-rtl.md) (simple language) |
+
+---
+
+## 1. Problem Statement
+
+The default UI is built for older students/adults. Younger learners need bigger touch
+targets, simpler words, picture-forward navigation, and fewer decisions. Without an
+age-appropriate mode, elementary students (a key K-12 segment) struggle to use the app
+independently.
+
+## 2. Goals
+
+- An **age-appropriate mode** (auto by grade level / age signal, with override) that
+  simplifies navigation, enlarges targets, reduces text, and uses friendly visuals.
+- Apply to core young-student flows: home, courses, reading (M8.4), simple quizzes,
+  to-dos.
+
+## 3. Non-Goals
+
+- A separate app. Re-skinning instructor/parent/HE experiences. Content simplification
+  (server reading-level 11.6 handles content).
+
+## 4. User Stories
+
+- **As a 2nd grader**, I see big, picture-based buttons and simple words and can find my
+  reading and my to-dos by myself.
+
+## 5. What already exists (reuse)
+
+- **Server**: grade-level/age scoping (13.6) signals the mode. **Mobile**: theme/components
+  (parameterize for the mode), M0.3 scaling, M8.4 reading.
+
+## 6. Functional Requirements
+
+- **FR-1.** The app MUST select an **age-appropriate mode** based on the student's grade
+  level/age (with a settings override), persisted.
+- **FR-2.** In this mode, core young-student flows MUST use **larger targets, simplified
+  navigation (fewer tabs/options), icon-forward affordances, and simpler copy**.
+- **FR-3.** Complex/advanced features MUST be hidden or simplified, not just shrunk.
+- **FR-4.** The mode MUST coexist with accessibility settings (M0.3) without conflict.
+
+## 7. Non-Functional
+
+- **Consistency**: implemented as a theme/layout variant + simplified navigation config,
+  not forked screens. **Accessibility**: still fully M0.3-compliant. **Privacy**: minor policy.
+
+## 8. Design / Approach
+
+Add an `UIMode` (standard / young) to `Core/Design` driving sizing, spacing, copy
+variants, and a simplified navigation set; gate per grade-level signal + override.
+Apply to home, courses, reading, simple quiz, to-dos first.
+
+## 9. Files to touch
+
+**iOS** — `Core/Design/UIMode.swift` + theme/type variants *(new)*, simplified nav in `MainTabView.swift`, mode-aware copy in core young flows, settings toggle.
+
+**Android** — `core/design/UIMode.kt` + theme variants *(new)*, simplified nav in `RootScreen.kt`, mode-aware young flows, settings toggle.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A young student's account loads age-appropriate mode automatically (override available).
+2. Core young flows show larger targets, simpler nav/copy, icon-forward affordances.
+3. Advanced features are hidden/simplified appropriately; M0.3 accessibility still holds. Both apps build.
+
+## 11. Phasing
+
+1. `UIMode` variant in design system + selection by grade-level + override.
+2. Apply to home/courses/to-dos/reading/simple quiz.
+3. Copy simplification + icon affordances; Android parity; verification with young-user testing.
+</content>

--- a/docs/plan/mobile/M11.1-take-attendance.md
+++ b/docs/plan/mobile/M11.1-take-attendance.md
@@ -1,0 +1,89 @@
+# M11.1 — Take Attendance (Instructor, Mobile)
+
+> Let a teacher take daily/class attendance from the phone — tap through the roster,
+> mark present/absent/tardy/excused, and save. Source: 13.2 daily attendance,
+> `CourseAttendance`/`AttendanceDashboard`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M11 — Instructor on Mobile |
+| **Severity** | MAJOR (K12) — teachers take attendance while standing in the room; the phone is the natural device |
+| **Status (today)** | PARTIAL — mobile shows attendance **sessions (read)** (`fetchAttendanceSessions`/`Detail`); cannot mark/take |
+| **Estimated effort** | S |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — attendance session create/mark endpoints exist |
+| **Depends on** | Attendance read views (built) |
+
+---
+
+## 1. Problem Statement
+
+Taking attendance is a daily, in-the-room task — ideally one-handed on a phone. Mobile
+can read attendance but not take it, forcing teachers back to a computer for a task
+that should take 30 seconds at the classroom door.
+
+## 2. Goals
+
+- Start/open a class **attendance session** and mark each student
+  present/absent/tardy/excused fast.
+- Quick actions (mark all present, then flag exceptions); save + edit later.
+- Show a small **summary** (present/absent counts).
+
+## 3. Non-Goals
+
+- Attendance policy/report configuration (admin/web). Student-facing attendance is read (built).
+
+## 4. User Stories
+
+- **As a teacher**, I open today's class, tap "all present," flag two absences, and save.
+- **As a teacher**, I fix a wrong mark later.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: attendance session create + per-student mark endpoints.
+  **Mobile**: `CourseAttendanceView`/`Screen` (read) to extend; roster from course; theme.
+
+## 6. Functional Requirements
+
+- **FR-1.** A teacher MUST open/create the day's **attendance session** for a class/section.
+- **FR-2.** The roster MUST present each student with a fast **status control**
+  (present/absent/tardy/excused); a **mark-all-present** + exception flow MUST exist.
+- **FR-3.** Marks MUST **save** (per-mark or batch) and be **editable** later; a summary
+  shows counts.
+- **FR-4.** Permission MUST be enforced server-side (only staff with rights); UI hides
+  taking for students.
+- **FR-5.** Section scoping MUST be respected where the course has sections.
+
+## 7. Non-Functional
+
+- **Speed**: one-handed, large targets, minimal taps. **Offline**: marks queue (M0.2) and
+  sync. **Accessibility**: status controls labelled.
+
+## 8. Design / Approach
+
+Extend `CourseAttendanceView`/`Screen` with a teacher **take** mode: `TakeAttendanceView`
+(roster + status segmented controls + mark-all). Calls in `LMSAPIFeatures.swift`/`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Courses/TakeAttendanceView.swift` *(new)*, `Features/Courses/CourseAttendanceView.swift` (take entry), `Core/LMS/LMSAPIFeatures.swift`, `project.pbxproj`.
+
+**Android** — `features/courses/TakeAttendanceScreen.kt` *(new)*, `features/courses/CourseSections.kt`/attendance entry, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A teacher opens/creates today's session and marks the roster, including mark-all-present + exceptions.
+2. Marks save and are editable; the summary shows correct counts; matches web.
+3. Only authorized staff can take; students can't. Section scoping respected.
+4. Offline marks queue and sync. Both apps build.
+
+## 11. Phasing
+
+1. Take mode roster + status marking + save.
+2. Mark-all + exceptions + edit + summary.
+3. Offline queue (M0.2); section scoping; Android parity; verification.
+</content>

--- a/docs/plan/mobile/M11.2-instructor-announce.md
+++ b/docs/plan/mobile/M11.2-instructor-announce.md
@@ -1,0 +1,88 @@
+# M11.2 — Post Announcement / Broadcast (Instructor, Mobile)
+
+> Let staff post a course announcement (and district/admins send a broadcast) from the
+> phone. Source: 13.10 district announcement / emergency broadcast, announcements,
+> `BroadcastComposer`, `fetchMyBroadcasts` (mobile already reads broadcasts).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M11 — Instructor on Mobile |
+| **Severity** | MINOR–MAJOR — emergency/timely comms must be sendable from anywhere |
+| **Status (today)** | PARTIAL — mobile **reads** announcements/broadcasts (`AnnouncementsViews`, `fetchMyBroadcasts`); cannot compose/send |
+| **Estimated effort** | S |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — announcement/broadcast create endpoints exist |
+| **Depends on** | M11 instructor shell · [M0.1](M0.1-push-deep-links.md) (delivery) |
+
+---
+
+## 1. Problem Statement
+
+Timely course announcements and emergency district broadcasts sometimes must go out
+when the sender isn't at a computer (snow day, schedule change). Mobile can read them
+but not send them. Authorized staff need a quick, safe compose-and-send.
+
+## 2. Goals
+
+- **Compose & post** a course announcement (title/body, optional attachment, audience).
+- **Broadcast** (district/admin) to a scope, including an **emergency** priority.
+- Reuse the existing read surface; gate by permission.
+
+## 3. Non-Goals
+
+- Rich newsletter authoring (web). Managing audiences/segments beyond existing scopes.
+
+## 4. User Stories
+
+- **As a teacher**, I post "Class moved to Room 204 today" from the hallway.
+- **As an admin**, I send an emergency early-dismissal broadcast from my phone.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: announcement create, broadcast/emergency send. **Mobile**:
+  `AnnouncementsViews` + `fetchMyBroadcasts` (read), inbox composer pattern, M0.1 delivery.
+
+## 6. Functional Requirements
+
+- **FR-1.** Staff with permission MUST **compose and post** a course announcement
+  (title, body with basic formatting, optional attachment, audience = course/section).
+- **FR-2.** Authorized admins MUST send a **broadcast** to a scope, with an **emergency/
+  high-priority** option that triggers immediate push (M0.1).
+- **FR-3.** Permission MUST be enforced server-side; the compose action is hidden for
+  users without rights.
+- **FR-4.** A **confirm** step MUST precede sending (especially emergency), with audience
+  + reach shown; sent items appear in the read list.
+
+## 7. Non-Functional
+
+- **Safety**: hard-to-misfire emergency send (explicit confirm). **Accessibility**: composer
+  labelled. **Offline**: requires connection (no queued broadcasts).
+
+## 8. Design / Approach
+
+Extend announcements: `AnnouncementComposerView` (course) + `BroadcastComposerView`
+(admin) mirroring inbox compose; permission-gated entry. Calls in `LMSAPIFeatures.swift`/
+`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Home/AnnouncementComposerView.swift`, `BroadcastComposerView.swift` *(new)*, `Features/Home/AnnouncementsViews.swift` (gated entry), `Core/LMS/LMSAPIFeatures.swift`, `project.pbxproj`.
+
+**Android** — `features/home/AnnouncementComposer.kt`, `BroadcastComposer.kt` *(new)*, `features/home/Announcements*.kt`, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. An authorized teacher posts a course announcement that appears for students (and pushes per prefs).
+2. An authorized admin sends a broadcast; emergency priority triggers immediate push with a confirm gate.
+3. Unauthorized users never see compose. Both apps build.
+
+## 11. Phasing
+
+1. Course announcement composer (permission-gated).
+2. Broadcast + emergency priority + confirm.
+3. Push integration (M0.1); Android parity; verification.
+</content>

--- a/docs/plan/mobile/M12.1-eportfolio.md
+++ b/docs/plan/mobile/M12.1-eportfolio.md
@@ -1,0 +1,91 @@
+# M12.1 — e-Portfolio & Artifacts (Mobile)
+
+> View and build a learning portfolio on the phone: add artifacts (including photos of
+> physical work), organize, reflect, and share a public portfolio link. Source:
+> 14.12 e-portfolio/capstone, `my-portfolios-page`/`portfolio-editor-page`/
+> `portfolio-artifact-content-page`/public portfolio pages.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M12 — Portfolios & Credentials |
+| **Severity** | MINOR–MAJOR (HE) — capstone/portfolio programs need artifact capture, ideal on a phone camera |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — portfolio + artifact + public-portfolio endpoints exist |
+| **Depends on** | [M3.2](M3.2-course-files.md) (artifact preview/upload), [M5.1](M5.1-assignment-submission.md) (capture/upload reuse) |
+
+---
+
+## 1. Problem Statement
+
+Portfolios collect evidence of learning over time — and much of that evidence (artwork,
+lab work, presentations) is physical and best captured with a phone camera. Mobile has
+no portfolio support, so students can't build or show their portfolio where capture is
+easiest.
+
+## 2. Goals
+
+- View the student's **portfolio(s)** and their **artifacts**.
+- **Add artifacts**: photo/video capture, file upload (reuse M5.1 capture/upload),
+  link, or pull from a graded submission; add title/reflection/tags.
+- Organize sections and **share** a public portfolio link.
+
+## 3. Non-Goals
+
+- Heavy layout/theming of the public portfolio (web). Reviewer/grading of portfolios (web).
+
+## 4. User Stories
+
+- **As a student**, I photograph my painting and add it to my portfolio with a reflection.
+- **As a student**, I share my portfolio link with a mentor.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: portfolio CRUD, artifact CRUD, public portfolio. **Mobile**:
+  M5.1 camera/upload, M3.2 preview, markdown for reflections, share sheet.
+
+## 6. Functional Requirements
+
+- **FR-1.** A **My Portfolio** surface MUST list portfolios and their artifacts/sections.
+- **FR-2.** The student MUST **add an artifact** via camera/library/file (reuse M5.1
+  uploader), link, or from a graded submission, with title, **reflection**, and tags.
+- **FR-3.** Artifacts MUST be **viewable** (M3.2 preview); sections reorderable; edit/delete
+  per policy.
+- **FR-4.** The student MUST get a **public share** link (open/copy/share) respecting
+  visibility settings.
+
+## 7. Non-Functional
+
+- **Privacy**: visibility/sharing controls respected; minor policy. **Offline**: artifact
+  capture queues (M0.2). **Accessibility**: artifacts have alt text; editor labelled.
+
+## 8. Design / Approach
+
+`Features/Portfolio/` (iOS) / `features/portfolio/` (Android): `PortfolioView`,
+`ArtifactEditorView` (reuse M5.1 uploader + reflection), `ArtifactDetailView` (M3.2
+preview). Calls in `LMSAPIFeatures.swift`/`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Portfolio/PortfolioView.swift`, `ArtifactEditorView.swift`, `ArtifactDetailView.swift` *(new)*, reuse M5.1/M3.2, `Core/LMS/LMSAPIFeatures.swift`, profile/course entry, `project.pbxproj`.
+
+**Android** — `features/portfolio/*` *(new)*, reuse uploader/preview, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A student sees their portfolio(s) and artifacts.
+2. Adding an artifact via camera/file/link/from-submission persists with reflection + tags.
+3. Artifacts preview correctly; sections reorder; share link works per visibility. Both apps build.
+
+## 11. Phasing
+
+1. Portfolio + artifact list/detail (read).
+2. Add artifact (capture/upload/link/from-submission) + reflection.
+3. Sections + public share.
+4. Android parity; offline capture; verification.
+</content>

--- a/docs/plan/mobile/M12.2-credentials-transcripts.md
+++ b/docs/plan/mobile/M12.2-credentials-transcripts.md
@@ -1,0 +1,92 @@
+# M12.2 — Credentials Wallet & Transcripts (Mobile)
+
+> A wallet for the student's verified achievements: co-curricular record (CCR),
+> academic/CE transcripts, CEUs, and verifiable credentials — viewable, shareable, and
+> exportable. Source: 14.13 co-curricular transcript, 14.17 CEU tracking, transcripts,
+> `MyCCR`/`MyCredentials`/`CeTranscript`/`transcripts-page`, 15.6 LinkedIn/Open Badges export.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M12 — Portfolios & Credentials |
+| **Severity** | MINOR (HE/SL) — proof of achievement students want on hand and shareable |
+| **Status (today)** | MISSING (M9.3 covers course certs/badges; this is the broader transcript/CCR wallet) |
+| **Estimated effort** | S |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — CCR, transcripts, CEU, credential-verify endpoints exist |
+| **Depends on** | [M9.3](M9.3-certificates-gamification.md) (shares certs/badges + share infra) |
+
+---
+
+## 1. Problem Statement
+
+Students accumulate transcripts, co-curricular records, CEUs, and verifiable credentials
+they need to show advisors, employers, or other institutions — often from their phone.
+Mobile has no consolidated, shareable wallet for these, so proof-of-achievement lives
+only on the web.
+
+## 2. Goals
+
+- A **wallet** consolidating transcripts, CCR, CEUs, certificates/badges (with M9.3).
+- **View/verify/share/export** each (system share, LinkedIn add-to-profile, Open Badges,
+  PDF where available).
+- Show verification status / verifiable-credential proof.
+
+## 3. Non-Goals
+
+- Issuing credentials or editing transcripts (registrar/admin/web). Official transcript
+  ordering/payment beyond linking to the existing flow.
+
+## 4. User Stories
+
+- **As a student**, I pull up my CE transcript on my phone to show an advisor.
+- **As a student**, I export a credential to LinkedIn.
+- **As a verifier**, I confirm a shared credential is authentic.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: CCR, transcript, CEU, credential verify endpoints; CCR verify
+  page (`verify/CcrVerify`). **Mobile**: M9.3 credentials/share infra; M3.2 PDF preview.
+
+## 6. Functional Requirements
+
+- **FR-1.** A **Credentials/Wallet** surface MUST list transcripts, CCR, CEUs, and
+  certificates/badges (M9.3) with detail.
+- **FR-2.** Each item MUST be **viewable** (incl. PDF via M3.2) and **shareable/exportable**
+  (system share, LinkedIn, Open Badges, PDF download) per policy.
+- **FR-3.** **Verification** status / verifiable-credential proof MUST be shown, with a
+  shareable verify link.
+- **FR-4.** Official/ordered transcripts MUST link to the existing request flow.
+
+## 7. Non-Functional
+
+- **Privacy/Security**: credentials are sensitive + verifiable; never spoofable client-side
+  (server is source of truth). **Offline**: cached view. **Accessibility**: labelled.
+
+## 8. Design / Approach
+
+`Features/Wallet/` (iOS) / `features/wallet/` (Android): `WalletView` (sectioned),
+`CredentialDetailView` (view/verify/share/export). Reuse M9.3 share + M3.2 PDF. Calls in
+`LMSAPIFeatures.swift`/`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Wallet/WalletView.swift`, `CredentialDetailView.swift` *(new)*, reuse M9.3/M3.2, `Core/LMS/LMSAPIFeatures.swift`, profile entry, `project.pbxproj`.
+
+**Android** — `features/wallet/*` *(new)*, reuse share/preview, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. The wallet lists transcripts, CCR, CEUs, and certificates/badges with detail.
+2. Each item views (incl. PDF) and shares/exports (system/LinkedIn/Open Badges/PDF) per policy.
+3. Verification status + verify link show correctly; official transcript links to the request flow. Both apps build.
+
+## 11. Phasing
+
+1. Wallet list + credential detail (view).
+2. Share/export (reuse M9.3) + verify status.
+3. Transcript request link; Android parity; offline; verification.
+</content>

--- a/docs/plan/mobile/M2.1-calendar-todos.md
+++ b/docs/plan/mobile/M2.1-calendar-todos.md
@@ -1,0 +1,142 @@
+# M2.1 — Calendar & To-Dos (Mobile)
+
+> One place to answer "what's due and when": a unified to-do list and calendar across
+> all the student's courses, with due dates, events, and tap-through to the work.
+> Source: `calendar` / `course-calendar`, `todos-page`, `student_todos.go`,
+> 16.5 calendar feeds (`.ics`), academic calendar.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M2 — Home, Dashboard & Notifications |
+| **Severity** | MAJOR — phone-first students live out of "what's due"; this is the daily driver |
+| **Status (today)** | MISSING — no calendar or to-do surface on mobile |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — `calendar_http.go`, `student_todos.go`, `…/courses/{code}/calendar.ics` exist |
+| **Depends on** | M3.1/M4.1/M5.1 (items to tap into) · M0.1 (reminders via push) |
+
+---
+
+## 1. Problem Statement
+
+The thing a student opens their phone to check is "what do I need to do today/this
+week." Today there's no native to-do or calendar, so they can't see upcoming due
+dates or events without a browser. This is the most-used surface on competing apps
+and a daily retention driver.
+
+## 2. Goals
+
+- A **To-Do** list aggregating upcoming/overdue assignments, quizzes, and tasks
+  across all courses, sorted by due date, each tapping into the item.
+- A **Calendar** (month + agenda) of due dates and course/academic events.
+- Filter by course; clear overdue vs. upcoming vs. completed states.
+- Optional **subscribe to calendar feed** (`.ics`) into the device calendar.
+- Hook for due-date **reminder** notifications via [M0.1](M0.1-push-deep-links.md).
+
+## 3. Non-Goals
+
+- Creating/editing calendar events (instructor/admin) — web-only for now.
+- Conference scheduling is [M10.2](M10.2-conference-booking.md); office hours is
+  [M7.3](M7.3-office-hours.md).
+
+## 4. User Stories
+
+- **As a student**, I open the app and immediately see "Due today: Quiz 3; Due Fri:
+  Essay 2," and tap straight into them.
+- **As a student**, I switch to a month view to plan my week.
+- **As a student**, I filter to just my Chemistry course.
+- **As a student**, I add my course calendar to my phone's calendar app.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: `student_todos.go` (aggregated to-dos), `calendar_http.go`
+  (events across courses), `GET …/courses/{course_code}/calendar.ics` (feed),
+  academic-calendar endpoints for term events.
+- **Mobile**: dashboard/home shell already exists (`DashboardView` / `DashboardTab`),
+  theme, cards, date formatting helpers.
+
+## 6. Functional Requirements
+
+- **FR-1.** A **To-Do** view MUST list upcoming + overdue items (assignments,
+  quizzes, tasks) across all courses, grouped by due bucket (Overdue, Today, This
+  week, Later), each row showing course, title, type, due time, and submission status.
+- **FR-2.** Tapping a to-do MUST open its native destination (quiz→M4.1,
+  assignment→M5.1, page→M3.1). Completed/submitted items MUST be visually distinct and
+  filterable.
+- **FR-3.** A **Calendar** view MUST offer a month grid with due/event dots and an
+  **agenda** list for a selected day; events include assignment/quiz due dates and
+  course + academic-calendar events.
+- **FR-4.** Both views MUST support **filter by course** and respect the student's
+  enrolled set; an all-courses default.
+- **FR-5.** The student MUST be able to **subscribe** a course (or all) calendar feed
+  to the device calendar via the `.ics` URL (with the authed/token feed), or add a
+  single event to the device calendar.
+- **FR-6.** Each dated item MUST optionally schedule a **local reminder**/push
+  ([M0.1](M0.1-push-deep-links.md)) at a student-chosen lead time; defaults sane,
+  fully optional.
+- **FR-7.** Time handling MUST be locale/timezone correct (ties to
+  [M0.4](M0.4-i18n-rtl.md)); "due 11:59 PM" reflects the course/user timezone.
+
+## 7. Non-Functional
+
+- **Offline**: last-synced to-dos/calendar render from cache with a stale chip; no
+  blank screen offline.
+- **Performance**: to-do first paint from cache instant; month navigation < 200 ms.
+- **Accessibility**: calendar grid navigable and labelled (date, has-events); agenda
+  rows announce course+due; Dynamic Type.
+
+## 8. Design / Approach
+
+- **iOS**: new `Features/Planner/` with `TodosView` (sectioned buckets),
+  `CalendarView` (month grid + agenda; a compact custom grid or `UICalendarView`
+  wrapper), `CalendarSubscribeSheet` (EventKit add / `.ics` subscribe). Add todos +
+  calendar calls to `LMSAPIFeatures.swift`; models to `LMSFeatureModels.swift`.
+  Surface a "Due soon" widget on the existing Dashboard.
+- **Android**: `features/planner/` with `TodosScreen`, `CalendarScreen`
+  (month + agenda), device-calendar insert via `CalendarContract`/intent. Add calls
+  to `LmsApi.kt`, models to `LmsFeatureModels.kt`; dashboard "due soon" card.
+- **Reminders** schedule local notifications (and/or rely on server push from M0.1)
+  keyed to due dates.
+
+## 9. Files to touch
+
+**iOS**
+- `clients/ios/Lextures/Features/Planner/TodosView.swift` *(new)*
+- `clients/ios/Lextures/Features/Planner/CalendarView.swift` *(new)*
+- `clients/ios/Lextures/Features/Planner/CalendarSubscribeSheet.swift` *(new)*
+- `clients/ios/Lextures/Core/LMS/LMSAPIFeatures.swift` — todos + calendar
+- `clients/ios/Lextures/Core/LMS/LMSFeatureModels.swift` — todo/event models
+- `clients/ios/Lextures/Features/Dashboard/DashboardView.swift` — "due soon" widget
+- `clients/ios/Lextures.xcodeproj/project.pbxproj`
+
+**Android**
+- `.../features/planner/TodosScreen.kt`, `CalendarScreen.kt` *(new)*
+- `.../core/lms/LmsApi.kt`, `.../core/lms/LmsFeatureModels.kt`
+- `.../features/dashboard/DashboardTab.kt` — "due soon" card
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. The To-Do view lists overdue/today/this-week items across all courses with course,
+   type, and due time, matching the web to-do set.
+2. Tapping a to-do opens the right native item; completed items are distinct and
+   filterable.
+3. The Calendar shows a month grid with dots and a day agenda; due dates and
+   academic events appear on the correct days in the user's timezone.
+4. Filtering by course narrows both views.
+5. Subscribing adds the course calendar to the device calendar; adding a single event
+   works.
+6. Setting a reminder produces a notification at the chosen lead time.
+7. Offline shows last-synced data with a stale chip. Both apps build.
+
+## 11. Phasing
+
+1. To-Do list (read + buckets + routing) on both platforms + dashboard "due soon."
+2. Calendar month + agenda; course filter.
+3. `.ics` subscribe + single-event add to device calendar.
+4. Reminders via M0.1; offline cache (M0.2).
+5. Android parity; timezone/locale correctness; accessibility + verification.
+</content>

--- a/docs/plan/mobile/M2.2-notification-center.md
+++ b/docs/plan/mobile/M2.2-notification-center.md
@@ -1,0 +1,87 @@
+# M2.2 — Notification Center & Preferences (Mobile)
+
+> A complete in-app notification center and granular per-category preferences, paired
+> with the native push from M0.1. Source: 6.2 email/notifications, notification
+> preferences, `notification_preferences_http.go`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M2 — Home, Dashboard & Notifications |
+| **Severity** | MAJOR — controls signal/noise; required for healthy push adoption |
+| **Status (today)** | PARTIAL — a notifications list exists (`NotificationsView`/`Screen`); no categorized center, no preference controls |
+| **Estimated effort** | S |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — `notification_preferences_http.go` + notifications endpoints exist |
+| **Depends on** | [M0.1](M0.1-push-deep-links.md) (delivery + deep-link router) |
+
+---
+
+## 1. Problem Statement
+
+The current notifications list is flat and read-only with no controls. Students need
+to triage (filter by type, mark read, tap through) and, crucially, **control which
+notifications they get** so push is useful rather than annoying.
+
+## 2. Goals
+
+- A categorized **notification center**: filter, mark read/unread, mark-all-read,
+  tap-through via the M0.1 router, unread badge.
+- **Preferences** per category × channel (push/email) honored by the backend.
+
+## 3. Non-Goals
+
+- The push transport itself (M0.1). Email content/templates (server).
+
+## 4. User Stories
+
+- **As a student**, I filter to "Grades," clear them, and mute "Discussion" push.
+- **As a student**, the bell badge reflects what I haven't read.
+
+## 5. What already exists (reuse)
+
+- **Mobile**: existing notifications list to extend; M0.1 router for taps.
+- **Server (no changes)**: notifications list/read + `notification_preferences_http.go`.
+
+## 6. Functional Requirements
+
+- **FR-1.** The center MUST list notifications with type, summary, timestamp, and
+  read/unread; support **filter by category** and **mark read / mark-all-read**.
+- **FR-2.** Tapping MUST deep-link via the M0.1 router to the relevant screen.
+- **FR-3.** A **preferences** screen MUST expose per-category toggles across channels
+  (at minimum push on/off; email where applicable) persisted via the preferences API,
+  and MUST gate push delivery (M0.1) accordingly.
+- **FR-4.** An **unread badge** MUST reflect count and clear as items are read.
+
+## 7. Non-Functional
+
+- **Accessibility**: rows + toggles labelled; badge exposed. **Offline**: list renders
+  from cache (M0.2); preference writes queue.
+
+## 8. Design / Approach
+
+Extend `NotificationsView`/`NotificationsScreen` with filtering + read actions; add a
+`NotificationPreferencesView`/`Screen`. Calls in `LMSAPIFeatures.swift` / `LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Profile/NotificationsView.swift` (center), `Features/Profile/NotificationPreferencesView.swift` *(new)*, `Core/LMS/LMSAPIFeatures.swift`, `project.pbxproj`.
+
+**Android** — `features/profile/NotificationsScreen.kt`, `features/profile/NotificationPreferencesScreen.kt` *(new)*, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. The center filters by category, marks read/all-read, and taps through correctly.
+2. Toggling a category off stops that push (verified against M0.1) and persists across
+   devices.
+3. The unread badge is accurate. Both apps build.
+
+## 11. Phasing
+
+1. Center: filter + read actions + badge.
+2. Preferences screen wired to the API + M0.1 gating.
+3. Android parity; offline cache; verification.
+</content>

--- a/docs/plan/mobile/M3.1-module-content-viewer.md
+++ b/docs/plan/mobile/M3.1-module-content-viewer.md
@@ -1,0 +1,162 @@
+# M3.1 — Module Content Viewer (Mobile)
+
+> A student opens a course, sees its modules and items in order, knows what's locked
+> and why, reads content pages and external/textbook resources, and taps an item to
+> the right native experience (page, quiz → [M4.1](M4.1-quiz-taker.md), assignment →
+> [M5.1](M5.1-assignment-submission.md), file → [M3.2](M3.2-course-files.md)).
+> Source: course modules, content/external-link/textbook module pages, 8.7 preview,
+> 1.11 conditional release / module requirements.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M3 — Courses, Modules & Content |
+| **Severity** | BLOCKER — the spine of "doing coursework"; everything else hangs off it |
+| **Status (today)** | PARTIAL — mobile fetches course structure + a generic `ItemDetailView`, but does not render content pages or content types, nor module locking/requirements |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — `course_structure` modules endpoints, `module_content_page.go`, content-pages endpoint, `modules/progress`, requirements endpoint exist |
+| **Depends on** | — · **Unblocks** routing for M4.1, M5.1, M3.2, M3.3 |
+
+---
+
+## 1. Problem Statement
+
+The module list is how a student navigates a course week-to-week — read this page,
+watch this, take that quiz, submit that assignment, in this order, with later items
+locked until prerequisites are met. Mobile shows course structure but doesn't render
+the actual content pages or convey the locked/required state, so a student can't
+follow the intended path on a phone. This is the connective tissue for all P0 work.
+
+## 2. Goals
+
+- Render a course's **modules → items** list with per-item type icons, completion
+  state, and locked/required indicators.
+- Render **content pages** natively (rich text, images, embedded media, math).
+- Show **conditional release**: why an item/module is locked and what unlocks it.
+- Track and reflect **module progress / completion** as items are viewed/done.
+- Route each item type to its correct native destination (or a graceful web view for
+  web-only types).
+
+## 3. Non-Goals
+
+- Module/content **authoring** stays web-only.
+- H5P/SCORM/LTI runtime is [M3.3](M3.3-interactive-content.md) (here we route to it
+  or show a placeholder).
+- Files browser UI is [M3.2](M3.2-course-files.md) (here a "file" item deep-links there).
+
+## 4. User Stories
+
+- **As a student**, I open a course and see Module 1, 2, 3 with their items and which
+  I've finished.
+- **As a student**, I read a content page — text, diagrams, a video, an equation —
+  comfortably on my phone.
+- **As a student**, I see that "Quiz 2" is locked until I finish "Reading 2," and the
+  app tells me exactly that.
+- **As a student**, finishing a reading marks it complete and unlocks the next item.
+
+## 5. What already exists (reuse)
+
+- **Mobile**: `fetchCourseStructure`, `fetchItemDetail`, `CourseDetailView`/`CourseDetailScreen`
+  already render a course shell + items list. Extend rather than replace.
+- **Server (no changes)**:
+  - `GET …/courses/{course_code}/structure/modules` (+ per-module sub-collections for
+    content-pages, assignments, quizzes, external-links, textbook-resources, headings,
+    requirements).
+  - `GET …/courses/{course_code}/content-pages/{item_id}` → rendered content + markups.
+  - `GET …/courses/{course_code}/structure/modules/{module_id}/requirements` → unlock rules.
+  - `POST …/courses/{course_code}/modules/progress` → record/read completion.
+- **Rendering**: reuse `Core/Notebook/NotebookMarkdown.*` for rich text + math;
+  reuse M3.2 preview for embedded images/PDF.
+
+## 6. Functional Requirements
+
+- **FR-1.** The course view MUST list **modules in order**, each expandable to its
+  **items in order**, with a per-item **type icon** (page, quiz, assignment, file,
+  link, textbook, interactive) and a **completion indicator**.
+- **FR-2.** Each module/item MUST show its **lock state**. Locked items MUST be
+  visibly disabled and, on tap, explain the unlock requirement(s) (e.g. "Complete
+  *Reading 2* and score ≥ 80% on *Quiz 1*") from the requirements endpoint.
+- **FR-3.** Tapping a **content page** MUST open a native reader rendering rich text,
+  inline images, embedded video, links, and math; long pages scroll smoothly with a
+  sticky title.
+- **FR-4.** Item taps MUST route by type: page → reader; quiz → [M4.1](M4.1-quiz-taker.md);
+  assignment → [M5.1](M5.1-assignment-submission.md); file → [M3.2](M3.2-course-files.md)
+  preview; external link → in-app web view (with external-open option); textbook
+  resource → reader/web view; H5P/SCORM/LTI → [M3.3](M3.3-interactive-content.md)
+  (placeholder until that ships).
+- **FR-5.** Viewing/completing an item MUST update **module progress** via the
+  progress endpoint and reflect new completion + any newly unlocked items without a
+  manual refresh.
+- **FR-6.** The course header MUST expose the existing course tabs already present on
+  mobile (Modules, Grades, Syllabus, Attendance) plus new Modules-as-default.
+- **FR-7.** External links MUST open in an in-app browser by default (keeps session/
+  context), with a clear "open in Safari/Chrome" affordance.
+
+## 7. Non-Functional
+
+- **Offline**: last-fetched structure + previously opened content pages render from
+  cache with a staleness chip ([M0.2](M0.2-offline-sync.md)); progress writes queue.
+- **Accessibility**: items are a single labelled control announcing type + lock +
+  completion; reader respects Dynamic Type; media has controls reachable by
+  VoiceOver/TalkBack.
+- **Performance**: module list renders from cache instantly; content page first paint
+  < 500 ms on cached payloads.
+
+## 8. Design / Approach
+
+Extend the existing course feature:
+
+- **iOS** (`Features/Courses/`): add `ModuleListView` (sectioned modules → items with
+  state), `ContentPageView` (markdown/media reader), and a `ModuleItemRoute` switch.
+  Extend `CourseDetailView` to default to Modules. Add content-page + requirements +
+  progress calls to `LMSAPIFeatures.swift`; models to `LMSFeatureModels.swift`.
+- **Android** (`features/courses/`): `ModuleList` composable + `ContentPageScreen` +
+  item-route `when`; extend `CourseDetailScreen`. Add calls to `LmsApi.kt`, models to
+  `LmsFeatureModels.kt`.
+- **In-app web view**: small reusable `WebItemView` (WKWebView / Compose WebView) with
+  auth header injection for external/textbook/LTI fallbacks.
+
+## 9. Files to touch
+
+**iOS**
+- `clients/ios/Lextures/Features/Courses/ModuleListView.swift` *(new)*
+- `clients/ios/Lextures/Features/Courses/ContentPageView.swift` *(new)*
+- `clients/ios/Lextures/Features/Courses/WebItemView.swift` *(new)*
+- `clients/ios/Lextures/Features/Courses/CourseDetailView.swift` — default to modules, route items
+- `clients/ios/Lextures/Core/LMS/LMSAPIFeatures.swift` — content page / requirements / progress
+- `clients/ios/Lextures/Core/LMS/LMSFeatureModels.swift` — module/item/lock/progress models
+- `clients/ios/Lextures.xcodeproj/project.pbxproj`
+
+**Android**
+- `.../features/courses/ModuleList.kt`, `ContentPageScreen.kt`, `WebItemScreen.kt` *(new)*
+- `.../features/courses/CourseDetailScreen.kt` — default modules + routing
+- `.../core/lms/LmsApi.kt`, `.../core/lms/LmsFeatureModels.kt`
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A course opens to an ordered module list; each item shows a type icon and
+   completion state matching the web.
+2. A locked item is disabled and, on tap, names the exact unlock requirement(s).
+3. A content page renders text, an image, an embedded video, and an equation
+   correctly and scrolls smoothly.
+4. Each item type routes to the right destination (quiz→M4.1, assignment→M5.1,
+   file→M3.2, link→in-app web); unimplemented interactive types show a clear
+   placeholder, not a crash.
+5. Completing an item updates progress and unlocks dependent items without a manual
+   refresh, matching server state.
+6. Offline, a previously opened module list and content page still render (stale
+   chip), and a completion recorded offline syncs on reconnect.
+7. Both apps build; existing Grades/Syllabus/Attendance tabs still work.
+
+## 11. Phasing
+
+1. Module list with order, type icons, completion (read) on both platforms.
+2. Content page reader (text/image/math) + routing skeleton.
+3. Lock state + requirements explanation; progress write + unlock refresh.
+4. Embedded media + in-app web view for external/textbook.
+5. Android parity; offline cache hook (M0.2); accessibility + verification.
+</content>

--- a/docs/plan/mobile/M3.2-course-files.md
+++ b/docs/plan/mobile/M3.2-course-files.md
@@ -1,0 +1,139 @@
+# M3.2 — Course Files Browser & Preview (Mobile)
+
+> Browse a course's files/folders, preview images, PDFs, and media in-app, and
+> download for offline. Source: `course-files-page`, 8.1 object storage,
+> 8.7 image/PDF previewing, 8.3 adaptive video streaming.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M3 — Courses, Modules & Content |
+| **Severity** | MAJOR — students need course materials (slides, PDFs, readings) on the go |
+| **Status (today)** | MISSING — no files UI on mobile |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — `course_file_manager.go`, `course_file_content.go`, `course_file_preview.go`, files items/folders endpoints exist |
+| **Depends on** | — · **Used by** M3.1 (file items), M5.1 (preview submitted attachments), M6.1 (annotated-file viewing) |
+
+---
+
+## 1. Problem Statement
+
+Course materials live in the Files area — lecture slides, reading PDFs, worksheets,
+videos. A mobile student currently can't open any of them. They need to browse the
+folder tree, preview common formats inline, and keep key files for offline study
+(e.g. on a commute with no signal).
+
+## 2. Goals
+
+- Browse course **folders and files** with a familiar list/tree.
+- **Preview** images, PDFs, and audio/video inline without leaving the app.
+- **Download** a file and open it offline; show download/cached state.
+- Reuse this preview surface from M3.1 (file items), M5.1 (submitted attachments),
+  and M6.1 (annotated returns).
+
+## 3. Non-Goals
+
+- File **management** (upload to course Files, move/rename/delete, sharing) — that's
+  instructor/admin and stays web-only for now.
+- Real-time collaborative file manager WebSocket (`files/ws`) — not needed for the
+  read/preview student flow.
+
+## 4. User Stories
+
+- **As a student**, I open Files, drill into "Week 3," and read the lecture PDF.
+- **As a student**, I download the reading so I can study it on the subway offline.
+- **As a student**, I watch a lecture clip that adapts to my connection.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**:
+  - `GET …/courses/{course_code}/files/folders` and `…/files/folders/{folder_id}` → tree.
+  - `GET …/courses/{course_code}/files/items` and `…/files/items/{item_id}` → metadata.
+  - `GET …/courses/{course_code}/files/items/{item_id}/content` → bytes (range-supported).
+  - `GET …/courses/{course_code}/files/items/{item_id}/preview` → preview render.
+- **Mobile**: `Core/Networking` client (range/byte support), `CourseHeroImage` shows
+  authed image loading already exists; theme + cards.
+
+## 6. Functional Requirements
+
+- **FR-1.** A course MUST expose a **Files** surface listing folders and files with
+  name, type icon, size, and modified date; tapping a folder navigates in; a
+  breadcrumb/back returns up the tree.
+- **FR-2.** Tapping an **image** MUST open a zoomable viewer; a **PDF** MUST open a
+  paged native PDF viewer (PDFKit / Android PdfRenderer or equivalent) with page
+  scrubbing; **audio/video** MUST play with native controls and HTTP range/adaptive
+  streaming.
+- **FR-3.** Unpreviewable types MUST offer **Download** + **Open in…** (system share /
+  open-in handler) rather than failing.
+- **FR-4.** A file MUST be **downloadable for offline**; cached files show a "saved"
+  badge and open from cache when offline. A simple per-course cache size view + clear
+  action MUST exist (ties into [M0.2](M0.2-offline-sync.md)).
+- **FR-5.** All file fetches MUST use the authed networking client (no public URLs);
+  large media MUST stream (range requests), not fully buffer before play.
+- **FR-6.** This preview component MUST be reusable: M3.1 file items, M5.1 submitted
+  attachments, and M6.1 annotated files all open the same viewer.
+
+## 7. Non-Functional
+
+- **Performance**: folder list paginates/virtualizes; PDF renders page-by-page
+  (don't load the whole doc); video starts within ~2 s on a normal connection.
+- **Offline**: cached files openable offline; clear stale/availability messaging.
+- **Accessibility**: list rows labelled with type+size; PDF/zoom controls reachable;
+  media controls VoiceOver/TalkBack accessible.
+- **Storage**: respect a cache budget; LRU eviction; user can clear.
+
+## 8. Design / Approach
+
+- **iOS** (`Features/Files/`): `CourseFilesView` (folder/file list + breadcrumb),
+  `FilePreviewView` (switch on MIME → `ImageViewer` / `PDFKitView` (`PDFView`) /
+  `AVPlayer`), `FileDownloadManager` (URLSession download tasks + on-disk cache
+  index). Add files calls to `LMSAPIFeatures.swift`; models to `LMSFeatureModels.swift`.
+- **Android** (`features/files/`): `CourseFilesScreen`, `FilePreviewScreen`
+  (Coil image / PdfRenderer pager / ExoPlayer), `FileDownloadManager`
+  (DownloadManager or OkHttp + cache index). Add calls to `LmsApi.kt`, models to
+  `LmsFeatureModels.kt`.
+- **Caching** integrates with M0.2's cache store (shared budget + eviction).
+
+## 9. Files to touch
+
+**iOS**
+- `clients/ios/Lextures/Features/Files/CourseFilesView.swift` *(new)*
+- `clients/ios/Lextures/Features/Files/FilePreviewView.swift` *(new — reusable)*
+- `clients/ios/Lextures/Core/LMS/FileDownloadManager.swift` *(new)*
+- `clients/ios/Lextures/Core/LMS/LMSAPIFeatures.swift` — files/folders/content/preview
+- `clients/ios/Lextures/Core/LMS/LMSFeatureModels.swift` — file/folder models
+- `clients/ios/Lextures/Features/Courses/CourseDetailView.swift` — add Files tab
+- `clients/ios/Lextures.xcodeproj/project.pbxproj`
+
+**Android**
+- `.../features/files/CourseFilesScreen.kt`, `FilePreviewScreen.kt` *(new)*
+- `.../core/lms/FileDownloadManager.kt` *(new)*
+- `.../core/lms/LmsApi.kt`, `.../core/lms/LmsFeatureModels.kt`
+- `.../features/courses/CourseDetailScreen.kt` — add Files tab
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A Files tab lists folders/files with icons, size, date; navigating into folders
+   and back works via breadcrumb.
+2. Images open zoomable; PDFs open paged with scrubbing; a lecture video streams with
+   native controls.
+3. An unpreviewable type offers Download + Open in… and doesn't crash.
+4. Downloading a PDF lets it open later in airplane mode; the cache view shows size
+   and can be cleared.
+5. All fetches are authenticated; a large video starts streaming without fully
+   downloading first.
+6. The same preview opens from a module file item (M3.1) and a submitted attachment
+   (M5.1). Both apps build.
+
+## 11. Phasing
+
+1. Folder/file list + breadcrumb (read) on both platforms.
+2. Image + PDF preview (reusable component).
+3. Audio/video streaming.
+4. Download + offline cache + cache management.
+5. Android parity; wire into M3.1/M5.1/M6.1; accessibility + verification.
+</content>

--- a/docs/plan/mobile/M3.3-interactive-content.md
+++ b/docs/plan/mobile/M3.3-interactive-content.md
@@ -1,0 +1,101 @@
+# M3.3 — Interactive Content: H5P / SCORM / LTI (Mobile)
+
+> Run the interactive content types a course uses — H5P activities, SCORM packages,
+> and LTI 1.3 tools — inside the app via a secured, instrumented web container that
+> reports completion/score back. Source: 8.12 H5P, 2.14 SCORM/xAPI/cmi5, 2.12 LTI 1.3.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M3 — Courses, Modules & Content |
+| **Severity** | MAJOR — many courses deliver graded activities exclusively via H5P/SCORM/LTI |
+| **Status (today)** | MISSING — module items of these types have no mobile runtime |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI + WKWebView), Android (Compose + WebView) |
+| **Backend** | No changes — H5P, SCORM, LTI-launch endpoints exist (per 8.12/2.14/2.12) |
+| **Depends on** | [M3.1](M3.1-module-content-viewer.md) (routes these item types here) |
+
+---
+
+## 1. Problem Statement
+
+A large fraction of real course content is packaged as H5P, SCORM, or external LTI
+tools. If those items dead-end on mobile, students with those courses can't complete
+required, often-graded work. A secure embedded web runtime with proper launch + result
+reporting brings them to parity without native re-implementation.
+
+## 2. Goals
+
+- Launch and complete **H5P** activities, **SCORM** packages, and **LTI 1.3** tools in
+  an in-app web container with the user's session.
+- Report **completion/score/xAPI/cmi5** results back via the existing endpoints.
+- Handle full-screen, orientation, media, and resume sensibly on a phone.
+
+## 3. Non-Goals
+
+- Authoring/importing these packages (web/server). Tools that hard-require desktop
+  show a graceful "best on a larger screen" with open-externally.
+
+## 4. User Stories
+
+- **As a student**, I complete an H5P interactive video and it marks done with my score.
+- **As a student**, I finish a SCORM module and my progress/score records.
+- **As a student**, I launch the publisher's LTI tool already authenticated.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: H5P play endpoint, SCORM launch/runtime + xAPI/cmi5
+  reporting, LTI 1.3 launch (signed) endpoints. **Mobile**: M3.1's `WebItemView`
+  container + auth header/session injection; theme; progress write (M3.1).
+
+## 6. Functional Requirements
+
+- **FR-1.** H5P/SCORM/LTI module items MUST open in a **secured web container** with the
+  user's authenticated session (header/cookie/token bridge), full-screen with a clear
+  close, orientation support, and media playback.
+- **FR-2.** **SCORM/xAPI/cmi5** runtime calls MUST reach the server so completion/score
+  record correctly; **H5P** completion MUST report back; **LTI 1.3** MUST perform a
+  signed launch and accept AGS grade passback server-side.
+- **FR-3.** On completion, module **progress/grade** MUST update (via M3.1 / M6.1)
+  without a manual refresh; resume returns to prior state where the runtime supports it.
+- **FR-4.** Network/launch failures MUST degrade gracefully (retry, open-externally).
+
+## 7. Non-Functional
+
+- **Security**: scoped web container; no third-party cookie leakage; tokens not exposed
+  to arbitrary tool JS beyond what the launch requires; certificate validation.
+- **Accessibility**: container respects Dynamic Type/zoom where the content allows;
+  close/controls reachable.
+- **Offline**: these are online activities; show a clear "needs connection."
+
+## 8. Design / Approach
+
+Extend M3.1's `WebItemView`/`WebItemScreen` into a `LaunchContainer` that injects
+session, handles JS bridges (SCORM API/xAPI), fullscreen + orientation, and
+completion callbacks → progress/grade refresh. iOS WKWebView + `WKScriptMessageHandler`;
+Android WebView + `@JavascriptInterface`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Courses/LaunchContainerView.swift` *(new, extends WebItemView)*, `Features/Courses/ContentPageView.swift`/`CourseDetailView.swift` (route types), `Core/LMS/LMSAPIFeatures.swift` (launch/report), `project.pbxproj`.
+
+**Android** — `features/courses/LaunchContainerScreen.kt` *(new)*, routing in `CourseDetailScreen.kt`, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. H5P, SCORM, and LTI items each launch in-app with the user's session.
+2. Completing each records completion/score server-side identical to web (SCORM/xAPI
+   runtime calls succeed; LTI grade passback works).
+3. Module progress/grade reflects completion without manual refresh.
+4. A failed launch offers retry / open-externally; offline shows a clear message. Both apps build.
+
+## 11. Phasing
+
+1. `LaunchContainer` with session injection + fullscreen/orientation.
+2. SCORM/xAPI JS bridge + completion reporting.
+3. H5P completion + LTI 1.3 signed launch + passback verification.
+4. Android parity; progress/grade refresh; verification.
+</content>

--- a/docs/plan/mobile/M3.4-conditional-release.md
+++ b/docs/plan/mobile/M3.4-conditional-release.md
@@ -1,0 +1,81 @@
+# M3.4 — Conditional Release & Prerequisites UX (Mobile)
+
+> Polish how locked items/modules communicate *why* they're locked and what unlocks
+> them, including prerequisite chains and mastery gates. Source: 1.11 conditional
+> release / module requirements (the deeper UX beyond M3.1's basics).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M3 — Courses, Modules & Content |
+| **Severity** | MINOR — M3.1 covers the basics; this is clarity/UX polish |
+| **Status (today)** | Folded into [M3.1](M3.1-module-content-viewer.md) at a basic level |
+| **Estimated effort** | XS |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — requirements/unlock endpoints exist |
+| **Depends on** | [M3.1](M3.1-module-content-viewer.md) |
+
+---
+
+## 1. Problem Statement
+
+Students get frustrated when something is locked and they don't understand the path to
+unlock it. Beyond M3.1's basic lock indicator, we want clear, motivating prerequisite
+explanations (chains, scores needed, what's left) so students self-navigate.
+
+## 2. Goals
+
+- Rich **"why locked / how to unlock"** explanations, including multi-step prerequisite chains.
+- Show **progress toward** unlock (e.g., "2 of 3 done; need ≥80% on Quiz 1").
+- Deep-link to the **next required** item.
+
+## 3. Non-Goals
+
+- Configuring release rules (instructor/web).
+
+## 4. User Stories
+
+- **As a student**, a locked exam clearly says exactly what I still need and links me there.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: requirements endpoint (per M3.1). **Mobile**: M3.1 module/lock UI.
+
+## 6. Functional Requirements
+
+- **FR-1.** A locked item MUST show a structured explanation of **all** unmet requirements
+  with current status per requirement.
+- **FR-2.** It MUST show **progress** toward unlock and a **"go to next required"** action.
+- **FR-3.** When the last requirement is met, the item MUST unlock and reflect immediately.
+
+## 7. Non-Functional
+
+- **Accessibility**: requirement list labelled; progress non-color-only. **Offline**: uses
+  cached requirements (M0.2).
+
+## 8. Design / Approach
+
+Enhance M3.1's lock detail into a `RequirementsView` component (requirement rows +
+progress + next-action). No new endpoints.
+
+## 9. Files to touch
+
+**iOS** — `Features/Courses/RequirementsView.swift` *(new)*, used by `ModuleListView`/`ContentPageView`.
+
+**Android** — `features/courses/RequirementsView.kt` *(new)*, used by module list.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A locked item lists all unmet requirements with per-item status and overall progress.
+2. "Go to next required" routes correctly; meeting the last requirement unlocks immediately.
+3. Accessible + offline-tolerant. Both apps build.
+
+## 11. Phasing
+
+1. Requirements detail component + progress.
+2. Next-required routing + unlock refresh.
+3. Android parity; verification.
+</content>

--- a/docs/plan/mobile/M4.1-quiz-taker.md
+++ b/docs/plan/mobile/M4.1-quiz-taker.md
@@ -1,0 +1,189 @@
+# M4.1 — Quiz Taker & Question Types (Mobile)
+
+> Take a quiz end-to-end on a phone: start an attempt, answer every supported
+> question type one screen at a time, autosave as you go, watch the timer, submit,
+> and see results. Source: 2.2 question types, 2.3 math rendering/input,
+> 2.7 time limits/auto-submit, 2.8 per-attempt shuffling, 2.9 multiple attempts,
+> web `course-module-quiz-page` / `course-module-quiz-attempt-page`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M4 — Quizzes & Assessment |
+| **Severity** | BLOCKER — students cannot complete coursework on mobile without it |
+| **Status (today)** | PARTIAL — mobile reads quiz **attempts** (`fetchQuizAttempts`) but cannot start/answer/submit. Taking happens on web only |
+| **Estimated effort** | L |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — `quiz_delivery_http.go` / `quiz_submit_http.go` already expose the full attempt lifecycle |
+| **Depends on** | M3.1 (module content viewer routes a quiz item here) · benefits from M0.2 (offline answer queue) |
+
+---
+
+## 1. Problem Statement
+
+Quizzes are the single most common graded activity, and today a mobile student can
+only *see that an attempt exists* — they must open a browser to actually take one.
+For a phone-first student that means they cannot do the core thing the product is
+for. We need a native quiz-taking flow that is calm and unambiguous on a small
+screen: one question at a time, obvious navigation, never lose an answer, and a
+clear, honest timer.
+
+## 2. Goals
+
+- Start, answer, and submit a quiz attempt natively on both platforms.
+- Support every question type the web delivers (see FR-2) including math input.
+- Autosave each answer so a dropped connection, a phone call, or app backgrounding
+  never loses work.
+- Honor time limits with a visible countdown and server-authoritative auto-submit.
+- Honor attempt policies (multiple attempts, shuffling) exactly as the server dictates.
+- Show results/feedback after submission per the quiz's reveal policy.
+
+## 3. Non-Goals
+
+- Quiz **authoring** stays web-only.
+- Lockdown / kiosk enforcement is its own story ([M4.2](M4.2-lockdown-kiosk.md));
+  here we only emit the existing `focus-loss` signals.
+- Code-execution questions are deferred to [M5.3](M5.3-code-execution.md) (render a
+  "best on a larger screen" notice if encountered).
+- Manual/essay grading is unchanged (server grades; results show "pending review").
+
+## 4. User Stories
+
+- **As a student**, I tap a quiz in a module, read the rules, and start my attempt.
+- **As a student**, I answer one question per screen, move next/back, and see which
+  questions I've answered and which remain.
+- **As a student on a flaky bus connection**, my answers save as I go and the app
+  tells me clearly if something failed to save.
+- **As a student**, I see how much time is left and the quiz submits itself fairly
+  when time runs out.
+- **As a student**, after submitting I see my score and any released feedback.
+
+## 5. What already exists (reuse)
+
+- **API (mobile)**: `fetchQuizAttempts` and `fetchItemDetail` already exist
+  (`Core/LMS/LMSAPIFeatures.swift`, Android `core/lms/LmsApi.kt`). The quiz item is
+  reached from course structure / item detail.
+- **Server lifecycle (no changes)** under `quiz_delivery_http.go` & `quiz_submit_http.go`:
+  - `POST  /api/v1/courses/{course_code}/quizzes/{item_id}/start` → create/resume attempt.
+  - `GET   …/quizzes/{item_id}/attempts/{attempt_id}/current-question` → server-paced delivery.
+  - `POST  …/attempts/{attempt_id}/advance` → save current answer + advance.
+  - `POST  …/attempts/{attempt_id}/focus-loss` (+ `focus-loss-events`) → integrity signal.
+  - `POST  …/quizzes/{item_id}/submit` → final submit.
+  - `GET   …/quizzes/{item_id}/results` and `…/attempts/{attempt_id}/grading` → results.
+- **Design**: `LexturesTheme`/`LexturesType`, existing card/row/error components,
+  `LMSErrorBanner`. **Math**: reuse the notebook markdown/LaTeX rendering already in
+  `Core/Notebook/NotebookMarkdown.*` for question prompts and math answers.
+
+## 6. Functional Requirements
+
+- **FR-1.** A quiz module item MUST open a native **Quiz Intro** screen showing
+  title, instructions, time limit, allowed attempts + attempts used, and
+  points/grading note, with a primary **Start / Resume attempt** action. If an
+  in-progress attempt exists, the app MUST resume it.
+- **FR-2.** The taker MUST render and accept input for every delivered question
+  type: multiple choice, multiple answer, true/false, short answer / fill-in,
+  numeric, matching, ordering, dropdown/cloze, essay/long text, file-upload
+  question, and math (LaTeX-rendered prompt; math/numeric input). Unknown/code types
+  MUST degrade gracefully with a clear "open on web" notice and not block the rest.
+- **FR-3.** The taker MUST present **one question per screen** (server-paced via
+  `current-question`/`advance`) with Previous/Next, a question palette
+  (answered / unanswered / flagged), and a flag-for-review toggle.
+- **FR-4.** Answers MUST **autosave** on change/blur via `advance` (debounced),
+  with a visible per-question save state (saving / saved / failed-retry). Failures
+  MUST surface and retry; if offline ([M0.2](M0.2-offline-sync.md)) answers queue
+  locally and a non-dismissable "not yet saved" indicator shows.
+- **FR-5.** If the quiz is timed, the taker MUST show a countdown derived from the
+  **server** attempt deadline (not device clock), warn at a threshold, and trigger
+  submit when it hits zero. The server remains authoritative on expiry.
+- **FR-6.** The taker MUST honor shuffling and attempt order exactly as the server
+  returns them (no client reordering) and respect the allowed-attempts policy
+  (block Start when exhausted, with the reason shown).
+- **FR-7.** On submit the app MUST show a confirm summary (answered/unanswered
+  counts), POST `submit`, and route to a **Results** screen showing score (or
+  "pending review" for manual items) and any released per-question feedback per the
+  quiz reveal policy.
+- **FR-8.** The taker MUST emit `focus-loss` on app background/resign-active so
+  existing integrity reporting works (no UI change here; enforcement is M4.2).
+
+## 7. Non-Functional
+
+- **Resilience**: no answer loss across backgrounding, call interruption, or network
+  blips; resume returns to the same question. Submit is idempotent client-side
+  (guard double-tap).
+- **Accessibility**: every option is a labelled, ≥44pt target; palette states are
+  conveyed non-visually; countdown changes are announced politely (not spammed);
+  Dynamic Type throughout.
+- **Performance**: question transition < 300 ms from cached attempt state; math
+  renders without layout jump.
+- **Integrity/Privacy**: only the existing focus-loss signals are sent; no
+  screenshots/keystroke capture. Honor server reveal policy — never show correct
+  answers the server withheld.
+
+## 8. Design / Approach
+
+New feature module `Features/Quiz/` (iOS) and `features/quiz/` (Android):
+
+- **iOS**: `QuizIntroView`, `QuizTakerView` (owns attempt state, current index,
+  per-question answer cache, save-state map, countdown), `QuizQuestionView`
+  (switch over a `QuizQuestionKind` enum → per-type subviews), `QuizPaletteView`,
+  `QuizResultsView`. Add `QuizDeliveryAPI` methods to `LMSAPIFeatures.swift` and a
+  `QuizAttemptState` + `QuizQuestion`/`QuizAnswer` models to `LMSFeatureModels.swift`.
+  Countdown is a `TimelineView` driven by the server deadline.
+- **Android**: mirror with `QuizIntroScreen`, `QuizTakerScreen` (ViewModel holds
+  attempt + answers + save state + ticking deadline), `QuizQuestion` composable with
+  a `when` over question kind, `QuizPalette`, `QuizResultsScreen`. Add delivery
+  methods to `LmsApi.kt`, models to `LmsFeatureModels.kt`.
+- **Autosave** is a per-question debounced `advance` call with optimistic local
+  state and a small status chip. Offline path defers to [M0.2](M0.2-offline-sync.md)'s
+  queue (same `advance` payload, replayed in order on reconnect).
+- **Routing**: the module/item detail's quiz branch opens `QuizIntro` instead of the
+  current read-only attempts list (which moves under a "previous attempts" section).
+
+## 9. Files to touch
+
+**iOS**
+- `clients/ios/Lextures/Features/Quiz/QuizIntroView.swift` *(new)*
+- `clients/ios/Lextures/Features/Quiz/QuizTakerView.swift` *(new)*
+- `clients/ios/Lextures/Features/Quiz/QuizQuestionViews.swift` *(new — per-type inputs)*
+- `clients/ios/Lextures/Features/Quiz/QuizResultsView.swift` *(new)*
+- `clients/ios/Lextures/Core/LMS/LMSAPIFeatures.swift` — delivery/submit calls
+- `clients/ios/Lextures/Core/LMS/LMSFeatureModels.swift` — attempt/question/answer models
+- `clients/ios/Lextures/Features/Courses/ItemDetailView.swift` — route quiz items to intro
+- `clients/ios/Lextures.xcodeproj/project.pbxproj` — register new files
+
+**Android**
+- `.../features/quiz/QuizIntroScreen.kt`, `QuizTakerScreen.kt`, `QuizQuestion.kt`, `QuizResultsScreen.kt` *(new)*
+- `.../core/lms/LmsApi.kt` — delivery/submit calls
+- `.../core/lms/LmsFeatureModels.kt` — attempt/question/answer models
+- `.../features/courses/ItemDetailScreen.kt` — route quiz items to intro
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. Opening a quiz module item shows intro with time limit, attempts used/allowed,
+   and a Start/Resume action; an exhausted-attempts quiz blocks Start with the reason.
+2. Starting delivers questions one per screen; every supported type accepts input;
+   math prompts render correctly; an unsupported type shows a graceful "open on web"
+   card without blocking other questions.
+3. Answers autosave (visible saved state); killing/backgrounding the app and
+   reopening resumes the same attempt with answers intact.
+4. A timed quiz shows a server-derived countdown, warns near the end, and the
+   server-recorded submission matches whether the student or the timer submitted.
+5. Submitting shows answered/unanswered confirm, records the attempt identically to
+   a web submission, and the Results screen shows score (or "pending review") and
+   released feedback only.
+6. Backgrounding mid-attempt emits a focus-loss event server-side.
+7. Both apps build; the previous read-only attempts view still reachable as history.
+
+## 11. Phasing
+
+1. Models + `QuizDeliveryAPI` (start/current-question/advance/submit/results) on both platforms.
+2. iOS intro → taker → MCQ/TF/short-answer/numeric happy path + autosave.
+3. Remaining question types (matching, ordering, cloze, essay, file, math).
+4. Timer + auto-submit + palette/flagging + results.
+5. Android parity.
+6. Offline answer queue hook ([M0.2](M0.2-offline-sync.md)); focus-loss emission.
+7. Accessibility pass + on-device verification; update this doc with deltas.
+</content>

--- a/docs/plan/mobile/M4.2-lockdown-kiosk.md
+++ b/docs/plan/mobile/M4.2-lockdown-kiosk.md
@@ -1,0 +1,95 @@
+# M4.2 — Lockdown / Kiosk Mode (Mobile)
+
+> Enforce exam integrity on device: single-app/guided-access lock, block app
+> switching/screenshots where the platform allows, and report focus-loss during a
+> locked quiz. Source: 2.10 lockdown/kiosk mode, quiz focus-loss endpoints.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M4 — Quizzes & Assessment |
+| **Severity** | MINOR–MAJOR — required for proctored/secured exams; many courses don't need it |
+| **Status (today)** | MISSING — M4.1 emits focus-loss but enforces nothing |
+| **Estimated effort** | M |
+| **Platforms** | iOS (Guided Access / Single App Mode), Android (Screen Pinning / Lock Task) |
+| **Backend** | No changes — focus-loss + proctoring-config endpoints exist |
+| **Depends on** | [M4.1](M4.1-quiz-taker.md) |
+
+---
+
+## 1. Problem Statement
+
+Secured/proctored quizzes require limiting what a student can do during the attempt.
+M4.1 reports focus-loss but doesn't restrict the device. For exams flagged as secured,
+we need platform-level lockdown and clear integrity reporting.
+
+## 2. Goals
+
+- Enter a **locked** state for quizzes flagged secured: single-app/guided-access,
+  block app switching, and (where allowed) screenshots/recording.
+- Report **focus-loss / lock exits** to the server (already-existing endpoints).
+- Clear student communication about what's enforced and why.
+
+## 3. Non-Goals
+
+- Third-party proctoring SDK integration (config exists; live proctoring is web/vendor).
+- Defeating a jailbroken/rooted device (best-effort; server flags anomalies).
+
+## 4. User Stories
+
+- **As a student**, a secured exam locks my phone to the quiz; if I try to leave, it's
+  recorded and I'm warned.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: `…/attempts/{id}/focus-loss(+events)`, `…/quizzes/{id}/proctoring-config`.
+  **Mobile**: M4.1 taker + focus-loss emission; platform APIs (Guided Access prompt /
+  `UIAccessibility.isGuidedAccessEnabled`; Android `startLockTask`).
+
+## 6. Functional Requirements
+
+- **FR-1.** When a quiz is flagged **secured** (proctoring-config), the taker MUST enter a
+  lockdown state: request/enter single-app (iOS Guided Access / Android screen pinning),
+  hide sensitive UI, and disable share/multitask affordances the app controls.
+- **FR-2.** **Screenshot/recording** MUST be blocked where the platform allows (Android
+  `FLAG_SECURE`; iOS detect screenshot/recording and report).
+- **FR-3.** Exiting lockdown or losing focus MUST **report** via focus-loss endpoints and
+  warn the student; repeated violations follow server policy.
+- **FR-4.** The student MUST be told **before** starting what lockdown entails; entering is
+  explicit.
+- **FR-5.** On submit/exit, lockdown MUST cleanly release.
+
+## 7. Non-Functional
+
+- **Integrity vs. UX**: enforce without trapping a student permanently (graceful exit on
+  submit/emergency). **Privacy**: no covert capture; only existing signals.
+  **Accessibility**: lockdown must not break VoiceOver/TalkBack for the exam.
+
+## 8. Design / Approach
+
+Add a `LockdownController` to M4.1: gate entry on proctoring-config, manage platform lock
+APIs + `FLAG_SECURE`, hook screenshot/recording detection → focus-loss. iOS Guided Access
+guidance + detection; Android Lock Task.
+
+## 9. Files to touch
+
+**iOS** — `Features/Quiz/LockdownController.swift` *(new)*, `Features/Quiz/QuizTakerView.swift` (gate + lock), `Core/LMS/LMSAPIFeatures.swift` (config/focus-loss), `project.pbxproj`.
+
+**Android** — `features/quiz/LockdownController.kt` *(new)*, `QuizTakerScreen.kt` (lock task + FLAG_SECURE), `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A secured quiz enters lockdown with explicit consent and a clear explanation.
+2. App-switch/exit attempts are recorded via focus-loss and warned; screenshots blocked
+   where the platform allows.
+3. Lockdown releases cleanly on submit. Non-secured quizzes are unaffected. Both apps build.
+
+## 11. Phasing
+
+1. Secured detection + pre-start explanation + enter/exit lock (iOS Guided Access / Android pinning).
+2. FLAG_SECURE / screenshot-recording detection + focus-loss reporting.
+3. Violation policy + clean release; Android parity; verification.
+</content>

--- a/docs/plan/mobile/M5.1-assignment-submission.md
+++ b/docs/plan/mobile/M5.1-assignment-submission.md
@@ -1,0 +1,171 @@
+# M5.1 — Assignment Submission (Mobile)
+
+> Let a student actually **turn in work** from their phone: read the assignment,
+> submit a text entry and/or file/photo/media, resubmit before the deadline, and see
+> submission status, due dates, and (after grading) their grade + feedback.
+> Source: module assignment page, 3.13 resubmission workflow, 8.2 resumable/chunked
+> uploads, 8.7 image/pdf preview.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M5 — Assignments & Submissions |
+| **Severity** | BLOCKER — without it a mobile student can read assignments but cannot complete them |
+| **Status (today)** | MISSING — mobile can fetch *grading* submissions (instructor) and `fetchMySubmission`, but a student cannot create/upload a submission |
+| **Estimated effort** | L |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — `assignment_submission_text_http.go`, `assignment_submission_upload_http.go`, `assignment_submissions_http.go` already expose student submit + "mine" |
+| **Depends on** | M3.1 (module viewer routes an assignment item here) · M6.1 (grade/feedback view) · M0.2 (offline draft queue) |
+
+---
+
+## 1. Problem Statement
+
+A student can read an assignment but has no way to hand it in from the app — the most
+basic academic action after taking a quiz. Phone-first students need to submit a
+typed response or, very commonly, a **photo of handwritten work** or a file from
+their device, then confirm it landed and resubmit if allowed. Today that forces them
+to a computer, which many do not have.
+
+## 2. Goals
+
+- Submit a **text** entry and/or **file/photo/media** attachment for an assignment.
+- Use the camera and photo library directly (capture or pick), plus the system file
+  picker, with resumable upload so large/slow uploads survive a flaky connection.
+- Show submission status clearly: not started, draft, submitted (with timestamp +
+  version), late, graded.
+- Support resubmission within policy and show attempt/version history.
+- After grading, deep-link to grade + feedback ([M6.1](M6.1-grades-feedback.md)).
+
+## 3. Non-Goals
+
+- Rich inline document editing — students attach files; they don't author docs here.
+- Peer review is [M5.2](M5.2-peer-review.md); originality *report viewing* is M6.1.
+- Group-submission authoring beyond what the server already resolves (we display the
+  group context the API returns).
+
+## 4. User Stories
+
+- **As a student**, I read the assignment, type my answer, attach a photo of my
+  worksheet, and submit — then see "Submitted, v1, 2 minutes ago."
+- **As a student with one bar of signal**, my large PDF keeps uploading and resumes
+  if it drops, and I'm told if it failed.
+- **As a student**, I notice a typo, so I resubmit before the due date and the app
+  shows v2 as the active submission.
+- **As a student**, after it's graded I tap through to my score, rubric, and the
+  instructor's comments.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**:
+  - `GET  …/assignments/{item_id}/submissions/mine` → my current submission + history/status.
+  - `POST …/assignments/{item_id}/submissions/text` → text entry.
+  - `POST …/assignments/{item_id}/submissions/upload` → file upload (chunked/resumable per 8.2).
+  - `…/submissions/{submission_id}/attachments/archive`, `…/originality/*` for later.
+- **Mobile**: `fetchMySubmission` exists (`LMSAPIFeatures.swift` / `LmsApi.kt`) and the
+  `AssignmentSubmission` model (incl. `bodyText`, attachment fields added in
+  `../speed-grader-mobile.md`). Networking client supports multipart; reuse it.
+- **Design**: cards/rows, `LMSErrorBanner`, theme. Preview reuses M3.2's file preview.
+
+## 6. Functional Requirements
+
+- **FR-1.** An assignment module item MUST open a native **Assignment Detail** screen:
+  title, instructions (rendered), points, due/available dates (with late indicator),
+  allowed submission types, attempts/resubmission policy, and current status from
+  `submissions/mine`.
+- **FR-2.** When submission is open, the student MUST be able to compose a **text
+  entry** (multiline, draft-saved locally) and/or attach files via **camera capture,
+  photo/video library, and the system document picker**, per the assignment's allowed
+  types. Disallowed types MUST be hidden/disabled with a reason.
+- **FR-3.** Attachments MUST upload via the **resumable/chunked** endpoint with
+  per-file progress, cancel, and retry; an interrupted upload MUST resume rather than
+  restart. Total/size limits from the server MUST be enforced client-side with a
+  clear message.
+- **FR-4.** Submitting MUST POST text and/or confirm uploaded attachments, then show
+  a confirmation with **version number and timestamp**; a late submission MUST be
+  clearly marked late (but allowed if the server allows it).
+- **FR-5.** If resubmission is allowed, the student MUST be able to submit again; the
+  screen MUST show submission **history/versions** and which is active. If not
+  allowed (or past a hard deadline), submit MUST be disabled with the reason.
+- **FR-6.** A submitted attachment MUST be **previewable** in-app (image/PDF via
+  M3.2 preview) so the student can confirm what they turned in.
+- **FR-7.** Once graded, the screen MUST surface score + a link into
+  [M6.1](M6.1-grades-feedback.md) feedback (rubric, comments, annotations, a/v).
+- **FR-8.** A text draft MUST persist locally so leaving and returning (or losing
+  network) never loses unsubmitted typing; offline submits queue via
+  [M0.2](M0.2-offline-sync.md) and clearly show "will submit when online."
+
+## 7. Non-Functional
+
+- **Reliability**: resumable uploads; idempotent submit (guard double-tap / retries);
+  no silent data loss.
+- **Privacy/Permissions**: request camera/photos/files permissions just-in-time with
+  rationale; degrade gracefully if denied (offer the other input methods).
+- **Accessibility**: labelled inputs and attachment chips; upload progress announced;
+  ≥44pt targets; Dynamic Type.
+- **Performance**: image capture downscaled to a sane max before upload to save data;
+  show progress within 200 ms of starting.
+
+## 8. Design / Approach
+
+New `Features/Assignments/` (iOS) / `features/assignments/` (Android):
+
+- **iOS**: `AssignmentDetailView` (status + instructions + actions), `SubmissionComposerView`
+  (text editor + attachment list + pickers), `AttachmentUploader` (chunked upload
+  state machine with progress/resume), `SubmissionHistoryView`. Use `PhotosPicker`,
+  `UIImagePickerController`/camera, and `.fileImporter`. Add submit/upload calls to
+  `LMSAPIFeatures.swift`; extend models in `LMSFeatureModels.swift`.
+- **Android**: `AssignmentDetailScreen`, `SubmissionComposerScreen`, an upload
+  worker/state holder, `SubmissionHistoryScreen`. Use `ActivityResultContracts`
+  (TakePicture, GetContent/OpenDocument). Add calls to `LmsApi.kt`, models to
+  `LmsFeatureModels.kt`.
+- **Resumable upload**: wrap the existing chunked-upload endpoint in a small client
+  state machine (offset tracking, retry/backoff). Offline → enqueue the composed
+  submission (text + local file refs) in M0.2's outbox.
+- **Routing**: assignment items from M3.1 open `AssignmentDetail`; "graded" state
+  links into M6.1.
+
+## 9. Files to touch
+
+**iOS**
+- `clients/ios/Lextures/Features/Assignments/AssignmentDetailView.swift` *(new)*
+- `clients/ios/Lextures/Features/Assignments/SubmissionComposerView.swift` *(new)*
+- `clients/ios/Lextures/Features/Assignments/AttachmentUploader.swift` *(new)*
+- `clients/ios/Lextures/Core/LMS/LMSAPIFeatures.swift` — submit text/upload, mine
+- `clients/ios/Lextures/Core/LMS/LMSFeatureModels.swift` — submission/version/status models
+- `clients/ios/Lextures/Features/Courses/ItemDetailView.swift` — route assignment items
+- `clients/ios/Lextures.xcodeproj/project.pbxproj`
+
+**Android**
+- `.../features/assignments/AssignmentDetailScreen.kt`, `SubmissionComposerScreen.kt`, `AttachmentUploader.kt` *(new)*
+- `.../core/lms/LmsApi.kt`, `.../core/lms/LmsFeatureModels.kt`
+- `.../features/courses/ItemDetailScreen.kt` — route assignment items
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. An assignment item opens a detail screen with instructions, due date (late
+   marked), allowed types, and current status from `submissions/mine`.
+2. A student can submit a text entry, a camera photo, a library video, and a picked
+   PDF (per allowed types); disallowed types aren't offered.
+3. A large file shows progress and resumes after toggling airplane mode mid-upload.
+4. After submit, status shows version + timestamp identical to a web submission;
+   a past-due submit is marked late when the server allows it.
+5. With resubmission allowed, a second submit creates v2 shown as active with v1 in
+   history; when not allowed, submit is disabled with a reason.
+6. A submitted PDF/image is previewable in-app.
+7. After grading, the screen links into M6.1 showing score + feedback.
+8. A text draft survives app restart; an offline submit queues and completes on
+   reconnect. Both apps build.
+
+## 11. Phasing
+
+1. Models + `submissions/mine` wiring + Assignment Detail (read/status) on both platforms.
+2. iOS text submission + draft persistence + resubmission/history.
+3. iOS attachments: pickers + chunked resumable uploader + progress.
+4. Android parity.
+5. Graded-state link into M6.1; attachment preview via M3.2.
+6. Offline outbox hook (M0.2); accessibility + on-device verification.
+</content>

--- a/docs/plan/mobile/M5.2-peer-review.md
+++ b/docs/plan/mobile/M5.2-peer-review.md
@@ -1,0 +1,96 @@
+# M5.2 — Peer Review (Mobile)
+
+> Complete assigned peer reviews on a phone: read a classmate's submission, score it
+> against the rubric, leave comments, and submit — plus see reviews received.
+> Source: 3.15 peer review & peer assessment, `peer_review_http.go`, `peer-reviews-page`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M5 — Assignments & Submissions |
+| **Severity** | MAJOR — peer review is frequently required, time-boxed work students need to do anywhere |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — `peer_review_http.go` exposes assignments, submit, received |
+| **Depends on** | [M5.1](M5.1-assignment-submission.md) (submission preview), [M6.1](M6.1-grades-feedback.md) (rubric UI), [M3.2](M3.2-course-files.md) (attachment preview) |
+
+---
+
+## 1. Problem Statement
+
+Peer review tasks are assigned with deadlines and count for credit, but mobile can't
+do them — so a phone-first student misses required work. They need to read assigned
+peers' submissions and submit rubric-based feedback on device.
+
+## 2. Goals
+
+- See **assigned** peer reviews (due dates, progress) and complete each: read the
+  submission, score the rubric, comment, submit.
+- See **reviews received** on one's own work.
+- Support anonymity rules the server enforces.
+
+## 3. Non-Goals
+
+- Configuring peer-review settings (instructor/web). Calibrated/peer-grade weighting
+  config stays server-side.
+
+## 4. User Stories
+
+- **As a student**, I open my 3 assigned reviews, read each peer's essay, score the
+  rubric, and submit feedback.
+- **As a student**, I read the anonymous feedback peers gave me.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: `peer_review_http.go` (assigned list, submission to review,
+  rubric, submit review, received). **Mobile**: M6.1 rubric component, M3.2 preview,
+  markdown renderer, M5.1 submission rendering.
+
+## 6. Functional Requirements
+
+- **FR-1.** A **Peer Reviews** surface MUST list assigned reviews with peer-submission
+  reference (respecting anonymity), due date, and done/remaining state.
+- **FR-2.** Opening one MUST render the **submission to review** (text + attachment
+  preview via M3.2) and a **rubric** scorer + comments (reuse M6.1 rubric UI).
+- **FR-3.** Submitting MUST persist scores/comments via the peer-review endpoint and
+  mark the review complete; resubmission/edit allowed where policy permits.
+- **FR-4.** A **received** view MUST show feedback on the student's own work per
+  release policy/anonymity.
+- **FR-5.** Anonymity the server applies MUST be honored (never reveal redacted identity).
+
+## 7. Non-Functional
+
+- **Offline**: read assigned items from cache; submitted reviews queue (M0.2).
+- **Accessibility**: rubric + comment inputs labelled; preview accessible.
+
+## 8. Design / Approach
+
+`Features/PeerReview/` (iOS) / `features/peerreview/` (Android): `PeerReviewListView`,
+`PeerReviewDetailView` (submission preview + rubric scorer + comment), `ReviewsReceivedView`.
+Reuse M6.1 `RubricScorer` and M3.2 `FilePreviewView`. Calls in `LMSAPIFeatures.swift` /
+`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/PeerReview/PeerReviewListView.swift`, `PeerReviewDetailView.swift`, `ReviewsReceivedView.swift` *(new)*, reuse M6.1 rubric + M3.2 preview, `Core/LMS/LMSAPIFeatures.swift`, `Features/Courses/CourseDetailView.swift` (entry), `project.pbxproj`.
+
+**Android** — `features/peerreview/*` *(new)*, reuse rubric/preview, `core/lms/LmsApi.kt`, `features/courses/CourseDetailScreen.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. Assigned reviews list with due dates and progress, honoring anonymity.
+2. A review shows the peer submission (text + attachments) and a working rubric scorer + comments.
+3. Submitting records scores/comments identical to web and marks the review done.
+4. Received feedback displays per release policy. Both apps build.
+
+## 11. Phasing
+
+1. Assigned list + detail (read submission) + rubric scorer.
+2. Submit + complete + edit.
+3. Received view; offline queue (M0.2).
+4. Android parity; verification.
+</content>

--- a/docs/plan/mobile/M5.3-code-execution.md
+++ b/docs/plan/mobile/M5.3-code-execution.md
@@ -1,0 +1,91 @@
+# M5.3 — Code-Execution Questions (Mobile)
+
+> Let students answer code questions on a phone: a mobile-friendly code editor, run
+> against test cases via the server runner, and see results. Source: 2.4 code-execution
+> questions, agent code-test-runner.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M5 — Assignments & Submissions (assessment) |
+| **Severity** | MINOR — important for CS courses; awkward but doable on phones |
+| **Status (today)** | MISSING — M4.1 degrades code questions to "open on web" |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — code execution/test-runner endpoints exist (server-side sandbox) |
+| **Depends on** | [M4.1](M4.1-quiz-taker.md) |
+
+---
+
+## 1. Problem Statement
+
+CS courses use code-execution questions. M4.1 currently punts them to web. A
+mobile-appropriate code editor + server-side run lets students at least complete and
+test simpler code questions on a phone, removing a hard dependency on a laptop.
+
+## 2. Goals
+
+- A phone-usable **code editor** (monospace, syntax highlight, indentation helpers,
+  language selection per question).
+- **Run** against the question's tests via the server runner; show pass/fail + output.
+- Submit as the answer within the quiz/assignment flow (server executes; never on device).
+
+## 3. Non-Goals
+
+- On-device code execution (security). A full IDE — this is "good enough to answer."
+  Heavy multi-file projects stay web (graceful notice).
+
+## 4. User Stories
+
+- **As a CS student**, I write a function on my phone, run the tests, fix a failure, and submit.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: sandboxed code execution + test runner; results. **Mobile**:
+  M4.1 question framework; monospace/markdown rendering.
+
+## 6. Functional Requirements
+
+- **FR-1.** A code question MUST render a **code editor** with monospace font, basic
+  syntax highlighting, auto-indent, and a numeric/symbol input aid; language is fixed by
+  the question.
+- **FR-2.** A **Run** action MUST execute on the **server** against the question's tests
+  and show per-test pass/fail + stdout/stderr; the code MUST never run on device.
+- **FR-3.** The code MUST submit as the answer via the M4.1/assignment submit path;
+  re-run/edit allowed until submit.
+- **FR-4.** Large/multi-file questions MUST degrade with a clear "best on a larger screen."
+
+## 7. Non-Functional
+
+- **Security**: all execution server-side sandboxed. **Performance**: run results stream/
+  return promptly with a clear running state. **Accessibility**: editor usable with
+  larger fonts; controls labelled.
+
+## 8. Design / Approach
+
+`CodeQuestionView` in M4.1's question set: a `CodeEditor` (UITextView/`AttributedString`
+highlight on iOS; `BasicTextField` + highlighter on Android) + run/results panel. Calls in
+`LMSAPIFeatures.swift`/`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Quiz/CodeQuestionView.swift`, `Core/UI/CodeEditor.swift` *(new)*, `Core/LMS/LMSAPIFeatures.swift` (run), `project.pbxproj`.
+
+**Android** — `features/quiz/CodeQuestionView.kt`, `core/ui/CodeEditor.kt` *(new)*, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A code question shows a usable editor with highlighting and input aids.
+2. Run executes server-side and shows per-test pass/fail + output; nothing runs on device.
+3. Submitting records the code as the answer identically to web; edit/re-run until submit.
+4. Oversized questions degrade gracefully. Both apps build.
+
+## 11. Phasing
+
+1. Code editor component + language setup.
+2. Run against tests + results panel.
+3. Submit integration with M4.1; Android parity; verification.
+</content>

--- a/docs/plan/mobile/M6.1-grades-feedback.md
+++ b/docs/plan/mobile/M6.1-grades-feedback.md
@@ -1,0 +1,155 @@
+# M6.1 — Grades, Feedback & What-If (Mobile)
+
+> Beyond the current read-only grade list: a student sees per-assignment grades,
+> opens **rich feedback** (rubric scores, instructor comments, inline annotations on
+> their file, audio/video feedback), projects their grade with **what-if** scores,
+> and understands how the course total is computed. Source: `course-my-grades`
+> (built-read), 3.1 inline annotation, 3.2 audio/video feedback, 3.6 grade
+> categories, 3.16 what-if grades, rubrics.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M6 — Grades & Feedback |
+| **Severity** | MAJOR — "what did I get and why" is a top-3 student need; feedback closes the loop |
+| **Status (today)** | PARTIAL — mobile shows `fetchMyGrades` (a flat read). No feedback detail, annotations, a/v, what-if, or weighting breakdown |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — grade detail, rubric, markups (`assignment_markups.go`/`content_page_markups.go`), a/v feedback, and what-if compute already serve the web |
+| **Depends on** | M3.2 (file/annotation preview) · M5.1 (submission link) |
+
+---
+
+## 1. Problem Statement
+
+The current mobile grades view tells a student their score but not *why* — no rubric
+breakdown, no instructor comments, no inline annotations on the document they turned
+in, no audio/video feedback playback, and no way to see how a future score would
+move their grade. Feedback is where learning happens; without it mobile grades are a
+dead number.
+
+## 2. Goals
+
+- Per-course grade list with category weighting and running total breakdown.
+- Open an assignment's **full feedback**: rubric criterion scores + comments,
+  overall instructor comment, inline **annotations** on the submitted file, and
+  **audio/video** feedback playback.
+- **What-if**: enter hypothetical scores for upcoming/ungraded items and see the
+  projected course total update live (client-side projection mirroring the web).
+- Clear states for excused/exempt, late penalty, dropped-lowest, and pending review.
+
+## 3. Non-Goals
+
+- Instructor grading is the Speed Grader story (`../speed-grader-mobile.md`); this is
+  student-facing.
+- Standards-based mastery view is [M6.2](M6.2-standards-mastery.md).
+- Grade disputes/regrade requests messaging routes through [M7.1](M7.1-discussions.md)/inbox.
+
+## 4. User Stories
+
+- **As a student**, I tap Essay 2 and read the rubric: which criteria I lost points
+  on and the teacher's note, plus their margin notes on my PDF.
+- **As a student**, I listen to the 30-second voice note my instructor left.
+- **As a student**, I type "if I get 90% on the final, what's my grade?" and see it.
+- **As a student**, I see my course total is weighted (Homework 20%, Exams 50%…) and
+  understand my standing.
+
+## 5. What already exists (reuse)
+
+- **Mobile**: `fetchMyGrades` + `CourseGradesView`/`CourseGradesScreen` already render
+  a grade list — extend, don't replace. `fetchMySubmission` links submission ↔ grade.
+- **Server (no changes)**: grade detail + category weights via existing my-grades
+  payload; rubric + criterion scores on the submission grade; markups via
+  `assignment_markups.go` / `content_page_markups.go` / `quiz_markups.go`; a/v
+  feedback as attachments on the grade; what-if is a client projection over the same
+  category/weight data the web uses.
+- **Rendering**: M3.2 file preview for annotated docs; `AVPlayer`/ExoPlayer for a/v.
+
+## 6. Functional Requirements
+
+- **FR-1.** The course grades view MUST show each graded item (score / max, %,
+  status), the **category** it belongs to with its weight, and the computed **running
+  total**; excused/exempt, late, dropped, and pending-review states MUST be labelled.
+- **FR-2.** Tapping a graded assignment MUST open **Feedback Detail**: overall score,
+  **rubric** with per-criterion points + comments, overall instructor comment, and
+  links to the submission.
+- **FR-3.** If the submission has inline **annotations/markups**, the student MUST be
+  able to view their file with the annotations overlaid (reuse M3.2 PDF/image preview
+  + a markup overlay layer).
+- **FR-4.** If the grade includes **audio/video** feedback, it MUST play inline with
+  native controls.
+- **FR-5.** A **What-If** mode MUST let the student enter hypothetical scores for
+  ungraded (or override graded) items and show the projected course total recompute
+  live; entering/exiting what-if MUST never mutate real grades and MUST be clearly
+  labelled "hypothetical."
+- **FR-6.** Quiz grades MUST link to released per-question results (from M4.1) where
+  the reveal policy allows.
+- **FR-7.** The computation MUST match the web's grade engine (weighting, drop rules,
+  posting policy) — never show grades the posting policy hides.
+
+## 7. Non-Functional
+
+- **Correctness**: what-if and totals must match the web grade calculator exactly
+  (reuse the same rules; consider sharing logic via the documented algorithm in
+  `lms/gradebook/compute-course-final-percent.ts`).
+- **Privacy**: respect grade posting policy + blind/muted states; don't reveal
+  unposted grades.
+- **Offline**: last-synced grades render with a stale chip; a/v + annotated files need
+  network unless previously cached.
+- **Accessibility**: rubric is a labelled structure (criterion → points → comment);
+  a/v controls reachable; what-if inputs labelled.
+
+## 8. Design / Approach
+
+- **iOS** (`Features/Grades/`): extend `CourseGradesView` with category sections +
+  total; add `GradeFeedbackView` (rubric + comments + a/v player), reuse
+  `FilePreviewView` (M3.2) with a `MarkupOverlay`, and `WhatIfController` (pure
+  projection over category/weight model). Add grade-detail/rubric/markup calls to
+  `LMSAPIFeatures.swift`; models to `LMSFeatureModels.swift`.
+- **Android** (`features/grades/`): mirror with `GradeFeedbackScreen`, markup overlay
+  on `FilePreviewScreen`, `WhatIfState` holder. Add calls to `LmsApi.kt`, models to
+  `LmsFeatureModels.kt`.
+- **What-if** is local-only state layered over the real grade model; a reset returns
+  to actuals.
+
+## 9. Files to touch
+
+**iOS**
+- `clients/ios/Lextures/Features/Courses/CourseGradesView.swift` — categories + total + what-if entry
+- `clients/ios/Lextures/Features/Grades/GradeFeedbackView.swift` *(new)*
+- `clients/ios/Lextures/Features/Grades/WhatIfController.swift` *(new)*
+- `clients/ios/Lextures/Features/Files/FilePreviewView.swift` — markup overlay layer (from M3.2)
+- `clients/ios/Lextures/Core/LMS/LMSAPIFeatures.swift` — grade detail / rubric / markups / a-v
+- `clients/ios/Lextures/Core/LMS/LMSFeatureModels.swift` — grade/rubric/markup models
+- `clients/ios/Lextures.xcodeproj/project.pbxproj`
+
+**Android**
+- `.../features/courses/CourseGradesScreen.kt` — categories + total + what-if
+- `.../features/grades/GradeFeedbackScreen.kt`, `WhatIfState.kt` *(new)*
+- `.../features/files/FilePreviewScreen.kt` — markup overlay
+- `.../core/lms/LmsApi.kt`, `.../core/lms/LmsFeatureModels.kt`
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. Course grades show items with score/%, category + weight, and a running total that
+   matches the web for the same data.
+2. Opening a graded assignment shows the rubric (per-criterion points + comments) and
+   the overall instructor comment.
+3. An annotated PDF shows the instructor's inline markups overlaid on the student's file.
+4. Audio/video feedback plays inline.
+5. What-if lets the student enter a hypothetical final score and see the projected
+   total change live, clearly labelled hypothetical, with no effect on real grades.
+6. Excused/late/dropped/pending states are labelled; unposted grades are hidden per policy.
+7. Both apps build; existing read-only grades still function.
+
+## 11. Phasing
+
+1. Categories + weighting + running total on the existing grades view (both platforms).
+2. Feedback detail: rubric + comments + a/v playback.
+3. Annotation overlay on M3.2 preview.
+4. What-if projection (parity with web calculator).
+5. Android parity; offline cache; accessibility + verification.
+</content>

--- a/docs/plan/mobile/M6.2-standards-mastery.md
+++ b/docs/plan/mobile/M6.2-standards-mastery.md
@@ -1,0 +1,95 @@
+# M6.2 — Standards-Based Grades & Mastery (Mobile)
+
+> Show students mastery the way standards-based courses actually report it: per-standard
+> proficiency, a mastery heatmap, and (K-12) report-card-style outcomes. Source:
+> 3.7 standards-based grading, 9.3 mastery/skill heatmap, 1.3 standards alignment,
+> 13.4 report cards (student view).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M6 — Grades & Feedback |
+| **Severity** | MAJOR (K12) — many districts grade on standards, not points; points-only mobile misrepresents the grade |
+| **Status (today)** | MISSING — mobile grades are points-only |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — standards gradebook, mastery, outcomes, report-card endpoints exist |
+| **Depends on** | [M6.1](M6.1-grades-feedback.md) (grades surface) |
+
+---
+
+## 1. Problem Statement
+
+In standards-based courses, the meaningful signal is per-standard proficiency, not a
+percentage. Mobile shows only points, so K-12 students (and parents, via M10.1) can't
+see how they're doing against standards or read their report card on a phone.
+
+## 2. Goals
+
+- Per-course **standards/outcomes** list with proficiency level per standard.
+- A **mastery heatmap** adapted to a phone (skill × proficiency).
+- Student-facing **report card** / outcomes summary (read).
+- Link each standard to the evidence (assignments) behind it.
+
+## 3. Non-Goals
+
+- Editing standards alignment/scales or generating report cards (instructor/admin/web).
+
+## 4. User Stories
+
+- **As a K-12 student**, I see I'm "Proficient" on most standards but "Developing" on
+  two, and what to practice.
+- **As a student**, I open my report card on my phone.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: standards gradebook, mastery heatmap, outcomes report,
+  report-card endpoints. **Mobile**: M6.1 grades surface; theme; M8.x for practice links.
+
+## 6. Functional Requirements
+
+- **FR-1.** A course MUST offer a **Standards/Mastery** view listing aligned standards
+  with the student's current proficiency level and trend.
+- **FR-2.** A **mastery heatmap** MUST render legibly on a phone (compact grid or list
+  with color-coded proficiency), color-safe and labelled.
+- **FR-3.** A standard MUST link to the **evidence** (contributing assignments/quizzes)
+  and, where available, a **practice** suggestion (M8.x).
+- **FR-4.** A student-facing **report card** / outcomes summary MUST be viewable (read)
+  per release policy.
+- **FR-5.** Proficiency scales/labels MUST match the course's configured scale exactly.
+
+## 7. Non-Functional
+
+- **Accessibility**: never color-only — proficiency has text/label; heatmap navigable.
+- **Offline**: render from cache (M0.2). **Privacy**: respect release policy.
+
+## 8. Design / Approach
+
+`Features/Mastery/` (iOS) / `features/mastery/` (Android): `StandardsView` (list +
+proficiency), `MasteryHeatmapView` (compact), `ReportCardView`. Add a Mastery tab to
+the course. Calls in `LMSAPIFeatures.swift` / `LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Mastery/StandardsView.swift`, `MasteryHeatmapView.swift`, `ReportCardView.swift` *(new)*, `Features/Courses/CourseDetailView.swift` (tab), `Core/LMS/LMSAPIFeatures.swift`, `project.pbxproj`.
+
+**Android** — `features/mastery/*` *(new)*, `features/courses/CourseDetailScreen.kt`, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A standards course shows per-standard proficiency matching the web, using the
+   course's scale labels.
+2. The heatmap renders legibly and accessibly (not color-only) on a phone.
+3. A standard links to its contributing evidence and a practice suggestion where available.
+4. The student report card is viewable per policy. Both apps build.
+
+## 11. Phasing
+
+1. Standards list + proficiency (read).
+2. Mastery heatmap (compact, accessible).
+3. Report card + evidence/practice links.
+4. Android parity; offline; verification.
+</content>

--- a/docs/plan/mobile/M7.1-discussions.md
+++ b/docs/plan/mobile/M7.1-discussions.md
@@ -1,0 +1,141 @@
+# M7.1 — Course Discussions (Mobile)
+
+> Read and participate in threaded course discussions: browse topics, read threads,
+> post replies, upvote, and get notified of new activity. Source: 6.1 threaded
+> discussion forums, `course-discussions-page`, `discussions_http.go`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M7 — Communication |
+| **Severity** | MAJOR — discussions are often graded participation and the main async class conversation |
+| **Status (today)** | MISSING — mobile has 1:1 Inbox but no course discussions |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — `discussions_http.go` exposes threads, posts, upvote |
+| **Depends on** | M3.1 (a discussion module item routes here) · M0.1 (reply notifications) |
+
+---
+
+## 1. Problem Statement
+
+Discussions are where class conversation happens and are frequently graded
+participation. A mobile student can send a private message but can't see or post in
+their courses' discussion forums, cutting them out of a core, often-required
+activity when they don't have a computer.
+
+## 2. Goals
+
+- Browse a course's discussion **topics/threads** and read full threaded
+  conversations.
+- **Post** a new thread (where allowed) and **reply** at any depth.
+- **Upvote** posts; see counts and sort.
+- Surface **unread/new** activity and notify on replies ([M0.1](M0.1-push-deep-links.md)).
+- Handle attachments and basic rich text/math in posts (reuse notebook markdown).
+
+## 3. Non-Goals
+
+- Discussion **authoring/moderation** tools (pin/lock/grade) — instructor/web for now
+  (basic report/flag MAY be included).
+- Group-space discussions are covered under [M7.4](M7.4-groups-collab.md) (same
+  component reused).
+
+## 4. User Stories
+
+- **As a student**, I open my course's discussions, read the prompt, and post my
+  required response.
+- **As a student**, I reply to a classmate and upvote a helpful answer.
+- **As a student**, I get a notification when someone replies to my post and tap
+  straight into the thread.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**:
+  - `GET/POST …/courses/{course_code}/discussion-threads/{thread_id}` and
+    `…/discussion-threads/{thread_id}/posts` → threads + posts.
+  - `…/discussion-posts/{post_id}` (edit/delete per policy) and
+    `…/discussion-posts/{post_id}/upvote`.
+- **Mobile**: Inbox feature (`InboxView`/`MessageDetailView`, compose) is a good
+  pattern to mirror for list→thread→compose; theme, cards, markdown renderer.
+
+## 6. Functional Requirements
+
+- **FR-1.** A course MUST expose a **Discussions** surface listing topics/threads with
+  title, author, reply count, last-activity time, and unread/new indicator.
+- **FR-2.** Opening a thread MUST render the **threaded** post tree (nested replies),
+  with author, timestamp, body (rich text/math), attachments, and upvote count.
+- **FR-3.** The student MUST be able to **reply** to a thread or a specific post
+  (composer with text, math, and attachment), and **create a new thread** where the
+  topic allows it.
+- **FR-4.** The student MUST be able to **upvote/un-upvote** a post with optimistic UI.
+- **FR-5.** New replies (especially to the student's own posts) MUST be reflected as
+  unread and MAY trigger a push ([M0.1](M0.1-push-deep-links.md)) that deep-links into
+  the thread.
+- **FR-6.** Required/graded discussions MUST show their participation/due context (and
+  link to the grade via [M6.1](M6.1-grades-feedback.md) once graded).
+- **FR-7.** Editing/deleting one's own posts MUST be available where server policy
+  allows; a basic **report/flag** action SHOULD exist.
+
+## 7. Non-Functional
+
+- **Performance**: thread loads lazily/paginates deep trees; replies appear
+  optimistically then reconcile.
+- **Offline**: last-read threads render from cache; composing offline queues the post
+  ([M0.2](M0.2-offline-sync.md)) with a "will post when online" state.
+- **Accessibility**: nesting conveyed non-visually (indent level announced); upvote is
+  a labelled toggle; composer labelled; Dynamic Type.
+- **Safety**: respect content-filter/moderation server responses; never render blocked
+  content.
+
+## 8. Design / Approach
+
+- **iOS** (`Features/Discussions/`): `DiscussionsListView`, `DiscussionThreadView`
+  (recursive/indented post rows + upvote), `PostComposerView` (mirror Inbox compose +
+  attachments + markdown). Add discussions calls to `LMSAPIFeatures.swift`; models to
+  `LMSFeatureModels.swift`.
+- **Android** (`features/discussions/`): `DiscussionsListScreen`,
+  `DiscussionThreadScreen`, `PostComposerScreen`. Add calls to `LmsApi.kt`, models to
+  `LmsFeatureModels.kt`.
+- Reuse the markdown/math renderer (`Core/Notebook/NotebookMarkdown.*`) for bodies and
+  M3.2 preview for attachments. Reuse this component for M7.4 group discussions.
+
+## 9. Files to touch
+
+**iOS**
+- `clients/ios/Lextures/Features/Discussions/DiscussionsListView.swift` *(new)*
+- `clients/ios/Lextures/Features/Discussions/DiscussionThreadView.swift` *(new)*
+- `clients/ios/Lextures/Features/Discussions/PostComposerView.swift` *(new)*
+- `clients/ios/Lextures/Core/LMS/LMSAPIFeatures.swift` — threads/posts/upvote
+- `clients/ios/Lextures/Core/LMS/LMSFeatureModels.swift` — thread/post models
+- `clients/ios/Lextures/Features/Courses/CourseDetailView.swift` — Discussions tab/route
+- `clients/ios/Lextures.xcodeproj/project.pbxproj`
+
+**Android**
+- `.../features/discussions/DiscussionsListScreen.kt`, `DiscussionThreadScreen.kt`, `PostComposerScreen.kt` *(new)*
+- `.../core/lms/LmsApi.kt`, `.../core/lms/LmsFeatureModels.kt`
+- `.../features/courses/CourseDetailScreen.kt` — Discussions tab/route
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A course's Discussions list shows threads with author, reply count, last activity,
+   and unread state.
+2. Opening a thread shows the nested reply tree with bodies, attachments, and upvote
+   counts rendered correctly.
+3. A student can create a new thread (where allowed) and reply to a thread/post; the
+   post appears and persists identically to web.
+4. Upvoting toggles optimistically and reconciles with the server.
+5. A reply to the student's post produces a notification that deep-links into the thread.
+6. Offline, last-read threads render and a composed reply queues then posts on reconnect.
+7. Both apps build; Inbox still works.
+
+## 11. Phasing
+
+1. Discussions list + thread read (nested) on both platforms.
+2. Reply + new thread composer (text/math) + upvote.
+3. Attachments; report/flag; edit/delete own.
+4. Notifications/deep-link (M0.1) + offline queue (M0.2).
+5. Android parity; accessibility + verification; reuse for M7.4.
+</content>

--- a/docs/plan/mobile/M7.2-ai-tutor.md
+++ b/docs/plan/mobile/M7.2-ai-tutor.md
@@ -1,0 +1,145 @@
+# M7.2 — AI Tutor & Ask-AI (Mobile)
+
+> A floating, always-available AI tutor that answers questions in the context of the
+> current course/material, streams its response, and respects guardrails — plus the
+> standalone Ask-AI / study-buddy surface. Source: 6.9 AI tutor, `ask-ai-page`,
+> 15.12 AI study buddy, `tutor.go`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M7 — Communication |
+| **Severity** | MAJOR — a key differentiator and a force-multiplier for solo/phone-first learners |
+| **Status (today)** | MISSING — no AI tutor on mobile |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — `tutor.go` exposes `…/courses/{code}/tutor/conversation` and `…/tutor/message` (streaming) |
+| **Depends on** | M3.1 (context handoff from the item being viewed) · uses latest Claude models per repo AI guidance |
+
+---
+
+## 1. Problem Statement
+
+Self-learners and phone-first students often have no one to ask when they're stuck.
+The web AI tutor fills that gap with context-aware help, but it's absent on mobile —
+exactly where solo learners spend their time. A native, streaming tutor that knows
+what course/page the student is on makes the app genuinely tutoring, not just
+content delivery.
+
+## 2. Goals
+
+- A **floating tutor button** reachable from course/content screens that opens a chat
+  scoped to the current course/item context.
+- **Streaming** responses (SSE) rendered incrementally with markdown + math.
+- Persistent **conversation** history per course; start-new and continue.
+- A standalone **Ask-AI / study buddy** entry (not tied to a course) for general help.
+- Respect server-side guardrails, rate limits, and AI-usage disclosure (10.17).
+
+## 3. Non-Goals
+
+- Changing tutor prompts/models/policies — those live server-side; mobile is a client.
+- AI grading/authoring agents (instructor) — out of scope.
+- On-device inference — all inference is server-mediated.
+
+## 4. User Stories
+
+- **As a student stuck on a problem**, I tap the tutor button on the page and ask
+  "explain step 3," and it answers about *this* page.
+- **As a self-learner**, I open Ask-AI to brainstorm a study plan.
+- **As a student**, I scroll back through yesterday's tutoring conversation.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: `tutor.go` →
+  `POST/GET …/courses/{course_code}/tutor/conversation` (create/list),
+  `POST …/courses/{course_code}/tutor/message` (send + **stream** the reply).
+- **Mobile**: networking client; **SSE/streaming** support pattern (push SSE exists
+  server-side; client gets a streaming read helper here). Markdown/math renderer
+  (`Core/Notebook/NotebookMarkdown.*`) for rendering responses. Theme + chat-like
+  patterns from Inbox.
+- **AI guidance**: follow the repo's Claude model guidance (latest Claude models);
+  no provider hardcoding on the client — the server owns model choice.
+
+## 6. Functional Requirements
+
+- **FR-1.** A **floating tutor affordance** MUST be available on course home, module
+  items, and content pages; opening it MUST pass the current course (and item, when
+  applicable) as context to the conversation.
+- **FR-2.** Sending a message MUST stream the assistant reply **incrementally**
+  (token/chunk-by-chunk) with a typing/stop affordance; partial markdown/math renders
+  progressively and finalizes cleanly.
+- **FR-3.** Conversations MUST **persist** per course and be resumable; the student
+  MUST be able to start a new conversation and scroll history.
+- **FR-4.** A standalone **Ask-AI** entry (e.g., from Profile/Home) MUST offer general
+  (non-course) tutoring using the same chat UI.
+- **FR-5.** The UI MUST surface the **AI-usage disclosure** (per 10.17) and any
+  server-returned rate-limit / quota / safety messages gracefully (no dead-ends).
+- **FR-6.** Errors and stream interruptions MUST degrade gracefully (retry, keep the
+  partial answer, clear messaging); cancelling a stream MUST stop generation.
+- **FR-7.** Code/math/links in responses MUST render readably on a phone (code blocks
+  scroll horizontally; equations via the math renderer).
+
+## 7. Non-Functional
+
+- **Performance**: first streamed token visible quickly; smooth incremental render
+  without jank; long conversations virtualize.
+- **Privacy/Compliance**: respect AI disclosure + any age gating the server enforces;
+  don't send PII the server didn't ask for; honor minor-account policies.
+- **Resilience**: stream resume/retry on flaky networks; offline → clear "needs
+  connection" (no queued generation).
+- **Accessibility**: streaming text announced sensibly (not per token); input + stop
+  reachable; Dynamic Type.
+
+## 8. Design / Approach
+
+- **iOS** (`Features/Tutor/`): `TutorChatView` (message list + composer + stop),
+  `TutorLauncher` (floating button modifier usable on course screens),
+  `TutorStreamClient` (URLSession bytes/SSE reader yielding chunks). Add tutor calls
+  to `LMSAPIFeatures.swift`; models to `LMSFeatureModels.swift`.
+- **Android** (`features/tutor/`): `TutorChatScreen`, a reusable `TutorFab`, a
+  streaming reader (OkHttp SSE / `bufferedReader` over the response). Add calls to
+  `LmsApi.kt`, models to `LmsFeatureModels.kt`.
+- Context (courseCode/itemId) is captured at launch and sent with the first message.
+  Reuse the markdown/math renderer for assistant content.
+
+## 9. Files to touch
+
+**iOS**
+- `clients/ios/Lextures/Features/Tutor/TutorChatView.swift` *(new)*
+- `clients/ios/Lextures/Features/Tutor/TutorLauncher.swift` *(new — floating button modifier)*
+- `clients/ios/Lextures/Core/LMS/TutorStreamClient.swift` *(new — SSE/stream reader)*
+- `clients/ios/Lextures/Core/LMS/LMSAPIFeatures.swift` — conversation/message
+- `clients/ios/Lextures/Core/LMS/LMSFeatureModels.swift` — conversation/message models
+- `clients/ios/Lextures/Features/Courses/CourseDetailView.swift` + `ContentPageView.swift` — attach launcher
+- `clients/ios/Lextures.xcodeproj/project.pbxproj`
+
+**Android**
+- `.../features/tutor/TutorChatScreen.kt`, `TutorFab.kt` *(new)*
+- `.../core/lms/TutorStreamClient.kt` *(new)*
+- `.../core/lms/LmsApi.kt`, `.../core/lms/LmsFeatureModels.kt`
+- `.../features/courses/CourseDetailScreen.kt` + content page — attach launcher
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A tutor button appears on course/content screens; opening it on a content page lets
+   the tutor answer about that page's context.
+2. Sending a question streams the answer incrementally with markdown/math rendered,
+   and a Stop control halts generation.
+3. Conversations persist per course, are resumable, and a "new conversation" starts fresh.
+4. A standalone Ask-AI works without a course.
+5. AI-usage disclosure is visible; rate-limit/safety responses show graceful messages.
+6. A dropped network mid-stream keeps the partial answer and offers retry; offline
+   shows a clear "needs connection."
+7. Both apps build.
+
+## 11. Phasing
+
+1. Streaming client + tutor models on both platforms.
+2. iOS course-scoped chat (send/stream/persist) + launcher on content screens.
+3. New conversation + history + standalone Ask-AI.
+4. Disclosure + rate-limit/safety handling; cancel/retry.
+5. Android parity; accessibility + verification.
+</content>

--- a/docs/plan/mobile/M7.3-office-hours.md
+++ b/docs/plan/mobile/M7.3-office-hours.md
@@ -1,0 +1,86 @@
+# M7.3 — Office Hours Booking (Mobile)
+
+> Find an instructor's office-hours availability, book a slot, and manage/cancel
+> bookings from the phone. Source: 6.7 office hours, `course-office-hours-page`,
+> `conference-availability-setup`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M7 — Communication |
+| **Severity** | MINOR–MAJOR — valuable for HE; students book help on the go |
+| **Status (today)** | MISSING |
+| **Estimated effort** | S |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — office-hours availability/booking endpoints exist |
+| **Depends on** | [M2.1](M2.1-calendar-todos.md) (show booking on calendar) · M0.1 (reminders) |
+
+---
+
+## 1. Problem Statement
+
+Students need help and instructors publish office hours, but mobile can't show
+availability or book. A simple booking flow lets students grab help slots anywhere.
+
+## 2. Goals
+
+- View an instructor/course's **available** office-hours slots.
+- **Book**, **reschedule**, and **cancel**; see upcoming bookings.
+- Surface bookings on the calendar (M2.1) and remind via push (M0.1).
+
+## 3. Non-Goals
+
+- Instructors setting availability (web). Live video join is web (link out).
+
+## 4. User Stories
+
+- **As a student**, I book Tuesday 3pm office hours and get a reminder.
+- **As a student**, I cancel when something comes up.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: availability + booking + cancel endpoints. **Mobile**: M2.1
+  calendar, theme, M0.1 reminders.
+
+## 6. Functional Requirements
+
+- **FR-1.** A course MUST show **available office-hours slots** (time, location/modality,
+  instructor), with timezone-correct times.
+- **FR-2.** The student MUST be able to **book** a slot (optional note/topic) and see a
+  confirmation; double-booking/conflicts surface clearly.
+- **FR-3.** The student MUST be able to **cancel/reschedule** within policy and see
+  upcoming bookings.
+- **FR-4.** A booking MUST appear on the **calendar** (M2.1) and MAY schedule a reminder (M0.1).
+- **FR-5.** Online meeting links MUST open (in-app web / external) at meeting time.
+
+## 7. Non-Functional
+
+- **Accessibility**: slot list + booking labelled. **Offline**: read from cache; booking
+  requires connection. **Timezone**: correct per M0.4.
+
+## 8. Design / Approach
+
+`Features/OfficeHours/` (iOS) / `features/officehours/` (Android): `OfficeHoursView`
+(slots), `BookingSheet`, `MyBookingsView`. Calls in `LMSAPIFeatures.swift`/`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/OfficeHours/OfficeHoursView.swift`, `BookingSheet.swift`, `MyBookingsView.swift` *(new)*, `Features/Courses/CourseDetailView.swift` (entry), `Core/LMS/LMSAPIFeatures.swift`, `project.pbxproj`.
+
+**Android** — `features/officehours/*` *(new)*, `features/courses/CourseDetailScreen.kt`, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. Available slots show with correct local times.
+2. Booking persists, shows confirmation, and appears on the calendar; conflicts surface.
+3. Cancel/reschedule works within policy; reminders fire. Both apps build.
+
+## 11. Phasing
+
+1. Slots view + book.
+2. Cancel/reschedule + my bookings + calendar integration.
+3. Reminders (M0.1); Android parity; verification.
+</content>

--- a/docs/plan/mobile/M7.4-groups-collab.md
+++ b/docs/plan/mobile/M7.4-groups-collab.md
@@ -1,0 +1,93 @@
+# M7.4 — Group Spaces & Collaborative Docs (Mobile)
+
+> Participate in group spaces (group discussions, files, members) and view/comment on
+> collaborative documents from the phone. Source: 6.6 group spaces, 6.5 collaborative
+> documents, `course-groups-page`, `course-collab-docs-page`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M7 — Communication |
+| **Severity** | MAJOR — group assignments require coordinating in the group space |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — group spaces + collab-docs endpoints exist |
+| **Depends on** | [M7.1](M7.1-discussions.md) (reuse discussion component), [M3.2](M3.2-course-files.md) (group files), [M5.1](M5.1-assignment-submission.md) (group submission) |
+
+---
+
+## 1. Problem Statement
+
+Group work needs a shared space — discussion, files, members, and a working doc. With
+no mobile group space, a phone-first student can't coordinate or contribute to group
+assignments, which often block on exactly that coordination.
+
+## 2. Goals
+
+- See the student's **group(s)** per course: members, group discussion, group files.
+- **Group discussion** (reuse M7.1) and **group files** (reuse M3.2).
+- **Collaborative documents**: view, and add comments/light edits where supported
+  (full real-time editing stays web).
+- Support **group submission** handoff (M5.1).
+
+## 3. Non-Goals
+
+- Real-time multi-cursor co-editing (web). Forming/managing groups (instructor/web).
+
+## 4. User Stories
+
+- **As a student**, I open my project group, message my teammates, and grab our shared files.
+- **As a student**, I read our collaborative doc and leave a comment.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: group spaces (members/discussion/files), collab-docs (read +
+  comment) endpoints. **Mobile**: M7.1 discussion component, M3.2 files/preview, M5.1
+  submission.
+
+## 6. Functional Requirements
+
+- **FR-1.** A course MUST show the student's **group(s)** with members, and entries for
+  group **discussion** (M7.1) and group **files** (M3.2).
+- **FR-2.** **Collaborative documents** MUST be viewable (rendered), with the ability to
+  add **comments** and light edits where the API allows; concurrent editing beyond that
+  is read-only with an "edit on web" affordance.
+- **FR-3.** Where the group has a **group assignment**, submission MUST route to M5.1 in
+  group context.
+- **FR-4.** Updates (new group post/comment) MAY notify via M0.1 deep-linking into the group.
+
+## 7. Non-Functional
+
+- **Offline**: group reads cached (M0.2); comments/posts queue. **Accessibility**:
+  members/docs/comments labelled.
+
+## 8. Design / Approach
+
+`Features/Groups/` (iOS) / `features/groups/` (Android): `GroupSpaceView` (tabs:
+Members / Discussion → M7.1 / Files → M3.2), `CollabDocView` (render + comments). Calls
+in `LMSAPIFeatures.swift`/`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Groups/GroupSpaceView.swift`, `CollabDocView.swift` *(new)*, reuse M7.1/M3.2, `Features/Courses/CourseDetailView.swift` (entry), `Core/LMS/LMSAPIFeatures.swift`, `project.pbxproj`.
+
+**Android** — `features/groups/*` *(new)*, reuse discussion/files, `features/courses/CourseDetailScreen.kt`, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. A student sees their group(s), members, group discussion, and group files.
+2. Group discussion and files reuse M7.1/M3.2 and work identically in group context.
+3. A collaborative doc renders and accepts a comment; heavy editing routes to web.
+4. Group assignment submission works via M5.1. Both apps build.
+
+## 11. Phasing
+
+1. Group space (members + discussion + files via reuse).
+2. Collab doc view + comments.
+3. Group submission handoff; notifications.
+4. Android parity; offline; verification.
+</content>

--- a/docs/plan/mobile/M8.1-review-spaced-repetition.md
+++ b/docs/plan/mobile/M8.1-review-spaced-repetition.md
@@ -1,0 +1,138 @@
+# M8.1 — Review & Spaced Repetition (Mobile)
+
+> A daily "what should I study now" review surface: due flashcard-style retrieval
+> practice scheduled by the spaced-repetition engine, gradeable on a phone in spare
+> minutes, with progress and streaks. Source: 1.5 spaced repetition / retrieval
+> practice, `review-session-page`, recommendations engine.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M8 — Adaptive & Study Tools |
+| **Severity** | MAJOR — spaced practice is the highest-leverage *mobile-native* learning behavior (short, frequent, on the go) |
+| **Status (today)** | MISSING — no review/practice surface on mobile |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — spaced-repetition review session endpoints already power the web `review-session-page` |
+| **Depends on** | M4.1 (shares question rendering) · M0.1 (daily review reminders) |
+
+---
+
+## 1. Problem Statement
+
+Spaced repetition is the single study habit most suited to a phone — short bursts,
+many times a day, wherever the student is. The engine and review sessions exist on
+web but not on mobile, so the most mobile-appropriate learning loop is missing
+exactly where it would be used most. Pairing it with reminders (M0.1) drives both
+learning outcomes and daily retention.
+
+## 2. Goals
+
+- A **Review** surface showing how many items are **due** today across courses.
+- A focused **review session**: present a due item, reveal the answer, self-grade
+  (e.g., Again / Hard / Good / Easy), and schedule the next interval via the engine.
+- Show **progress** (reviewed today, remaining, streak) and per-deck/course filters.
+- Daily **review reminder** via [M0.1](M0.1-push-deep-links.md).
+- Reuse M4.1 question rendering for item types that aren't plain cards.
+
+## 3. Non-Goals
+
+- Authoring cards/retrieval items (instructor/system-generated) — web/server side.
+- Tuning the scheduling algorithm — the server owns intervals; mobile reports grades.
+- Misconception remediation flows (1.10) beyond linking out where the server surfaces them.
+
+## 4. User Stories
+
+- **As a student**, I see "12 reviews due," start a session, and clear them in five
+  minutes on the bus.
+- **As a student**, I reveal each answer, grade how well I knew it, and the app
+  schedules the next review.
+- **As a student**, a gentle reminder nudges me to keep my streak.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: the spaced-repetition session endpoints backing
+  `review-session-page` (fetch due queue, submit a grade/rating that advances the
+  schedule) and the recommendations API for "what to study next."
+- **Mobile**: M4.1 question rendering (`Features/Quiz/QuizQuestionViews`) for non-card
+  items; markdown/math renderer; theme; dashboard for the "due" entry point.
+
+## 6. Functional Requirements
+
+- **FR-1.** A **Review** entry (dashboard widget + dedicated screen) MUST show the
+  count of items **due now** across all courses, with optional per-course/per-deck
+  filter.
+- **FR-2.** A **review session** MUST present one due item at a time: prompt, a
+  **reveal answer** action, then a **self-grade** control (the rating scale the engine
+  expects). For non-card item types, reuse M4.1's renderers.
+- **FR-3.** Submitting a rating MUST call the engine to **schedule the next interval**
+  and advance to the next due item; the session MUST show progress (done / remaining)
+  and end with a summary (reviewed count, streak).
+- **FR-4.** The surface MUST reflect **streak / daily-goal** state and integrate a
+  daily **reminder** ([M0.1](M0.1-push-deep-links.md)) the student can enable/time.
+- **FR-5.** "What to study next" **recommendations** (from the recommendations API)
+  MAY be surfaced as suggested decks/items.
+- **FR-6.** Ratings submitted offline MUST queue and sync ([M0.2](M0.2-offline-sync.md))
+  without double-scheduling on replay (idempotent per item+timestamp).
+
+## 7. Non-Functional
+
+- **Performance**: card flip/advance < 200 ms from cached queue; prefetch the next
+  few items so a session runs smoothly offline.
+- **Offline**: a due session can be **completed offline** from a prefetched queue;
+  ratings sync later. This is a flagship offline use case (commute studying).
+- **Accessibility**: reveal + rating buttons labelled and ≥44pt; progress announced;
+  Dynamic Type; reduced-motion alternative to the flip animation.
+
+## 8. Design / Approach
+
+- **iOS** (`Features/Review/`): `ReviewHomeView` (due counts + filters + start),
+  `ReviewSessionView` (item → reveal → rating, progress, summary), reuse
+  `QuizQuestionViews` for typed items. Add review/recommendation calls to
+  `LMSAPIFeatures.swift`; models to `LMSFeatureModels.swift`. Dashboard "Reviews due"
+  widget.
+- **Android** (`features/review/`): `ReviewHomeScreen`, `ReviewSessionScreen`, reuse
+  quiz question composables. Add calls to `LmsApi.kt`, models to `LmsFeatureModels.kt`;
+  dashboard widget.
+- **Prefetch**: load N due items up front into the M0.2 cache so a session is
+  offline-capable; queue ratings in the outbox with idempotency keys.
+
+## 9. Files to touch
+
+**iOS**
+- `clients/ios/Lextures/Features/Review/ReviewHomeView.swift` *(new)*
+- `clients/ios/Lextures/Features/Review/ReviewSessionView.swift` *(new)*
+- `clients/ios/Lextures/Core/LMS/LMSAPIFeatures.swift` — due queue / submit rating / recommendations
+- `clients/ios/Lextures/Core/LMS/LMSFeatureModels.swift` — review item / rating models
+- `clients/ios/Lextures/Features/Dashboard/DashboardView.swift` — "Reviews due" widget
+- `clients/ios/Lextures.xcodeproj/project.pbxproj`
+
+**Android**
+- `.../features/review/ReviewHomeScreen.kt`, `ReviewSessionScreen.kt` *(new)*
+- `.../core/lms/LmsApi.kt`, `.../core/lms/LmsFeatureModels.kt`
+- `.../features/dashboard/DashboardTab.kt` — "Reviews due" widget
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. The Review surface shows the correct count of due items across courses, matching
+   the web review queue.
+2. A session presents items one at a time with reveal + the engine's rating scale;
+   typed items render via the quiz renderers.
+3. Submitting a rating schedules the next interval (verified by the item leaving the
+   due queue) and advances; the summary shows reviewed count and streak.
+4. A daily reminder can be enabled and fires at the chosen time.
+5. A prefetched session can be completed fully offline; ratings sync on reconnect with
+   no double-scheduling.
+6. Both apps build.
+
+## 11. Phasing
+
+1. Review home (due counts + filters) + session (card reveal + rating) on both platforms.
+2. Typed-item rendering via M4.1; progress + summary + streak.
+3. Reminders (M0.1); recommendations surfacing.
+4. Offline prefetch + idempotent rating queue (M0.2).
+5. Android parity; accessibility + verification.
+</content>

--- a/docs/plan/mobile/M8.2-paths-recommendations.md
+++ b/docs/plan/mobile/M8.2-paths-recommendations.md
@@ -1,0 +1,91 @@
+# M8.2 — Adaptive Paths & Recommendations (Mobile)
+
+> Follow an adaptive learning path step by step and get "what to do next"
+> recommendations on the phone. Source: 1.4 adaptive paths, 1.8 recommendations
+> engine, `my-paths`/`path-landing-page`, `learning_paths_http.go`, `recommendations_api.go`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M8 — Adaptive & Study Tools |
+| **Severity** | MAJOR (SL) — paths are the self-learner's core navigation; recommendations drive engagement |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — `learning_paths_http.go`, `recommendations_api.go`, catalog paths exist |
+| **Depends on** | [M3.1](M3.1-module-content-viewer.md) (path steps are content/items), [M9.1](M9.1-catalog-enroll.md) (enroll in a path) |
+
+---
+
+## 1. Problem Statement
+
+Self-learners navigate by path ("learn X"), not by course catalog browsing. Mobile has
+no path runner or recommendations, so the primary self-learner journey is missing and
+"what next" is unanswered.
+
+## 2. Goals
+
+- See **enrolled paths** and progress; run a path step-by-step with the next action obvious.
+- Surface **recommendations** ("study next," "you might like") on dashboard/home.
+- Enroll in / start a path (handoff to M9.1 for paid).
+
+## 3. Non-Goals
+
+- Authoring paths (creator/web). Tuning the recommender (server).
+
+## 4. User Stories
+
+- **As a self-learner**, I open my path and it tells me exactly the next lesson/quiz.
+- **As a self-learner**, the home screen suggests what to study next.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: `learning_paths_http.go` (my paths, progress, steps),
+  `recommendations_api.go`, `catalog/paths`. **Mobile**: M3.1 item rendering, dashboard,
+  M8.1/M9.x.
+
+## 6. Functional Requirements
+
+- **FR-1.** A **My Paths** surface MUST list enrolled paths with progress and a clear
+  **continue / next step** action that routes to the step's item (M3.1/M4.1/M5.1).
+- **FR-2.** A path MUST render its **ordered steps** with completion/lock state; the
+  next-best step is highlighted.
+- **FR-3.** **Recommendations** (study-next / suggested paths) MUST appear on
+  dashboard/home and link into the item/path.
+- **FR-4.** The student MUST be able to **start/enroll** in a path (free directly; paid
+  → M9.1 checkout).
+- **FR-5.** Progress through steps MUST update via the paths API and reflect immediately.
+
+## 7. Non-Functional
+
+- **Offline**: path/progress cached (M0.2). **Accessibility**: steps + next-action labelled.
+
+## 8. Design / Approach
+
+`Features/Paths/` (iOS) / `features/paths/` (Android): `MyPathsView`, `PathRunnerView`
+(ordered steps + continue), `RecommendationsSection` (dashboard). Calls in
+`LMSAPIFeatures.swift`/`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Paths/MyPathsView.swift`, `PathRunnerView.swift` *(new)*, `Features/Dashboard/DashboardView.swift` (recommendations), `Core/LMS/LMSAPIFeatures.swift`, `project.pbxproj`.
+
+**Android** — `features/paths/*` *(new)*, `features/dashboard/DashboardTab.kt`, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. My Paths lists enrolled paths with progress and a working continue/next-step.
+2. A path shows ordered steps with completion/lock; the next step routes correctly.
+3. Recommendations appear on home and link into items/paths.
+4. Enrolling in a free path works; a paid path routes to M9.1. Both apps build.
+
+## 11. Phasing
+
+1. My Paths + path runner (steps + continue).
+2. Recommendations on dashboard.
+3. Enroll/start (free + paid handoff).
+4. Android parity; offline; verification.
+</content>

--- a/docs/plan/mobile/M8.3-study-insights.md
+++ b/docs/plan/mobile/M8.3-study-insights.md
@@ -1,0 +1,89 @@
+# M8.3 — Study Insights & Self-Reflection (Mobile)
+
+> A personal progress + coaching surface: time/engagement, progress per course, streaks
+> and goals, and guided self-reflection prompts. Source: 9.1 per-student progress,
+> 9.9 learner self-reflection/coaching, `study-insights-page`, `student-progress-page`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M8 — Adaptive & Study Tools |
+| **Severity** | MINOR–MAJOR — boosts metacognition + retention; strong mobile fit |
+| **Status (today)** | MISSING |
+| **Estimated effort** | S |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — progress + reflection/coaching endpoints exist |
+| **Depends on** | [M8.1](M8.1-review-spaced-repetition.md) (streaks), [M2.1](M2.1-calendar-todos.md) (goals) |
+
+---
+
+## 1. Problem Statement
+
+Students rarely step back to see how they're doing or reflect on their learning. Web
+has progress + reflection tools; mobile has none. A personal insights surface with
+streaks, goals, and reflection prompts builds habits and self-awareness right where
+students spend time.
+
+## 2. Goals
+
+- A personal **progress** view: per-course completion, time/engagement, recent activity.
+- **Goals & streaks** (daily study goal, review streak) with gentle nudges (M0.1).
+- Guided **self-reflection** prompts and a light journal.
+
+## 3. Non-Goals
+
+- Instructor analytics (web). Cohort/comparative analytics.
+
+## 4. User Stories
+
+- **As a student**, I see I'm 60% through Biology and on a 5-day streak.
+- **As a student**, a weekly prompt asks me to reflect on what was hard.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: per-student progress, engagement, reflection/coaching
+  endpoints. **Mobile**: M8.1 streaks, M2.1 goals, dashboard, theme.
+
+## 6. Functional Requirements
+
+- **FR-1.** An **Insights** surface MUST show per-course progress and overall
+  activity/engagement in a phone-legible form.
+- **FR-2.** **Daily goal** + **streak** state MUST display, configurable, with optional
+  reminders (M0.1).
+- **FR-3.** Periodic **self-reflection** prompts MUST be presented with a place to
+  respond; entries persist server-side and are reviewable.
+- **FR-4.** Insights MUST link into the relevant course/review to act on them.
+
+## 7. Non-Functional
+
+- **Privacy**: personal data; respect minor policy. **Offline**: render from cache;
+  reflections queue. **Accessibility**: charts have text equivalents.
+
+## 8. Design / Approach
+
+`Features/Insights/` (iOS) / `features/insights/` (Android): `InsightsView` (progress +
+streak + goals), `ReflectionView` (prompt + journal). Calls in `LMSAPIFeatures.swift`/`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Insights/InsightsView.swift`, `ReflectionView.swift` *(new)*, `Features/Profile/ProfileView.swift` or Dashboard (entry), `Core/LMS/LMSAPIFeatures.swift`, `project.pbxproj`.
+
+**Android** — `features/insights/*` *(new)*, profile/dashboard entry, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. Insights shows per-course progress + engagement matching web.
+2. Goal/streak state displays and configures; reminders fire.
+3. A reflection prompt accepts and persists a response (reviewable). 
+4. Insights link into the relevant course/review. Both apps build.
+
+## 11. Phasing
+
+1. Progress + engagement view.
+2. Goals + streaks + reminders.
+3. Reflection prompts + journal.
+4. Android parity; offline; verification.
+</content>

--- a/docs/plan/mobile/M8.4-reading-log.md
+++ b/docs/plan/mobile/M8.4-reading-log.md
@@ -1,0 +1,91 @@
+# M8.4 — Reading Log & Book Club (Mobile)
+
+> Log reading, track progress toward reading goals, browse leveled readers, and join
+> book-club discussions — a strong phone-native habit for K-12. Source: 13.8 library /
+> book club / leveled reader, `reading-log-page`, `reading-dashboard-page`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M8 — Adaptive & Study Tools |
+| **Severity** | MINOR–MAJOR (K12) — daily reading logs are a core elementary routine; ideal on a phone |
+| **Status (today)** | MISSING |
+| **Estimated effort** | S |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — reading log + dashboard + leveled-reader/library endpoints exist |
+| **Depends on** | [M8.3](M8.3-study-insights.md) (goals/streaks), [M7.1](M7.1-discussions.md) (book-club discussion reuse) |
+
+---
+
+## 1. Problem Statement
+
+Reading logs are a daily K-12 routine and a natural phone task ("log tonight's 20
+minutes"). Web has reading log/dashboard and leveled readers; mobile has none, so the
+routine can't move to the device families actually use.
+
+## 2. Goals
+
+- **Log a reading** session (book, minutes/pages, note) toward a goal.
+- A **reading dashboard**: progress, streak, history.
+- Browse **leveled readers** / library and join **book-club** discussions (reuse M7.1).
+
+## 3. Non-Goals
+
+- Managing the library catalog (admin/web). Full e-reader DRM beyond M3.2 preview.
+
+## 4. User Stories
+
+- **As a young student**, I log "read 15 minutes of *Frog and Toad*."
+- **As a student**, I see my reading streak and pick my next leveled book.
+- **As a student**, I discuss this week's book with my class.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: reading log create/list, reading dashboard, leveled-reader/
+  library endpoints. **Mobile**: M8.3 goals/streaks, M7.1 discussion, M3.2 preview.
+
+## 6. Functional Requirements
+
+- **FR-1.** The student MUST be able to **log a reading session** (title/book, time
+  and/or pages, optional note/rating) toward any active reading goal.
+- **FR-2.** A **reading dashboard** MUST show progress to goal, streak, and recent log
+  entries; entries are editable/deletable per policy.
+- **FR-3.** A **leveled-reader/library** browse MUST list books at the student's level;
+  opening a digital reader uses M3.2 preview.
+- **FR-4.** **Book-club** discussions MUST reuse M7.1 in book-club context.
+- **FR-5.** Goals/streaks integrate with M8.3 and reminders (M0.1).
+
+## 7. Non-Functional
+
+- **Age-appropriate** UI (large targets, simple language) — ties to M10.4. **Offline**:
+  log entries queue (M0.2). **Accessibility**: simple, labelled inputs.
+
+## 8. Design / Approach
+
+`Features/Reading/` (iOS) / `features/reading/` (Android): `ReadingDashboardView`,
+`LogReadingSheet`, `LeveledLibraryView` (reuse M3.2 reader, M7.1 discussion). Calls in
+`LMSAPIFeatures.swift`/`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Reading/ReadingDashboardView.swift`, `LogReadingSheet.swift`, `LeveledLibraryView.swift` *(new)*, `Core/LMS/LMSAPIFeatures.swift`, entry from dashboard/course, `project.pbxproj`.
+
+**Android** — `features/reading/*` *(new)*, `core/lms/LmsApi.kt`, dashboard/course entry.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. Logging a reading session persists and counts toward the goal.
+2. The dashboard shows progress, streak, and editable history.
+3. Leveled readers list at the student's level and open via M3.2.
+4. Book-club discussion works via M7.1. Both apps build.
+
+## 11. Phasing
+
+1. Log reading + dashboard.
+2. Leveled library browse + reader.
+3. Book-club discussion reuse; reminders.
+4. Android parity; offline; verification.
+</content>

--- a/docs/plan/mobile/M9.1-catalog-enroll.md
+++ b/docs/plan/mobile/M9.1-catalog-enroll.md
@@ -1,0 +1,93 @@
+# M9.1 — Catalog Browse & Enroll (Mobile)
+
+> Discover and enroll in courses/paths: browse the public catalog, search, view a
+> course/path landing page, and self-enroll (free immediately; paid → M9.2). Source:
+> 15.1 public catalog, 15.2 self-paced enrollment, 14.2 catalog/registration,
+> `explore-catalog-page`/`explore-course-page`/`paths-catalog-page`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M9 — Self-Learner & Commerce |
+| **Severity** | MAJOR (SL) — the front door for self-learners; no mobile discovery = no mobile growth |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — catalog/course/path landing + enroll endpoints exist |
+| **Depends on** | [M9.2](M9.2-checkout-billing.md) (paid enroll), [M8.2](M8.2-paths-recommendations.md) (path runner), App Store policy (see Non-Goals) |
+
+---
+
+## 1. Problem Statement
+
+Self-learners discover courses by browsing/searching a catalog and reading a landing
+page before enrolling. Mobile offers none of this, so a phone-first prospective
+learner can't find or start a course at all.
+
+## 2. Goals
+
+- Browse/search the **catalog** (courses + paths) with categories/filters.
+- A **landing page**: description, outcomes, syllabus preview, reviews, price.
+- **Self-enroll** free courses immediately; paid → M9.2 checkout.
+
+## 3. Non-Goals
+
+- Authoring catalog listings (creator/web). 
+- **App Store policy**: digital-course purchases may require platform IAP. v1 supports
+  free enroll natively; paid purchase routing is handled in [M9.2](M9.2-checkout-billing.md)
+  per store rules (out of scope here beyond the handoff).
+
+## 4. User Stories
+
+- **As a self-learner**, I search "Spanish A1," read the landing page and reviews, and enroll free.
+- **As a self-learner**, I browse paths by topic.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: catalog list/search, course/path landing, reviews, enroll.
+  **Mobile**: courses list, `CourseHeroImage`, theme, M8.2 path runner, M9.3 reviews.
+
+## 6. Functional Requirements
+
+- **FR-1.** A **Catalog** surface MUST browse and **search** courses + paths with
+  category/level/price filters and hero imagery.
+- **FR-2.** A **landing page** MUST show description, outcomes, syllabus preview,
+  instructor, **reviews/ratings** (M9.3), and price/free badge.
+- **FR-3.** **Free** courses/paths MUST self-enroll immediately and appear in the
+  student's courses/paths; **paid** MUST route to checkout (M9.2).
+- **FR-4.** Already-enrolled items MUST show "continue" instead of enroll.
+
+## 7. Non-Functional
+
+- **Performance**: catalog paginates/virtualizes; images lazy-load. **Offline**: cached
+  browse; enroll needs connection. **Accessibility**: cards + filters labelled.
+
+## 8. Design / Approach
+
+`Features/Catalog/` (iOS) / `features/catalog/` (Android): `CatalogView` (search +
+filters + grid), `CourseLandingView`/`PathLandingView`. Calls in `LMSAPIFeatures.swift`/
+`LmsApi.kt`. Could surface as a tab or from Courses.
+
+## 9. Files to touch
+
+**iOS** — `Features/Catalog/CatalogView.swift`, `CourseLandingView.swift`, `PathLandingView.swift` *(new)*, `Core/LMS/LMSAPIFeatures.swift`, nav entry, `project.pbxproj`.
+
+**Android** — `features/catalog/*` *(new)*, `core/lms/LmsApi.kt`, nav entry.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. Catalog browse + search + filters return correct results with imagery.
+2. A landing page shows outcomes, syllabus preview, reviews, and price.
+3. Enrolling in a free course adds it to the student's courses; paid routes to M9.2.
+4. Enrolled items show "continue." Both apps build.
+
+## 11. Phasing
+
+1. Catalog browse/search/filter.
+2. Course + path landing pages (with reviews from M9.3).
+3. Free enroll + paid handoff (M9.2).
+4. Android parity; offline browse; verification.
+</content>

--- a/docs/plan/mobile/M9.2-checkout-billing.md
+++ b/docs/plan/mobile/M9.2-checkout-billing.md
@@ -1,0 +1,100 @@
+# M9.2 — Checkout & Billing (Mobile)
+
+> Purchase paid courses/paths/bundles and manage billing on mobile, compliant with App
+> Store / Play billing policy. Source: 15.3 Stripe billing, checkout success/cancel,
+> 16.8 payment provider abstraction, `billing-settings`, 15.13 tax.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M9 — Self-Learner & Commerce |
+| **Severity** | MAJOR (SL) — monetization on mobile, but gated by platform store rules |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | Possibly minimal — Stripe checkout + webhooks exist; IAP receipt validation may need a server hook if IAP is required |
+| **Depends on** | [M9.1](M9.1-catalog-enroll.md) (enroll entry) |
+
+---
+
+## 1. Problem Statement
+
+Paid courses can't be purchased on mobile, and naive web-Stripe checkout inside an app
+violates App Store rules for digital goods. We need a compliant purchase path plus
+billing management (receipts, subscriptions, payment methods) viewable on device.
+
+## 2. Goals
+
+- A **compliant purchase** flow for paid courses/paths/bundles.
+- **Billing management**: purchase history/receipts, active subscriptions, manage/cancel.
+- Correct **tax** display (15.13) and clear pricing.
+
+## 3. Non-Goals
+
+- Re-implementing the payment backend. Affiliate/creator payouts (web).
+
+## 4. Open decision (must resolve before build)
+
+Digital-goods purchases on iOS/Android generally **require platform IAP** (StoreKit /
+Play Billing) with revenue share, unless they qualify for an exemption (e.g.,
+education/"reader" provisions, or purchases made outside the app). Options:
+1. **Platform IAP** (StoreKit 2 / Play Billing) + server receipt validation → entitlement.
+2. **Buy-on-web** only (no in-app purchase UI; link out) where policy permits.
+3. **Hybrid** by platform/region.
+Resolve with current store policy before implementation; this story documents the path,
+default-leaning to (1) for in-app purchases and (2) as fallback.
+
+## 5. What already exists (reuse)
+
+- **Server**: Stripe checkout sessions + webhooks (15.3), billing settings, tax (15.13),
+  payment abstraction (16.8). **Mobile**: M9.1 landing/price, auth, deep-link router
+  (checkout return).
+
+## 6. Functional Requirements
+
+- **FR-1.** A paid item MUST present a compliant **purchase** action (IAP via StoreKit/
+  Play Billing, or web-checkout handoff per the resolved policy), granting entitlement
+  on success.
+- **FR-2.** On success, the item MUST appear enrolled (entitlement reflected) and the
+  app routes into it; cancel returns cleanly (reuse `checkout/success`/`cancel` flows
+  via deep links if web-checkout).
+- **FR-3.** A **billing** screen MUST show purchase history/receipts, active
+  subscriptions, and manage/cancel (linking to the platform subscription manager for IAP).
+- **FR-4.** **Tax/total** MUST display correctly before purchase.
+- **FR-5.** Server entitlement is the source of truth (receipt validated server-side).
+
+## 7. Non-Functional
+
+- **Compliance**: follow App Store/Play billing rules exactly; **security**: never
+  trust client-only purchase state — server validates receipts. **Privacy**: payment
+  data handled by the platform/Stripe, not stored by us.
+
+## 8. Design / Approach
+
+`Features/Billing/` (iOS StoreKit 2 or `SafariView`/web handoff) / Android Play Billing
+or Custom Tabs handoff; `BillingView` for history/subscriptions. Receipt → server
+validation endpoint (add if IAP). Calls in `LMSAPIFeatures.swift`/`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Billing/PurchaseFlow.swift`, `BillingView.swift` *(new)*, deep-link return handling (M0.1), `Core/LMS/LMSAPIFeatures.swift`, `project.pbxproj`.
+
+**Android** — `features/billing/*` *(new)*, Play Billing client, `core/lms/LmsApi.kt`, deep-link return.
+
+**Backend** — add IAP receipt-validation → entitlement endpoint **only if** IAP path chosen.
+
+## 10. Acceptance Criteria
+
+1. A paid course can be purchased via the resolved compliant path and grants entitlement.
+2. Success enrolls + routes in; cancel returns cleanly; server validates the receipt.
+3. Billing screen lists receipts and active subscriptions with manage/cancel.
+4. Tax/total displays correctly. Both apps build and pass store review for billing.
+
+## 11. Phasing
+
+1. Resolve the IAP vs. web-checkout policy decision (§4).
+2. Implement chosen purchase path + entitlement + return handling.
+3. Billing/subscription management screen.
+4. Tax/receipt display; store-review compliance; verification.
+</content>

--- a/docs/plan/mobile/M9.3-certificates-gamification.md
+++ b/docs/plan/mobile/M9.3-certificates-gamification.md
@@ -1,0 +1,93 @@
+# M9.3 — Certificates, Badges, Gamification & Reviews (Mobile)
+
+> The motivation + completion layer: earn/view certificates and open badges, see
+> points/streaks/leaderboards, and leave course reviews. Source: 15.5 certificates/
+> open badges, 15.6 LinkedIn share, 15.9 gamification, 15.7 reviews/ratings,
+> `MyCredentials`/`LeaderboardWidget`/`course-reviews`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Epic** | M9 — Self-Learner & Commerce |
+| **Severity** | MINOR–MAJOR (SL) — completion proof + motivation drive retention and word-of-mouth |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | No changes — certificates, badges, gamification, reviews endpoints exist |
+| **Depends on** | [M9.1](M9.1-catalog-enroll.md) (reviews on landing), [M8.3](M8.3-study-insights.md) (streaks) |
+
+---
+
+## 1. Problem Statement
+
+Finishing a course should feel rewarding and produce shareable proof. Mobile shows no
+certificates/badges, no points/leaderboard, and no way to review a course — removing
+the motivation loop and social proof exactly where self-learners engage daily.
+
+## 2. Goals
+
+- View/earn **certificates** and **open badges**; share (incl. LinkedIn / system share).
+- **Gamification**: points, streaks, levels, **leaderboard** (privacy-respecting).
+- Write/read **course reviews & ratings** (feeds M9.1 landing).
+
+## 3. Non-Goals
+
+- Configuring gamification rules or issuing criteria (admin/web). Affiliate (web).
+
+## 4. User Stories
+
+- **As a self-learner**, I finish a course, get a certificate, and share the badge to LinkedIn.
+- **As a learner**, I see my points and where I rank.
+- **As a learner**, I rate a course I finished.
+
+## 5. What already exists (reuse)
+
+- **Server (no changes)**: certificates/badges (issue/list/verify), gamification
+  (points/leaderboard), reviews CRUD. **Mobile**: profile, M9.1 landing, share sheets, theme.
+
+## 6. Functional Requirements
+
+- **FR-1.** A **Credentials** surface MUST list earned certificates + open badges with
+  detail, verify link, and **share** (system share + LinkedIn add-to-profile / Open
+  Badges export).
+- **FR-2.** A **gamification** view MUST show points, level, streak, and a **leaderboard**
+  honoring privacy settings (opt-out respected; minors handled per policy).
+- **FR-3.** The student MUST be able to **submit/edit a review + rating** for a completed
+  course; reviews display on the M9.1 landing.
+- **FR-4.** Newly earned certificates/badges MAY notify via M0.1.
+
+## 7. Non-Functional
+
+- **Privacy**: leaderboard respects opt-out and minor policy; never expose PII. **Offline**:
+  credentials cached. **Accessibility**: badges have alt text; leaderboard labelled.
+
+## 8. Design / Approach
+
+`Features/Credentials/` + `Features/Gamification/` (iOS) / `features/credentials` +
+`features/gamification` (Android): `CredentialsView`, `BadgeDetailView`,
+`GamificationView`/`LeaderboardView`, `ReviewComposer`. Reuse share sheets. Calls in
+`LMSAPIFeatures.swift`/`LmsApi.kt`.
+
+## 9. Files to touch
+
+**iOS** — `Features/Credentials/CredentialsView.swift`, `BadgeDetailView.swift`, `Features/Gamification/GamificationView.swift`, `Features/Catalog/ReviewComposer.swift` *(new)*, profile/landing entries, `Core/LMS/LMSAPIFeatures.swift`, `project.pbxproj`.
+
+**Android** — `features/credentials/*`, `features/gamification/*`, `features/catalog/ReviewComposer.kt` *(new)*, `core/lms/LmsApi.kt`.
+
+**Backend** — none.
+
+## 10. Acceptance Criteria
+
+1. Earned certificates/badges list with detail, verify, and working share (incl. LinkedIn/Open Badges).
+2. Gamification shows points/level/streak and a privacy-respecting leaderboard.
+3. A completed-course review submits/edits and appears on the M9.1 landing.
+4. New credential notifies via M0.1. Both apps build.
+
+## 11. Phasing
+
+1. Credentials list + detail + share.
+2. Gamification + leaderboard (privacy).
+3. Review composer → landing.
+4. Android parity; offline; verification.
+</content>

--- a/docs/plan/mobile/README.md
+++ b/docs/plan/mobile/README.md
@@ -1,0 +1,206 @@
+# Lextures Mobile — Web-Parity Plan
+
+> Goal: make the **native iOS (SwiftUI) and Android (Jetpack Compose) apps as useful
+> as the web application** for users who do not have a computer. The student journey
+> must be fully completable on a phone; instructors, parents, and self-learners get
+> the high-value subset of their workflows. The UI/UX must be clean, intuitive, and
+> obvious to any student with no training.
+
+This folder holds one implementation story per mobile feature, following the
+mobile-tuned story format established by [`../speed-grader-mobile.md`](../speed-grader-mobile.md)
+(leaner and more actionable than the full web [`../_TEMPLATE.md`](../_TEMPLATE.md):
+it adds **What already exists (reuse)**, **Files to touch**, and **Phasing**, which
+matter for native work). The umbrella program docs live in
+[`../21-mobile-offline-cross-platform/`](../21-mobile-offline-cross-platform/).
+
+---
+
+## 1. Why this matters
+
+Not every Lextures user owns a laptop. K-12 students are phone-first, self-learners
+study on commutes, and many households share a single device. If a feature exists
+only on the web, those users effectively cannot use it. For launch, the bar is:
+**a student can do their entire academic life — read content, take quizzes, submit
+work, see grades and feedback, communicate, and study — without ever opening a
+browser.** This plan sequences the work to hit that bar, then widens to parents,
+self-learners, and on-the-go instructors.
+
+## 2. Platform strategy (decided)
+
+- **Native, not hybrid.** The apps are already native: iOS in SwiftUI
+  (`clients/ios/Lextures`), Android in Jetpack Compose
+  (`clients/android/app/src/main/kotlin/com/lextures/android`). We continue native —
+  the 21.1 plan's "hybrid/Capacitor" open question is **closed in favor of native**,
+  because the foundation (auth, networking, design system, navigation shell,
+  notebooks, grading) already ships natively and performs well.
+- **Thin client over the existing REST API.** No bespoke mobile backend. Each story
+  reuses existing endpoints under `server/internal/httpserver/`; new server work is
+  called out explicitly per story and kept minimal (push tokens, a couple of
+  read aggregations). Every mobile request sends `X-Platform: ios|android` and
+  `X-App-Version`.
+- **Shared building blocks per platform.** New screens reuse the existing
+  `Core/Networking` API client, `Core/Design` theme (`LexturesTheme`/`LexturesType`),
+  `Core/Auth` session + secure token store, and the `LMSAPI*` layer. Stories add
+  endpoints/models to those layers rather than spinning up parallel stacks.
+- **Parity of capability, not pixels.** Mobile re-imagines each flow for a phone
+  (one-question-at-a-time quizzes, card lists instead of grids, bottom sheets
+  instead of modals). It is not a literal port of the web DOM.
+
+## 3. Current state (what already ships natively)
+
+Verified in the iOS/Android trees as of this plan:
+
+| Area | iOS | Android | Notes |
+|---|---|---|---|
+| Auth (email/password, signup, secure token store, session) | ✅ | ✅ | Keychain / encrypted store; no SSO/MFA/magic-link/biometric yet |
+| Navigation shell (Home, Courses, Notebooks, Inbox, Profile tabs) | ✅ | ✅ | 5-tab bar; no deep-link routing yet |
+| Dashboard / Home + announcements | ✅ | ✅ | Read-only |
+| Courses: list, detail, syllabus, **grades (read)**, attendance (read), item detail | ✅ | ✅ | View-only; no module content-type rendering |
+| Grading: backlog, submissions list, **Speed Grader** | ✅ | ✅ | Instructor; see `../speed-grader-mobile.md` |
+| Inbox: list, thread, compose | ✅ | ✅ | 1:1 messaging |
+| Notebooks: editor, drawing, pages, slash commands, markdown, sync | ✅ | ✅ | Rich; near-parity with web notebooks |
+| Profile + notifications list | ✅ | ✅ | Read; no settings depth |
+
+**API already wired (mobile side):** courses, course structure, item detail, my
+grades, my submission, grading backlog/submissions, submission grade put, mailbox
+messages, send message, unread count, notifications, broadcasts, attendance
+sessions, quiz **attempts (read)**, syllabus, notebooks, me.
+
+**The big student-facing gaps** (drive P0): taking a quiz, **submitting** an
+assignment, rendering module content types (pages/files/links/LTI/H5P/SCORM),
+discussions, calendar/to-dos, viewing rich feedback (annotations, audio/video,
+rubrics), what-if grades, the AI tutor, adaptive review/paths, native push +
+deep links, and offline.
+
+## 4. Epics & numbering
+
+Stories are named `M{epic}.{n}-{slug}.md`. Each story targets **both** iOS and
+Android unless noted. Epics:
+
+| Epic | Theme |
+|---|---|
+| **M0** | Foundation & Platform — offline cache/sync, native push (APNs/FCM), deep links, biometric lock, accessibility, i18n/RTL, app-version/observability |
+| **M1** | Auth & Onboarding — SSO, MFA, magic link, biometric unlock, onboarding/diagnostic |
+| **M2** | Home, Dashboard & Notifications — dashboard widgets, to-dos, notification center, global feed |
+| **M3** | Courses, Modules & Content — module list, content pages, files, external/LTI/H5P/SCORM/textbook items, conditional release |
+| **M4** | Quizzes & Assessment — quiz taker, all question types, math/code input, timers/auto-submit, multiple attempts, lockdown |
+| **M5** | Assignments & Submissions — file/text/media upload, resumable uploads, resubmission, peer review, originality |
+| **M6** | Grades & Feedback — grades detail, what-if, rubric/annotation/audio-video feedback, standards-based view |
+| **M7** | Communication — discussions, announcements, office hours, group spaces, collab docs, AI tutor, in-context help |
+| **M8** | Adaptive & Study Tools — review (spaced repetition), paths, recommendations, hints, mastery, study insights, reading log |
+| **M9** | Self-Learner & Commerce — catalog, enroll, checkout/billing, certificates/badges, gamification, reviews |
+| **M10** | K-12 & Parent — parent portal, attendance-taking, behavior/PBIS, report cards, conference booking, hall pass, age-appropriate UI |
+| **M11** | Instructor on Mobile — grading depth, take attendance, post announcement, quick authoring caps |
+| **M12** | Portfolios & Credentials — e-portfolio, co-curricular transcript, CCR, certificates wallet |
+
+## 5. Full backlog (every web feature → mobile disposition)
+
+Disposition: **P0** = launch-blocking student core · **P1** = high-value breadth ·
+**P2** = nice-to-have / later · **Web-only** = stays on web (authoring/admin-heavy or
+desktop-bound), reachable via an in-app web view when a student truly needs it.
+"Built" = already shipping natively (extend only).
+
+### Student-critical (P0)
+
+| Story | Source feature(s) | Status today | Disposition |
+|---|---|---|---|
+| [M4.1 Quiz taker & question types](M4.1-quiz-taker.md) | 2.2 question types, 2.3 math, 2.7 timers/auto-submit, 2.8 shuffling, 2.9 attempts, quiz attempt page | Attempts read-only | **P0** |
+| [M5.1 Assignment submission](M5.1-assignment-submission.md) | 3.13 resubmission, 8.2 resumable upload, module assignment page | None (grade-only) | **P0** |
+| [M3.1 Module content viewer](M3.1-module-content-viewer.md) | module content/external-link/textbook pages, 8.7 image/pdf preview, 1.11 conditional release | None | **P0** |
+| [M3.2 Course files browser](M3.2-course-files.md) | course-files-page, 8.1 storage, 8.7 preview | None | **P0** |
+| [M2.1 Calendar & to-dos](M2.1-calendar-todos.md) | calendar, todos-page, 16.5 feeds | None | **P0** |
+| [M6.1 Grades, feedback & what-if](M6.1-grades-feedback.md) | my-grades (built-read), 3.1 annotation, 3.2 a/v feedback, 3.16 what-if, rubrics | Grades read-only | **P0** |
+| [M7.1 Course discussions](M7.1-discussions.md) | 6.1 threaded forums, course-discussions-page | None | **P0** |
+| [M7.2 AI tutor & Ask-AI](M7.2-ai-tutor.md) | 6.9 AI tutor, ask-ai-page, 15.12 study buddy | None | **P0** |
+| [M8.1 Review & spaced repetition](M8.1-review-spaced-repetition.md) | 1.5 spaced repetition, review-session-page | None | **P0** |
+| [M0.1 Native push & deep links](M0.1-push-deep-links.md) | 6.3 push, 21.5 APNs/FCM | None | **P0** |
+| [M0.2 Offline mode & sync](M0.2-offline-sync.md) | 7.3 offline PWA (web), 21.x offline | None | **P0** |
+
+### High-value breadth (P1)
+
+| Story | Source feature(s) | Disposition |
+|---|---|---|
+| [M1.1 SSO, MFA & magic link](M1.1-sso-mfa-magic-link.md) | 4.1/4.2 SSO, 4.6 MFA, 4.7 magic link | **P1** |
+| [M1.2 Biometric unlock & sessions](M1.2-biometric-sessions.md) | 4.8/4.9 sessions, biometric | **P1** |
+| [M1.3 Onboarding & placement diagnostic](M1.3-onboarding-diagnostic.md) | onboarding, 1.7/15.11 diagnostic | **P1** |
+| [M2.2 Notification center & preferences](M2.2-notification-center.md) | 6.2 notifications, notification prefs | **P1** |
+| [M3.3 Interactive content: H5P/SCORM/LTI](M3.3-interactive-content.md) | 8.12 H5P, 2.14 SCORM/xAPI, 2.12 LTI 1.3 | **P1** |
+| [M5.2 Peer review](M5.2-peer-review.md) | 3.15 peer review | **P1** |
+| [M6.2 Standards-based grades & mastery](M6.2-standards-mastery.md) | 3.7 SBG, 9.3 mastery heatmap, 13.4 report cards (student) | **P1** |
+| [M7.3 Office hours booking](M7.3-office-hours.md) | 6.7 office hours | **P1** |
+| [M7.4 Group spaces & collab docs](M7.4-groups-collab.md) | 6.6 groups, 6.5 collab docs | **P1** |
+| [M8.2 Adaptive paths & recommendations](M8.2-paths-recommendations.md) | 1.4 paths, 1.8 recommendations, my-paths | **P1** |
+| [M8.3 Study insights & self-reflection](M8.3-study-insights.md) | 9.1 progress, 9.9 reflection, study-insights | **P1** |
+| [M8.4 Reading log & book club](M8.4-reading-log.md) | 13.8 leveled reader, reading-log/dashboard | **P1** |
+| [M9.1 Catalog browse & enroll](M9.1-catalog-enroll.md) | 15.1 catalog, 15.2 self-paced enroll, 14.2 registration | **P1** |
+| [M9.2 Checkout & billing](M9.2-checkout-billing.md) | 15.3 Stripe billing, checkout, 16.8 payment abstraction | **P1** |
+| [M9.3 Certificates, badges & gamification](M9.3-certificates-gamification.md) | 15.5 certs/badges, 15.9 gamification, leaderboard | **P1** |
+| [M10.1 Parent portal](M10.1-parent-portal.md) | 13.1 parent portal, parent-dashboard | **P1** |
+| [M10.2 Conference booking (parent)](M10.2-conference-booking.md) | 13.12 conference scheduling | **P1** |
+| [M11.1 Take attendance (instructor)](M11.1-take-attendance.md) | 13.2 daily attendance | **P1** |
+| [M0.3 Accessibility: VoiceOver/TalkBack & dynamic type](M0.3-accessibility.md) | 12.1/12.2/12.8 a11y | **P1** |
+| [M0.4 i18n, locale & RTL](M0.4-i18n-rtl.md) | 11.1 i18n, 11.2 RTL, 11.3/11.4 locale/tz | **P1** |
+| [M1.4 Profile, settings & accommodations](M1.4-settings-accommodations.md) | settings, my-accommodations, 12.10 engine | **P1** |
+
+### Later / situational (P2)
+
+| Story | Source feature(s) | Disposition |
+|---|---|---|
+| [M3.4 Conditional release & prerequisites UX](M3.4-conditional-release.md) | 1.11 conditional release polish | **P2** |
+| [M4.2 Lockdown / kiosk mode](M4.2-lockdown-kiosk.md) | 2.10 lockdown | **P2** |
+| [M5.3 Code-execution questions](M5.3-code-execution.md) | 2.4 code exec | **P2** |
+| [M10.3 Behavior/PBIS & hall pass](M10.3-behavior-hallpass.md) | 13.3 behavior, 13.9 hall pass | **P2** |
+| [M10.4 Age-appropriate UI mode](M10.4-age-appropriate-ui.md) | 13.11 age-appropriate UI | **P2** |
+| [M11.2 Post announcement / broadcast](M11.2-instructor-announce.md) | 13.10 broadcast, announcements compose | **P2** |
+| [M12.1 e-Portfolio & artifacts](M12.1-eportfolio.md) | 14.12 e-portfolio, portfolios pages | **P2** |
+| [M12.2 Credentials wallet & transcripts](M12.2-credentials-transcripts.md) | 14.13 CCR, transcripts, 15.6 LinkedIn share | **P2** |
+
+### Stays web-only (reachable via in-app web view)
+
+Authoring and admin surfaces that are desktop-bound and out of scope for native:
+question-bank/blueprint/outcomes authoring (2.1, 5.6, 9.5 authoring), gradebook
+grid editing & curving/CSV (3.11, 3.17 instructor), org/admin consoles (5.x admin,
+10.x compliance, 17.x ops, 18 admin experience), SIS/SCIM/OneRoster config (4.3–4.5,
+13.7, 14.1), integrations/webhooks/marketplace (16.x), CLI (21-cli), course
+authoring/import (QTI/Common Cartridge 2.13, Canvas import), proctoring config
+(14.9), evaluation/template authoring (14.7). Mobile links out to these with a
+"best on a larger screen" affordance rather than reimplementing them.
+
+## 6. Sequencing / roadmap
+
+1. **Wave 1 — Student core (P0).** M0.1 push + M0.2 offline scaffolding land first
+   (cross-cutting), then M4.1 quiz taker, M5.1 submission, M3.1/M3.2 content+files,
+   M2.1 calendar, M6.1 grades+feedback, M7.1 discussions, M7.2 AI tutor, M8.1 review.
+   Exit criteria: a student completes a full week of coursework with no browser.
+2. **Wave 2 — Breadth (P1).** Auth depth (M1.x), interactive content (M3.3),
+   standards/mastery (M6.2), groups/office-hours (M7.3/M7.4), adaptive (M8.2–M8.4),
+   self-learner commerce (M9.x), parent (M10.1/M10.2), accessibility & i18n
+   (M0.3/M0.4), settings (M1.4), instructor attendance (M11.1).
+3. **Wave 3 — Situational (P2).** Lockdown, code exec, behavior/hall-pass,
+   age-appropriate UI, e-portfolio/credentials, instructor broadcast.
+
+Each wave ships behind staged store releases (TestFlight / Play internal track →
+pilot cohort → GA). Per-feature server flags gate anything risky.
+
+## 7. Cross-cutting requirements (every story inherits)
+
+- **Accessibility:** VoiceOver/TalkBack labels, Dynamic Type / font scaling, ≥44×44pt
+  targets, reduced-motion respect. Reuse `LexturesTheme`/`LexturesType`.
+- **Offline-aware:** read paths show last-cached data with a staleness indicator;
+  write paths queue and sync (see [M0.2](M0.2-offline-sync.md)).
+- **Secure:** auth via the existing secure token store; no PII in logs; certificate
+  pinning configurable.
+- **Empty / loading / error / offline** states are mandatory for every screen.
+- **Dark mode** follows system; both platforms already theme-aware.
+- **No new backend unless the story says so**, and then it's minimal and listed.
+
+## 8. Conventions
+
+- File naming: `M{epic}.{n}-{kebab-slug}.md`.
+- A story is "ready" when every section is filled (no `…` placeholders), names the
+  exact iOS/Android files to touch, and lists acceptance criteria testable on device.
+- Cross-link stories with relative markdown links.
+- Reference existing native code by path (e.g.
+  `clients/ios/Lextures/Features/Courses/CourseDetailView.swift`).
+</content>
+</invoke>

--- a/server/internal/httpserver/cache_layer.go
+++ b/server/internal/httpserver/cache_layer.go
@@ -1,10 +1,13 @@
 package httpserver
 
 import (
+	"bufio"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -92,6 +95,23 @@ func (w *cacheHeaderWriter) Write(b []byte) (int, error) {
 		w.WriteHeader(http.StatusOK)
 	}
 	return w.ResponseWriter.Write(b)
+}
+
+func (w *cacheHeaderWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (w *cacheHeaderWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, errors.New("http.Hijacker not supported")
+}
+
+func (w *cacheHeaderWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
 }
 
 func requestIsAuthenticated(r *http.Request) bool {

--- a/server/internal/httpserver/course_file_content.go
+++ b/server/internal/httpserver/course_file_content.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/lextures/lextures/server/internal/apierr"
 	"github.com/lextures/lextures/server/internal/repos/coursefiles"
 	"github.com/lextures/lextures/server/internal/service/filestorage"
+	"github.com/lextures/lextures/server/internal/service/imageproxy"
 )
 
 // handleGetCourseFileContent is GET /api/v1/courses/{course_code}/course-files/{file_id}/content
@@ -48,10 +50,11 @@ func (d Deps) handleGetCourseFileContent() http.HandlerFunc {
 			return
 		}
 
+		resizeOpts := parseCourseFileImageResizeOpts(r)
 		cfg := d.effectiveConfig()
 
-		// S3-backed: generate presigned URL and redirect
-		if d.Storage != nil {
+		// S3-backed: generate presigned URL and redirect (skip when serving a resized thumbnail)
+		if d.Storage != nil && resizeOpts.MaxWidth <= 0 && resizeOpts.MaxHeight <= 0 {
 			ttl := time.Duration(cfg.StoragePresignTTL) * time.Second
 			if ttl <= 0 {
 				ttl = time.Hour
@@ -78,9 +81,56 @@ func (d Deps) handleGetCourseFileContent() http.HandlerFunc {
 		if ct == "" {
 			ct = "application/octet-stream"
 		}
+		if resizeOpts.MaxWidth > 0 || resizeOpts.MaxHeight > 0 {
+			resized, resizedCT, err := imageproxy.ResizeIfNeeded(b, ct, resizeOpts)
+			if err != nil {
+				if errors.Is(err, imageproxy.ErrNotImage) {
+					apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Resize is only supported for images.")
+					return
+				}
+				apierr.WriteJSON(w, http.StatusUnprocessableEntity, apierr.CodeInternal, "Could not resize image.")
+				return
+			}
+			b = resized
+			ct = resizedCT
+		}
 		w.Header().Set("Content-Type", ct)
 		w.Header().Set("Cache-Control", "private, max-age=86400")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(b)
 	}
+}
+
+const courseFileImageResizeMaxDim = 2048
+
+func parseCourseFileImageResizeOpts(r *http.Request) imageproxy.ResizeOpts {
+	q := r.URL.Query()
+	maxW := clampCourseFileImageResizeDim(q.Get("w"))
+	maxH := clampCourseFileImageResizeDim(q.Get("h"))
+	quality := 85
+	if raw := strings.TrimSpace(q.Get("q")); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 && n <= 100 {
+			quality = n
+		}
+	}
+	return imageproxy.ResizeOpts{
+		MaxWidth:  maxW,
+		MaxHeight: maxH,
+		Quality:   quality,
+	}
+}
+
+func clampCourseFileImageResizeDim(raw string) int {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	if n > courseFileImageResizeMaxDim {
+		return courseFileImageResizeMaxDim
+	}
+	return n
 }

--- a/server/internal/httpserver/courses_catalog_settings.go
+++ b/server/internal/httpserver/courses_catalog_settings.go
@@ -38,7 +38,8 @@ type putCatalogPinBody struct {
 }
 
 type pinnedCoursesResponse struct {
-	Courses []course.PinnedCourseSummary `json:"courses"`
+	Courses []course.PinnedCourseSummary   `json:"courses"`
+	Rows    [][]course.PinnedCourseSummary `json:"rows"`
 }
 
 func (d Deps) handleGetCourseCatalogSettings() http.HandlerFunc {
@@ -248,16 +249,68 @@ func (d Deps) handleGetCourseCatalogPins() http.HandlerFunc {
 		if !ok {
 			return
 		}
-		courses, err := course.ListUserPinnedCourseSummaries(r.Context(), d.Pool, userID)
+		rows, err := course.ListUserPinnedCourseRows(r.Context(), d.Pool, userID)
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load pinned courses.")
 			return
 		}
-		if courses == nil {
-			courses = []course.PinnedCourseSummary{}
+		if rows == nil {
+			rows = [][]course.PinnedCourseSummary{}
+		}
+		courses := make([]course.PinnedCourseSummary, 0)
+		for _, row := range rows {
+			courses = append(courses, row...)
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		_ = json.NewEncoder(w).Encode(pinnedCoursesResponse{Courses: courses})
+		_ = json.NewEncoder(w).Encode(pinnedCoursesResponse{Courses: courses, Rows: rows})
+	}
+}
+
+func (d Deps) handlePutCourseCatalogPinLayout() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.Header().Set("Allow", http.MethodPut)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		userID, ok := d.meUserID(w, r)
+		if !ok {
+			return
+		}
+		var body struct {
+			Rows [][]string `json:"rows"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		if body.Rows == nil {
+			body.Rows = [][]string{}
+		}
+		rows := make([][]uuid.UUID, 0, len(body.Rows))
+		for _, row := range body.Rows {
+			parsedRow := make([]uuid.UUID, 0, len(row))
+			for _, rawID := range row {
+				id, err := uuid.Parse(strings.TrimSpace(rawID))
+				if err != nil {
+					apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid course id in pin layout.")
+					return
+				}
+				parsedRow = append(parsedRow, id)
+			}
+			rows = append(rows, parsedRow)
+		}
+		if err := course.ReplaceUserCatalogPinLayout(r.Context(), d.Pool, userID, rows); err != nil {
+			if strings.Contains(err.Error(), "pin row exceeds") ||
+				strings.Contains(err.Error(), "duplicate") ||
+				strings.Contains(err.Error(), "unpinned") {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to save pin layout.")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/server/internal/httpserver/courses_routes.go
+++ b/server/internal/httpserver/courses_routes.go
@@ -8,6 +8,7 @@ func (d Deps) registerCourseRoutes(r chi.Router) {
 	r.Put("/api/v1/courses/catalog-settings", d.handlePutCourseCatalogSettings())
 	r.Post("/api/v1/courses/catalog-settings/migrate-local", d.handleMigrateCourseCatalogLocalStorage())
 	r.Get("/api/v1/courses/catalog-pins", d.handleGetCourseCatalogPins())
+	r.Put("/api/v1/courses/catalog-pins/layout", d.handlePutCourseCatalogPinLayout())
 	r.Put("/api/v1/courses/catalog-pin", d.handlePutCourseCatalogPin())
 	r.Put("/api/v1/courses/catalog-nickname", d.handlePutCourseCatalogNickname())
 	r.Put("/api/v1/courses/catalog-order", d.handlePutCourseCatalogOrder())

--- a/server/internal/httpserver/websocket_middleware_test.go
+++ b/server/internal/httpserver/websocket_middleware_test.go
@@ -1,0 +1,55 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/coder/websocket"
+	"github.com/lextures/lextures/server/internal/auth"
+)
+
+func TestCommunicationWS_UpgradeThroughMiddlewareChain(t *testing.T) {
+	t.Parallel()
+	signer := auth.NewJWTSigner("test-jwt-secret-for-ws-middleware-test")
+	srv := httptest.NewServer(NewHandler(Deps{JWTSigner: signer, Comm: nil}))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/api/v1/communication/ws"
+	ctx := t.Context()
+	conn, resp, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		if resp != nil {
+			t.Fatalf("websocket dial failed: %v (HTTP %d)", err, resp.StatusCode)
+		}
+		t.Fatalf("websocket dial failed: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "") })
+
+	if resp != nil && resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusSwitchingProtocols)
+	}
+}
+
+func TestNotificationsWS_UpgradeThroughMiddlewareChain(t *testing.T) {
+	t.Parallel()
+	signer := auth.NewJWTSigner("test-jwt-secret-for-ws-middleware-test")
+	srv := httptest.NewServer(NewHandler(Deps{JWTSigner: signer, NotifHub: nil}))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/api/v1/ws/notifications"
+	ctx := t.Context()
+	conn, resp, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		if resp != nil {
+			t.Fatalf("websocket dial failed: %v (HTTP %d)", err, resp.StatusCode)
+		}
+		t.Fatalf("websocket dial failed: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "") })
+
+	if resp != nil && resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusSwitchingProtocols)
+	}
+}

--- a/server/internal/repos/course/catalog_user_prefs.go
+++ b/server/internal/repos/course/catalog_user_prefs.go
@@ -54,6 +54,7 @@ type PinnedCourseSummary struct {
 }
 
 const maxCatalogPins = 20
+const maxCatalogPinsPerRow = 4
 
 func defaultCatalogPrefs() UserCatalogPrefs {
 	labels := make(map[string]string, len(DefaultKanbanColumnLabels))
@@ -346,7 +347,7 @@ func ListUserCatalogPinIDs(ctx context.Context, pool *pgxpool.Pool, userID uuid.
 SELECT course_id
 FROM course.user_course_catalog_pins
 WHERE user_id = $1
-ORDER BY sort_order ASC, updated_at ASC
+ORDER BY row_index ASC, sort_order ASC, updated_at ASC
 `, userID)
 	if err != nil {
 		return nil, err
@@ -411,19 +412,142 @@ SELECT EXISTS (
 	if already {
 		return nil
 	}
-	var nextSort int
+	var rowIndex, sortOrder int
 	if err := pool.QueryRow(ctx, `
-SELECT COALESCE(MAX(sort_order), -1) + 1
+SELECT COALESCE(MAX(row_index), 0), COUNT(*)::int
 FROM course.user_course_catalog_pins
-WHERE user_id = $1
-`, userID).Scan(&nextSort); err != nil {
+WHERE user_id = $1 AND row_index = (SELECT COALESCE(MAX(row_index), 0) FROM course.user_course_catalog_pins WHERE user_id = $1)
+`, userID).Scan(&rowIndex, &sortOrder); err != nil {
 		return err
 	}
+	if sortOrder >= maxCatalogPinsPerRow {
+		rowIndex++
+		sortOrder = 0
+	}
 	_, err = pool.Exec(ctx, `
-INSERT INTO course.user_course_catalog_pins (user_id, course_id, sort_order, updated_at)
-VALUES ($1, $2, $3, now())
-`, userID, courseID, nextSort)
+INSERT INTO course.user_course_catalog_pins (user_id, course_id, row_index, sort_order, updated_at)
+VALUES ($1, $2, $3, $4, now())
+`, userID, courseID, rowIndex, sortOrder)
 	return err
+}
+
+// ReplaceUserCatalogPinLayout replaces the sidebar pin grid for the user.
+// Each inner slice is one row (at most maxCatalogPinsPerRow course ids).
+func ReplaceUserCatalogPinLayout(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, rows [][]uuid.UUID) error {
+	seen := map[uuid.UUID]struct{}{}
+	var placements []struct {
+		courseID  uuid.UUID
+		rowIndex  int
+		sortOrder int
+	}
+	for rowIndex, row := range rows {
+		if len(row) > maxCatalogPinsPerRow {
+			return fmt.Errorf("pin row exceeds limit")
+		}
+		for sortOrder, id := range row {
+			if _, dup := seen[id]; dup {
+				return fmt.Errorf("duplicate course in pin layout")
+			}
+			seen[id] = struct{}{}
+			placements = append(placements, struct {
+				courseID  uuid.UUID
+				rowIndex  int
+				sortOrder int
+			}{courseID: id, rowIndex: rowIndex, sortOrder: sortOrder})
+		}
+	}
+	if len(placements) == 0 {
+		return nil
+	}
+
+	idList := make([]uuid.UUID, 0, len(placements))
+	for id := range seen {
+		idList = append(idList, id)
+	}
+	var pinned int
+	if err := pool.QueryRow(ctx, `
+SELECT COUNT(*)
+FROM course.user_course_catalog_pins
+WHERE user_id = $1 AND course_id = ANY($2::uuid[])
+`, userID, idList).Scan(&pinned); err != nil {
+		return err
+	}
+	if pinned != len(idList) {
+		return fmt.Errorf("pin layout includes unpinned courses")
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	for _, p := range placements {
+		if _, err := tx.Exec(ctx, `
+UPDATE course.user_course_catalog_pins
+SET row_index = $3, sort_order = $4, updated_at = now()
+WHERE user_id = $1 AND course_id = $2
+`, userID, p.courseID, p.rowIndex, p.sortOrder); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+// ListUserPinnedCourseRows returns pinned courses grouped by sidebar row.
+func ListUserPinnedCourseRows(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) ([][]PinnedCourseSummary, error) {
+	rows, err := pool.Query(ctx, `
+SELECT
+    c.id,
+    c.course_code,
+    c.title,
+    c.hero_image_url,
+    c.hero_image_object_position,
+    n.nickname,
+    p.row_index
+FROM course.user_course_catalog_pins p
+JOIN course.courses c ON c.id = p.course_id
+JOIN course.course_enrollments e ON e.course_id = c.id AND e.user_id = p.user_id
+LEFT JOIN course.user_course_catalog_nicknames n ON n.user_id = p.user_id AND n.course_id = c.id
+WHERE p.user_id = $1
+  AND (e.active OR e.state IN ('withdrawn', 'dropped', 'no_credit', 'audit', 'incomplete'))
+  AND NOT c.archived
+ORDER BY p.row_index ASC, p.sort_order ASC, p.updated_at ASC
+`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	rowByIndex := map[int][]PinnedCourseSummary{}
+	var rowOrder []int
+	for rows.Next() {
+		var item PinnedCourseSummary
+		var rowIndex int
+		if err := rows.Scan(
+			&item.ID,
+			&item.CourseCode,
+			&item.Title,
+			&item.HeroImageURL,
+			&item.HeroImageObjectPosition,
+			&item.CatalogNickname,
+			&rowIndex,
+		); err != nil {
+			return nil, err
+		}
+		if _, ok := rowByIndex[rowIndex]; !ok {
+			rowOrder = append(rowOrder, rowIndex)
+		}
+		rowByIndex[rowIndex] = append(rowByIndex[rowIndex], item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	out := make([][]PinnedCourseSummary, 0, len(rowOrder))
+	for _, rowIndex := range rowOrder {
+		out = append(out, rowByIndex[rowIndex])
+	}
+	return out, nil
 }
 
 // ListUserPinnedCourseSummaries returns pinned enrolled courses for sidebar shortcuts.
@@ -443,7 +567,7 @@ LEFT JOIN course.user_course_catalog_nicknames n ON n.user_id = p.user_id AND n.
 WHERE p.user_id = $1
   AND (e.active OR e.state IN ('withdrawn', 'dropped', 'no_credit', 'audit', 'incomplete'))
   AND NOT c.archived
-ORDER BY p.sort_order ASC, p.updated_at ASC
+ORDER BY p.row_index ASC, p.sort_order ASC, p.updated_at ASC
 `, userID)
 	if err != nil {
 		return nil, err

--- a/server/internal/service/imageproxy/resize.go
+++ b/server/internal/service/imageproxy/resize.go
@@ -1,0 +1,99 @@
+package imageproxy
+
+import (
+	"bytes"
+	"errors"
+	"image"
+	_ "image/gif"
+	"image/jpeg"
+	_ "image/png"
+	"strings"
+
+	"golang.org/x/image/draw"
+)
+
+var ErrNotImage = errors.New("not a supported raster image")
+
+// ResizeOpts describes optional downscaling for course-file thumbnails.
+type ResizeOpts struct {
+	MaxWidth  int
+	MaxHeight int
+	Quality   int // JPEG quality 1–100; values <= 0 default to 85
+}
+
+// ResizeIfNeeded downscales raster image bytes when max width/height are set.
+// Returns original bytes when no resize dimension is requested.
+func ResizeIfNeeded(data []byte, mime string, opts ResizeOpts) ([]byte, string, error) {
+	if opts.MaxWidth <= 0 && opts.MaxHeight <= 0 {
+		return data, strings.TrimSpace(mime), nil
+	}
+	if !isRasterImageMIME(mime) {
+		return nil, "", ErrNotImage
+	}
+
+	src, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, "", err
+	}
+	bounds := src.Bounds()
+	srcW := bounds.Dx()
+	srcH := bounds.Dy()
+	if srcW <= 0 || srcH <= 0 {
+		return nil, "", ErrNotImage
+	}
+
+	dstW, dstH := fitWithin(srcW, srcH, opts.MaxWidth, opts.MaxHeight)
+	if dstW >= srcW && dstH >= srcH {
+		return data, strings.TrimSpace(mime), nil
+	}
+
+	dst := image.NewRGBA(image.Rect(0, 0, dstW, dstH))
+	draw.CatmullRom.Scale(dst, dst.Bounds(), src, bounds, draw.Over, nil)
+
+	quality := opts.Quality
+	if quality <= 0 || quality > 100 {
+		quality = 85
+	}
+	var out bytes.Buffer
+	if err := jpeg.Encode(&out, dst, &jpeg.Options{Quality: quality}); err != nil {
+		return nil, "", err
+	}
+	return out.Bytes(), "image/jpeg", nil
+}
+
+func isRasterImageMIME(mime string) bool {
+	switch strings.ToLower(strings.TrimSpace(mime)) {
+	case "image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp":
+		return true
+	default:
+		return strings.HasPrefix(strings.ToLower(strings.TrimSpace(mime)), "image/")
+	}
+}
+
+func fitWithin(srcW, srcH, maxW, maxH int) (int, int) {
+	if maxW <= 0 {
+		maxW = srcW
+	}
+	if maxH <= 0 {
+		maxH = srcH
+	}
+	scale := 1.0
+	if sw := float64(maxW) / float64(srcW); sw < scale {
+		scale = sw
+	}
+	if sh := float64(maxH) / float64(srcH); sh < scale {
+		scale = sh
+	}
+	if scale >= 1 {
+		return srcW, srcH
+	}
+	dstW := int(float64(srcW)*scale + 0.5)
+	dstH := int(float64(srcH)*scale + 0.5)
+	if dstW < 1 {
+		dstW = 1
+	}
+	if dstH < 1 {
+		dstH = 1
+	}
+	return dstW, dstH
+}

--- a/server/internal/service/imageproxy/resize_test.go
+++ b/server/internal/service/imageproxy/resize_test.go
@@ -1,0 +1,89 @@
+package imageproxy
+
+import (
+	"bytes"
+	"image"
+	"image/jpeg"
+	"image/png"
+	"testing"
+)
+
+func TestResizeIfNeeded_NoDimensions_Passthrough(t *testing.T) {
+	src := mustJPEG(t, 800, 400)
+	out, ct, err := ResizeIfNeeded(src, "image/jpeg", ResizeOpts{})
+	if err != nil {
+		t.Fatalf("ResizeIfNeeded: %v", err)
+	}
+	if ct != "image/jpeg" {
+		t.Fatalf("content type = %q want image/jpeg", ct)
+	}
+	if !bytes.Equal(out, src) {
+		t.Fatal("expected passthrough bytes")
+	}
+}
+
+func TestResizeIfNeeded_DownscalesWidth(t *testing.T) {
+	src := mustJPEG(t, 1200, 600)
+	out, ct, err := ResizeIfNeeded(src, "image/jpeg", ResizeOpts{MaxWidth: 400, Quality: 80})
+	if err != nil {
+		t.Fatalf("ResizeIfNeeded: %v", err)
+	}
+	if ct != "image/jpeg" {
+		t.Fatalf("content type = %q want image/jpeg", ct)
+	}
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(out))
+	if err != nil {
+		t.Fatalf("DecodeConfig: %v", err)
+	}
+	if cfg.Width > 400 {
+		t.Fatalf("width = %d want <= 400", cfg.Width)
+	}
+	if cfg.Height > 200 {
+		t.Fatalf("height = %d want <= 200", cfg.Height)
+	}
+}
+
+func TestResizeIfNeeded_PNGInput(t *testing.T) {
+	src := mustPNG(t, 640, 480)
+	out, ct, err := ResizeIfNeeded(src, "image/png", ResizeOpts{MaxWidth: 320, MaxHeight: 240, Quality: 82})
+	if err != nil {
+		t.Fatalf("ResizeIfNeeded: %v", err)
+	}
+	if ct != "image/jpeg" {
+		t.Fatalf("content type = %q want image/jpeg", ct)
+	}
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(out))
+	if err != nil {
+		t.Fatalf("DecodeConfig: %v", err)
+	}
+	if cfg.Width > 320 || cfg.Height > 240 {
+		t.Fatalf("size = %dx%d want within 320x240", cfg.Width, cfg.Height)
+	}
+}
+
+func TestResizeIfNeeded_NotImage(t *testing.T) {
+	_, _, err := ResizeIfNeeded([]byte("plain"), "text/plain", ResizeOpts{MaxWidth: 100})
+	if err != ErrNotImage {
+		t.Fatalf("err = %v want ErrNotImage", err)
+	}
+}
+
+func mustJPEG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 90}); err != nil {
+		t.Fatalf("jpeg.Encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func mustPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("png.Encode: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/server/migrations/343_user_course_catalog_pin_rows.sql
+++ b/server/migrations/343_user_course_catalog_pin_rows.sql
@@ -1,0 +1,18 @@
+-- Per-user row layout for pinned course shortcuts (max 4 per row in the sidebar).
+
+ALTER TABLE course.user_course_catalog_pins
+    ADD COLUMN row_index INT NOT NULL DEFAULT 0 CHECK (row_index >= 0);
+
+-- Backfill existing flat sort_order into rows of up to four pins.
+UPDATE course.user_course_catalog_pins
+SET
+    row_index = sort_order / 4,
+    sort_order = sort_order % 4;
+
+DROP INDEX IF EXISTS course.idx_user_course_catalog_pins_user_sort;
+
+CREATE INDEX idx_user_course_catalog_pins_user_row_sort
+    ON course.user_course_catalog_pins (user_id, row_index, sort_order);
+
+COMMENT ON COLUMN course.user_course_catalog_pins.row_index IS
+    'Zero-based row in the sidebar pin grid; sort_order is the position within the row (0-3).';


### PR DESCRIPTION
## Summary

- Add iOS-style drag-and-drop for sidebar pinned courses with a multi-row grid (up to 4 pins per row), persisted via a new `PUT /api/v1/courses/catalog-pins/layout` endpoint and migration 343.
- Serve smaller catalog hero thumbnails through a server-side image proxy/resize path so sidebar and course catalog tiles load faster without fetching full-resolution images.
- Route WebSocket connections through the Vite dev-server proxy when the API runs on a different localhost port, fixing broken notification and communication WS when port 8080 is SSH-tunneled without upgrade support.
- Add mobile feature plan docs under `docs/plan/mobile/`.

## Test plan

- [ ] Run migration 343 and verify existing flat pin order backfills into rows of four.
- [ ] Pin/unpin courses from the catalog; confirm sidebar updates and layout persists after reload.
- [ ] Drag pinned courses within and across rows; confirm order saves and survives refresh.
- [ ] Verify catalog/sidebar hero images load at thumbnail size; course dashboard still uses full quality.
- [ ] In local dev (`5173` → `8080`), confirm notification and communication WebSockets connect via the page origin.
- [ ] `npm run test` and `npm run typecheck` in `clients/web/`
- [ ] `go test ./... -short` in `server/`


Made with [Cursor](https://cursor.com)