### PR TITLE
feat(migrations): rollback strategy and expand/contract pattern (plan 17.10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: go mod download
         run: go mod download
 
+      - name: Migration lint (plan 17.10)
+        run: go run ./cmd/migrate-lint
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:

--- a/docs/adr/0002-expand-contract-migrations.md
+++ b/docs/adr/0002-expand-contract-migrations.md
@@ -1,0 +1,59 @@
+# ADR 0002 — Expand/Contract Migrations Over Automatic Down-Migrations
+
+- **Status:** Accepted
+- **Date:** 2026-06-29
+- **Plan:** [17.10 Database Migration Rollback Strategy](../completed/17-platform-performance-operability/17.10-database-migration-rollback.md)
+
+## Context
+
+Lextures applies forward-only SQL migrations at startup via an internal runner
+compatible with the `_sqlx_migrations` table. Production incidents from bad
+migrations historically required a full database restore — slow and data-losing.
+Blue/green deploys (plan 17.9) additionally require schema changes that remain
+compatible with the previous app version during the canary window.
+
+Two rollback strategies were considered:
+
+1. **Traditional up/down** — every migration has reversible SQL; a `rollback`
+   command reverts the latest version automatically.
+2. **Expand/contract with corrective forward migrations** — schema changes are
+   staged across multiple deploys; rollbacks are either manual `down.sql` for
+   simple additive changes or a new forward migration that restores the prior state.
+
+## Decision
+
+Adopt **expand/contract as the default development process**, with **companion
+`down.sql` files required for every migration** but automatic rollback limited to
+recent, tested additive changes.
+
+Rationale:
+
+1. Expand/contract is the only safe pattern for zero-downtime blue/green deploys;
+   a single reversible `down.sql` cannot undo data migrations or contract steps
+   without data loss.
+2. Requiring `down.sql` (even as documented stubs) forces authors to consider
+   rollback before merge and gives on-call a starting point for manual recovery.
+3. Corrective forward migrations are safer for production because they follow the
+   same tested apply path as normal deploys and do not delete `_sqlx_migrations`
+   history rows silently.
+4. The existing `_sqlx_migrations` checksum model already prevents editing
+   applied migrations; down files are not executed automatically, avoiding
+   accidental schema drift on restart.
+
+## Consequences
+
+- All new migrations must include `NNN_*.down.sql`; CI blocks PRs without them.
+- Destructive DDL in up migrations emits CI warnings; reviewers must confirm an
+  expand phase already shipped.
+- `go run ./cmd/migrate rollback` is available for emergencies on migrations with
+  executable down SQL; stubs direct operators to the runbook and backup restore.
+- `DEPLOY_ID` is recorded on new migration rows for incident correlation.
+- Large backfills must use batched `UPDATE` (documented in `server/migrations/README.md`).
+
+## Alternatives considered
+
+- **sqlx `migrate revert`** — not used; our runner is custom and shares the
+  `_sqlx_migrations` table with a legacy Rust service. Revert semantics differ and
+  risk diverging checksum history.
+- **ORM-generated migrations** — rejected (plan non-goal); SQL files remain the
+  source of truth for auditability.

--- a/docs/completed/17-platform-performance-operability/17.10-database-migration-rollback.md
+++ b/docs/completed/17-platform-performance-operability/17.10-database-migration-rollback.md
@@ -2,6 +2,20 @@
 
 > Implementation plan. Source: [docs/MISSING_FEATURES.md](../../MISSING_FEATURES.md) §17.10.
 
+## Implementation Status (shipped)
+
+**Delivered:**
+
+- `server/migrations/README.md` — expand/contract pattern, naming, down.sql requirement, batched backfill guidance.
+- Companion `.down.sql` for all 341 up migrations (stubs + executable rollback for recent additive migrations).
+- Migration `345_migration_deploy_tracking.sql` — `deploy_id` column on `_sqlx_migrations`; recorded from `DEPLOY_ID` env at apply time.
+- `server/internal/migrate/` — skip down files on apply, `RollbackLatest`, `LintFS`, structured apply/rollback logging.
+- `server/cmd/migrate` and `server/cmd/migrate-lint` — operational rollback and CI lint entrypoints.
+- CI step in `.github/workflows/ci.yml` — blocks missing down.sql/secrets; warns on destructive DDL.
+- ADR `docs/adr/0002-expand-contract-migrations.md`.
+- Runbook `docs/runbooks/database-migration-rollback.md`.
+- Tests: unit lint/rollback helpers; Postgres integration (`TestRollbackLatest_Integration`, `TestLint_EmbeddedMigrations`).
+
 ## Metadata
 
 | Field | Value |
@@ -10,7 +24,7 @@
 | **Section** | Platform, Performance & Operability |
 | **Severity** | MAJOR |
 | **Markets** | K12, HE, SL |
-| **Status (today)** | MISSING (`pgx/v5` migrations are forward-only; no documented down-migration strategy) |
+| **Status (today)** | DONE — expand/contract docs, down.sql convention, CI lint, rollback runbook, deploy_id tracking, `go run ./cmd/migrate rollback`. |
 | **Estimated effort** | S (1–2 w) |
 | **Owner (proposed)** | Platform / Backend team |
 | **Depends on** | Nothing — can start immediately |

--- a/docs/runbooks/database-migration-rollback.md
+++ b/docs/runbooks/database-migration-rollback.md
@@ -1,0 +1,147 @@
+# Runbook — Rolling Back a Database Migration (Plan 17.10)
+
+Use this runbook when a migration reached staging or production and causes errors
+(schema mismatch, constraint too strict, data loss risk). Goal: restore a working
+schema in **under 10 minutes** without a full backup restore when possible.
+
+## Prerequisites
+
+- `DATABASE_URL` for the target environment
+- `kubectl` / SSH access to run commands against the app host or a migration jump box
+- Git checkout matching the deploy under investigation
+- `DEPLOY_ID` from the failing deploy (Git SHA / release tag) for correlation
+
+## Decision tree
+
+```
+Bad migration applied?
+├─ Simple additive migration (CREATE TABLE / ADD nullable column) with tested down.sql
+│  └─ Path A: Manual rollback (fast)
+├─ Data migration or contract step (DROP/RENAME/TYPE change)
+│  └─ Path B: Corrective forward migration (preferred)
+└─ Unknown / down.sql is a stub
+   └─ Path C: Backup restore (see database-backup-restore.md)
+```
+
+## Path A — Manual rollback (down.sql)
+
+**When:** Latest migration is additive and has executable SQL in its `.down.sql`
+(not a "Rollback not supported" stub). Tested in staging first.
+
+1. **Stop new deploys** — pause CI/CD or hold the canary so no new instances start
+   with the bad migration while you recover.
+
+2. **Drain traffic** (production) — remove instances from the load balancer or scale
+   to zero so no requests hit a schema-incompatible binary.
+
+3. **Verify the target migration:**
+
+   ```bash
+   cd server
+   psql "$DATABASE_URL" -c \
+     "SELECT version, description, deploy_id, installed_on FROM _sqlx_migrations ORDER BY version DESC LIMIT 3;"
+   ```
+
+4. **Dry-run the down SQL** (staging only):
+
+   ```bash
+   latest=$(ls migrations/*.sql | grep -v down | sort -V | tail -1)
+   down="${latest%.sql}.down.sql"
+   cat "$down"
+   ```
+
+5. **Execute rollback:**
+
+   ```bash
+   DATABASE_URL=... go run ./cmd/migrate rollback
+   ```
+
+   Exit codes: `0` success, `1` error, `3` rollback not supported (use Path B or C).
+
+6. **Verify schema** — confirm the rolled-back object is gone or reverted:
+
+   ```bash
+   psql "$DATABASE_URL" -c "\d settings.device_push_tokens"   # example
+   ```
+
+7. **Smoke test** — start the **previous** app version (before the bad migration)
+   against the database:
+
+   ```bash
+   curl -fsS http://localhost:8080/health/ready
+   ```
+
+8. **Re-deploy** — ship a fixed forward migration in a new PR; do not re-apply the
+   bad migration file.
+
+### Timing target
+
+| Step | Target |
+|---|---|
+| Identify latest migration | 1 min |
+| Rollback command | 2 min |
+| Smoke test | 5 min |
+
+## Path B — Corrective forward migration
+
+**When:** The bad migration altered or deleted data, renamed columns, or the
+`down.sql` is a stub. This is the **preferred production path** for contract-phase
+changes.
+
+1. Revert the application deploy to the last known-good release (traffic on old code).
+
+2. Author a **new** migration that restores compatibility:
+
+   ```sql
+   -- 346_restore_device_push_tokens.sql
+   -- Corrective migration: re-add column dropped prematurely in 345_bad.sql
+   ALTER TABLE settings.device_push_tokens ADD COLUMN IF NOT EXISTS token TEXT;
+   ```
+
+3. Include a `down.sql` (may be stub if rollback is restore-from-backup).
+
+4. Test on a staging snapshot:
+
+   ```bash
+   DATABASE_URL=... go test ./internal/migrate/... -run TestRun_FullMigrations -count=1
+   ```
+
+5. Apply via normal deploy (`RUN_MIGRATIONS=true`).
+
+## Path C — Backup restore
+
+**When:** Data was corrupted, down.sql is unsupported, or Paths A/B are unsafe.
+
+Follow `docs/runbooks/database-backup-restore.md`. Expect longer RTO and possible
+data loss since the last backup.
+
+## Staging validation (required before production)
+
+Run this checklist whenever adding executable `down.sql` to a new migration:
+
+1. Apply all migrations on a fresh DB.
+2. `go run ./cmd/migrate rollback` — confirm success.
+3. `go run ./cmd/server` (or integration tests) — confirm app starts.
+4. Re-apply migrations — confirm idempotency.
+
+CI runs `TestRollbackLatest_Integration` against Postgres when `DATABASE_URL` is set.
+
+## Correlating incidents with deploys
+
+After migration `345_migration_deploy_tracking`, each new row in `_sqlx_migrations`
+may include `deploy_id`:
+
+```sql
+SELECT version, description, deploy_id, installed_on
+FROM _sqlx_migrations
+WHERE installed_on > now() - interval '24 hours'
+ORDER BY version DESC;
+```
+
+Set `DEPLOY_ID` in the deployment environment to populate this field.
+
+## Related documents
+
+- `server/migrations/README.md` — expand/contract pattern and naming
+- `docs/adr/0002-expand-contract-migrations.md` — architecture decision
+- `docs/runbooks/database-backup-restore.md` — full restore procedure

--- a/server/cmd/migrate-lint/main.go
+++ b/server/cmd/migrate-lint/main.go
@@ -1,0 +1,31 @@
+// Command migrate-lint validates SQL migration conventions for CI and local development.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/lextures/lextures/server"
+	"github.com/lextures/lextures/server/internal/migrate"
+)
+
+func main() {
+	res, err := migrate.LintFS(serverdata.Migrations, "migrations")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "migrate lint: %v\n", err)
+		os.Exit(2)
+	}
+
+	report := migrate.FormatLintReport(res)
+	if report != "" {
+		fmt.Print(report)
+	}
+
+	for _, w := range res.Warnings {
+		fmt.Fprintf(os.Stderr, "::warning file=server/migrations::%s\n", w)
+	}
+
+	if len(res.Errors) > 0 {
+		os.Exit(1)
+	}
+}

