### PR TITLE
fix(demo): repair migration 345 renumber collision blocking deploy

### DIFF
--- a/server/internal/migrate/repair.go
+++ b/server/internal/migrate/repair.go
@@ -362,6 +362,88 @@ SELECT EXISTS (
 	return tx.Commit(ctx)
 }
 
+// repairMigration345RenumberCollision fixes demo DBs that applied submission_annotation_anchor
+// as v345 before main's 345_migration_deploy_tracking.sql landed and the anchor migration
+// was renumbered to 346 (plan 17.10 / admin console renumber).
+func repairMigration345RenumberCollision(ctx context.Context, c *pgx.Conn, fsys fs.FS, dir string) error {
+	if !migrateRepairChecksumsEnabled() {
+		return nil
+	}
+	var v345Desc string
+	err := c.QueryRow(ctx,
+		`SELECT description FROM `+sqlxMigrationsTable+` WHERE version = 345`,
+	).Scan(&v345Desc)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("migrate repair v345 renumber: %w", err)
+	}
+	if v345Desc != "submission_annotation_anchor" {
+		return nil
+	}
+	var deployIDColumn bool
+	err = c.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = current_schema()
+			  AND table_name = $1
+			  AND column_name = 'deploy_id'
+		)`, sqlxMigrationsTable).Scan(&deployIDColumn)
+	if err != nil {
+		return fmt.Errorf("migrate repair v345 renumber: %w", err)
+	}
+	if deployIDColumn {
+		return nil
+	}
+
+	deployBody, err := fs.ReadFile(fsys, dir+"/345_migration_deploy_tracking.sql")
+	if err != nil {
+		return fmt.Errorf("migrate repair v345 renumber: read deploy_tracking: %w", err)
+	}
+	if _, err := c.Exec(ctx, string(deployBody)); err != nil {
+		return fmt.Errorf("migrate repair v345 renumber: apply deploy_tracking: %w", err)
+	}
+
+	deploySum := sqlxChecksum(deployBody)
+	anchorBody, err := fs.ReadFile(fsys, dir+"/346_submission_annotation_anchor.sql")
+	if err != nil {
+		return fmt.Errorf("migrate repair v345 renumber: read submission_annotation_anchor: %w", err)
+	}
+	anchorSum := sqlxChecksum(anchorBody)
+
+	tx, err := c.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx,
+		`UPDATE `+sqlxMigrationsTable+` SET description = $1, checksum = $2 WHERE version = 345`,
+		"migration_deploy_tracking", deploySum[:],
+	); err != nil {
+		return fmt.Errorf("migrate repair v345 renumber: update v345: %w", err)
+	}
+
+	var v346Exists bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM `+sqlxMigrationsTable+` WHERE version = 346)`,
+	).Scan(&v346Exists); err != nil {
+		return fmt.Errorf("migrate repair v345 renumber: check v346: %w", err)
+	}
+	if !v346Exists {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO `+sqlxMigrationsTable+` (version, description, success, checksum, execution_time) VALUES ($1, $2, true, $3, 0)`,
+			int64(346), "submission_annotation_anchor", anchorSum[:],
+		); err != nil {
+			return fmt.Errorf("migrate repair v345 renumber: insert v346: %w", err)
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
 // repairMigration334RenumberCollision fixes dev/demo DBs that applied
 // quiz_manual_grading_is_correct_backfill as v334 before main's 334_marketplace.sql
 // landed and the backfill was renumbered to 335.

--- a/server/internal/migrate/repair_345_test.go
+++ b/server/internal/migrate/repair_345_test.go
@@ -1,0 +1,88 @@
+package migrate
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/lextures/lextures/server"
+)
+
+// TestRepairMigration345RenumberCollision_Integration simulates the demo droplet DB that
+// applied submission_annotation_anchor as v345 before plan 17.10 renumbered deploy tracking
+// to 345 and the anchor migration to 346.
+func TestRepairMigration345RenumberCollision_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("use full go test to exercise migration repair with Postgres")
+	}
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("set DATABASE_URL to run integration test")
+	}
+	t.Setenv("MIGRATE_REPAIR_CHECKSUMS", "1")
+
+	ctx := context.Background()
+	if err := RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("baseline migrate: %v", err)
+	}
+
+	cfg, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := pgx.ConnectConfig(ctx, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	// Roll back migration metadata to the pre-renumber demo state at v345.
+	if _, err := conn.Exec(ctx, `DELETE FROM _sqlx_migrations WHERE version >= 345`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Exec(ctx, `ALTER TABLE _sqlx_migrations DROP COLUMN IF EXISTS deploy_id`); err != nil {
+		t.Fatal(err)
+	}
+	anchorBody, err := serverdata.Migrations.ReadFile("migrations/346_submission_annotation_anchor.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Exec(ctx, string(anchorBody)); err != nil {
+		t.Fatal(err)
+	}
+	anchorSum := sqlxChecksum(anchorBody)
+	if _, err := conn.Exec(ctx,
+		`INSERT INTO _sqlx_migrations (version, description, success, checksum, execution_time)
+		 VALUES (345, 'submission_annotation_anchor', true, $1, 0)`,
+		anchorSum[:],
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("repair migrate: %v", err)
+	}
+
+	var v345Desc, v346Desc string
+	if err := conn.QueryRow(ctx, `SELECT description FROM _sqlx_migrations WHERE version = 345`).Scan(&v345Desc); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.QueryRow(ctx, `SELECT description FROM _sqlx_migrations WHERE version = 346`).Scan(&v346Desc); err != nil {
+		t.Fatal(err)
+	}
+	if v345Desc != "migration_deploy_tracking" {
+		t.Fatalf("v345 description = %q, want migration_deploy_tracking", v345Desc)
+	}
+	if v346Desc != "submission_annotation_anchor" {
+		t.Fatalf("v346 description = %q, want submission_annotation_anchor", v346Desc)
+	}
+
+	var latest int64
+	if err := conn.QueryRow(ctx, `SELECT max(version) FROM _sqlx_migrations`).Scan(&latest); err != nil {
+		t.Fatal(err)
+	}
+	if latest < 350 {
+		t.Fatalf("latest migration version = %d, want >= 350", latest)
+	}
+}

--- a/server/internal/migrate/run.go
+++ b/server/internal/migrate/run.go
@@ -72,6 +72,9 @@ func runLocked(ctx context.Context, conn *pgx.Conn, fsys fs.FS, dir string) erro
 	if err := repairMigration334RenumberCollision(ctx, conn, fsys, dir); err != nil {
 		return err
 	}
+	if err := repairMigration345RenumberCollision(ctx, conn, fsys, dir); err != nil {
+		return err
+	}
 	if err := repairDemoMigrationChecksums(ctx, conn, fsys, dir); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deploy Demo has failed on every push to `main` since run [#451](https://github.com/StudyDrift/lextures/actions/runs/28402946718) (including [#455](https://github.com/StudyDrift/lextures/actions/runs/28413719174)). Images build and Terraform succeed, but **Build and start stack** exits immediately because the API container cannot finish migrations.

**Root cause:** The demo droplet DB still has migration **v345** recorded as `submission_annotation_anchor` (last successful deploy at `7d5a8aa8`). Plan 17.10 added `345_migration_deploy_tracking.sql` and the admin console work renumbered the anchor migration to **v346**. On startup the migrator reads the new v345 file, sees a checksum mismatch against the stored row, and the server exits — `docker compose up --wait` then fails and [demo.lextures.com](https://demo.lextures.com) stays down (Cloudflare 521).

## Fix

Add `repairMigration345RenumberCollision`, following the same pattern as the existing v289/v292/v294/v308/v334 renumber repairs. When `MIGRATE_REPAIR_CHECKSUMS=1` (already set in `docker-compose.deploy.yml`):

1. Detect demo DBs with v345 = `submission_annotation_anchor` and no `deploy_id` column
2. Apply `345_migration_deploy_tracking.sql` (idempotent)
3. Update v345 metadata to `migration_deploy_tracking`
4. Insert v346 metadata for `submission_annotation_anchor` (schema already applied)

## Test plan

- [x] `go test ./internal/migrate -run TestRepairMigration345RenumberCollision_Integration` (simulates pre-renumber demo state, verifies repair through v350)
- [x] `go test ./internal/migrate/... -short`
- [ ] Merge to `main` and confirm Deploy Demo run completes **Build and start stack** and `/health` checks pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1628-b045-720a-b960-8af66b2e7a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1628-b045-720a-b960-8af66b2e7a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