--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -1,0 +1,75 @@
+// Command migrate provides operational helpers for database migrations (plan 17.10).
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/lextures/lextures/server"
+	"github.com/lextures/lextures/server/internal/migrate"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "rollback":
+		rollbackCmd(os.Args[2:])
+	case "lint":
+		lintCmd()
+	default:
+		usage()
+		os.Exit(2)
+	}
+}
+
+func rollbackCmd(args []string) {
+	fs := flag.NewFlagSet("rollback", flag.ExitOnError)
+	dsn := fs.String("dsn", os.Getenv("DATABASE_URL"), "Postgres connection string")
+	_ = fs.Parse(args)
+
+	if *dsn == "" {
+		fmt.Fprintln(os.Stderr, "migrate rollback: set -dsn or DATABASE_URL")
+		os.Exit(2)
+	}
+	err := migrate.RollbackLatest(context.Background(), serverdata.Migrations, *dsn)
+	if err != nil {
+		if errors.Is(err, migrate.ErrRollbackNotSupported) {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(3)
+		}
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println("rollback complete")
+}
+
+func lintCmd() {
+	res, err := migrate.LintFS(serverdata.Migrations, "migrations")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "migrate lint: %v\n", err)
+		os.Exit(2)
+	}
+	fmt.Print(migrate.FormatLintReport(res))
+	for _, w := range res.Warnings {
+		fmt.Fprintf(os.Stderr, "::warning file=server/migrations::%s\n", w)
+	}
+	if len(res.Errors) > 0 {
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `Usage:
+  migrate rollback [-dsn URL]   Roll back the most recent migration using its down.sql
+  migrate lint                  Validate migration conventions (down.sql, secrets, destructive patterns)
+
+Environment:
+  DATABASE_URL   Default connection string for rollback
+`)
+}

--- a/server/internal/migrate/down.go
+++ b/server/internal/migrate/down.go
@@ -40,10 +40,7 @@ func rollbackSupported(body []byte) bool {
 		return false
 	}
 	lower := strings.ToLower(stripped)
-	if strings.Contains(lower, "rollback not supported") {
-		return false
-	}
-	return true
+	return !strings.Contains(lower, "rollback not supported")
 }
 
 // stripSQLComments removes -- line comments and /* */ block comments.

--- a/server/internal/migrate/down.go
+++ b/server/internal/migrate/down.go
@@ -1,0 +1,74 @@
+package migrate
+
+import (
+	"strings"
+)
+
+// downMigrationPath returns the companion rollback file for an up migration path.
+// Example: migrations/001_users.sql → migrations/001_users.down.sql
+func downMigrationPath(upPath string) string {
+	if strings.HasSuffix(upPath, ".sql") {
+		return upPath[:len(upPath)-4] + ".down.sql"
+	}
+	return upPath + ".down.sql"
+}
+
+// isDownMigration reports whether filename is a rollback companion (not an up migration).
+func isDownMigration(name string) bool {
+	base := name
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		base = name[i+1:]
+	}
+	return strings.HasSuffix(base, ".down.sql")
+}
+
+// isUpMigration reports whether filename is a forward migration SQL file.
+func isUpMigration(name string) bool {
+	base := name
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		base = name[i+1:]
+	}
+	return strings.HasSuffix(base, ".sql") && !strings.HasSuffix(base, ".down.sql")
+}
+
+// rollbackSupported reports whether down SQL contains executable rollback statements.
+// Stubs that are comment-only or contain "rollback not supported" return false.
+func rollbackSupported(body []byte) bool {
+	stripped := stripSQLComments(string(body))
+	stripped = strings.TrimSpace(stripped)
+	if stripped == "" {
+		return false
+	}
+	lower := strings.ToLower(stripped)
+	if strings.Contains(lower, "rollback not supported") {
+		return false
+	}
+	return true
+}
+
+// stripSQLComments removes -- line comments and /* */ block comments.
+func stripSQLComments(sql string) string {
+	var b strings.Builder
+	lines := strings.Split(sql, "\n")
+	for _, line := range lines {
+		if idx := strings.Index(line, "--"); idx >= 0 {
+			line = line[:idx]
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	out := b.String()
+	for {
+		start := strings.Index(out, "/*")
+		if start < 0 {
+			break
+		}
+		end := strings.Index(out[start:], "*/")
+		if end < 0 {
+			out = out[:start]
+			break
+		}
+		out = out[:start] + out[start+end+2:]
+	}
+	return out
+}

--- a/server/internal/migrate/integration_test.go
+++ b/server/internal/migrate/integration_test.go
@@ -2,6 +2,7 @@ package migrate
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -10,7 +11,7 @@ import (
 	"github.com/lextures/lextures/server/internal/db"
 )
 
-// TestRun_FullMigrations_Integration runs the 115 SQL files when DATABASE_URL is set (CI, local).
+// TestRun_FullMigrations_Integration runs the SQL files when DATABASE_URL is set (CI, local).
 func TestRun_FullMigrations_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("use full go test to exercise migrations with Postgres")
@@ -34,5 +35,43 @@ func TestRun_FullMigrations_Integration(t *testing.T) {
 	defer p.Close()
 	if err := FromPool(ctx, serverdata.Migrations, p); err != nil {
 		t.Fatalf("from pool: %v", err)
+	}
+}
+
+// TestRollbackLatest_Integration rolls back the latest migration with a real down.sql and re-applies.
+func TestRollbackLatest_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("use full go test to exercise migrations with Postgres")
+	}
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("set DATABASE_URL to run integration test")
+	}
+	ctx := context.Background()
+	if err := RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatal(err)
+	}
+
+	err := RollbackLatest(ctx, serverdata.Migrations, dsn)
+	if err != nil {
+		if errors.Is(err, ErrRollbackNotSupported) {
+			t.Skip("latest migration has no executable down.sql")
+		}
+		t.Fatal(err)
+	}
+
+	if err := RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("re-apply after rollback: %v", err)
+	}
+}
+
+// TestLint_EmbeddedMigrations ensures every up migration has a companion down.sql.
+func TestLint_EmbeddedMigrations(t *testing.T) {
+	res, err := LintFS(serverdata.Migrations, "migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Errors) > 0 {
+		t.Fatalf("lint errors:\n%s", FormatLintReport(res))
 	}
 }

--- a/server/internal/migrate/lint.go
+++ b/server/internal/migrate/lint.go
@@ -1,0 +1,116 @@
+package migrate
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// LintResult holds migration lint findings for CI and local checks.
+type LintResult struct {
+	MissingDown []string
+	Warnings    []string
+	Errors      []string
+}
+
+// LintFS validates migration conventions under dir (e.g. "migrations").
+func LintFS(fsys fs.FS, dir string) (LintResult, error) {
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return LintResult{}, fmt.Errorf("migrate lint: readdir: %w", err)
+	}
+
+	var list []migrationFile
+	for _, e := range entries {
+		if e.IsDir() || !isUpMigration(e.Name()) {
+			continue
+		}
+		p := dir + "/" + e.Name()
+		mf, perr := parseMigrationName(p)
+		if perr != nil {
+			return LintResult{}, perr
+		}
+		list = append(list, mf)
+	}
+	sortMigrations(list)
+
+	var res LintResult
+	secretPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)postgres(ql)?://[^\s'"]+`),
+		regexp.MustCompile(`(?i)(api[_-]?key|secret|password)\s*=\s*['"][^'"]+['"]`),
+	}
+	destructivePatterns := []struct {
+		re      *regexp.Regexp
+		message string
+	}{
+		{regexp.MustCompile(`(?i)\bDROP\s+COLUMN\b`), "DROP COLUMN — use expand/contract; remove old column only after all app instances use the new schema"},
+		{regexp.MustCompile(`(?i)\bDROP\s+TABLE\b`), "DROP TABLE — prefer soft-delete or rename; contract only after traffic is on the new schema"},
+		{regexp.MustCompile(`(?i)\bRENAME\s+COLUMN\b`), "RENAME COLUMN — add a new column and dual-write instead of renaming in place"},
+		{regexp.MustCompile(`(?i)\bALTER\s+COLUMN\b[^;]*\bTYPE\b`), "ALTER COLUMN TYPE — use expand/contract with a new column and batched backfill"},
+	}
+
+	for _, mf := range list {
+		upPath := dir + "/" + mf.Name
+		body, rerr := fs.ReadFile(fsys, upPath)
+		if rerr != nil {
+			return LintResult{}, fmt.Errorf("migrate lint: read %q: %w", upPath, rerr)
+		}
+		text := string(body)
+
+		downPath := downMigrationPath(upPath)
+		if _, derr := fs.Stat(fsys, downPath); derr != nil {
+			res.Errors = append(res.Errors, fmt.Sprintf("missing companion down migration: %s", filepath.Base(downPath)))
+		}
+
+		for _, pat := range secretPatterns {
+			if pat.MatchString(text) {
+				res.Errors = append(res.Errors, fmt.Sprintf("%s: possible inline secret — migrations must not contain credentials", mf.Name))
+				break
+			}
+		}
+
+		for _, dp := range destructivePatterns {
+			if dp.re.MatchString(text) {
+				res.Warnings = append(res.Warnings, fmt.Sprintf("%s: %s", mf.Name, dp.message))
+			}
+		}
+
+		if isUnbatchedFullTableUpdate(text) {
+			res.Warnings = append(res.Warnings, fmt.Sprintf(
+				"%s: full-table UPDATE without batching — use batched UPDATE (1,000 rows/transaction) to avoid long locks",
+				mf.Name,
+			))
+		}
+	}
+
+	return res, nil
+}
+
+func isUnbatchedFullTableUpdate(sql string) bool {
+	upper := strings.ToUpper(sql)
+	if !strings.Contains(upper, "UPDATE ") {
+		return false
+	}
+	if strings.Contains(upper, "LIMIT ") || strings.Contains(upper, "BATCH") {
+		return false
+	}
+	// Heuristic: UPDATE ... SET without WHERE or with WHERE true is a full-table scan.
+	if strings.Contains(upper, "WHERE") {
+		return false
+	}
+	return true
+}
+
+// FormatLintReport renders lint output for humans and CI annotation consumers.
+func FormatLintReport(res LintResult) string {
+	var b strings.Builder
+	for _, e := range res.Errors {
+		fmt.Fprintf(&b, "ERROR: %s\n", e)
+	}
+	for _, w := range res.Warnings {
+		fmt.Fprintf(&b, "WARNING: %s\n", w)
+	}
+	return b.String()
+}

--- a/server/internal/migrate/lint_test.go
+++ b/server/internal/migrate/lint_test.go
@@ -1,0 +1,119 @@
+package migrate
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestDownMigrationPath(t *testing.T) {
+	got := downMigrationPath("migrations/001_users.sql")
+	want := "migrations/001_users.down.sql"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestIsDownMigration(t *testing.T) {
+	if !isDownMigration("001_users.down.sql") {
+		t.Fatal("expected down migration")
+	}
+	if isDownMigration("001_users.sql") {
+		t.Fatal("expected up migration")
+	}
+}
+
+func TestRollbackSupported(t *testing.T) {
+	cases := []struct {
+		body string
+		want bool
+	}{
+		{"-- Rollback not supported: restore from backup\n", false},
+		{"DROP TABLE foo;\n", true},
+		{"-- comment only\n", false},
+		{"/* block */ -- Rollback not supported\n", false},
+	}
+	for _, tc := range cases {
+		if got := rollbackSupported([]byte(tc.body)); got != tc.want {
+			t.Fatalf("body %q: got %v want %v", tc.body, got, tc.want)
+		}
+	}
+}
+
+func TestParseMigrationName_RejectsDown(t *testing.T) {
+	if _, err := parseMigrationName("migrations/001_users.down.sql"); err == nil {
+		t.Fatal("expected error for down migration")
+	}
+}
+
+func TestLintFS_MissingDown(t *testing.T) {
+	fsys := fstest.MapFS{
+		"migrations/001_a.sql": &fstest.MapFile{Data: []byte("CREATE TABLE a (id INT);")},
+	}
+	res, err := LintFS(fsys, "migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Errors) != 1 || !strings.Contains(res.Errors[0], "missing companion") {
+		t.Fatalf("errors: %#v", res.Errors)
+	}
+}
+
+func TestLintFS_DestructiveWarning(t *testing.T) {
+	fsys := fstest.MapFS{
+		"migrations/010_drop.sql":      &fstest.MapFile{Data: []byte("ALTER TABLE t DROP COLUMN old;")},
+		"migrations/010_drop.down.sql": &fstest.MapFile{Data: []byte("-- stub\n")},
+	}
+	res, err := LintFS(fsys, "migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Warnings) == 0 {
+		t.Fatal("expected destructive warning")
+	}
+}
+
+func TestLintFS_UnbatchedUpdateWarning(t *testing.T) {
+	fsys := fstest.MapFS{
+		"migrations/020_backfill.sql":      &fstest.MapFile{Data: []byte("UPDATE big SET x = 1;")},
+		"migrations/020_backfill.down.sql": &fstest.MapFile{Data: []byte("-- stub\n")},
+	}
+	res, err := LintFS(fsys, "migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "full-table UPDATE") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("warnings: %#v", res.Warnings)
+	}
+}
+
+func TestLintFS_SecretDetection(t *testing.T) {
+	fsys := fstest.MapFS{
+		"migrations/030_bad.sql":      &fstest.MapFile{Data: []byte("SELECT 1; -- postgres://user:pass@host/db")},
+		"migrations/030_bad.down.sql": &fstest.MapFile{Data: []byte("-- stub\n")},
+	}
+	res, err := LintFS(fsys, "migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Errors) == 0 {
+		t.Fatal("expected secret error")
+	}
+}
+
+func TestFormatLintReport(t *testing.T) {
+	out := FormatLintReport(LintResult{
+		Errors:   []string{"missing down"},
+		Warnings: []string{"DROP COLUMN"},
+	})
+	if !strings.Contains(out, "ERROR:") || !strings.Contains(out, "WARNING:") {
+		t.Fatalf("report: %q", out)
+	}
+}

--- a/server/internal/migrate/parse.go
+++ b/server/internal/migrate/parse.go
@@ -22,6 +22,9 @@ func parseMigrationName(filename string) (migrationFile, error) {
 	if i := strings.LastIndex(filename, "/"); i >= 0 {
 		base = filename[i+1:]
 	}
+	if isDownMigration(base) {
+		return migrationFile{}, fmt.Errorf("migration: %q is a down migration companion, not an up migration", filename)
+	}
 	m := migrationName.FindStringSubmatch(base)
 	if len(m) != 3 {
 		return migrationFile{}, fmt.Errorf("migration: invalid file name %q (expected NNN_desc.sql)", filename)

--- a/server/internal/migrate/rollback.go
+++ b/server/internal/migrate/rollback.go
@@ -1,0 +1,126 @@
+package migrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// RollbackLatest applies the down.sql companion for the most recently applied migration.
+// Returns ErrRollbackNotSupported when the companion is a documented no-op stub.
+func RollbackLatest(ctx context.Context, fsys fs.FS, dsn string) error {
+	if dsn == "" {
+		return fmt.Errorf("migrate: empty database URL")
+	}
+	cfg, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		return fmt.Errorf("migrate: parse config: %w", err)
+	}
+	cfg.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+	conn, err := pgx.ConnectConfig(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("migrate: connect: %w", err)
+	}
+	defer func() { _ = conn.Close(ctx) }()
+	return rollbackLatestLocked(ctx, conn, fsys, "migrations")
+}
+
+// RollbackLatestFromPool is like RollbackLatest but uses an existing pool's DSN.
+func RollbackLatestFromPool(ctx context.Context, fsys fs.FS, pool *pgxpool.Pool) error {
+	if pool == nil {
+		return fmt.Errorf("migrate: nil pool")
+	}
+	return RollbackLatest(ctx, fsys, pool.Config().ConnString())
+}
+
+// ErrRollbackNotSupported is returned when the down.sql file is a documented stub.
+var ErrRollbackNotSupported = errors.New("migrate: rollback not supported for this migration")
+
+func rollbackLatestLocked(ctx context.Context, conn *pgx.Conn, fsys fs.FS, dir string) error {
+	lid, err := takeAdvisoryLock(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("migrate: lock: %w", err)
+	}
+	defer func() { _ = releaseAdvisoryLock(context.Background(), conn, lid) }()
+
+	var version int64
+	var description string
+	sel := fmt.Sprintf(
+		"SELECT version, description FROM %s WHERE success = true ORDER BY version DESC LIMIT 1",
+		sqlxMigrationsTable,
+	)
+	if err := conn.QueryRow(ctx, sel).Scan(&version, &description); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("migrate: no applied migrations to roll back")
+		}
+		return fmt.Errorf("migrate: latest migration: %w", err)
+	}
+
+	upName, err := findMigrationNameByVersion(fsys, dir, int(version))
+	if err != nil {
+		return err
+	}
+	upPath := dir + "/" + upName
+	downPath := downMigrationPath(upPath)
+
+	downBody, err := fs.ReadFile(fsys, downPath)
+	if err != nil {
+		return fmt.Errorf("migrate: read %q: %w", downPath, err)
+	}
+	if !rollbackSupported(downBody) {
+		return fmt.Errorf("%w (%s)", ErrRollbackNotSupported, upName)
+	}
+
+	t0 := time.Now()
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, string(downBody)); err != nil {
+		return fmt.Errorf("migrate: rollback v%d: %w", version, err)
+	}
+	del := fmt.Sprintf("DELETE FROM %s WHERE version = $1", sqlxMigrationsTable)
+	if _, err := tx.Exec(ctx, del, version); err != nil {
+		return fmt.Errorf("migrate: remove migration row v%d: %w", version, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+
+	elapsed := time.Since(t0)
+	slog.Info("migration rolled back",
+		"version", version,
+		"description", description,
+		"file", upName,
+		"duration_ms", elapsed.Milliseconds(),
+	)
+	return nil
+}
+
+func findMigrationNameByVersion(fsys fs.FS, dir string, version int) (string, error) {
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return "", fmt.Errorf("migrate: readdir: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !isUpMigration(e.Name()) {
+			continue
+		}
+		mf, perr := parseMigrationName(dir + "/" + e.Name())
+		if perr != nil {
+			continue
+		}
+		if mf.Version == version {
+			return mf.Name, nil
+		}
+	}
+	return "", fmt.Errorf("migrate: no up migration file for version %d", version)
+}

--- a/server/internal/migrate/run.go
+++ b/server/internal/migrate/run.go
@@ -8,6 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -78,7 +81,7 @@ func runLocked(ctx context.Context, conn *pgx.Conn, fsys fs.FS, dir string) erro
 	}
 	var list []migrationFile
 	for _, e := range entries {
-		if e.IsDir() {
+		if e.IsDir() || !isUpMigration(e.Name()) {
 			continue
 		}
 		p := dir + "/" + e.Name()
@@ -89,10 +92,14 @@ func runLocked(ctx context.Context, conn *pgx.Conn, fsys fs.FS, dir string) erro
 		list = append(list, mf)
 	}
 	sortMigrations(list)
+	trackDeployID := hasDeployIDColumn(ctx, conn)
 	for _, mf := range list {
 		p := dir + "/" + mf.Name
-		if err := applyIfNeeded(ctx, conn, fsys, p, mf); err != nil {
+		if err := applyIfNeeded(ctx, conn, fsys, p, mf, trackDeployID); err != nil {
 			return err
+		}
+		if !trackDeployID && hasDeployIDColumn(ctx, conn) {
+			trackDeployID = true
 		}
 	}
 	return nil
@@ -105,7 +112,8 @@ func ensureMigrationsTable(ctx context.Context, c *pgx.Conn) error {
   installed_on TIMESTAMPTZ NOT NULL DEFAULT now(),
   success BOOLEAN NOT NULL,
   checksum BYTEA NOT NULL,
-  execution_time BIGINT NOT NULL
+  execution_time BIGINT NOT NULL,
+  deploy_id TEXT
 );`, sqlxMigrationsTable)
 	_, err := c.Exec(ctx, q)
 	if err != nil {
@@ -128,7 +136,20 @@ func checkNotDirty(ctx context.Context, c *pgx.Conn) error {
 	return fmt.Errorf("migrate: previous migration (version %d) did not complete successfully; fix _sqlx_migrations before continuing", ver)
 }
 
-func applyIfNeeded(ctx context.Context, c *pgx.Conn, fsys fs.FS, rel string, mf migrationFile) error {
+func hasDeployIDColumn(ctx context.Context, c *pgx.Conn) bool {
+	var exists bool
+	err := c.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = current_schema()
+			  AND table_name = $1
+			  AND column_name = 'deploy_id'
+		)`, sqlxMigrationsTable).Scan(&exists)
+	return err == nil && exists
+}
+
+func applyIfNeeded(ctx context.Context, c *pgx.Conn, fsys fs.FS, rel string, mf migrationFile, trackDeployID bool) error {
 	body, err := fs.ReadFile(fsys, rel)
 	if err != nil {
 		return fmt.Errorf("migrate: read %q: %w", rel, err)
@@ -159,8 +180,23 @@ func applyIfNeeded(ctx context.Context, c *pgx.Conn, fsys fs.FS, rel string, mf 
 	if _, err := tx.Exec(ctx, string(body)); err != nil {
 		return fmt.Errorf("migrate: exec v%d: %w", mf.Version, err)
 	}
-	ins := fmt.Sprintf("INSERT INTO %s (version, description, success, checksum, execution_time) VALUES ($1, $2, true, $3, -1)", sqlxMigrationsTable)
-	if _, err := tx.Exec(ctx, ins, int64(mf.Version), mf.Description, sum[:]); err != nil {
+	deployID := strings.TrimSpace(os.Getenv("DEPLOY_ID"))
+	var ins string
+	var insArgs []any
+	if trackDeployID {
+		ins = fmt.Sprintf(
+			"INSERT INTO %s (version, description, success, checksum, execution_time, deploy_id) VALUES ($1, $2, true, $3, -1, $4)",
+			sqlxMigrationsTable,
+		)
+		insArgs = []any{int64(mf.Version), mf.Description, sum[:], deployID}
+	} else {
+		ins = fmt.Sprintf(
+			"INSERT INTO %s (version, description, success, checksum, execution_time) VALUES ($1, $2, true, $3, -1)",
+			sqlxMigrationsTable,
+		)
+		insArgs = []any{int64(mf.Version), mf.Description, sum[:]}
+	}
+	if _, err := tx.Exec(ctx, ins, insArgs...); err != nil {
 		return err
 	}
 	if err := tx.Commit(ctx); err != nil {
@@ -171,5 +207,12 @@ func applyIfNeeded(ctx context.Context, c *pgx.Conn, fsys fs.FS, rel string, mf 
 	if _, err := c.Exec(ctx, u, elapsed, int64(mf.Version)); err != nil {
 		return fmt.Errorf("migrate: set execution time v%d: %w", mf.Version, err)
 	}
+	slog.Info("migration applied",
+		"version", mf.Version,
+		"description", mf.Description,
+		"file", mf.Name,
+		"duration_ms", time.Since(t0).Milliseconds(),
+		"deploy_id", deployID,
+	)
 	return nil
 }

--- a/server/migrations/001_users.down.sql
+++ b/server/migrations/001_users.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 001_users.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/002_courses.down.sql
+++ b/server/migrations/002_courses.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 002_courses.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/003_user_ai_and_course_hero.down.sql
+++ b/server/migrations/003_user_ai_and_course_hero.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 003_user_ai_and_course_hero.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/004_communication.down.sql
+++ b/server/migrations/004_communication.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 004_communication.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/005_course_code_only.down.sql
+++ b/server/migrations/005_course_code_only.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 005_course_code_only.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/006_course_setup_model.down.sql
+++ b/server/migrations/006_course_setup_model.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 006_course_setup_model.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/007_course_enrollments.down.sql
+++ b/server/migrations/007_course_enrollments.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 007_course_enrollments.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/008_rbac.down.sql
+++ b/server/migrations/008_rbac.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 008_rbac.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/009_user_app_roles.down.sql
+++ b/server/migrations/009_user_app_roles.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 009_user_app_roles.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/010_course_hero_object_position.down.sql
+++ b/server/migrations/010_course_hero_object_position.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 010_course_hero_object_position.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/011_user_and_course_schemas.down.sql
+++ b/server/migrations/011_user_and_course_schemas.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 011_user_and_course_schemas.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/012_user_ai_settings_schema.down.sql
+++ b/server/migrations/012_user_ai_settings_schema.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 012_user_ai_settings_schema.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/013_user_course_grants.down.sql
+++ b/server/migrations/013_user_course_grants.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 013_user_course_grants.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/014_course_structure.down.sql
+++ b/server/migrations/014_course_structure.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 014_course_structure.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/015_app_roles_description_scope.down.sql
+++ b/server/migrations/015_app_roles_description_scope.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 015_app_roles_description_scope.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/016_enrollment_teacher_not_owner.down.sql
+++ b/server/migrations/016_enrollment_teacher_not_owner.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 016_enrollment_teacher_not_owner.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/017_course_syllabus.down.sql
+++ b/server/migrations/017_course_syllabus.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 017_course_syllabus.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/018_rename_module_create_to_item_create.down.sql
+++ b/server/migrations/018_rename_module_create_to_item_create.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 018_rename_module_create_to_item_create.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/019_backfill_course_item_create_grants.down.sql
+++ b/server/migrations/019_backfill_course_item_create_grants.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 019_backfill_course_item_create_grants.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/020_course_structure_parent.down.sql
+++ b/server/migrations/020_course_structure_parent.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 020_course_structure_parent.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/021_module_content_pages.down.sql
+++ b/server/migrations/021_module_content_pages.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 021_module_content_pages.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/022_module_publish_visibility.down.sql
+++ b/server/migrations/022_module_publish_visibility.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 022_module_publish_visibility.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/023_course_structure_due_at.down.sql
+++ b/server/migrations/023_course_structure_due_at.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 023_course_structure_due_at.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/024_course_structure_assignment_kind.down.sql
+++ b/server/migrations/024_course_structure_assignment_kind.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 024_course_structure_assignment_kind.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/025_module_assignments.down.sql
+++ b/server/migrations/025_module_assignments.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 025_module_assignments.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/026_course_markdown_theme.down.sql
+++ b/server/migrations/026_course_markdown_theme.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 026_course_markdown_theme.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/027_course_grading.down.sql
+++ b/server/migrations/027_course_grading.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 027_course_grading.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/028_default_ai_models.down.sql
+++ b/server/migrations/028_default_ai_models.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 028_default_ai_models.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/029_user_audit.down.sql
+++ b/server/migrations/029_user_audit.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 029_user_audit.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/030_reports_view_permission.down.sql
+++ b/server/migrations/030_reports_view_permission.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 030_reports_view_permission.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/031_platform_inbox_sender.down.sql
+++ b/server/migrations/031_platform_inbox_sender.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 031_platform_inbox_sender.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/032_user_profile_fields.down.sql
+++ b/server/migrations/032_user_profile_fields.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 032_user_profile_fields.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/033_module_quizzes.down.sql
+++ b/server/migrations/033_module_quizzes.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 033_module_quizzes.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/034_ui_theme.down.sql
+++ b/server/migrations/034_ui_theme.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 034_ui_theme.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/035_ensure_module_quizzes_schema.down.sql
+++ b/server/migrations/035_ensure_module_quizzes_schema.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 035_ensure_module_quizzes_schema.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/036_settings_system_prompts.down.sql
+++ b/server/migrations/036_settings_system_prompts.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 036_settings_system_prompts.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/037_quiz_generation_system_prompt.down.sql
+++ b/server/migrations/037_quiz_generation_system_prompt.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 037_quiz_generation_system_prompt.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/038_syllabus_section_system_prompt.down.sql
+++ b/server/migrations/038_syllabus_section_system_prompt.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 038_syllabus_section_system_prompt.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/039_quiz_delivery_settings.down.sql
+++ b/server/migrations/039_quiz_delivery_settings.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 039_quiz_delivery_settings.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/040_quiz_adaptive.down.sql
+++ b/server/migrations/040_quiz_adaptive.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 040_quiz_adaptive.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/041_course_enrollments_user_role_unique.down.sql
+++ b/server/migrations/041_course_enrollments_user_role_unique.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 041_course_enrollments_user_role_unique.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/042_backfill_enrollments_update_grants.down.sql
+++ b/server/migrations/042_backfill_enrollments_update_grants.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 042_backfill_enrollments_update_grants.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/043_course_structure_items_archived.down.sql
+++ b/server/migrations/043_course_structure_items_archived.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 043_course_structure_items_archived.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/044_quiz_comprehensive_settings.down.sql
+++ b/server/migrations/044_quiz_comprehensive_settings.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 044_quiz_comprehensive_settings.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/045_syllabus_require_acceptance.down.sql
+++ b/server/migrations/045_syllabus_require_acceptance.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 045_syllabus_require_acceptance.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/046_course_relative_schedule.down.sql
+++ b/server/migrations/046_course_relative_schedule.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 046_course_relative_schedule.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/047_adaptive_quiz_batch_prompt.down.sql
+++ b/server/migrations/047_adaptive_quiz_batch_prompt.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 047_adaptive_quiz_batch_prompt.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/048_user_course_catalog_order.down.sql
+++ b/server/migrations/048_user_course_catalog_order.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 048_user_course_catalog_order.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/049_course_archived.down.sql
+++ b/server/migrations/049_course_archived.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 049_course_archived.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/050_user_course_catalog_order_repair.down.sql
+++ b/server/migrations/050_user_course_catalog_order_repair.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 050_user_course_catalog_order_repair.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/051_content_page_user_markups.down.sql
+++ b/server/migrations/051_content_page_user_markups.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 051_content_page_user_markups.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/052_course_files.down.sql
+++ b/server/migrations/052_course_files.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 052_course_files.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/053_module_item_points_worth.down.sql
+++ b/server/migrations/053_module_item_points_worth.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 053_module_item_points_worth.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/054_seed_default_assignment_groups.down.sql
+++ b/server/migrations/054_seed_default_assignment_groups.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 054_seed_default_assignment_groups.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/055_course_enrollments_read_permission.down.sql
+++ b/server/migrations/055_course_enrollments_read_permission.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 055_course_enrollments_read_permission.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/056_course_items_create_grants.down.sql
+++ b/server/migrations/056_course_items_create_grants.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 056_course_items_create_grants.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/057_enrollments_catalog_teacher_ta.down.sql
+++ b/server/migrations/057_enrollments_catalog_teacher_ta.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 057_enrollments_catalog_teacher_ta.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/058_remove_student_rbac_manage.down.sql
+++ b/server/migrations/058_remove_student_rbac_manage.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 058_remove_student_rbac_manage.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/059_course_gradebook_view_permission.down.sql
+++ b/server/migrations/059_course_gradebook_view_permission.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 059_course_gradebook_view_permission.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/060_module_external_links.down.sql
+++ b/server/migrations/060_module_external_links.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 060_module_external_links.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/061_global_admin_role.down.sql
+++ b/server/migrations/061_global_admin_role.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 061_global_admin_role.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/062_user_audit_structure_item_on_delete_cascade.down.sql
+++ b/server/migrations/062_user_audit_structure_item_on_delete_cascade.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 062_user_audit_structure_item_on_delete_cascade.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/063_module_assignment_delivery_settings.down.sql
+++ b/server/migrations/063_module_assignment_delivery_settings.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 063_module_assignment_delivery_settings.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/064_course_feed.down.sql
+++ b/server/migrations/064_course_feed.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 064_course_feed.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/065_syllabus_user_markups.down.sql
+++ b/server/migrations/065_syllabus_user_markups.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 065_syllabus_user_markups.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/066_enrollment_groups.down.sql
+++ b/server/migrations/066_enrollment_groups.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 066_enrollment_groups.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/067_course_grades.down.sql
+++ b/server/migrations/067_course_grades.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 067_course_grades.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/068_password_reset_tokens.down.sql
+++ b/server/migrations/068_password_reset_tokens.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 068_password_reset_tokens.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/069_quiz_attempts_responses.down.sql
+++ b/server/migrations/069_quiz_attempts_responses.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 069_quiz_attempts_responses.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/070_assignment_rubrics.down.sql
+++ b/server/migrations/070_assignment_rubrics.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 070_assignment_rubrics.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/071_module_assignments_late_submission.down.sql
+++ b/server/migrations/071_module_assignments_late_submission.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 071_module_assignments_late_submission.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/072_course_learning_outcomes.down.sql
+++ b/server/migrations/072_course_learning_outcomes.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 072_course_learning_outcomes.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/073_course_feature_flags.down.sql
+++ b/server/migrations/073_course_feature_flags.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 073_course_feature_flags.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/074_course_outcome_link_levels.down.sql
+++ b/server/migrations/074_course_outcome_link_levels.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 074_course_outcome_link_levels.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/075_question_bank.down.sql
+++ b/server/migrations/075_question_bank.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 075_question_bank.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/076_quiz_lockdown_mode.down.sql
+++ b/server/migrations/076_quiz_lockdown_mode.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 076_quiz_lockdown_mode.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/077_student_accommodations.down.sql
+++ b/server/migrations/077_student_accommodations.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 077_student_accommodations.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/078_user_student_id.down.sql
+++ b/server/migrations/078_user_student_id.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 078_user_student_id.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/079_surveys.down.sql
+++ b/server/migrations/079_surveys.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 079_surveys.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/080_question_versioning.down.sql
+++ b/server/migrations/080_question_versioning.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 080_question_versioning.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/081_question_versioning_backfill_published.down.sql
+++ b/server/migrations/081_question_versioning_backfill_published.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 081_question_versioning_backfill_published.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/082_per_attempt_shuffling.down.sql
+++ b/server/migrations/082_per_attempt_shuffling.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 082_per_attempt_shuffling.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/083_quiz_time_limits_auto_submit.down.sql
+++ b/server/migrations/083_quiz_time_limits_auto_submit.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 083_quiz_time_limits_auto_submit.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/084_enrollment_quiz_overrides.down.sql
+++ b/server/migrations/084_enrollment_quiz_overrides.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 084_enrollment_quiz_overrides.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/085_schema_debt_settings_version_indexes_fk.down.sql
+++ b/server/migrations/085_schema_debt_settings_version_indexes_fk.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 085_schema_debt_settings_version_indexes_fk.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/086_signup_teacher_course_create.down.sql
+++ b/server/migrations/086_signup_teacher_course_create.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 086_signup_teacher_course_create.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/087_learner_model.down.sql
+++ b/server/migrations/087_learner_model.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 087_learner_model.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/088_concept_graph.down.sql
+++ b/server/migrations/088_concept_graph.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 088_concept_graph.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/089_standards_alignment.down.sql
+++ b/server/migrations/089_standards_alignment.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 089_standards_alignment.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/090_adaptive_paths.down.sql
+++ b/server/migrations/090_adaptive_paths.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 090_adaptive_paths.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/091_spaced_repetition.down.sql
+++ b/server/migrations/091_spaced_repetition.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 091_spaced_repetition.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/092_irt_calibration.down.sql
+++ b/server/migrations/092_irt_calibration.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 092_irt_calibration.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/093_diagnostic_placement.down.sql
+++ b/server/migrations/093_diagnostic_placement.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 093_diagnostic_placement.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/094_recommendations_engine.down.sql
+++ b/server/migrations/094_recommendations_engine.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 094_recommendations_engine.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/095_hints_scaffolding.down.sql
+++ b/server/migrations/095_hints_scaffolding.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 095_hints_scaffolding.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/096_misconceptions.down.sql
+++ b/server/migrations/096_misconceptions.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 096_misconceptions.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/097_lti.down.sql
+++ b/server/migrations/097_lti.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 097_lti.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/098_module_assignment_submissions.down.sql
+++ b/server/migrations/098_module_assignment_submissions.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 098_module_assignment_submissions.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/099_submission_annotations.down.sql
+++ b/server/migrations/099_submission_annotations.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 099_submission_annotations.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/100_competency_courses.down.sql
+++ b/server/migrations/100_competency_courses.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 100_competency_courses.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/101_qti_common_cartridge_import.down.sql
+++ b/server/migrations/101_qti_common_cartridge_import.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 101_qti_common_cartridge_import.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/102_submission_feedback_media.down.sql
+++ b/server/migrations/102_submission_feedback_media.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 102_submission_feedback_media.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/103_assignment_blind_grading.down.sql
+++ b/server/migrations/103_assignment_blind_grading.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 103_assignment_blind_grading.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/104_moderated_grading.down.sql
+++ b/server/migrations/104_moderated_grading.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 104_moderated_grading.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/105_originality_detection.down.sql
+++ b/server/migrations/105_originality_detection.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 105_originality_detection.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/106_grading_schemes.down.sql
+++ b/server/migrations/106_grading_schemes.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 106_grading_schemes.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/107_standards_based_grading.down.sql
+++ b/server/migrations/107_standards_based_grading.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 107_standards_based_grading.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/108_grade_posting_policies.down.sql
+++ b/server/migrations/108_grade_posting_policies.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 108_grade_posting_policies.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/109_assignment_group_drop_rules.down.sql
+++ b/server/migrations/109_assignment_group_drop_rules.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 109_assignment_group_drop_rules.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/110_grade_audit_events.down.sql
+++ b/server/migrations/110_grade_audit_events.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 110_grade_audit_events.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/111_grade_excused_state.down.sql
+++ b/server/migrations/111_grade_excused_state.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 111_grade_excused_state.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/112_submission_resubmission_workflow.down.sql
+++ b/server/migrations/112_submission_resubmission_workflow.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 112_submission_resubmission_workflow.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/113_originality_report_storage.down.sql
+++ b/server/migrations/113_originality_report_storage.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 113_originality_report_storage.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/114_saml_sso.down.sql
+++ b/server/migrations/114_saml_sso.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 114_saml_sso.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/115_oidc_sso.down.sql
+++ b/server/migrations/115_oidc_sso.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 115_oidc_sso.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/116_course_enrollment_roles_catalog.down.sql
+++ b/server/migrations/116_course_enrollment_roles_catalog.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 116_course_enrollment_roles_catalog.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/117_oneroster_provisioning.down.sql
+++ b/server/migrations/117_oneroster_provisioning.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 117_oneroster_provisioning.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/118_platform_app_settings.down.sql
+++ b/server/migrations/118_platform_app_settings.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 118_platform_app_settings.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/119_password_policy.down.sql
+++ b/server/migrations/119_password_policy.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 119_password_policy.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/120_clever_classlink.down.sql
+++ b/server/migrations/120_clever_classlink.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 120_clever_classlink.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/121_oidc_providers_clever_classlink.down.sql
+++ b/server/migrations/121_oidc_providers_clever_classlink.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 121_oidc_providers_clever_classlink.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/122_scim_provisioning.down.sql
+++ b/server/migrations/122_scim_provisioning.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 122_scim_provisioning.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/123_mfa_totp_webauthn.down.sql
+++ b/server/migrations/123_mfa_totp_webauthn.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 123_mfa_totp_webauthn.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/124_magic_link_tokens.down.sql
+++ b/server/migrations/124_magic_link_tokens.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 124_magic_link_tokens.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/125_refresh_tokens.down.sql
+++ b/server/migrations/125_refresh_tokens.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 125_refresh_tokens.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/126_session_management_refresh_columns.down.sql
+++ b/server/migrations/126_session_management_refresh_columns.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 126_session_management_refresh_columns.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/127_organizations.down.sql
+++ b/server/migrations/127_organizations.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 127_organizations.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/128_platform_smtp_settings.down.sql
+++ b/server/migrations/128_platform_smtp_settings.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 128_platform_smtp_settings.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/129_org_units.down.sql
+++ b/server/migrations/129_org_units.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 129_org_units.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/130_terms.down.sql
+++ b/server/migrations/130_terms.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 130_terms.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/131_course_sections.down.sql
+++ b/server/migrations/131_course_sections.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 131_course_sections.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/132_cross_listing.down.sql
+++ b/server/migrations/132_cross_listing.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 132_cross_listing.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/133_course_blueprints.down.sql
+++ b/server/migrations/133_course_blueprints.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 133_course_blueprints.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/134_org_branding.down.sql
+++ b/server/migrations/134_org_branding.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 134_org_branding.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/135_org_role_grants.down.sql
+++ b/server/migrations/135_org_role_grants.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 135_org_role_grants.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/136_extended_course_enrollment_roles.down.sql
+++ b/server/migrations/136_extended_course_enrollment_roles.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 136_extended_course_enrollment_roles.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/137_parent_student_links.down.sql
+++ b/server/migrations/137_parent_student_links.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 137_parent_student_links.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/138_discussion_forums.down.sql
+++ b/server/migrations/138_discussion_forums.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 138_discussion_forums.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/139_course_home_landing.down.sql
+++ b/server/migrations/139_course_home_landing.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 139_course_home_landing.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/140_cli_auth_sessions.down.sql
+++ b/server/migrations/140_cli_auth_sessions.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 140_cli_auth_sessions.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/141_email_notifications.down.sql
+++ b/server/migrations/141_email_notifications.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 141_email_notifications.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/142_onboarding_events.down.sql
+++ b/server/migrations/142_onboarding_events.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 142_onboarding_events.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/143_permission_first_rbac.down.sql
+++ b/server/migrations/143_permission_first_rbac.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 143_permission_first_rbac.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/144_push_notifications.down.sql
+++ b/server/migrations/144_push_notifications.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 144_push_notifications.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/145_virtual_classrooms.down.sql
+++ b/server/migrations/145_virtual_classrooms.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 145_virtual_classrooms.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/146_collab_docs.down.sql
+++ b/server/migrations/146_collab_docs.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 146_collab_docs.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/147_live_sessions_flag.down.sql
+++ b/server/migrations/147_live_sessions_flag.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 147_live_sessions_flag.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/148_group_spaces.down.sql
+++ b/server/migrations/148_group_spaces.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 148_group_spaces.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/149_office_hours.down.sql
+++ b/server/migrations/149_office_hours.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 149_office_hours.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/150_support_widget.down.sql
+++ b/server/migrations/150_support_widget.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 150_support_widget.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/151_ai_tutor.down.sql
+++ b/server/migrations/151_ai_tutor.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 151_ai_tutor.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/152_multilingual_messaging.down.sql
+++ b/server/migrations/152_multilingual_messaging.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 152_multilingual_messaging.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/153_storage_objects.down.sql
+++ b/server/migrations/153_storage_objects.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 153_storage_objects.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/154_storage_migrations.down.sql
+++ b/server/migrations/154_storage_migrations.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 154_storage_migrations.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/155_tus_uploads.down.sql
+++ b/server/migrations/155_tus_uploads.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 155_tus_uploads.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/156_drm_settings.down.sql
+++ b/server/migrations/156_drm_settings.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 156_drm_settings.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/157_transcode_jobs.down.sql
+++ b/server/migrations/157_transcode_jobs.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 157_transcode_jobs.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/158_captions.down.sql
+++ b/server/migrations/158_captions.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 158_captions.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/159_storage_quotas.down.sql
+++ b/server/migrations/159_storage_quotas.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 159_storage_quotas.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/160_cloud_provider_settings.down.sql
+++ b/server/migrations/160_cloud_provider_settings.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 160_cloud_provider_settings.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/161_user_legal_acknowledgements.down.sql
+++ b/server/migrations/161_user_legal_acknowledgements.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 161_user_legal_acknowledgements.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/162_av_scan.down.sql
+++ b/server/migrations/162_av_scan.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 162_av_scan.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/163_oer_library.down.sql
+++ b/server/migrations/163_oer_library.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 163_oer_library.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/164_equation_editor_audit.down.sql
+++ b/server/migrations/164_equation_editor_audit.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 164_equation_editor_audit.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/165_h5p_packages.down.sql
+++ b/server/migrations/165_h5p_packages.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 165_h5p_packages.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/166_trust_sub_processor_subscriptions.down.sql
+++ b/server/migrations/166_trust_sub_processor_subscriptions.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 166_trust_sub_processor_subscriptions.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/167_equation_editor_open_audit.down.sql
+++ b/server/migrations/167_equation_editor_open_audit.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 167_equation_editor_open_audit.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/168_student_progress.down.sql
+++ b/server/migrations/168_student_progress.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 168_student_progress.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/169_at_risk_alerts.down.sql
+++ b/server/migrations/169_at_risk_alerts.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 169_at_risk_alerts.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/170_item_stats.down.sql
+++ b/server/migrations/170_item_stats.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 170_item_stats.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/171_mastery_heatmap_cache.down.sql
+++ b/server/migrations/171_mastery_heatmap_cache.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 171_mastery_heatmap_cache.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/172_platform_feature_flags.down.sql
+++ b/server/migrations/172_platform_feature_flags.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 172_platform_feature_flags.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/173_outcomes_report.down.sql
+++ b/server/migrations/173_outcomes_report.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 173_outcomes_report.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/174_xapi_caliper_emission.down.sql
+++ b/server/migrations/174_xapi_caliper_emission.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 174_xapi_caliper_emission.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/175_engagement_events.down.sql
+++ b/server/migrations/175_engagement_events.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 175_engagement_events.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/176_report_schedules.down.sql
+++ b/server/migrations/176_report_schedules.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 176_report_schedules.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/177_self_reflection.down.sql
+++ b/server/migrations/177_self_reflection.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 177_self_reflection.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/178_instructor_insights.down.sql
+++ b/server/migrations/178_instructor_insights.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 178_instructor_insights.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/179_ferpa.down.sql
+++ b/server/migrations/179_ferpa.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 179_ferpa.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/180_coppa.down.sql
+++ b/server/migrations/180_coppa.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 180_coppa.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/181_coppa_platform_settings.down.sql
+++ b/server/migrations/181_coppa_platform_settings.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 181_coppa_platform_settings.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/182_gdpr.down.sql
+++ b/server/migrations/182_gdpr.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 182_gdpr.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/183_gdpr_platform_settings.down.sql
+++ b/server/migrations/183_gdpr_platform_settings.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 183_gdpr_platform_settings.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/184_show_help_popover.down.sql
+++ b/server/migrations/184_show_help_popover.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 184_show_help_popover.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/185_ccpa.down.sql
+++ b/server/migrations/185_ccpa.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 185_ccpa.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/186_ccpa_platform_settings.down.sql
+++ b/server/migrations/186_ccpa_platform_settings.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 186_ccpa_platform_settings.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/187_dpa.down.sql
+++ b/server/migrations/187_dpa.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 187_dpa.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/188_state_privacy.down.sql
+++ b/server/migrations/188_state_privacy.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 188_state_privacy.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/189_state_privacy_platform_settings.down.sql
+++ b/server/migrations/189_state_privacy_platform_settings.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 189_state_privacy_platform_settings.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/190_soc2_compliance.down.sql
+++ b/server/migrations/190_soc2_compliance.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 190_soc2_compliance.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/191_iso_isms.down.sql
+++ b/server/migrations/191_iso_isms.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 191_iso_isms.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/192_vibe_activities.down.sql
+++ b/server/migrations/192_vibe_activities.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 192_vibe_activities.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/193_data_residency.down.sql
+++ b/server/migrations/193_data_residency.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 193_data_residency.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/194_encryption_at_rest.down.sql
+++ b/server/migrations/194_encryption_at_rest.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 194_encryption_at_rest.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/195_admin_audit_log.down.sql
+++ b/server/migrations/195_admin_audit_log.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 195_admin_audit_log.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/196_pii_redaction_logs.down.sql
+++ b/server/migrations/196_pii_redaction_logs.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 196_pii_redaction_logs.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/197_backup_restore_rpo_rto.down.sql
+++ b/server/migrations/197_backup_restore_rpo_rto.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 197_backup_restore_rpo_rto.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/198_security_reports.down.sql
+++ b/server/migrations/198_security_reports.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 198_security_reports.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/199_ai_disclosure.down.sql
+++ b/server/migrations/199_ai_disclosure.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 199_ai_disclosure.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/200_user_locale.down.sql
+++ b/server/migrations/200_user_locale.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 200_user_locale.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/201_i18n_locale_rtl.down.sql
+++ b/server/migrations/201_i18n_locale_rtl.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 201_i18n_locale_rtl.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/202_user_locale_timezone.down.sql
+++ b/server/migrations/202_user_locale_timezone.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 202_user_locale_timezone.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/203_user_timezone.down.sql
+++ b/server/migrations/203_user_timezone.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 203_user_timezone.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/204_reading_level.down.sql
+++ b/server/migrations/204_reading_level.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 204_reading_level.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/205_translation_memory.down.sql
+++ b/server/migrations/205_translation_memory.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 205_translation_memory.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/206_a11y_screen_reader_audit.down.sql
+++ b/server/migrations/206_a11y_screen_reader_audit.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 206_a11y_screen_reader_audit.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/209_video_captions_accessibility.down.sql
+++ b/server/migrations/209_video_captions_accessibility.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 209_video_captions_accessibility.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/210_alt_text_enforcement.down.sql
+++ b/server/migrations/210_alt_text_enforcement.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 210_alt_text_enforcement.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/211_user_reading_preferences.down.sql
+++ b/server/migrations/211_user_reading_preferences.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 211_user_reading_preferences.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/212_high_contrast_reduced_motion.down.sql
+++ b/server/migrations/212_high_contrast_reduced_motion.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 212_high_contrast_reduced_motion.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/213_read_aloud_tts.down.sql
+++ b/server/migrations/213_read_aloud_tts.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 213_read_aloud_tts.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/214_speech_to_text.down.sql
+++ b/server/migrations/214_speech_to_text.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 214_speech_to_text.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/215_accommodations_engine.down.sql
+++ b/server/migrations/215_accommodations_engine.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 215_accommodations_engine.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/216_parent_portal.down.sql
+++ b/server/migrations/216_parent_portal.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 216_parent_portal.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/217_attendance.down.sql
+++ b/server/migrations/217_attendance.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 217_attendance.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/218_course_at_risk_config.down.sql
+++ b/server/migrations/218_course_at_risk_config.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 218_course_at_risk_config.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/219_notebook_flash_cards_prompt.down.sql
+++ b/server/migrations/219_notebook_flash_cards_prompt.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 219_notebook_flash_cards_prompt.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/220_behavior_pbis.down.sql
+++ b/server/migrations/220_behavior_pbis.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 220_behavior_pbis.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/221_notebook_flashcards_model.down.sql
+++ b/server/migrations/221_notebook_flashcards_model.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 221_notebook_flashcards_model.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/222_report_cards.down.sql
+++ b/server/migrations/222_report_cards.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 222_report_cards.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/223_standards_sbg.down.sql
+++ b/server/migrations/223_standards_sbg.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 223_standards_sbg.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/224_course_files_manager.down.sql
+++ b/server/migrations/224_course_files_manager.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 224_course_files_manager.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/225_course_attendance_sessions.down.sql
+++ b/server/migrations/225_course_attendance_sessions.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 225_course_attendance_sessions.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/226_grade_level.down.sql
+++ b/server/migrations/226_grade_level.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 226_grade_level.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/227_sis_integration.down.sql
+++ b/server/migrations/227_sis_integration.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 227_sis_integration.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/228_org_type.down.sql
+++ b/server/migrations/228_org_type.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 228_org_type.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/229_library.down.sql
+++ b/server/migrations/229_library.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 229_library.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/230_course_whiteboard.down.sql
+++ b/server/migrations/230_course_whiteboard.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 230_course_whiteboard.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/231_hall_pass.down.sql
+++ b/server/migrations/231_hall_pass.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 231_hall_pass.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/232_broadcasts.down.sql
+++ b/server/migrations/232_broadcasts.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 232_broadcasts.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/233_ui_mode.down.sql
+++ b/server/migrations/233_ui_mode.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 233_ui_mode.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/234_vibe_activity_model.down.sql
+++ b/server/migrations/234_vibe_activity_model.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 234_vibe_activity_model.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/235_cloud_provider_credentials.down.sql
+++ b/server/migrations/235_cloud_provider_credentials.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 235_cloud_provider_credentials.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/236_command_palette_search.down.sql
+++ b/server/migrations/236_command_palette_search.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 236_command_palette_search.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/237_conference_scheduling.down.sql
+++ b/server/migrations/237_conference_scheduling.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 237_conference_scheduling.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/238_student_demographics.down.sql
+++ b/server/migrations/238_student_demographics.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 238_student_demographics.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/239_content_filter_integration.down.sql
+++ b/server/migrations/239_content_filter_integration.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 239_content_filter_integration.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/240_canvas_import_jobs.down.sql
+++ b/server/migrations/240_canvas_import_jobs.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 240_canvas_import_jobs.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/241_feed_announcements_channel.down.sql
+++ b/server/migrations/241_feed_announcements_channel.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 241_feed_announcements_channel.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/242_student_notebook_tasks.down.sql
+++ b/server/migrations/242_student_notebook_tasks.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 242_student_notebook_tasks.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/243_he_sis_integration.down.sql
+++ b/server/migrations/243_he_sis_integration.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 243_he_sis_integration.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/244_course_catalog.down.sql
+++ b/server/migrations/244_course_catalog.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 244_course_catalog.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/245_enrollment_state_machine.down.sql
+++ b/server/migrations/245_enrollment_state_machine.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 245_enrollment_state_machine.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/246_incomplete_grades.down.sql
+++ b/server/migrations/246_incomplete_grades.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 246_incomplete_grades.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/247_final_grade_submissions.down.sql
+++ b/server/migrations/247_final_grade_submissions.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 247_final_grade_submissions.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/248_academic_calendar.down.sql
+++ b/server/migrations/248_academic_calendar.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 248_academic_calendar.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/249_course_evaluations.down.sql
+++ b/server/migrations/249_course_evaluations.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 249_course_evaluations.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/250_plagiarism_workflow.down.sql
+++ b/server/migrations/250_plagiarism_workflow.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 250_plagiarism_workflow.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/251_course_grade_instructor_comment.down.sql
+++ b/server/migrations/251_course_grade_instructor_comment.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 251_course_grade_instructor_comment.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/252_user_course_catalog_prefs.down.sql
+++ b/server/migrations/252_user_course_catalog_prefs.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 252_user_course_catalog_prefs.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/253_live_sessions_default_off.down.sql
+++ b/server/migrations/253_live_sessions_default_off.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 253_live_sessions_default_off.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/254_quiz_proctoring.down.sql
+++ b/server/migrations/254_quiz_proctoring.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 254_quiz_proctoring.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/255_he_library_ereserves.down.sql
+++ b/server/migrations/255_he_library_ereserves.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 255_he_library_ereserves.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/256_bookstore_textbook.down.sql
+++ b/server/migrations/256_bookstore_textbook.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 256_bookstore_textbook.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/257_eportfolio_capstone.down.sql
+++ b/server/migrations/257_eportfolio_capstone.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 257_eportfolio_capstone.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/259_co_curricular_transcript.down.sql
+++ b/server/migrations/259_co_curricular_transcript.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 259_co_curricular_transcript.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/260_ff_eportfolio_platform_flag.down.sql
+++ b/server/migrations/260_ff_eportfolio_platform_flag.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 260_ff_eportfolio_platform_flag.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/261_portfolio_heading_artifact_type.down.sql
+++ b/server/migrations/261_portfolio_heading_artifact_type.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 261_portfolio_heading_artifact_type.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/262_student_notebooks.down.sql
+++ b/server/migrations/262_student_notebooks.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 262_student_notebooks.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/263_transcripts.down.sql
+++ b/server/migrations/263_transcripts.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 263_transcripts.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/264_transcript_delivery.down.sql
+++ b/server/migrations/264_transcript_delivery.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 264_transcript_delivery.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/265_transcript_urgency_range.down.sql
+++ b/server/migrations/265_transcript_urgency_range.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 265_transcript_urgency_range.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/266_user_course_catalog_pins.down.sql
+++ b/server/migrations/266_user_course_catalog_pins.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 266_user_course_catalog_pins.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/267_feature_flags_env_to_db.down.sql
+++ b/server/migrations/267_feature_flags_env_to_db.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 267_feature_flags_env_to_db.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/268_ff_ui_mode_column.down.sql
+++ b/server/migrations/268_ff_ui_mode_column.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 268_ff_ui_mode_column.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/269_advising.down.sql
+++ b/server/migrations/269_advising.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 269_advising.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/270_research_consent.down.sql
+++ b/server/migrations/270_research_consent.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 270_research_consent.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/271_accessibility_services.down.sql
+++ b/server/migrations/271_accessibility_services.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 271_accessibility_services.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/272_api_tokens.down.sql
+++ b/server/migrations/272_api_tokens.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 272_api_tokens.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/273_api_token_course_ids.down.sql
+++ b/server/migrations/273_api_token_course_ids.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 273_api_token_course_ids.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/274_ceu_tracking.down.sql
+++ b/server/migrations/274_ceu_tracking.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 274_ceu_tracking.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/275_consortium.down.sql
+++ b/server/migrations/275_consortium.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 275_consortium.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/276_public_course_catalog.down.sql
+++ b/server/migrations/276_public_course_catalog.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 276_public_course_catalog.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/277_self_paced_mode.down.sql
+++ b/server/migrations/277_self_paced_mode.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 277_self_paced_mode.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/278_billing_stripe.down.sql
+++ b/server/migrations/278_billing_stripe.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 278_billing_stripe.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/279_learning_paths.down.sql
+++ b/server/migrations/279_learning_paths.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 279_learning_paths.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/280_enrollment_invitations.down.sql
+++ b/server/migrations/280_enrollment_invitations.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 280_enrollment_invitations.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/281_ai_usage_logs.down.sql
+++ b/server/migrations/281_ai_usage_logs.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 281_ai_usage_logs.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/283_credentials_linkedin_share.down.sql
+++ b/server/migrations/283_credentials_linkedin_share.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 283_credentials_linkedin_share.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/284_course_reviews.down.sql
+++ b/server/migrations/284_course_reviews.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 284_course_reviews.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/285_revenue_share.down.sql
+++ b/server/migrations/285_revenue_share.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 285_revenue_share.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/286_canvas_grade_sync_enabled.down.sql
+++ b/server/migrations/286_canvas_grade_sync_enabled.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 286_canvas_grade_sync_enabled.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/287_gamification.down.sql
+++ b/server/migrations/287_gamification.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 287_gamification.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/288_user_phone_sms_notifications.down.sql
+++ b/server/migrations/288_user_phone_sms_notifications.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 288_user_phone_sms_notifications.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/289_study_reminders.down.sql
+++ b/server/migrations/289_study_reminders.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 289_study_reminders.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/290_grading_agent.down.sql
+++ b/server/migrations/290_grading_agent.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 290_grading_agent.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/291_grader_agent_model.down.sql
+++ b/server/migrations/291_grader_agent_model.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 291_grader_agent_model.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/292_learner_goals.down.sql
+++ b/server/migrations/292_learner_goals.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 292_learner_goals.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/293_instructor_comments_json.down.sql
+++ b/server/migrations/293_instructor_comments_json.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 293_instructor_comments_json.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/294_course_files_submission_size_500mb.down.sql
+++ b/server/migrations/294_course_files_submission_size_500mb.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 294_course_files_submission_size_500mb.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/295_course_archived_metadata.down.sql
+++ b/server/migrations/295_course_archived_metadata.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 295_course_archived_metadata.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/296_study_buddy.down.sql
+++ b/server/migrations/296_study_buddy.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 296_study_buddy.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/297_public_api.down.sql
+++ b/server/migrations/297_public_api.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 297_public_api.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/298_api_tokens_service_and_rotation.down.sql
+++ b/server/migrations/298_api_tokens_service_and_rotation.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 298_api_tokens_service_and_rotation.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/299_webhook_subscriptions.down.sql
+++ b/server/migrations/299_webhook_subscriptions.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 299_webhook_subscriptions.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/300_integrations.down.sql
+++ b/server/migrations/300_integrations.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 300_integrations.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/301_calendar_tokens.down.sql
+++ b/server/migrations/301_calendar_tokens.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 301_calendar_tokens.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/302_bot_connections.down.sql
+++ b/server/migrations/302_bot_connections.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 302_bot_connections.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/303_conditional_release.down.sql
+++ b/server/migrations/303_conditional_release.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 303_conditional_release.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/304_assignment_overrides.down.sql
+++ b/server/migrations/304_assignment_overrides.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 304_assignment_overrides.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/305_scorm_packages.down.sql
+++ b/server/migrations/305_scorm_packages.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 305_scorm_packages.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/306_peer_review.down.sql
+++ b/server/migrations/306_peer_review.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 306_peer_review.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/307_whatif_grades.down.sql
+++ b/server/migrations/307_whatif_grades.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 307_whatif_grades.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/308_grade_curving.down.sql
+++ b/server/migrations/308_grade_curving.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 308_grade_curving.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/309_submission_attachments.down.sql
+++ b/server/migrations/309_submission_attachments.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 309_submission_attachments.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/310_scim_groups.down.sql
+++ b/server/migrations/310_scim_groups.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 310_scim_groups.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/311_grading_agent_workflow.down.sql
+++ b/server/migrations/311_grading_agent_workflow.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 311_grading_agent_workflow.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/312_grading_agent_templates.down.sql
+++ b/server/migrations/312_grading_agent_templates.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 312_grading_agent_templates.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/313_code_execution_enabled.down.sql
+++ b/server/migrations/313_code_execution_enabled.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 313_code_execution_enabled.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/314_grading_agent_flagged.down.sql
+++ b/server/migrations/314_grading_agent_flagged.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 314_grading_agent_flagged.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/315_grading_agent_held.down.sql
+++ b/server/migrations/315_grading_agent_held.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 315_grading_agent_held.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/316_tax_compliance.down.sql
+++ b/server/migrations/316_tax_compliance.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 316_tax_compliance.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/317_tenant_ai_settings.down.sql
+++ b/server/migrations/317_tenant_ai_settings.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 317_tenant_ai_settings.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/318_grading_agent_default_templates.down.sql
+++ b/server/migrations/318_grading_agent_default_templates.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 318_grading_agent_default_templates.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/319_ai_grader_template_prompt.down.sql
+++ b/server/migrations/319_ai_grader_template_prompt.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 319_ai_grader_template_prompt.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/320_ai_grader_template_prompt_v2.down.sql
+++ b/server/migrations/320_ai_grader_template_prompt_v2.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 320_ai_grader_template_prompt_v2.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/321_grading_agent_run_terminal_states.down.sql
+++ b/server/migrations/321_grading_agent_run_terminal_states.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 321_grading_agent_run_terminal_states.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/322_grading_agent_review_indexes.down.sql
+++ b/server/migrations/322_grading_agent_review_indexes.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 322_grading_agent_review_indexes.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/323_grading_agent_results_unique_run_submission.down.sql
+++ b/server/migrations/323_grading_agent_results_unique_run_submission.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 323_grading_agent_results_unique_run_submission.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/324_grading_agent_run_mode.down.sql
+++ b/server/migrations/324_grading_agent_run_mode.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 324_grading_agent_run_mode.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/325_submission_body_text.down.sql
+++ b/server/migrations/325_submission_body_text.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 325_submission_body_text.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/326_grading_agent_input_modality.down.sql
+++ b/server/migrations/326_grading_agent_input_modality.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 326_grading_agent_input_modality.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/327_grader_agent_multimodal_grading_flags.down.sql
+++ b/server/migrations/327_grader_agent_multimodal_grading_flags.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 327_grader_agent_multimodal_grading_flags.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/328_grading_agent_run_filter.down.sql
+++ b/server/migrations/328_grading_agent_run_filter.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 328_grading_agent_run_filter.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/329_grading_agent_normalize_legacy_nodes.down.sql
+++ b/server/migrations/329_grading_agent_normalize_legacy_nodes.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 329_grading_agent_normalize_legacy_nodes.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/330_grading_agent_run_cancel.down.sql
+++ b/server/migrations/330_grading_agent_run_cancel.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 330_grading_agent_run_cancel.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/331_grading_agent_run_cost.down.sql
+++ b/server/migrations/331_grading_agent_run_cost.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 331_grading_agent_run_cost.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/332_zapier_connector.down.sql
+++ b/server/migrations/332_zapier_connector.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 332_zapier_connector.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/333_payments.down.sql
+++ b/server/migrations/333_payments.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 333_payments.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/334_marketplace.down.sql
+++ b/server/migrations/334_marketplace.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 334_marketplace.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/335_quiz_manual_grading_is_correct_backfill.down.sql
+++ b/server/migrations/335_quiz_manual_grading_is_correct_backfill.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 335_quiz_manual_grading_is_correct_backfill.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/336_student_todo_board.down.sql
+++ b/server/migrations/336_student_todo_board.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 336_student_todo_board.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/337_canvas_structure_item_ids.down.sql
+++ b/server/migrations/337_canvas_structure_item_ids.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 337_canvas_structure_item_ids.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/338_job_queue.down.sql
+++ b/server/migrations/338_job_queue.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 338_job_queue.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/339_report_cards_enabled.down.sql
+++ b/server/migrations/339_report_cards_enabled.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 339_report_cards_enabled.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/340_scheduler.down.sql
+++ b/server/migrations/340_scheduler.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 340_scheduler.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/341_redis_cache.down.sql
+++ b/server/migrations/341_redis_cache.down.sql
@@ -1,0 +1,2 @@
+-- Rollback for 341_redis_cache.sql
+ALTER TABLE settings.platform_app_settings DROP COLUMN IF EXISTS ff_redis_cache;

--- a/server/migrations/342_api_token_rate_limit.down.sql
+++ b/server/migrations/342_api_token_rate_limit.down.sql
@@ -1,0 +1,2 @@
+-- Rollback for 342_api_token_rate_limit.sql
+ALTER TABLE auth.api_tokens DROP COLUMN IF EXISTS rate_limit_per_min;

--- a/server/migrations/343_user_course_catalog_pin_rows.down.sql
+++ b/server/migrations/343_user_course_catalog_pin_rows.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 343_user_course_catalog_pin_rows.sql
+-- See docs/runbooks/database-migration-rollback.md

--- a/server/migrations/344_device_push_tokens.down.sql
+++ b/server/migrations/344_device_push_tokens.down.sql
@@ -1,0 +1,2 @@
+-- Rollback for 344_device_push_tokens.sql (tested in CI integration test)
+DROP TABLE IF EXISTS settings.device_push_tokens;

--- a/server/migrations/345_migration_deploy_tracking.down.sql
+++ b/server/migrations/345_migration_deploy_tracking.down.sql
@@ -1,0 +1,3 @@
+-- Rollback not supported: restore from backup
+-- Companion to: 345_migration_deploy_tracking.sql
+-- Removing deploy_id tracking loses deploy correlation metadata only; schema is otherwise unchanged.

--- a/server/migrations/345_migration_deploy_tracking.sql
+++ b/server/migrations/345_migration_deploy_tracking.sql
@@ -1,0 +1,6 @@
+-- Plan 17.10: correlate applied migrations with deploys for incident response.
+
+ALTER TABLE _sqlx_migrations ADD COLUMN IF NOT EXISTS deploy_id TEXT;
+
+COMMENT ON COLUMN _sqlx_migrations.deploy_id IS
+    'Optional deploy identifier (DEPLOY_ID env) recorded when the migration was applied.';

--- a/server/migrations/README.md
+++ b/server/migrations/README.md
@@ -1,0 +1,126 @@
+# Database migrations
+
+Versioned SQL migrations for the Lextures Postgres schema. Applied at API startup when
+`RUN_MIGRATIONS=true` (or manually via `go run ./cmd/migrate`).
+
+## Naming convention
+
+| File | Purpose |
+|---|---|
+| `NNN_short_description.sql` | **Up** migration — applied in ascending numeric order |
+| `NNN_short_description.down.sql` | **Down** companion — manual rollback SQL (required for every up file) |
+
+- `NNN` is a zero-padded sequence number (e.g. `001`, `345`).
+- Use lowercase snake_case for the description.
+- One logical change per file when possible.
+
+## Adding a migration
+
+1. Pick the next sequence number: `ls server/migrations/*.sql | grep -v down | tail -1`
+2. Create `NNN_your_change.sql` with the forward DDL/DML.
+3. Create `NNN_your_change.down.sql` with rollback SQL, or a documented stub:
+
+   ```sql
+   -- Rollback not supported: restore from backup
+   -- Companion to: NNN_your_change.sql
+   -- See docs/runbooks/database-migration-rollback.md
+   ```
+
+4. Run `go run ./cmd/migrate lint` from `server/`.
+5. Run `go test ./internal/migrate/...` with `DATABASE_URL` set.
+
+## Expand / contract pattern (backward-compatible changes)
+
+Blue/green deploys require the **old** app version to keep running while the **new**
+version is canaried. Schema changes must therefore be backward-compatible during the
+overlap window.
+
+Follow the [expand / contract / migrate / contract](https://www.martinfowler.com/bliki/ParallelChange.html)
+sequence:
+
+### 1. Expand
+
+Add new columns, tables, or indexes **without removing** old ones.
+
+```sql
+-- Expand: add nullable column; old app ignores it
+ALTER TABLE course.courses ADD COLUMN IF NOT EXISTS new_field TEXT;
+```
+
+### 2. Migrate (dual-write / backfill)
+
+Backfill data in **batched** transactions (1,000 rows per batch) to avoid long table locks:
+
+```sql
+DO $$
+DECLARE
+  batch_size INT := 1000;
+  rows_updated INT;
+BEGIN
+  LOOP
+    UPDATE course.courses
+    SET new_field = legacy_field
+    WHERE id IN (
+      SELECT id FROM course.courses
+      WHERE new_field IS NULL AND legacy_field IS NOT NULL
+      LIMIT batch_size
+    );
+    GET DIAGNOSTICS rows_updated = ROW_COUNT;
+    EXIT WHEN rows_updated = 0;
+    COMMIT;  -- in a script: use separate transactions per batch
+  END LOOP;
+END $$;
+```
+
+Deploy app code that **writes to both** old and new columns during the transition.
+
+### 3. Contract
+
+Only after **all** running instances use the new schema, remove old columns in a
+separate migration:
+
+```sql
+-- Contract: safe only after every instance reads/writes new_field
+ALTER TABLE course.courses DROP COLUMN legacy_field;
+```
+
+Destructive operations (`DROP COLUMN`, `DROP TABLE`, `RENAME COLUMN`, `ALTER COLUMN TYPE`)
+emit **CI warnings** and require explicit reviewer sign-off.
+
+## NOT NULL and type changes
+
+- Adding `NOT NULL` without a `DEFAULT` rewrites the whole table on Postgres — add the
+  column nullable, backfill, then `SET NOT NULL` in a follow-up migration.
+- Column type changes require expand/contract with a new column and batched copy.
+
+## Rollback
+
+Automatic down-migration is **not** run at startup. To roll back the latest migration
+manually:
+
+```bash
+cd server
+DATABASE_URL=postgres://... go run ./cmd/migrate rollback
+```
+
+See `docs/runbooks/database-migration-rollback.md` for production procedures.
+
+## Deploy tracking
+
+Set `DEPLOY_ID` (e.g. Git SHA or release tag) when applying migrations so
+`_sqlx_migrations.deploy_id` correlates schema changes with deploys during incidents.
+
+## CI checks
+
+`go run ./cmd/migrate-lint` (also run in CI) validates:
+
+- Every up migration has a companion `.down.sql` (**blocks** on missing files)
+- No inline secrets in SQL files (**blocks**)
+- Destructive DDL patterns (**warns** — requires reviewer attention)
+- Full-table `UPDATE` without batching (**warns**)
+
+## References
+
+- ADR: `docs/adr/0002-expand-contract-migrations.md`
+- Runbook: `docs/runbooks/database-migration-rollback.md`
+- Implementation: `server/internal/migrate/`

--- a/server/scripts/gen_migration_down_stubs.py
+++ b/server/scripts/gen_migration_down_stubs.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Generate companion .down.sql files for every up migration in server/migrations/."""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "migrations"
+
+STUB = """-- Rollback not supported: restore from backup
+-- Companion to: {name}
+-- See docs/runbooks/database-migration-rollback.md
+"""
+
+# Recent additive migrations with tested rollback SQL (plan 17.10).
+REAL_DOWN: dict[str, str] = {
+    "344_device_push_tokens.sql": """-- Rollback for 344_device_push_tokens.sql (tested in CI integration test)
+DROP TABLE IF EXISTS settings.device_push_tokens;
+""",
+    "342_api_token_rate_limit.sql": """-- Rollback for 342_api_token_rate_limit.sql
+ALTER TABLE auth.api_tokens DROP COLUMN IF EXISTS rate_limit_per_min;
+""",
+    "341_redis_cache.sql": """-- Rollback for 341_redis_cache.sql
+ALTER TABLE settings.platform_app_settings DROP COLUMN IF EXISTS ff_redis_cache;
+""",
+}
+
+
+def main() -> None:
+    up_files = sorted(p for p in ROOT.glob("*.sql") if not p.name.endswith(".down.sql"))
+    created = 0
+    skipped = 0
+    for up in up_files:
+        down = up.with_name(up.stem + ".down.sql")
+        if down.exists():
+            skipped += 1
+            continue
+        body = REAL_DOWN.get(up.name, STUB.format(name=up.name))
+        down.write_text(body)
+        created += 1
+    print(f"created={created} skipped={skipped} total_up={len(up_files)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/serverdata.go
+++ b/server/serverdata.go
@@ -4,7 +4,7 @@ package serverdata
 
 import "embed"
 
-// Migrations is the SQLx 001–116 tree (a byte-for-byte copy of server/migrations).
+// Migrations is the SQL migration tree (server/migrations).
 //
 //go:embed all:migrations
 var Migrations embed.FS


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements plan **17.10 — Database Migration Rollback Strategy** so schema changes follow a documented expand/contract process, every up migration has a companion `down.sql`, and operators have a tested rollback path without full backup restore.

## Changes

- **`server/migrations/README.md`** — expand/contract pattern, naming convention, batched backfill guidance, rollback instructions
- **341 companion `.down.sql` files** — stubs for historical migrations; executable rollback SQL for recent additive migrations (341–344)
- **`345_migration_deploy_tracking.sql`** — adds `deploy_id` to `_sqlx_migrations` (populated from `DEPLOY_ID` env)
- **`server/internal/migrate/`** — skip down files on apply; `RollbackLatest`; `LintFS`; structured apply/rollback logging
- **`server/cmd/migrate`** — `rollback` and `lint` subcommands for operations
- **`server/cmd/migrate-lint`** — CI entrypoint
- **CI** — migration lint step blocks missing down.sql / inline secrets; warns on destructive DDL
- **Docs** — ADR `0002-expand-contract-migrations.md`, runbook `database-migration-rollback.md`
- Plan moved to `docs/completed/17-platform-performance-operability/17.10-database-migration-rollback.md`

## Testing

- `go test ./internal/migrate/... -short` (unit tests)
- `go run ./cmd/migrate-lint` (validates all embedded migrations)
- Postgres integration tests (`TestRollbackLatest_Integration`, `TestLint_EmbeddedMigrations`) run in CI with service Postgres

## Operator notes

- Set `DEPLOY_ID` (e.g. Git SHA) on deploy to correlate migrations with releases
- Roll back latest migration: `DATABASE_URL=... go run ./cmd/migrate rollback`
- Destructive DDL warnings in CI require explicit reviewer sign-off per expand/contract policy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1525-b6c3-7fb4-88b4-8dae5bf703d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1525-b6c3-7fb4-88b4-8dae5bf703d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

