### PR TITLE
feat(18.6): Maintenance banner controls

### DIFF
--- a/clients/web/src/app.tsx
+++ b/clients/web/src/app.tsx
@@ -157,6 +157,7 @@ export default function App() {
               <Route path="import" element={<Pages.AdminImport />} />
               <Route path="courses" element={<Pages.AdminCourses />} />
               <Route path="integrations" element={<Pages.AdminIntegrations />} />
+              <Route path="banners" element={<Pages.AdminBanners />} />
               <Route path="settings" element={<Pages.AdminSettingsPage />} />
               <Route path="audit-log" element={<Pages.AdminAuditLog />} />
               <Route path="search" element={<Pages.AdminSearchResults />} />

--- a/clients/web/src/components/StatusBanner.tsx
+++ b/clients/web/src/components/StatusBanner.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useState } from 'react'
+import { AlertTriangle, Info, X, XCircle } from 'lucide-react'
+import {
+  BANNER_POLL_INTERVAL_MS,
+  dismissBanner,
+  fetchActiveBanner,
+  isBannerDismissed,
+  type MaintenanceBanner,
+} from '../lib/banner-api'
+import { usePlatformFeatures } from '../context/platform-features-context'
+
+function severityLabel(severity: MaintenanceBanner['severity']): string {
+  switch (severity) {
+    case 'error':
+      return 'Error'
+    case 'warning':
+      return 'Warning'
+    default:
+      return 'Information'
+  }
+}
+
+function bannerTone(severity: MaintenanceBanner['severity']): string {
+  switch (severity) {
+    case 'error':
+      return 'border-red-200 bg-red-50 text-red-950 dark:border-red-900/60 dark:bg-red-950/50 dark:text-red-100'
+    case 'warning':
+      return 'border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-100'
+    default:
+      return 'border-sky-200 bg-sky-50 text-sky-950 dark:border-sky-900/60 dark:bg-sky-950/40 dark:text-sky-100'
+  }
+}
+
+function SeverityIcon({ severity }: { severity: MaintenanceBanner['severity'] }) {
+  switch (severity) {
+    case 'error':
+      return <XCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+    case 'warning':
+      return <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+    default:
+      return <Info className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+  }
+}
+
+type StatusBannerProps = {
+  orgSlug?: string | null
+}
+
+export function StatusBanner({ orgSlug = null }: StatusBannerProps) {
+  const { maintenanceBannerEnabled } = usePlatformFeatures()
+  const [banner, setBanner] = useState<MaintenanceBanner | null>(null)
+  const [hidden, setHidden] = useState(false)
+
+  const loadBanner = useCallback(async () => {
+    try {
+      const next = await fetchActiveBanner(orgSlug)
+      if (!next) {
+        setBanner(null)
+        setHidden(false)
+        return
+      }
+      setBanner(next)
+      setHidden(isBannerDismissed(next))
+    } catch {
+      setBanner(null)
+    }
+  }, [orgSlug])
+
+  useEffect(() => {
+    if (!maintenanceBannerEnabled) {
+      setBanner(null)
+      return
+    }
+    void loadBanner()
+    const timer = window.setInterval(() => {
+      void loadBanner()
+    }, BANNER_POLL_INTERVAL_MS)
+    return () => window.clearInterval(timer)
+  }, [loadBanner, maintenanceBannerEnabled])
+
+  if (!maintenanceBannerEnabled || !banner || hidden) {
+    return null
+  }
+
+  function onDismiss() {
+    dismissBanner(banner!)
+    setHidden(true)
+  }
+
+  const placementClass =
+    'max-md:fixed max-md:inset-x-0 max-md:bottom-0 max-md:z-50 max-md:border-t max-md:shadow-lg md:border-b'
+
+  return (
+    <aside
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className={`flex items-start gap-3 px-4 py-2 text-sm ${bannerTone(banner.severity)} ${placementClass}`}
+    >
+      <SeverityIcon severity={banner.severity} />
+      <div className="min-w-0 flex-1">
+        <p>
+          <span className="sr-only">{severityLabel(banner.severity)}: </span>
+          {banner.message}
+          {banner.ctaUrl ? (
+            <>
+              {' '}
+              <a
+                href={banner.ctaUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium underline underline-offset-2"
+              >
+                {banner.ctaText?.trim() || 'Learn more'}
+              </a>
+            </>
+          ) : null}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="rounded p-1 transition-[background-color,color,border-color] hover:bg-black/5 dark:hover:bg-white/10"
+        aria-label="Dismiss maintenance notice"
+      >
+        <X className="h-4 w-4" aria-hidden />
+      </button>
+    </aside>
+  )
+}

--- a/clients/web/src/components/__tests__/status-banner.test.tsx
+++ b/clients/web/src/components/__tests__/status-banner.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { StatusBanner } from '../StatusBanner'
+import * as bannerApi from '../../lib/banner-api'
+
+vi.mock('../../context/platform-features-context', () => ({
+  usePlatformFeatures: () => ({ maintenanceBannerEnabled: true, loading: false }),
+}))
+
+vi.mock('../../lib/banner-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof bannerApi>()
+  return {
+    ...actual,
+    fetchActiveBanner: vi.fn(),
+    BANNER_POLL_INTERVAL_MS: 60_000,
+  }
+})
+
+function renderBanner() {
+  return render(<StatusBanner />)
+}
+
+describe('StatusBanner', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.mocked(bannerApi.fetchActiveBanner).mockReset()
+  })
+
+  it('renders an active warning banner', async () => {
+    vi.mocked(bannerApi.fetchActiveBanner).mockResolvedValue({
+      id: 'b-1',
+      scope: 'global',
+      message: 'Maintenance at midnight',
+      severity: 'warning',
+      isActive: true,
+      updatedAt: '2026-06-30T12:00:00.000Z',
+    })
+    renderBanner()
+    expect(await screen.findByRole('status')).toHaveTextContent('Maintenance at midnight')
+  })
+
+  it('dismisses the banner and persists in localStorage', async () => {
+    const user = userEvent.setup()
+    vi.mocked(bannerApi.fetchActiveBanner).mockResolvedValue({
+      id: 'b-2',
+      scope: 'global',
+      message: 'Scheduled outage',
+      severity: 'error',
+      isActive: true,
+      updatedAt: '2026-06-30T12:00:00.000Z',
+    })
+    renderBanner()
+    await screen.findByRole('status')
+    await user.click(screen.getByRole('button', { name: /dismiss maintenance notice/i }))
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(localStorage.getItem('lextures.maintenanceBanner.dismissed')).toContain('b-2')
+  })
+})

--- a/clients/web/src/components/auth/public-auth-shell.tsx
+++ b/clients/web/src/components/auth/public-auth-shell.tsx
@@ -1,15 +1,24 @@
 import type { ReactNode } from 'react'
+import { lazy, Suspense } from 'react'
+
+const MaintenanceStatusBanner = lazy(() =>
+  import('../StatusBanner').then((m) => ({ default: m.StatusBanner })),
+)
 
 type PublicAuthShellProps = {
   children: ReactNode
+  orgSlug?: string | null
 }
 
 /**
  * Layout wrapper for public sign-in flows: warm neutral backdrop, no decorative “hero” gradient.
  */
-export function PublicAuthShell({ children }: PublicAuthShellProps) {
+export function PublicAuthShell({ children, orgSlug = null }: PublicAuthShellProps) {
   return (
     <div className="lex-auth-scene min-h-dvh text-stone-900">
+      <Suspense fallback={null}>
+        <MaintenanceStatusBanner orgSlug={orgSlug} />
+      </Suspense>
       <main className="flex min-h-dvh flex-col items-center justify-center px-4 py-12 sm:px-6 sm:py-16">
         <div className="relative z-10 w-full max-w-md">{children}</div>
       </main>

--- a/clients/web/src/components/layout/app-shell.tsx
+++ b/clients/web/src/components/layout/app-shell.tsx
@@ -24,6 +24,9 @@ import { LocaleBootstrapSync } from './locale-sync'
 import { LmsExperienceRoot } from './lms-experience-root'
 import { LegalUpdateBanner } from '../legal/legal-update-banner'
 
+const MaintenanceStatusBanner = lazy(() =>
+  import('../StatusBanner').then((m) => ({ default: m.StatusBanner })),
+)
 const IncidentStatusBanner = lazy(() =>
   import('../incident-status-banner').then((m) => ({ default: m.IncidentStatusBanner })),
 )
@@ -69,6 +72,9 @@ function AppShellLayout() {
             <TopBar />
           )}
           <OfflineBanner />
+          <Suspense fallback={null}>
+            <MaintenanceStatusBanner />
+          </Suspense>
           <Suspense fallback={null}>
             <IncidentStatusBanner />
           </Suspense>

--- a/clients/web/src/components/settings/platform-feature-definitions.ts
+++ b/clients/web/src/components/settings/platform-feature-definitions.ts
@@ -90,6 +90,12 @@ const PLATFORM_FEATURE_DEFINITIONS_UNSORTED: PlatformFeatureDefinition[] = [
       'Enables cross-course search for org admins across users, courses, and content within their organization.',
   },
   {
+    key: 'maintenanceBannerEnabled',
+    label: 'Maintenance banners',
+    description:
+      'Enables site-wide and org-scoped maintenance/outage banners with admin publishing and Statuspage webhook integration (plan 18.6).',
+  },
+  {
     key: 'ffZapierConnector',
     label: 'Zapier / Make connector',
     description: 'Enable REST-hook webhook subscriptions from Zapier and Make.com automation platforms.',

--- a/clients/web/src/components/settings/platform-settings-panel.tsx
+++ b/clients/web/src/components/settings/platform-settings-panel.tsx
@@ -73,6 +73,7 @@ function emptyForm(): PlatformSettingsPayload {
     impersonationEnabled: false,
     bulkCsvImportEnabled: false,
     adminSearchEnabled: false,
+    maintenanceBannerEnabled: true,
     ffZapierConnector: false,
     ffAdvisingIntegration: false,
     ffResearchConsent: false,

--- a/clients/web/src/components/settings/platform-settings-types.ts
+++ b/clients/web/src/components/settings/platform-settings-types.ts
@@ -51,6 +51,7 @@ export type PlatformSettingsPayload = {
   impersonationEnabled: boolean
   bulkCsvImportEnabled: boolean
   adminSearchEnabled: boolean
+  maintenanceBannerEnabled: boolean
   ffZapierConnector: boolean
   ffAdvisingIntegration: boolean
   ffResearchConsent: boolean

--- a/clients/web/src/context/platform-features-context.tsx
+++ b/clients/web/src/context/platform-features-context.tsx
@@ -66,6 +66,7 @@ export type PlatformFeatures = {
   impersonationEnabled: boolean
   bulkCsvImportEnabled: boolean
   adminSearchEnabled: boolean
+  maintenanceBannerEnabled: boolean
   ffZapierConnector: boolean
   ffCatalogIntegration: boolean
   ffEnrollmentStateMachine: boolean
@@ -162,6 +163,7 @@ const defaultFeatures: PlatformFeatures = {
   impersonationEnabled: false,
   bulkCsvImportEnabled: false,
   adminSearchEnabled: false,
+  maintenanceBannerEnabled: true,
   ffZapierConnector: false,
   ffCatalogIntegration: false,
   ffEnrollmentStateMachine: false,
@@ -257,6 +259,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
   impersonationEnabled: false,
   bulkCsvImportEnabled: false,
   adminSearchEnabled: false,
+  maintenanceBannerEnabled: true,
   ffZapierConnector: false,
     ffCatalogIntegration: false,
     ffEnrollmentStateMachine: false,
@@ -359,6 +362,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           impersonationEnabled: data.impersonationEnabled === true,
           bulkCsvImportEnabled: data.bulkCsvImportEnabled === true,
           adminSearchEnabled: data.adminSearchEnabled === true,
+          maintenanceBannerEnabled: data.maintenanceBannerEnabled !== false,
           ffZapierConnector: data.ffZapierConnector === true,
           ffCatalogIntegration: data.ffCatalogIntegration === true,
           ffEnrollmentStateMachine: data.ffEnrollmentStateMachine === true,
@@ -418,6 +422,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           impersonationEnabled: next.impersonationEnabled === true,
           bulkCsvImportEnabled: next.bulkCsvImportEnabled === true,
           adminSearchEnabled: next.adminSearchEnabled === true,
+          maintenanceBannerEnabled: next.maintenanceBannerEnabled !== false,
           ffZapierConnector: next.ffZapierConnector === true,
           ffCatalogIntegration: next.ffCatalogIntegration === true,
           ffEnrollmentStateMachine: next.ffEnrollmentStateMachine === true,

--- a/clients/web/src/lazy-pages.ts
+++ b/clients/web/src/lazy-pages.ts
@@ -96,6 +96,7 @@ export const AdminSettingsPage = lazy(() => import('./pages/admin/AdminSettings'
 export const AdminAuditLog = lazy(() => import('./pages/admin/AdminAuditLog'))
 export const AdminIntegrations = lazy(() => import('./pages/admin/AdminIntegrations'))
 export const AdminImport = lazy(() => import('./pages/admin/AdminImport'))
+export const AdminBanners = lazy(() => import('./pages/admin/AdminBanners'))
 export const AdminSearchResults = lazy(() => import('./pages/admin/AdminSearchResults'))
 export const AttendanceExport = lazy(() => import('./pages/admin/AttendanceExport'))
 export const BehaviorDashboard = lazy(() => import('./pages/admin/BehaviorDashboard'))

--- a/clients/web/src/lib/banner-api.ts
+++ b/clients/web/src/lib/banner-api.ts
@@ -1,0 +1,128 @@
+import { apiUrl, authorizedFetch } from './api'
+import { getAccessToken } from './auth'
+
+export type MaintenanceBanner = {
+  id: string
+  scope: 'global' | 'org'
+  orgId?: string
+  message: string
+  severity: 'info' | 'warning' | 'error'
+  ctaText?: string
+  ctaUrl?: string
+  startsAt?: string
+  expiresAt?: string
+  isActive: boolean
+  updatedAt: string
+}
+
+const DISMISS_STORAGE_KEY = 'lextures.maintenanceBanner.dismissed'
+export const BANNER_POLL_INTERVAL_MS = 30_000
+
+type DismissMap = Record<string, string>
+
+function readDismissMap(): DismissMap {
+  try {
+    const raw = localStorage.getItem(DISMISS_STORAGE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object') return {}
+    return parsed as DismissMap
+  } catch {
+    return {}
+  }
+}
+
+export function isBannerDismissed(banner: MaintenanceBanner): boolean {
+  const map = readDismissMap()
+  return map[banner.id] === banner.updatedAt
+}
+
+export function dismissBanner(banner: MaintenanceBanner): void {
+  const map = readDismissMap()
+  map[banner.id] = banner.updatedAt
+  localStorage.setItem(DISMISS_STORAGE_KEY, JSON.stringify(map))
+}
+
+export async function fetchActiveBanner(orgSlug?: string | null): Promise<MaintenanceBanner | null> {
+  const params = new URLSearchParams()
+  if (orgSlug) params.set('orgSlug', orgSlug)
+  const suffix = params.toString() ? `?${params.toString()}` : ''
+  const headers: HeadersInit = {}
+  const token = getAccessToken()
+  if (token) headers.Authorization = `Bearer ${token}`
+  const res = await fetch(apiUrl(`/api/v1/status/banner${suffix}`), { headers })
+  if (!res.ok) {
+    return null
+  }
+  const data = (await res.json()) as MaintenanceBanner | null
+  if (!data || !data.id) return null
+  return data
+}
+
+function orgQuery(orgId: string | null | undefined): string {
+  if (!orgId) return ''
+  return `?orgId=${encodeURIComponent(orgId)}`
+}
+
+export async function fetchAdminBanners(orgId?: string | null, scope?: 'global'): Promise<MaintenanceBanner[]> {
+  const params = new URLSearchParams()
+  if (orgId) params.set('orgId', orgId)
+  if (scope === 'global') params.set('scope', 'global')
+  const suffix = params.toString() ? `?${params.toString()}` : ''
+  const res = await authorizedFetch(`/api/v1/admin/banners${suffix}`)
+  if (!res.ok) throw new Error(`Failed to load banners (${res.status})`)
+  return res.json() as Promise<MaintenanceBanner[]>
+}
+
+export async function createAdminBanner(
+  body: {
+    scope: 'global' | 'org'
+    message: string
+    severity: 'info' | 'warning' | 'error'
+    ctaText?: string
+    ctaUrl?: string
+    startsAt?: string
+    expiresAt?: string
+  },
+  orgId?: string | null,
+): Promise<MaintenanceBanner> {
+  const res = await authorizedFetch(`/api/v1/admin/banners${orgQuery(orgId)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(text || `Failed to create banner (${res.status})`)
+  }
+  return res.json() as Promise<MaintenanceBanner>
+}
+
+export async function updateAdminBanner(
+  id: string,
+  body: {
+    message: string
+    severity: 'info' | 'warning' | 'error'
+    ctaText?: string
+    ctaUrl?: string
+    startsAt?: string
+    expiresAt?: string
+    isActive?: boolean
+  },
+  orgId?: string | null,
+): Promise<MaintenanceBanner> {
+  const res = await authorizedFetch(`/api/v1/admin/banners/${id}${orgQuery(orgId)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(`Failed to update banner (${res.status})`)
+  return res.json() as Promise<MaintenanceBanner>
+}
+
+export async function deleteAdminBanner(id: string, orgId?: string | null): Promise<void> {
+  const res = await authorizedFetch(`/api/v1/admin/banners/${id}${orgQuery(orgId)}`, {
+    method: 'DELETE',
+  })
+  if (!res.ok) throw new Error(`Failed to delete banner (${res.status})`)
+}

--- a/clients/web/src/lib/platform-features.ts
+++ b/clients/web/src/lib/platform-features.ts
@@ -52,6 +52,7 @@ export type PlatformFeaturesSnapshot = {
   impersonationEnabled?: boolean
   bulkCsvImportEnabled?: boolean
   adminSearchEnabled?: boolean
+  maintenanceBannerEnabled?: boolean
   ffZapierConnector?: boolean
   ffCatalogIntegration?: boolean
   ffEnrollmentStateMachine?: boolean
@@ -140,6 +141,7 @@ const defaults: PlatformFeaturesSnapshot = {
   impersonationEnabled: false,
   bulkCsvImportEnabled: false,
   adminSearchEnabled: false,
+  maintenanceBannerEnabled: true,
   ffZapierConnector: false,
   ffCatalogIntegration: false,
   ffEnrollmentStateMachine: false,

--- a/clients/web/src/pages/admin/AdminBanners.tsx
+++ b/clients/web/src/pages/admin/AdminBanners.tsx
@@ -1,0 +1,298 @@
+import { type FormEvent, useCallback, useEffect, useId, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { Loader2, Megaphone, Save, Trash2 } from 'lucide-react'
+import {
+  createAdminBanner,
+  deleteAdminBanner,
+  fetchAdminBanners,
+  type MaintenanceBanner,
+  updateAdminBanner,
+} from '../../lib/banner-api'
+import { fetchAdminConsoleCapabilities } from '../../lib/admin-console-api'
+import { usePlatformFeatures } from '../../context/platform-features-context'
+
+type BannerForm = {
+  scope: 'global' | 'org'
+  message: string
+  severity: 'info' | 'warning' | 'error'
+  ctaText: string
+  ctaUrl: string
+  startsAt: string
+  expiresAt: string
+}
+
+const emptyForm = (): BannerForm => ({
+  scope: 'org',
+  message: '',
+  severity: 'warning',
+  ctaText: '',
+  ctaUrl: '',
+  startsAt: '',
+  expiresAt: '',
+})
+
+function toLocalInputValue(iso?: string): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+function fromLocalInputValue(value: string): string | undefined {
+  if (!value.trim()) return undefined
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return undefined
+  return d.toISOString()
+}
+
+export default function AdminBannersPage() {
+  const formId = useId()
+  const { maintenanceBannerEnabled } = usePlatformFeatures()
+  const [searchParams] = useSearchParams()
+  const orgId = searchParams.get('orgId')
+  const [form, setForm] = useState<BannerForm>(emptyForm)
+  const [existing, setExisting] = useState<MaintenanceBanner[]>([])
+  const [isGlobalAdmin, setIsGlobalAdmin] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const previewBanner = useMemo<MaintenanceBanner | null>(() => {
+    if (!form.message.trim()) return null
+    return {
+      id: 'preview',
+      scope: form.scope,
+      message: form.message.trim(),
+      severity: form.severity,
+      ctaText: form.ctaText.trim() || undefined,
+      ctaUrl: form.ctaUrl.trim() || undefined,
+      isActive: true,
+      updatedAt: new Date().toISOString(),
+    }
+  }, [form])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const caps = await fetchAdminConsoleCapabilities()
+      setIsGlobalAdmin(caps.isGlobalAdmin)
+      const list = await fetchAdminBanners(orgId, caps.isGlobalAdmin ? undefined : undefined)
+      setExisting(list)
+      const active = list.find((b) => b.isActive)
+      if (active) {
+        setForm({
+          scope: active.scope,
+          message: active.message,
+          severity: active.severity,
+          ctaText: active.ctaText ?? '',
+          ctaUrl: active.ctaUrl ?? '',
+          startsAt: toLocalInputValue(active.startsAt),
+          expiresAt: toLocalInputValue(active.expiresAt),
+        })
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load banners.')
+    } finally {
+      setLoading(false)
+    }
+  }, [orgId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  async function onPublish(e: FormEvent) {
+    e.preventDefault()
+    setSaving(true)
+    setMessage(null)
+    setError(null)
+    try {
+      const body = {
+        scope: form.scope,
+        message: form.message.trim(),
+        severity: form.severity,
+        ctaText: form.ctaText.trim() || undefined,
+        ctaUrl: form.ctaUrl.trim() || undefined,
+        startsAt: fromLocalInputValue(form.startsAt),
+        expiresAt: fromLocalInputValue(form.expiresAt),
+      }
+      const active = existing.find((b) => b.isActive && b.scope === form.scope)
+      if (active) {
+        await updateAdminBanner(active.id, { ...body, isActive: true }, orgId)
+      } else {
+        await createAdminBanner(body, orgId)
+      }
+      setMessage('Banner published.')
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to publish banner.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function onClear() {
+    const active = existing.find((b) => b.isActive)
+    if (!active) {
+      setForm(emptyForm())
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      await deleteAdminBanner(active.id, orgId)
+      setForm(emptyForm())
+      setMessage('Banner cleared.')
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to clear banner.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!maintenanceBannerEnabled) {
+    return (
+      <p className="text-sm text-slate-500">
+        Maintenance banners are disabled. Enable them in Settings → Global platform.
+      </p>
+    )
+  }
+
+  if (loading) return <p className="text-sm text-slate-500">Loading banners…</p>
+
+  return (
+    <div>
+      <div className="flex items-center gap-2">
+        <Megaphone className="h-5 w-5 text-indigo-600" aria-hidden />
+        <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Maintenance notices</h1>
+      </div>
+      <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+        Publish a site-wide or organization notice visible to users until dismissed or expired.
+      </p>
+
+      {previewBanner ? (
+        <div className="mt-4 overflow-hidden rounded-lg border border-slate-200 dark:border-neutral-800">
+          <p className="bg-slate-50 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-500 dark:bg-neutral-950">
+            Preview
+          </p>
+          <aside
+            role="status"
+            className={`flex items-start gap-3 border-b px-4 py-2 text-sm ${
+              previewBanner.severity === 'error'
+                ? 'border-red-200 bg-red-50 text-red-950 dark:border-red-900/60 dark:bg-red-950/50 dark:text-red-100'
+                : previewBanner.severity === 'warning'
+                  ? 'border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-100'
+                  : 'border-sky-200 bg-sky-50 text-sky-950 dark:border-sky-900/60 dark:bg-sky-950/40 dark:text-sky-100'
+            }`}
+          >
+            <p className="flex-1">{previewBanner.message}</p>
+          </aside>
+        </div>
+      ) : null}
+
+      <form id={formId} onSubmit={(e) => void onPublish(e)} className="mt-6 max-w-xl space-y-4">
+        {isGlobalAdmin ? (
+          <label className="block text-sm">
+            <span className="text-slate-600 dark:text-slate-400">Scope</span>
+            <select
+              value={form.scope}
+              onChange={(e) => setForm({ ...form, scope: e.target.value as 'global' | 'org' })}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
+            >
+              <option value="org">Organization only</option>
+              <option value="global">Global (all organizations)</option>
+            </select>
+          </label>
+        ) : null}
+        <label className="block text-sm">
+          <span className="text-slate-600 dark:text-slate-400">Message</span>
+          <textarea
+            value={form.message}
+            onChange={(e) => setForm({ ...form, message: e.target.value })}
+            maxLength={500}
+            rows={3}
+            required
+            placeholder="Scheduled maintenance Sunday 2am–4am UTC"
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="text-slate-600 dark:text-slate-400">Severity</span>
+          <select
+            value={form.severity}
+            onChange={(e) => setForm({ ...form, severity: e.target.value as BannerForm['severity'] })}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
+          >
+            <option value="info">Info</option>
+            <option value="warning">Warning</option>
+            <option value="error">Error</option>
+          </select>
+        </label>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="block text-sm">
+            <span className="text-slate-600 dark:text-slate-400">Start (optional)</span>
+            <input
+              type="datetime-local"
+              value={form.startsAt}
+              onChange={(e) => setForm({ ...form, startsAt: e.target.value })}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-slate-600 dark:text-slate-400">Expires (optional)</span>
+            <input
+              type="datetime-local"
+              value={form.expiresAt}
+              onChange={(e) => setForm({ ...form, expiresAt: e.target.value })}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
+            />
+          </label>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="block text-sm">
+            <span className="text-slate-600 dark:text-slate-400">CTA label (optional)</span>
+            <input
+              value={form.ctaText}
+              onChange={(e) => setForm({ ...form, ctaText: e.target.value })}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-slate-600 dark:text-slate-400">CTA URL (optional)</span>
+            <input
+              type="url"
+              value={form.ctaUrl}
+              onChange={(e) => setForm({ ...form, ctaUrl: e.target.value })}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
+            />
+          </label>
+        </div>
+        {message ? <p className="text-sm text-green-700 dark:text-green-400">{message}</p> : null}
+        {error ? <p className="text-sm text-red-600 dark:text-red-400">{error}</p> : null}
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="submit"
+            disabled={saving}
+            className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-60"
+          >
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+            Publish
+          </button>
+          <button
+            type="button"
+            disabled={saving}
+            onClick={() => void onClear()}
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-neutral-700 dark:text-slate-200 dark:hover:bg-neutral-900"
+          >
+            <Trash2 className="h-4 w-4" />
+            Clear active banner
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/clients/web/src/pages/admin/AdminLayout.tsx
+++ b/clients/web/src/pages/admin/AdminLayout.tsx
@@ -4,6 +4,7 @@ import {
   BookOpen,
   FileUp,
   LayoutDashboard,
+  Megaphone,
   Plug,
   ScrollText,
   Settings,
@@ -13,6 +14,8 @@ import { useEffect, useState } from 'react'
 import { AdminSearchBar } from '../../components/admin/AdminSearchBar'
 import { fetchAdminConsoleCapabilities } from '../../lib/admin-console-api'
 import { usePlatformFeatures } from '../../context/platform-features-context'
+
+const bannersNavItem = { to: '/org-admin/banners', label: 'Notices', icon: Megaphone, end: false as const }
 
 const baseNavItems = [
   { to: '/org-admin', label: 'Overview', icon: LayoutDashboard, end: true },
@@ -26,7 +29,7 @@ const baseNavItems = [
 const importNavItem = { to: '/org-admin/import', label: 'Import', icon: FileUp, end: false as const }
 
 export default function AdminLayout() {
-  const { adminConsoleEnabled, bulkCsvImportEnabled } = usePlatformFeatures()
+  const { adminConsoleEnabled, bulkCsvImportEnabled, maintenanceBannerEnabled } = usePlatformFeatures()
   const [searchParams] = useSearchParams()
   const orgId = searchParams.get('orgId')
   const [canAccess, setCanAccess] = useState<boolean | null>(null)
@@ -66,9 +69,21 @@ export default function AdminLayout() {
     return `${path}?orgId=${encodeURIComponent(orgId)}`
   }
 
-  const navItems = bulkCsvImportEnabled
-    ? [...baseNavItems.slice(0, 2), importNavItem, ...baseNavItems.slice(2)]
-    : baseNavItems
+  const navItems = (() => {
+    let items = [...baseNavItems]
+    if (bulkCsvImportEnabled) {
+      items = [...items.slice(0, 2), importNavItem, ...items.slice(2)]
+    }
+    if (maintenanceBannerEnabled) {
+      const integrationsIdx = items.findIndex((i) => i.to === '/org-admin/integrations')
+      items = [
+        ...items.slice(0, integrationsIdx + 1),
+        bannersNavItem,
+        ...items.slice(integrationsIdx + 1),
+      ]
+    }
+    return items
+  })()
 
   return (
     <div className="flex min-h-0 flex-1 flex-col md:flex-row">

--- a/docs/completed/18-admin-experience/18.6-maintenance-banner.md
+++ b/docs/completed/18-admin-experience/18.6-maintenance-banner.md
@@ -10,7 +10,7 @@
 | **Section** | Admin Experience |
 | **Severity** | MINOR |
 | **Markets** | All |
-| **Status (today)** | MISSING |
+| **Status (today)** | IMPLEMENTED |
 | **Estimated effort** | XS (≤ 1 d) |
 | **Owner (proposed)** | Platform / Full-stack team |
 | **Depends on** | 18.1 (Admin console shell) |

--- a/e2e/tests/maintenance-banner.spec.ts
+++ b/e2e/tests/maintenance-banner.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Maintenance banner (plan 18.6)
+ */
+import { execSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test, expect } from '@playwright/test'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:8080'
+const PASSWORD = process.env.E2E_ADMIN_PASSWORD ?? 'E2eTestPass1!'
+
+function uniqueEmail(prefix = 'e2e-banner') {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}@test.invalid`
+}
+
+function authHeaders(token: string) {
+  return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+}
+
+function databaseUrl(): string {
+  return (
+    process.env.DATABASE_URL ??
+    process.env.E2E_DATABASE_URL ??
+    'postgres://studydrift:studydrift@localhost:5432/studydrift?sslmode=disable'
+  )
+}
+
+async function apiSignup(email: string) {
+  const res = await fetch(`${API_BASE}/api/v1/auth/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: PASSWORD, display_name: 'E2E User' }),
+  })
+  if (!res.ok && res.status !== 409) {
+    throw new Error(`signup failed: ${await res.text()}`)
+  }
+}
+
+async function apiLogin(email: string) {
+  const res = await fetch(`${API_BASE}/api/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: PASSWORD }),
+  })
+  if (!res.ok) throw new Error(`login failed: ${await res.text()}`)
+  return (await res.json()) as { access_token: string }
+}
+
+async function bootstrapGlobalAdmin(email: string) {
+  execSync(`go run ./cmd/bootstrap-admin -email=${email}`, {
+    cwd: path.join(repoRoot, 'server'),
+    env: { ...process.env, DATABASE_URL: databaseUrl() },
+    stdio: 'pipe',
+  })
+}
+
+async function enableFeatures(token: string) {
+  const res = await fetch(`${API_BASE}/api/v1/settings/platform`, {
+    method: 'PUT',
+    headers: authHeaders(token),
+    body: JSON.stringify({
+      adminConsoleEnabled: true,
+      maintenanceBannerEnabled: true,
+    }),
+  })
+  if (!res.ok) {
+    test.skip(true, `could not enable features: ${await res.text()}`)
+  }
+}
+
+test.describe.serial('Maintenance banner', () => {
+  test('MaintenanceBanner: public endpoint returns null when disabled', async () => {
+    const res = await fetch(`${API_BASE}/api/v1/status/banner`)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body === null || (typeof body === 'object' && body.id)).toBeTruthy()
+  })
+
+  test('MaintenanceBanner: admin publish, student sees, dismiss persists', async () => {
+    const gaEmail = uniqueEmail('ga')
+    await apiSignup(gaEmail)
+    try {
+      await bootstrapGlobalAdmin(gaEmail)
+    } catch (err) {
+      test.skip(true, `bootstrap unavailable: ${err}`)
+    }
+    const ga = await apiLogin(gaEmail)
+    await enableFeatures(ga.access_token)
+
+    const studentEmail = uniqueEmail('student')
+    await apiSignup(studentEmail)
+    const student = await apiLogin(studentEmail)
+
+    const createRes = await fetch(`${API_BASE}/api/v1/admin/banners`, {
+      method: 'POST',
+      headers: authHeaders(ga.access_token),
+      body: JSON.stringify({
+        scope: 'global',
+        message: 'Maintenance at midnight',
+        severity: 'warning',
+      }),
+    })
+    expect(createRes.status).toBe(201)
+
+    const publicRes = await fetch(`${API_BASE}/api/v1/status/banner`, {
+      headers: authHeaders(student.access_token),
+    })
+    expect(publicRes.status).toBe(200)
+    const banner = await publicRes.json()
+    expect(banner?.message).toBe('Maintenance at midnight')
+
+    const listRes = await fetch(`${API_BASE}/api/v1/admin/banners?scope=global`, {
+      headers: authHeaders(ga.access_token),
+    })
+    const list = (await listRes.json()) as { id: string }[]
+    const id = list[0]?.id
+    if (id) {
+      await fetch(`${API_BASE}/api/v1/admin/banners/${id}`, {
+        method: 'DELETE',
+        headers: authHeaders(ga.access_token),
+      })
+    }
+  })
+
+  test('MaintenanceBanner: statuspage webhook requires HMAC', async () => {
+    const res = await fetch(`${API_BASE}/api/v1/admin/banners/statuspage-webhook`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ incident: { id: 'x', name: 'Test', status: 'investigating' } }),
+    })
+    expect([401, 404]).toContain(res.status)
+  })
+})

--- a/server/.env.example
+++ b/server/.env.example
@@ -64,6 +64,7 @@ PUBLIC_WEB_ORIGIN=http://localhost:5173
 # STATUSPAGE_PAGE_ID=
 # STATUSPAGE_COMPONENT_MAP_PATH=config/statuspage-components.json
 # ALERTMANAGER_WEBHOOK_SECRET=
+# STATUSPAGE_WEBHOOK_SECRET=
 # STATUS_PAGE_SUMMARY_CACHE_SECS=60
 
 # Observability — Prometheus metrics, OpenTelemetry traces, Sentry (plan 17.7)

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -330,6 +330,8 @@ type Config struct {
 	BulkCsvImportEnabled bool
 	// AdminSearchEnabled gates org-wide admin search UI and /api/v1/admin/search APIs (plan 18.4).
 	AdminSearchEnabled bool
+	// MaintenanceBannerEnabled gates site-wide / org maintenance banners and banner admin APIs (plan 18.6).
+	MaintenanceBannerEnabled bool
 	// DataResidencyEnabled gates per-tenant region pinning enforcement and the data residency compliance admin API (plan 10.12).
 	DataResidencyEnabled bool
 	// AiDisclosureEnabled gates AI opt-out, gateway enforcement, inference logging, and disclosure APIs (plan 10.17). Defaults to true.
@@ -604,6 +606,8 @@ type Config struct {
 	StatuspageComponentMapJSON string
 	// AlertmanagerWebhookSecret authenticates Alertmanager webhook posts.
 	AlertmanagerWebhookSecret string
+	// StatuspageWebhookSecret verifies HMAC signatures on Statuspage incident webhooks (plan 18.6).
+	StatuspageWebhookSecret string
 	// StatusPageSummaryCacheSecs is the in-memory cache TTL for the summary proxy.
 	StatusPageSummaryCacheSecs int
 
@@ -843,6 +847,7 @@ func Load() Config {
 		StatuspagePageID:           firstNonEmptyTrimmed("STATUSPAGE_PAGE_ID"),
 		StatuspageComponentMapJSON: statuspageComponentMapJSON(),
 		AlertmanagerWebhookSecret:  firstNonEmptyTrimmed("ALERTMANAGER_WEBHOOK_SECRET"),
+		StatuspageWebhookSecret:    firstNonEmptyTrimmed("STATUSPAGE_WEBHOOK_SECRET"),
 		StatusPageSummaryCacheSecs: statusPageSummaryCacheSecs(),
 
 		Observability: observabilityFromEnv(),

--- a/server/internal/httpserver/banner_http.go
+++ b/server/internal/httpserver/banner_http.go
@@ -1,0 +1,515 @@
+package httpserver
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/lextures/lextures/server/internal/apierr"
+	bannersrepo "github.com/lextures/lextures/server/internal/repos/banners"
+	"github.com/lextures/lextures/server/internal/repos/organization"
+	bannersservice "github.com/lextures/lextures/server/internal/service/banners"
+	"github.com/lextures/lextures/server/internal/telemetry"
+)
+
+type bannerDTO struct {
+	ID        string  `json:"id"`
+	Scope     string  `json:"scope"`
+	OrgID     *string `json:"orgId,omitempty"`
+	Message   string  `json:"message"`
+	Severity  string  `json:"severity"`
+	CTAText   *string `json:"ctaText,omitempty"`
+	CTAURL    *string `json:"ctaUrl,omitempty"`
+	StartsAt  *string `json:"startsAt,omitempty"`
+	ExpiresAt *string `json:"expiresAt,omitempty"`
+	IsActive  bool    `json:"isActive"`
+	UpdatedAt string  `json:"updatedAt"`
+}
+
+func (d Deps) maintenanceBannerEnabled(w http.ResponseWriter) bool {
+	if !d.effectiveConfig().MaintenanceBannerEnabled {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Maintenance banners are not enabled.")
+		return false
+	}
+	return true
+}
+
+func (d Deps) registerBannerRoutes(r chi.Router) {
+	r.Get("/api/v1/status/banner", d.handleGetStatusBanner())
+	r.Get("/api/v1/admin/banners", d.handleListBanners())
+	r.Post("/api/v1/admin/banners", d.handleCreateBanner())
+	r.Put("/api/v1/admin/banners/{id}", d.handleUpdateBanner())
+	r.Delete("/api/v1/admin/banners/{id}", d.handleDeleteBanner())
+	r.Post("/api/v1/admin/banners/statuspage-webhook", d.handleStatuspageBannerWebhook())
+}
+
+// GET /api/v1/status/banner — public, cacheable banner for login and app shell.
+func (d Deps) handleGetStatusBanner() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.effectiveConfig().MaintenanceBannerEnabled {
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.Header().Set("Cache-Control", "public, max-age=10, stale-while-revalidate=60")
+			_ = json.NewEncoder(w).Encode(nil)
+			return
+		}
+		if d.Pool == nil {
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			_ = json.NewEncoder(w).Encode(nil)
+			return
+		}
+		ctx := r.Context()
+		now := time.Now().UTC()
+
+		var orgID *uuid.UUID
+		if userID, ok := d.optionalUserID(r); ok {
+			if oid, err := organization.OrgIDForUser(ctx, d.Pool, userID); err == nil {
+				orgID = &oid
+			}
+		} else if slug := orgSlugFromBrandingQuery(r); slug != "" {
+			if row, err := organization.GetBySlug(ctx, d.Pool, slug); err == nil && row != nil {
+				orgID = &row.ID
+			}
+		}
+
+		banner, err := bannersrepo.GetActiveForOrg(ctx, d.Pool, orgID, now)
+		if err != nil {
+			slog.Warn("banner query failed", "err", err)
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			_ = json.NewEncoder(w).Encode(nil)
+			return
+		}
+		d.recordBannerActiveMetric(banner)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("Cache-Control", "public, max-age=10, stale-while-revalidate=60")
+		if banner == nil {
+			_ = json.NewEncoder(w).Encode(nil)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(bannerToDTO(*banner))
+	}
+}
+
+func (d Deps) recordBannerActiveMetric(b *bannersrepo.Banner) {
+	m := telemetry.Default()
+	if m == nil {
+		return
+	}
+	if b == nil {
+		m.SetBannerActive("", "")
+		return
+	}
+	m.SetBannerActive(string(b.Scope), string(b.Severity))
+}
+
+func (d Deps) optionalUserID(r *http.Request) (uuid.UUID, bool) {
+	auth := strings.TrimSpace(r.Header.Get("Authorization"))
+	if !strings.HasPrefix(strings.ToLower(auth), "bearer ") {
+		return uuid.UUID{}, false
+	}
+	if d.JWTSigner == nil {
+		return uuid.UUID{}, false
+	}
+	user, err := d.JWTSigner.Verify(r.Context(), auth[7:])
+	if err != nil || strings.TrimSpace(user.UserID) == "" {
+		return uuid.UUID{}, false
+	}
+	id, err := uuid.Parse(user.UserID)
+	if err != nil {
+		return uuid.UUID{}, false
+	}
+	return id, true
+}
+
+// GET /api/v1/admin/banners
+func (d Deps) handleListBanners() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.maintenanceBannerEnabled(w) {
+			return
+		}
+		actor, targetOrg, globalAdmin, ok := d.adminConsoleAccess(w, r, false)
+		if !ok {
+			return
+		}
+		var list []bannersrepo.Banner
+		var err error
+		if globalAdmin && r.URL.Query().Get("scope") == "global" {
+			list, err = bannersrepo.List(r.Context(), d.Pool, nil, true)
+		} else {
+			list, err = bannersrepo.List(r.Context(), d.Pool, &targetOrg, false)
+		}
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to list banners.")
+			return
+		}
+		out := make([]bannerDTO, 0, len(list))
+		for _, b := range list {
+			out = append(out, bannerToDTO(b))
+		}
+		_ = actor
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+type bannerWriteBody struct {
+	Scope     string  `json:"scope"`
+	Message   string  `json:"message"`
+	Severity  string  `json:"severity"`
+	CTAText   *string `json:"ctaText"`
+	CTAURL    *string `json:"ctaUrl"`
+	StartsAt  *string `json:"startsAt"`
+	ExpiresAt *string `json:"expiresAt"`
+	IsActive  *bool   `json:"isActive"`
+}
+
+// POST /api/v1/admin/banners
+func (d Deps) handleCreateBanner() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.maintenanceBannerEnabled(w) {
+			return
+		}
+		actor, targetOrg, globalAdmin, ok := d.adminConsoleAccess(w, r, true)
+		if !ok {
+			return
+		}
+		body, err := readBannerBody(r)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		scope, err := bannersservice.ParseScope(body.Scope)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		if scope == "global" {
+			if !globalAdmin {
+				apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "Only global admins can create global banners.")
+				return
+			}
+		}
+		if err := bannersservice.ValidateMessage(body.Message); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		severity, err := bannersservice.ParseSeverity(body.Severity)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		startsAt, expiresAt, err := parseBannerTimes(body.StartsAt, body.ExpiresAt)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		var orgID *uuid.UUID
+		if scope == "org" {
+			orgID = &targetOrg
+		}
+		created, err := bannersrepo.Create(r.Context(), d.Pool, bannersrepo.CreateParams{
+			Scope:     bannersrepo.Scope(scope),
+			OrgID:     orgID,
+			Message:   strings.TrimSpace(body.Message),
+			Severity:  bannersrepo.Severity(severity),
+			CTAText:   body.CTAText,
+			CTAURL:    body.CTAURL,
+			StartsAt:  startsAt,
+			ExpiresAt: expiresAt,
+			CreatedBy: actor,
+		})
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to create banner.")
+			return
+		}
+		slog.Info("banner created", "banner_id", created.ID, "scope", created.Scope, "actor_id", actor)
+		telemetry.RecordBusinessEvent("banner_created")
+		writeJSON(w, http.StatusCreated, bannerToDTO(created))
+	}
+}
+
+// PUT /api/v1/admin/banners/{id}
+func (d Deps) handleUpdateBanner() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.maintenanceBannerEnabled(w) {
+			return
+		}
+		_, targetOrg, globalAdmin, ok := d.adminConsoleAccess(w, r, true)
+		if !ok {
+			return
+		}
+		id, err := uuid.Parse(chi.URLParam(r, "id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid banner id.")
+			return
+		}
+		existing, err := bannersrepo.GetByID(r.Context(), d.Pool, id)
+		if err != nil || existing == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Banner not found.")
+			return
+		}
+		if !bannerManageAllowed(existing, targetOrg, globalAdmin) {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission for this banner.")
+			return
+		}
+		body, err := readBannerBody(r)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		if err := bannersservice.ValidateMessage(body.Message); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		severity, err := bannersservice.ParseSeverity(body.Severity)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		startsAt, expiresAt, err := parseBannerTimes(body.StartsAt, body.ExpiresAt)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		isActive := true
+		if body.IsActive != nil {
+			isActive = *body.IsActive
+		}
+		updated, err := bannersrepo.Update(r.Context(), d.Pool, id, bannersrepo.UpdateParams{
+			Message:   strings.TrimSpace(body.Message),
+			Severity:  bannersrepo.Severity(severity),
+			CTAText:   body.CTAText,
+			CTAURL:    body.CTAURL,
+			StartsAt:  startsAt,
+			ExpiresAt: expiresAt,
+			IsActive:  isActive,
+		})
+		if err != nil || updated == nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to update banner.")
+			return
+		}
+		slog.Info("banner updated", "banner_id", updated.ID, "scope", updated.Scope)
+		telemetry.RecordBusinessEvent("banner_updated")
+		writeJSON(w, http.StatusOK, bannerToDTO(*updated))
+	}
+}
+
+// DELETE /api/v1/admin/banners/{id}
+func (d Deps) handleDeleteBanner() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.maintenanceBannerEnabled(w) {
+			return
+		}
+		_, targetOrg, globalAdmin, ok := d.adminConsoleAccess(w, r, true)
+		if !ok {
+			return
+		}
+		id, err := uuid.Parse(chi.URLParam(r, "id"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid banner id.")
+			return
+		}
+		existing, err := bannersrepo.GetByID(r.Context(), d.Pool, id)
+		if err != nil || existing == nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Banner not found.")
+			return
+		}
+		if !bannerManageAllowed(existing, targetOrg, globalAdmin) {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission for this banner.")
+			return
+		}
+		deleted, err := bannersrepo.Delete(r.Context(), d.Pool, id)
+		if err != nil || !deleted {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Banner not found.")
+			return
+		}
+		slog.Info("banner deleted", "banner_id", id)
+		telemetry.RecordBusinessEvent("banner_deleted")
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// POST /api/v1/admin/banners/statuspage-webhook
+func (d Deps) handleStatuspageBannerWebhook() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.maintenanceBannerEnabled(w) {
+			return
+		}
+		secret := strings.TrimSpace(d.effectiveConfig().StatuspageWebhookSecret)
+		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Could not read request body.")
+			return
+		}
+		if !verifyStatuspageHMAC(r, secret, body) {
+			apierr.WriteJSON(w, http.StatusUnauthorized, apierr.CodeUnauthorized, "Invalid webhook signature.")
+			return
+		}
+		payload, err := bannersservice.ParseStatuspageWebhook(body)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		inc := payload.Incident
+		externalID := "statuspage:" + strings.TrimSpace(inc.ID)
+		status := strings.ToLower(strings.TrimSpace(inc.Status))
+		if status == "resolved" || status == "completed" {
+			_ = bannersrepo.DeactivateByExternalID(r.Context(), d.Pool, externalID)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		severity := bannersservice.IncidentSeverity(inc.Impact, inc.Status)
+		if severity == "" {
+			severity = "warning"
+		}
+		message := bannersservice.IncidentMessage(inc.Name, inc.Status)
+		if err := bannersservice.ValidateMessage(message); err != nil {
+			message = "Service incident in progress"
+		}
+		systemActor, err := d.statuspageWebhookActor(r.Context())
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Webhook actor not configured.")
+			return
+		}
+		ext := externalID
+		_, err = bannersrepo.UpsertByExternalID(r.Context(), d.Pool, bannersrepo.CreateParams{
+			Scope:      bannersrepo.ScopeGlobal,
+			Message:    message,
+			Severity:   bannersrepo.Severity(severity),
+			ExternalID: &ext,
+			CreatedBy:  systemActor,
+		})
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to upsert banner.")
+			return
+		}
+		slog.Info("banner upserted from statuspage", "external_id", externalID, "status", inc.Status)
+		telemetry.RecordBusinessEvent("banner_statuspage_webhook")
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (d Deps) statuspageWebhookActor(ctx context.Context) (uuid.UUID, error) {
+	rows, err := d.Pool.Query(ctx, `
+SELECT u.id FROM "user".users u
+JOIN "user".user_role_assignments ura ON ura.user_id = u.id
+JOIN "user".app_roles ar ON ar.id = ura.role_id
+WHERE ar.name = 'Global Admin'
+ORDER BY u.created_at ASC
+LIMIT 1`)
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+	defer rows.Close()
+	if rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return uuid.UUID{}, err
+		}
+		return id, nil
+	}
+	return uuid.UUID{}, errNoGlobalAdmin
+}
+
+var errNoGlobalAdmin = errBannerWebhookActor("no global admin user found")
+
+type errBannerWebhookActor string
+
+func (e errBannerWebhookActor) Error() string { return string(e) }
+
+func verifyStatuspageHMAC(r *http.Request, secret string, body []byte) bool {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return false
+	}
+	sig := strings.TrimSpace(r.Header.Get("X-Statuspage-Signature"))
+	if sig == "" {
+		sig = strings.TrimSpace(r.Header.Get("X-Hub-Signature-256"))
+		if strings.HasPrefix(strings.ToLower(sig), "sha256=") {
+			sig = sig[7:]
+		}
+	}
+	if sig == "" {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+	return subtleConstantTimeEqual(strings.ToLower(sig), strings.ToLower(expected))
+}
+
+func bannerManageAllowed(b *bannersrepo.Banner, targetOrg uuid.UUID, globalAdmin bool) bool {
+	if b.Scope == bannersrepo.ScopeGlobal {
+		return globalAdmin
+	}
+	if !globalAdmin && (b.OrgID == nil || *b.OrgID != targetOrg) {
+		return false
+	}
+	return true
+}
+
+func readBannerBody(r *http.Request) (bannerWriteBody, error) {
+	var body bannerWriteBody
+	dec := json.NewDecoder(io.LimitReader(r.Body, 1<<20))
+	if err := dec.Decode(&body); err != nil {
+		return bannerWriteBody{}, err
+	}
+	if body.Scope == "" {
+		body.Scope = "org"
+	}
+	return body, nil
+}
+
+func parseBannerTimes(startsAt, expiresAt *string) (*time.Time, *time.Time, error) {
+	var startPtr, expirePtr *time.Time
+	if startsAt != nil && strings.TrimSpace(*startsAt) != "" {
+		t, err := time.Parse(time.RFC3339, strings.TrimSpace(*startsAt))
+		if err != nil {
+			return nil, nil, err
+		}
+		utc := t.UTC()
+		startPtr = &utc
+	}
+	if expiresAt != nil && strings.TrimSpace(*expiresAt) != "" {
+		t, err := time.Parse(time.RFC3339, strings.TrimSpace(*expiresAt))
+		if err != nil {
+			return nil, nil, err
+		}
+		utc := t.UTC()
+		expirePtr = &utc
+	}
+	return startPtr, expirePtr, nil
+}
+
+func bannerToDTO(b bannersrepo.Banner) bannerDTO {
+	dto := bannerDTO{
+		ID:       b.ID.String(),
+		Scope:    string(b.Scope),
+		Message:  b.Message,
+		Severity: string(b.Severity),
+		CTAText:  b.CTAText,
+		CTAURL:   b.CTAURL,
+		IsActive: b.IsActive,
+		UpdatedAt: b.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+	if b.OrgID != nil {
+		s := b.OrgID.String()
+		dto.OrgID = &s
+	}
+	if b.StartsAt != nil {
+		s := b.StartsAt.UTC().Format(time.RFC3339)
+		dto.StartsAt = &s
+	}
+	if b.ExpiresAt != nil {
+		s := b.ExpiresAt.UTC().Format(time.RFC3339)
+		dto.ExpiresAt = &s
+	}
+	return dto
+}

--- a/server/internal/httpserver/banner_http.go
+++ b/server/internal/httpserver/banner_http.go
@@ -397,25 +397,18 @@ func (d Deps) handleStatuspageBannerWebhook() http.HandlerFunc {
 }
 
 func (d Deps) statuspageWebhookActor(ctx context.Context) (uuid.UUID, error) {
-	rows, err := d.Pool.Query(ctx, `
+	row := d.Pool.QueryRow(ctx, `
 SELECT u.id FROM "user".users u
-JOIN "user".user_role_assignments ura ON ura.user_id = u.id
-JOIN "user".app_roles ar ON ar.id = ura.role_id
+JOIN "user".user_app_roles uar ON uar.user_id = u.id
+JOIN "user".app_roles ar ON ar.id = uar.role_id
 WHERE ar.name = 'Global Admin'
 ORDER BY u.created_at ASC
 LIMIT 1`)
-	if err != nil {
-		return uuid.UUID{}, err
+	var id uuid.UUID
+	if err := row.Scan(&id); err != nil {
+		return uuid.UUID{}, errNoGlobalAdmin
 	}
-	defer rows.Close()
-	if rows.Next() {
-		var id uuid.UUID
-		if err := rows.Scan(&id); err != nil {
-			return uuid.UUID{}, err
-		}
-		return id, nil
-	}
-	return uuid.UUID{}, errNoGlobalAdmin
+	return id, nil
 }
 
 var errNoGlobalAdmin = errBannerWebhookActor("no global admin user found")

--- a/server/internal/httpserver/banner_http_db_test.go
+++ b/server/internal/httpserver/banner_http_db_test.go
@@ -1,0 +1,282 @@
+package httpserver
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	serverdata "github.com/lextures/lextures/server"
+	"github.com/lextures/lextures/server/internal/auth"
+	"github.com/lextures/lextures/server/internal/config"
+	"github.com/lextures/lextures/server/internal/db"
+	"github.com/lextures/lextures/server/internal/migrate"
+	"github.com/lextures/lextures/server/internal/repos/organization"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+	"github.com/lextures/lextures/server/internal/repos/user"
+)
+
+func bannerTestSetup(t *testing.T) (*pgxpool.Pool, *auth.JWTSigner, string, uuid.UUID, uuid.UUID) {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+	if err := migrate.RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+
+	em := "banner-ga-" + time.Now().Format("20060102150405.000") + "@e.com"
+	ph, err := auth.HashPassword("longpassword0")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	row, err := user.InsertUser(ctx, pool, em, ph, nil)
+	if err != nil {
+		t.Fatalf("user: %v", err)
+	}
+	gaID, _ := uuid.Parse(row.ID)
+	if err := rbac.AssignUserRoleByName(ctx, pool, gaID, "Global Admin"); err != nil {
+		t.Fatalf("role: %v", err)
+	}
+	orgID, err := organization.OrgIDForUser(ctx, pool, gaID)
+	if err != nil {
+		t.Fatalf("org: %v", err)
+	}
+	signer := auth.NewJWTSignerWithPool("01234567890123456789012345678901", pool)
+	tok, err := signer.Sign(ctx, row.ID, em, "", "", nil)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return pool, signer, tok, gaID, orgID
+}
+
+func TestMaintenanceBanner_CreateListPublicDelete_Pg(t *testing.T) {
+	pool, signer, tok, _, orgID := bannerTestSetup(t)
+	h := NewHandler(Deps{
+		Pool:      pool,
+		JWTSigner: signer,
+		Config: config.Config{
+			MaintenanceBannerEnabled: true,
+			AdminConsoleEnabled:      true,
+		},
+	})
+
+	createBody := map[string]any{
+		"scope":    "org",
+		"message":  "Maintenance at midnight",
+		"severity": "warning",
+	}
+	bodyBytes, _ := json.Marshal(createBody)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/admin/banners", bytes.NewReader(bodyBytes))
+	r.Header.Set("Authorization", "Bearer "+tok)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	r2 := httptest.NewRequest(http.MethodGet, "/api/v1/status/banner", nil)
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, r2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("public status=%d", w2.Code)
+	}
+	var pub map[string]any
+	if err := json.Unmarshal(w2.Body.Bytes(), &pub); err != nil {
+		t.Fatalf("public json: %v", err)
+	}
+	if pub["message"] != "Maintenance at midnight" {
+		t.Fatalf("public message=%v", pub["message"])
+	}
+
+	otherEmail := "banner-other-" + time.Now().Format("20060102150405.000") + "@e.com"
+	other, err := user.InsertUser(context.Background(), pool, otherEmail, mustHash(t), nil)
+	if err != nil {
+		t.Fatalf("other user: %v", err)
+	}
+	otherID, _ := uuid.Parse(other.ID)
+	otherOrgRow, err := organization.Create(context.Background(), pool, "Other Org", "other-"+uuid.NewString()[:8], nil, nil, "", nil)
+	if err != nil {
+		t.Fatalf("create org: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(), `UPDATE "user".users SET org_id = $1 WHERE id = $2`, otherOrgRow.ID, otherID); err != nil {
+		t.Fatalf("assign org: %v", err)
+	}
+
+	otherTok, err := signer.Sign(context.Background(), other.ID, otherEmail, "", "", nil)
+	if err != nil {
+		t.Fatalf("other sign: %v", err)
+	}
+	r3 := httptest.NewRequest(http.MethodGet, "/api/v1/status/banner", nil)
+	r3.Header.Set("Authorization", "Bearer "+otherTok)
+	w3 := httptest.NewRecorder()
+	h.ServeHTTP(w3, r3)
+	var otherPub any
+	_ = json.Unmarshal(w3.Body.Bytes(), &otherPub)
+	if otherPub != nil {
+		t.Fatalf("other org should not see banner, got %v", otherPub)
+	}
+
+	var created map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &created)
+	id, _ := created["id"].(string)
+	del := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/banners/"+id, nil)
+	del.Header.Set("Authorization", "Bearer "+tok)
+	wDel := httptest.NewRecorder()
+	h.ServeHTTP(wDel, del)
+	if wDel.Code != http.StatusNoContent {
+		t.Fatalf("delete status=%d", wDel.Code)
+	}
+
+	r4 := httptest.NewRequest(http.MethodGet, "/api/v1/status/banner", nil)
+	r4.Header.Set("Authorization", "Bearer "+tok)
+	w4 := httptest.NewRecorder()
+	h.ServeHTTP(w4, r4)
+	var after any
+	_ = json.Unmarshal(w4.Body.Bytes(), &after)
+	if after != nil {
+		t.Fatalf("expected null after delete, got %v", after)
+	}
+	_ = orgID
+}
+
+func TestMaintenanceBanner_Expiry_Pg(t *testing.T) {
+	pool, signer, tok, _, _ := bannerTestSetup(t)
+	h := NewHandler(Deps{
+		Pool:      pool,
+		JWTSigner: signer,
+		Config: config.Config{
+			MaintenanceBannerEnabled: true,
+			AdminConsoleEnabled:      true,
+		},
+	})
+	exp := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	createBody := map[string]any{
+		"scope":     "global",
+		"message":   "Expired notice",
+		"severity":  "info",
+		"expiresAt": exp,
+	}
+	bodyBytes, _ := json.Marshal(createBody)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/admin/banners", bytes.NewReader(bodyBytes))
+	r.Header.Set("Authorization", "Bearer "+tok)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", w.Code, w.Body.String())
+	}
+	r2 := httptest.NewRequest(http.MethodGet, "/api/v1/status/banner", nil)
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, r2)
+	var pub any
+	_ = json.Unmarshal(w2.Body.Bytes(), &pub)
+	if pub != nil {
+		t.Fatalf("expired banner should not be active, got %v", pub)
+	}
+}
+
+func mustHash(t *testing.T) string {
+	t.Helper()
+	h, err := auth.HashPassword("longpassword0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+func TestMaintenanceBanner_OrgAdminScope_Pg(t *testing.T) {
+	pool, signer, gaTok, _, defOrg := bannerTestSetup(t)
+	ctx := context.Background()
+	orgAdminEmail := "banner-oa-" + time.Now().Format("20060102150405.000") + "@e.com"
+	oa, err := user.InsertUser(ctx, pool, orgAdminEmail, mustHash(t), nil)
+	if err != nil {
+		t.Fatalf("oa user: %v", err)
+	}
+	h := NewHandler(Deps{
+		Pool:      pool,
+		JWTSigner: signer,
+		Config: config.Config{
+			MaintenanceBannerEnabled: true,
+			AdminConsoleEnabled:      true,
+		},
+	})
+	grantBody := []byte(`{"userId":"` + oa.ID + `","role":"org_admin"}`)
+	rr := httptest.NewRequest(http.MethodPost, "/api/v1/orgs/"+defOrg.String()+"/role-grants", bytes.NewReader(grantBody))
+	rr.Header.Set("Authorization", "Bearer "+gaTok)
+	rr.Header.Set("Content-Type", "application/json")
+	wGrant := httptest.NewRecorder()
+	h.ServeHTTP(wGrant, rr)
+	if wGrant.Code != http.StatusCreated {
+		t.Fatalf("grant status=%d body=%s", wGrant.Code, wGrant.Body.String())
+	}
+	oaTok, err := signer.Sign(ctx, oa.ID, orgAdminEmail, "", "", nil)
+	if err != nil {
+		t.Fatalf("sign oa: %v", err)
+	}
+	bodyBytes, _ := json.Marshal(map[string]any{
+		"scope":    "org",
+		"message":  "District SSO migration Monday",
+		"severity": "info",
+	})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/admin/banners", bytes.NewReader(bodyBytes))
+	r.Header.Set("Authorization", "Bearer "+oaTok)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("org admin create status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestMaintenanceBanner_StatuspageWebhook_Pg(t *testing.T) {
+	pool, signer, _, _, _ := bannerTestSetup(t)
+	secret := "statuspage-test-secret"
+	h := NewHandler(Deps{
+		Pool:      pool,
+		JWTSigner: signer,
+		Config: config.Config{
+			MaintenanceBannerEnabled: true,
+			StatuspageWebhookSecret:  secret,
+		},
+	})
+	payload := []byte(`{"incident":{"id":"inc-1","name":"API degraded","status":"investigating","impact":"major"}}`)
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(payload)
+	sig := hex.EncodeToString(mac.Sum(nil))
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/admin/banners/statuspage-webhook", bytes.NewReader(payload))
+	r.Header.Set("X-Statuspage-Signature", sig)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("webhook status=%d body=%s", w.Code, w.Body.String())
+	}
+	r2 := httptest.NewRequest(http.MethodGet, "/api/v1/status/banner", nil)
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, r2)
+	var pub map[string]any
+	if err := json.Unmarshal(w2.Body.Bytes(), &pub); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if pub["severity"] != "error" {
+		t.Fatalf("severity=%v want error", pub["severity"])
+	}
+}

--- a/server/internal/httpserver/banner_http_db_test.go
+++ b/server/internal/httpserver/banner_http_db_test.go
@@ -41,6 +41,9 @@ func bannerTestSetup(t *testing.T) (*pgxpool.Pool, *auth.JWTSigner, string, uuid
 		t.Fatalf("pool: %v", err)
 	}
 	t.Cleanup(func() { pool.Close() })
+	if _, err := pool.Exec(ctx, `DELETE FROM platform.banners`); err != nil {
+		t.Fatalf("cleanup banners: %v", err)
+	}
 
 	em := "banner-ga-" + time.Now().Format("20060102150405.000") + "@e.com"
 	ph, err := auth.HashPassword("longpassword0")
@@ -94,6 +97,7 @@ func TestMaintenanceBanner_CreateListPublicDelete_Pg(t *testing.T) {
 	}
 
 	r2 := httptest.NewRequest(http.MethodGet, "/api/v1/status/banner", nil)
+	r2.Header.Set("Authorization", "Bearer "+tok)
 	w2 := httptest.NewRecorder()
 	h.ServeHTTP(w2, r2)
 	if w2.Code != http.StatusOK {
@@ -129,10 +133,12 @@ func TestMaintenanceBanner_CreateListPublicDelete_Pg(t *testing.T) {
 	r3.Header.Set("Authorization", "Bearer "+otherTok)
 	w3 := httptest.NewRecorder()
 	h.ServeHTTP(w3, r3)
-	var otherPub any
-	_ = json.Unmarshal(w3.Body.Bytes(), &otherPub)
-	if otherPub != nil {
-		t.Fatalf("other org should not see banner, got %v", otherPub)
+	var otherPub map[string]any
+	if err := json.Unmarshal(w3.Body.Bytes(), &otherPub); err != nil {
+		t.Fatalf("other json: %v", err)
+	}
+	if otherPub != nil && otherPub["message"] == "Maintenance at midnight" {
+		t.Fatalf("other org should not see org banner, got %v", otherPub)
 	}
 
 	var created map[string]any

--- a/server/internal/httpserver/banner_http_nodb_test.go
+++ b/server/internal/httpserver/banner_http_nodb_test.go
@@ -1,0 +1,69 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/config"
+)
+
+func TestMaintenanceBanner_FeatureDisabled_ReturnsNull(t *testing.T) {
+	d := Deps{Config: config.Config{MaintenanceBannerEnabled: false}}
+	h := NewHandler(d)
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/status/banner", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200", w.Code)
+	}
+	if body := w.Body.String(); body != "null\n" && body != "null" {
+		t.Fatalf("body=%q want null", body)
+	}
+}
+
+func TestMaintenanceBanner_AdminDisabled_Returns404(t *testing.T) {
+	d := Deps{Config: config.Config{MaintenanceBannerEnabled: false}}
+	h := NewHandler(d)
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/admin/banners", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status=%d want 404", w.Code)
+	}
+}
+
+func TestMaintenanceBanner_AdminUnauthenticated_Returns401(t *testing.T) {
+	d := Deps{Config: config.Config{MaintenanceBannerEnabled: true, AdminConsoleEnabled: true}}
+	h := NewHandler(d)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/admin/banners", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d want 401", w.Code)
+	}
+}
+
+func TestMaintenanceBanner_StatuspageWebhook_NoHMAC_Returns401(t *testing.T) {
+	d := Deps{Config: config.Config{
+		MaintenanceBannerEnabled:  true,
+		StatuspageWebhookSecret:   "test-secret",
+	}}
+	h := NewHandler(d)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/admin/banners/statuspage-webhook", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d want 401", w.Code)
+	}
+}
+
+func TestVerifyStatuspageHMAC(t *testing.T) {
+	secret := "shh"
+	body := []byte(`{"incident":{"id":"1","name":"Outage","status":"investigating","impact":"major"}}`)
+	mac := httptest.NewRequest(http.MethodPost, "/", nil)
+	mac.Header.Set("X-Statuspage-Signature", "deadbeef")
+	if verifyStatuspageHMAC(mac, secret, body) {
+		t.Fatal("expected invalid signature to fail")
+	}
+}

--- a/server/internal/httpserver/platform_features.go
+++ b/server/internal/httpserver/platform_features.go
@@ -111,6 +111,7 @@ type platformFeaturesJSON struct {
 	ImpersonationEnabled bool `json:"impersonationEnabled"`
 	BulkCsvImportEnabled bool `json:"bulkCsvImportEnabled"`
 	AdminSearchEnabled   bool `json:"adminSearchEnabled"`
+	MaintenanceBannerEnabled bool `json:"maintenanceBannerEnabled"`
 	OpenRouterConfigured bool `json:"openRouterConfigured"`
 	RagNotebookEnabled   bool `json:"ragNotebookEnabled"`
 	AiStudyBuddyEnabled  bool `json:"aiStudyBuddyEnabled"`
@@ -236,6 +237,7 @@ func platformFeaturesFromConfig(cfg config.Config) platformFeaturesJSON {
 		ImpersonationEnabled:         cfg.ImpersonationEnabled,
 		BulkCsvImportEnabled:         cfg.BulkCsvImportEnabled,
 		AdminSearchEnabled:           cfg.AdminSearchEnabled,
+		MaintenanceBannerEnabled:     cfg.MaintenanceBannerEnabled,
 	}
 }
 

--- a/server/internal/httpserver/server.go
+++ b/server/internal/httpserver/server.go
@@ -271,6 +271,7 @@ func NewHandler(d Deps) http.Handler {
 	d.registerAIProviderSettingsRoutes(r)
 	d.registerBackupOpsRoutes(r)
 	d.registerStatusRoutes(r)
+	d.registerBannerRoutes(r)
 	d.registerPIIRedactionRoutes(r)
 	d.registerUnimplementedV1(r)
 	d.mountRouterErrorHandlers(r)

--- a/server/internal/httpserver/settings_platform.go
+++ b/server/internal/httpserver/settings_platform.go
@@ -112,6 +112,7 @@ type platformSettingsJSON struct {
 	ImpersonationEnabled            bool `json:"impersonationEnabled"`
 	BulkCsvImportEnabled            bool `json:"bulkCsvImportEnabled"`
 	AdminSearchEnabled              bool `json:"adminSearchEnabled"`
+	MaintenanceBannerEnabled        bool `json:"maintenanceBannerEnabled"`
 	DataResidencyEnabled            bool `json:"dataResidencyEnabled"`
 	RTLEnabled                      bool `json:"rtlEnabled"`
 	SecurityDisclosureModuleEnabled bool `json:"securityDisclosureModuleEnabled"`
@@ -327,6 +328,7 @@ func (d Deps) handleGetPlatformSettings() http.HandlerFunc {
 			ImpersonationEnabled:            merged.ImpersonationEnabled,
 			BulkCsvImportEnabled:            merged.BulkCsvImportEnabled,
 			AdminSearchEnabled:              merged.AdminSearchEnabled,
+			MaintenanceBannerEnabled:        merged.MaintenanceBannerEnabled,
 			DataResidencyEnabled:            merged.DataResidencyEnabled,
 			RTLEnabled:                      merged.RTLEnabled,
 			SecurityDisclosureModuleEnabled: merged.SecurityDisclosureModuleEnabled,
@@ -515,6 +517,7 @@ type putPlatformBody struct {
 	ImpersonationEnabled            *bool `json:"impersonationEnabled"`
 	BulkCsvImportEnabled            *bool `json:"bulkCsvImportEnabled"`
 	AdminSearchEnabled              *bool `json:"adminSearchEnabled"`
+	MaintenanceBannerEnabled        *bool `json:"maintenanceBannerEnabled"`
 	DataResidencyEnabled            *bool `json:"dataResidencyEnabled"`
 	BackupModuleEnabled             *bool `json:"backupModuleEnabled"`
 	RTLEnabled                      *bool `json:"rtlEnabled"`
@@ -853,6 +856,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 		setBool("impersonationenabled", body.ImpersonationEnabled, func(v bool) { wr.ImpersonationEnabled = &v })
 		setBool("bulkcsvimportenabled", body.BulkCsvImportEnabled, func(v bool) { wr.BulkCsvImportEnabled = &v })
 		setBool("adminsearchenabled", body.AdminSearchEnabled, func(v bool) { wr.AdminSearchEnabled = &v })
+		setBool("maintenancebannerenabled", body.MaintenanceBannerEnabled, func(v bool) { wr.MaintenanceBannerEnabled = &v })
 		setBool("dataresidencyenabled", body.DataResidencyEnabled, func(v bool) { wr.DataResidencyEnabled = &v })
 		setBool("rtlenabled", body.RTLEnabled, func(v bool) { wr.RTLEnabled = &v })
 		setBool("securitydisclosuremoduleenabled", body.SecurityDisclosureModuleEnabled, func(v bool) { wr.SecurityDisclosureModuleEnabled = &v })
@@ -1022,6 +1026,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 			ImpersonationEnabled:            merged.ImpersonationEnabled,
 			BulkCsvImportEnabled:            merged.BulkCsvImportEnabled,
 			AdminSearchEnabled:              merged.AdminSearchEnabled,
+			MaintenanceBannerEnabled:        merged.MaintenanceBannerEnabled,
 			DataResidencyEnabled:            merged.DataResidencyEnabled,
 			RTLEnabled:                      merged.RTLEnabled,
 			SecurityDisclosureModuleEnabled: merged.SecurityDisclosureModuleEnabled,

--- a/server/internal/migrate/integration_gate.go
+++ b/server/internal/migrate/integration_gate.go
@@ -1,0 +1,36 @@
+package migrate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func integrationMigrateGatePath() string {
+	if dir := os.Getenv("TMPDIR"); dir != "" {
+		return filepath.Join(dir, "lextures-migrate-integration.lock")
+	}
+	return filepath.Join(os.TempDir(), "lextures-migrate-integration.lock")
+}
+
+// acquireIntegrationMigrateGate serializes Postgres-backed integration tests that share
+// one DATABASE_URL across parallel `go test` package binaries. No-op when unset.
+func acquireIntegrationMigrateGate() (func(), error) {
+	if os.Getenv("DATABASE_URL") == "" {
+		return func() {}, nil
+	}
+	path := integrationMigrateGatePath()
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open gate %q: %w", path, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("flock gate %q: %w", path, err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/server/internal/migrate/repair_345_test.go
+++ b/server/internal/migrate/repair_345_test.go
@@ -23,7 +23,13 @@ func TestRepairMigration345RenumberCollision_Integration(t *testing.T) {
 	t.Setenv("MIGRATE_REPAIR_CHECKSUMS", "1")
 
 	ctx := context.Background()
-	if err := RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+	release, err := acquireIntegrationMigrateGate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	if err := runWithFS(ctx, serverdata.Migrations, dsn); err != nil {
 		t.Fatalf("baseline migrate: %v", err)
 	}
 
@@ -60,7 +66,7 @@ func TestRepairMigration345RenumberCollision_Integration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := RunWithFS(ctx, serverdata.Migrations, dsn); err != nil {
+	if err := runWithFS(ctx, serverdata.Migrations, dsn); err != nil {
 		t.Fatalf("repair migrate: %v", err)
 	}
 

--- a/server/internal/migrate/rollback.go
+++ b/server/internal/migrate/rollback.go
@@ -15,6 +15,11 @@ import (
 // RollbackLatest applies the down.sql companion for the most recently applied migration.
 // Returns ErrRollbackNotSupported when the companion is a documented no-op stub.
 func RollbackLatest(ctx context.Context, fsys fs.FS, dsn string) error {
+	release, err := acquireIntegrationMigrateGate()
+	if err != nil {
+		return err
+	}
+	defer release()
 	if dsn == "" {
 		return fmt.Errorf("migrate: empty database URL")
 	}

--- a/server/internal/migrate/run.go
+++ b/server/internal/migrate/run.go
@@ -21,6 +21,15 @@ const sqlxMigrationsTable = "_sqlx_migrations"
 
 // RunWithFS applies SQL migrations from fsys (directory root, e.g. "migrations").
 func RunWithFS(ctx context.Context, fsys fs.FS, dsn string) error {
+	release, err := acquireIntegrationMigrateGate()
+	if err != nil {
+		return err
+	}
+	defer release()
+	return runWithFS(ctx, fsys, dsn)
+}
+
+func runWithFS(ctx context.Context, fsys fs.FS, dsn string) error {
 	if dsn == "" {
 		return fmt.Errorf("migrate: empty database URL")
 	}

--- a/server/internal/repos/banners/repo.go
+++ b/server/internal/repos/banners/repo.go
@@ -1,0 +1,267 @@
+// Package banners persists and queries platform.banners (plan 18.6).
+package banners
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Severity is the banner severity level.
+type Severity string
+
+const (
+	SeverityInfo    Severity = "info"
+	SeverityWarning Severity = "warning"
+	SeverityError   Severity = "error"
+)
+
+// Scope is global or org-scoped.
+type Scope string
+
+const (
+	ScopeGlobal Scope = "global"
+	ScopeOrg    Scope = "org"
+)
+
+// Banner is one maintenance/outage notice row.
+type Banner struct {
+	ID         uuid.UUID
+	Scope      Scope
+	OrgID      *uuid.UUID
+	Message    string
+	Severity   Severity
+	CTAText    *string
+	CTAURL     *string
+	StartsAt   *time.Time
+	ExpiresAt  *time.Time
+	IsActive   bool
+	ExternalID *string
+	CreatedBy  uuid.UUID
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// CreateParams holds fields for inserting a banner.
+type CreateParams struct {
+	Scope      Scope
+	OrgID      *uuid.UUID
+	Message    string
+	Severity   Severity
+	CTAText    *string
+	CTAURL     *string
+	StartsAt   *time.Time
+	ExpiresAt  *time.Time
+	ExternalID *string
+	CreatedBy  uuid.UUID
+}
+
+// UpdateParams holds mutable banner fields.
+type UpdateParams struct {
+	Message   string
+	Severity  Severity
+	CTAText   *string
+	CTAURL    *string
+	StartsAt  *time.Time
+	ExpiresAt *time.Time
+	IsActive  bool
+}
+
+const bannerColumns = `
+	id, scope, org_id, message, severity, cta_text, cta_url,
+	starts_at, expires_at, is_active, external_id, created_by, created_at, updated_at
+`
+
+func scanBanner(row pgx.Row) (Banner, error) {
+	var b Banner
+	var scope, severity string
+	err := row.Scan(
+		&b.ID, &scope, &b.OrgID, &b.Message, &severity, &b.CTAText, &b.CTAURL,
+		&b.StartsAt, &b.ExpiresAt, &b.IsActive, &b.ExternalID, &b.CreatedBy, &b.CreatedAt, &b.UpdatedAt,
+	)
+	if err != nil {
+		return Banner{}, err
+	}
+	b.Scope = Scope(scope)
+	b.Severity = Severity(severity)
+	return b, nil
+}
+
+func activeTimeClause(now time.Time) string {
+	_ = now
+	return `
+		AND is_active = TRUE
+		AND (starts_at IS NULL OR starts_at <= $1)
+		AND (expires_at IS NULL OR expires_at > $1)
+	`
+}
+
+// GetActiveForOrg returns the highest-priority active banner for a viewer.
+// Org-scoped banners take precedence over global banners.
+func GetActiveForOrg(ctx context.Context, pool *pgxpool.Pool, orgID *uuid.UUID, now time.Time) (*Banner, error) {
+	if orgID != nil {
+		row := pool.QueryRow(ctx, `
+SELECT `+bannerColumns+`
+FROM platform.banners
+WHERE scope = 'org' AND org_id = $2`+activeTimeClause(now)+`
+ORDER BY updated_at DESC
+LIMIT 1
+`, now, *orgID)
+		b, err := scanBanner(row)
+		if err == nil {
+			return &b, nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return nil, err
+		}
+	}
+	row := pool.QueryRow(ctx, `
+SELECT `+bannerColumns+`
+FROM platform.banners
+WHERE scope = 'global'`+activeTimeClause(now)+`
+ORDER BY updated_at DESC
+LIMIT 1
+`, now)
+	b, err := scanBanner(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+
+// List returns banners for admin management, optionally filtered by org.
+func List(ctx context.Context, pool *pgxpool.Pool, orgID *uuid.UUID, globalOnly bool) ([]Banner, error) {
+	var rows pgx.Rows
+	var err error
+	if globalOnly {
+		rows, err = pool.Query(ctx, `
+SELECT `+bannerColumns+`
+FROM platform.banners
+WHERE scope = 'global'
+ORDER BY updated_at DESC
+LIMIT 100`)
+	} else if orgID != nil {
+		rows, err = pool.Query(ctx, `
+SELECT `+bannerColumns+`
+FROM platform.banners
+WHERE scope = 'org' AND org_id = $1
+ORDER BY updated_at DESC
+LIMIT 100`, *orgID)
+	} else {
+		rows, err = pool.Query(ctx, `
+SELECT `+bannerColumns+`
+FROM platform.banners
+ORDER BY updated_at DESC
+LIMIT 100`)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Banner
+	for rows.Next() {
+		b, err := scanBanner(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+// GetByID loads one banner by primary key.
+func GetByID(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID) (*Banner, error) {
+	row := pool.QueryRow(ctx, `SELECT `+bannerColumns+` FROM platform.banners WHERE id = $1`, id)
+	b, err := scanBanner(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+
+// Create inserts a new banner.
+func Create(ctx context.Context, pool *pgxpool.Pool, p CreateParams) (Banner, error) {
+	row := pool.QueryRow(ctx, `
+INSERT INTO platform.banners
+  (scope, org_id, message, severity, cta_text, cta_url, starts_at, expires_at, external_id, created_by)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+RETURNING `+bannerColumns,
+		string(p.Scope), p.OrgID, p.Message, string(p.Severity),
+		p.CTAText, p.CTAURL, p.StartsAt, p.ExpiresAt, p.ExternalID, p.CreatedBy,
+	)
+	return scanBanner(row)
+}
+
+// UpsertByExternalID creates or updates a banner keyed by external_id (Statuspage incidents).
+func UpsertByExternalID(ctx context.Context, pool *pgxpool.Pool, p CreateParams) (Banner, error) {
+	if p.ExternalID == nil || *p.ExternalID == "" {
+		return Create(ctx, pool, p)
+	}
+	row := pool.QueryRow(ctx, `
+INSERT INTO platform.banners
+  (scope, org_id, message, severity, cta_text, cta_url, starts_at, expires_at, external_id, created_by)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+ON CONFLICT (external_id) WHERE external_id IS NOT NULL AND external_id <> ''
+DO UPDATE SET
+  message = EXCLUDED.message,
+  severity = EXCLUDED.severity,
+  cta_text = EXCLUDED.cta_text,
+  cta_url = EXCLUDED.cta_url,
+  starts_at = EXCLUDED.starts_at,
+  expires_at = EXCLUDED.expires_at,
+  is_active = TRUE,
+  updated_at = now()
+RETURNING `+bannerColumns,
+		string(p.Scope), p.OrgID, p.Message, string(p.Severity),
+		p.CTAText, p.CTAURL, p.StartsAt, p.ExpiresAt, p.ExternalID, p.CreatedBy,
+	)
+	return scanBanner(row)
+}
+
+// Update mutates an existing banner.
+func Update(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID, p UpdateParams) (*Banner, error) {
+	row := pool.QueryRow(ctx, `
+UPDATE platform.banners
+SET message = $2, severity = $3, cta_text = $4, cta_url = $5,
+    starts_at = $6, expires_at = $7, is_active = $8, updated_at = now()
+WHERE id = $1
+RETURNING `+bannerColumns,
+		id, p.Message, string(p.Severity), p.CTAText, p.CTAURL, p.StartsAt, p.ExpiresAt, p.IsActive,
+	)
+	b, err := scanBanner(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+
+// DeactivateByExternalID marks a webhook-managed banner inactive.
+func DeactivateByExternalID(ctx context.Context, pool *pgxpool.Pool, externalID string) error {
+	_, err := pool.Exec(ctx, `
+UPDATE platform.banners
+SET is_active = FALSE, updated_at = now()
+WHERE external_id = $1`, externalID)
+	return err
+}
+
+// Delete removes a banner row.
+func Delete(ctx context.Context, pool *pgxpool.Pool, id uuid.UUID) (bool, error) {
+	tag, err := pool.Exec(ctx, `DELETE FROM platform.banners WHERE id = $1`, id)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}

--- a/server/internal/repos/platformconfig/features.go
+++ b/server/internal/repos/platformconfig/features.go
@@ -138,6 +138,7 @@ func applyPlatformBools(out *config.Config, db *Row, def Defaults) {
 	out.ImpersonationEnabled = mergeBool(db.ImpersonationEnabled, false)
 	out.BulkCsvImportEnabled = mergeBool(db.BulkCsvImportEnabled, false)
 	out.AdminSearchEnabled = mergeBool(db.AdminSearchEnabled, false)
+	out.MaintenanceBannerEnabled = mergeBool(db.MaintenanceBannerEnabled, true)
 	out.DataResidencyEnabled = mergeBool(db.DataResidencyEnabled, false)
 	out.AiDisclosureEnabled = mergeBool(db.AiDisclosureEnabled, def.AiDisclosureEnabled)
 	out.RTLEnabled = mergeBool(db.RTLEnabled, false)

--- a/server/internal/repos/platformconfig/patch.go
+++ b/server/internal/repos/platformconfig/patch.go
@@ -129,6 +129,7 @@ func patch(ctx context.Context, pool *pgxpool.Pool, w *Write) error {
 	addBool("impersonation_enabled", w.ImpersonationEnabled)
 	addBool("bulk_csv_import_enabled", w.BulkCsvImportEnabled)
 	addBool("admin_search_enabled", w.AdminSearchEnabled)
+	addBool("maintenance_banner_enabled", w.MaintenanceBannerEnabled)
 	addBool("data_residency_enabled", w.DataResidencyEnabled)
 	addBool("ai_disclosure_enabled", w.AiDisclosureEnabled)
 	addBool("rtl_enabled", w.RTLEnabled)

--- a/server/internal/repos/platformconfig/platformconfig.go
+++ b/server/internal/repos/platformconfig/platformconfig.go
@@ -94,6 +94,7 @@ type Row struct {
 	ImpersonationEnabled            *bool
 	BulkCsvImportEnabled            *bool
 	AdminSearchEnabled              *bool
+	MaintenanceBannerEnabled        *bool
 	DataResidencyEnabled            *bool
 	AiDisclosureEnabled             *bool
 	RTLEnabled                      *bool
@@ -262,6 +263,7 @@ type Write struct {
 	ImpersonationEnabled            *bool
 	BulkCsvImportEnabled            *bool
 	AdminSearchEnabled              *bool
+	MaintenanceBannerEnabled        *bool
 	DataResidencyEnabled            *bool
 	AiDisclosureEnabled             *bool
 	RTLEnabled                      *bool
@@ -428,6 +430,7 @@ SELECT
 	impersonation_enabled,
 	bulk_csv_import_enabled,
 	admin_search_enabled,
+	maintenance_banner_enabled,
 	data_residency_enabled,
 	ai_disclosure_enabled,
 	rtl_enabled,
@@ -587,6 +590,7 @@ WHERE id = 1
 		&r.ImpersonationEnabled,
 		&r.BulkCsvImportEnabled,
 		&r.AdminSearchEnabled,
+		&r.MaintenanceBannerEnabled,
 		&r.DataResidencyEnabled,
 		&r.AiDisclosureEnabled,
 		&r.RTLEnabled,
@@ -797,6 +801,7 @@ INSERT INTO settings.platform_app_settings (
 	impersonation_enabled,
 	bulk_csv_import_enabled,
 	admin_search_enabled,
+	maintenance_banner_enabled,
 	data_residency_enabled,
 	ai_disclosure_enabled,
 	rtl_enabled,
@@ -961,6 +966,7 @@ ON CONFLICT (id) DO UPDATE SET
 	impersonation_enabled = COALESCE(EXCLUDED.impersonation_enabled, settings.platform_app_settings.impersonation_enabled),
 	bulk_csv_import_enabled = COALESCE(EXCLUDED.bulk_csv_import_enabled, settings.platform_app_settings.bulk_csv_import_enabled),
 	admin_search_enabled = COALESCE(EXCLUDED.admin_search_enabled, settings.platform_app_settings.admin_search_enabled),
+	maintenance_banner_enabled = COALESCE(EXCLUDED.maintenance_banner_enabled, settings.platform_app_settings.maintenance_banner_enabled),
 	data_residency_enabled = COALESCE(EXCLUDED.data_residency_enabled, settings.platform_app_settings.data_residency_enabled),
 	rtl_enabled = COALESCE(EXCLUDED.rtl_enabled, settings.platform_app_settings.rtl_enabled),
 	ai_disclosure_enabled = COALESCE(EXCLUDED.ai_disclosure_enabled, settings.platform_app_settings.ai_disclosure_enabled),
@@ -1118,6 +1124,7 @@ ON CONFLICT (id) DO UPDATE SET
 		w.ImpersonationEnabled,
 		w.BulkCsvImportEnabled,
 		w.AdminSearchEnabled,
+		w.MaintenanceBannerEnabled,
 		w.DataResidencyEnabled,
 		w.AiDisclosureEnabled,
 		w.RTLEnabled,

--- a/server/internal/service/banners/statuspage_webhook.go
+++ b/server/internal/service/banners/statuspage_webhook.go
@@ -1,0 +1,61 @@
+package banners
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// StatuspageWebhook is the subset of a Statuspage incident webhook payload we consume.
+type StatuspageWebhook struct {
+	Incident *StatuspageIncident `json:"incident"`
+}
+
+// StatuspageIncident holds incident fields from Statuspage.io webhooks.
+type StatuspageIncident struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Impact string `json:"impact"`
+}
+
+// ParseStatuspageWebhook unmarshals a Statuspage webhook body.
+func ParseStatuspageWebhook(body []byte) (StatuspageWebhook, error) {
+	var payload StatuspageWebhook
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return StatuspageWebhook{}, errors.New("invalid Statuspage payload")
+	}
+	if payload.Incident == nil || strings.TrimSpace(payload.Incident.ID) == "" {
+		return StatuspageWebhook{}, errors.New("incident id is required")
+	}
+	return payload, nil
+}
+
+// IncidentSeverity maps Statuspage impact/status to banner severity.
+func IncidentSeverity(impact, status string) string {
+	status = strings.ToLower(strings.TrimSpace(status))
+	if status == "resolved" || status == "completed" {
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(impact)) {
+	case "critical", "major":
+		return "error"
+	case "minor":
+		return "warning"
+	default:
+		return "warning"
+	}
+}
+
+// IncidentMessage builds a plain-text banner message from an incident.
+func IncidentMessage(name, status string) string {
+	name = strings.TrimSpace(name)
+	status = strings.TrimSpace(status)
+	if name == "" {
+		name = "Service incident"
+	}
+	if status != "" {
+		return name + " — status: " + status
+	}
+	return name
+}

--- a/server/internal/service/banners/validate.go
+++ b/server/internal/service/banners/validate.go
@@ -1,0 +1,50 @@
+package banners
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+var emailLike = regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)
+
+// ValidateMessage rejects empty or overlong messages and heuristic PII (email addresses).
+func ValidateMessage(message string) error {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return errors.New("message is required")
+	}
+	if len(message) > 500 {
+		return errors.New("message must be at most 500 characters")
+	}
+	if emailLike.MatchString(message) {
+		return errors.New("message must not contain email addresses")
+	}
+	return nil
+}
+
+// ParseSeverity normalizes a severity string.
+func ParseSeverity(s string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "info", "":
+		return "info", nil
+	case "warning":
+		return "warning", nil
+	case "error":
+		return "error", nil
+	default:
+		return "", errors.New("severity must be info, warning, or error")
+	}
+}
+
+// ParseScope normalizes a scope string.
+func ParseScope(s string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "global":
+		return "global", nil
+	case "org":
+		return "org", nil
+	default:
+		return "", errors.New("scope must be global or org")
+	}
+}

--- a/server/internal/service/banners/validate_test.go
+++ b/server/internal/service/banners/validate_test.go
@@ -1,0 +1,40 @@
+package banners
+
+import (
+	"testing"
+)
+
+func TestValidateMessage(t *testing.T) {
+	if err := ValidateMessage("Scheduled maintenance Sunday 2am UTC"); err != nil {
+		t.Fatalf("valid message: %v", err)
+	}
+	if err := ValidateMessage(""); err == nil {
+		t.Fatal("expected empty error")
+	}
+	if err := ValidateMessage("Contact admin@example.com for help"); err == nil {
+		t.Fatal("expected PII error")
+	}
+}
+
+func TestIncidentSeverity(t *testing.T) {
+	if got := IncidentSeverity("critical", "investigating"); got != "error" {
+		t.Fatalf("got %q want error", got)
+	}
+	if got := IncidentSeverity("minor", "monitoring"); got != "warning" {
+		t.Fatalf("got %q want warning", got)
+	}
+	if got := IncidentSeverity("major", "resolved"); got != "" {
+		t.Fatalf("resolved should return empty severity, got %q", got)
+	}
+}
+
+func TestParseStatuspageWebhook(t *testing.T) {
+	_, err := ParseStatuspageWebhook([]byte(`{"incident":{"id":"abc","name":"Outage"}}`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = ParseStatuspageWebhook([]byte(`{}`))
+	if err == nil {
+		t.Fatal("expected error for missing incident")
+	}
+}

--- a/server/internal/telemetry/metrics.go
+++ b/server/internal/telemetry/metrics.go
@@ -35,8 +35,9 @@ type Metrics struct {
 	aiProviderCalls     *prometheus.CounterVec
 	aiProviderLatency   *prometheus.HistogramVec
 	aiProviderCostTotal *prometheus.CounterVec
-	businessEvents      *prometheus.CounterVec
-	healthChecks        *prometheus.CounterVec
+		businessEvents      *prometheus.CounterVec
+		bannerActive        *prometheus.GaugeVec
+		healthChecks        *prometheus.CounterVec
 	buildInfo           *prometheus.GaugeVec
 }
 
@@ -92,6 +93,11 @@ func NewMetrics(deployColor ...string) *Metrics {
 			Name:      "business_events_total",
 			Help:      "Business events (enrollments, grade submissions, etc.) by type.",
 		}, []string{"event"}),
+		bannerActive: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "banner_active",
+			Help:      "Whether a maintenance banner is currently active (1) or not (0) by scope and severity (plan 18.6).",
+		}, []string{"scope", "severity"}),
 		healthChecks: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Name:      "health_check_total",
@@ -113,6 +119,7 @@ func NewMetrics(deployColor ...string) *Metrics {
 		m.aiProviderLatency,
 		m.aiProviderCostTotal,
 		m.businessEvents,
+		m.bannerActive,
 		m.healthChecks,
 		m.buildInfo,
 		collectors.NewGoCollector(),
@@ -182,6 +189,23 @@ func (m *Metrics) IncBusinessEvent(event string) {
 		return
 	}
 	m.businessEvents.WithLabelValues(event).Inc()
+}
+
+// SetBannerActive records the currently served maintenance banner gauge (plan 18.6).
+// Pass empty scope to clear all known label combinations to zero.
+func (m *Metrics) SetBannerActive(scope, severity string) {
+	for _, sc := range []string{"global", "org"} {
+		for _, sev := range []string{"info", "warning", "error"} {
+			m.bannerActive.WithLabelValues(sc, sev).Set(0)
+		}
+	}
+	if scope == "" {
+		return
+	}
+	if severity == "" {
+		severity = "info"
+	}
+	m.bannerActive.WithLabelValues(scope, severity).Set(1)
 }
 
 // IncHealthCheck records one health probe result (plan 17.8 Observability).

--- a/server/internal/telemetry/metrics_test.go
+++ b/server/internal/telemetry/metrics_test.go
@@ -77,3 +77,14 @@ func TestMetrics_IncBusinessEventEmptyNoop(t *testing.T) {
 		t.Error("empty event should not create a series")
 	}
 }
+
+func TestMetrics_SetBannerActive(t *testing.T) {
+	m := NewMetrics()
+	m.SetBannerActive("global", "warning")
+	rr := httptest.NewRecorder()
+	m.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := rr.Body.String()
+	if !strings.Contains(body, `lextures_banner_active{scope="global",severity="warning"} 1`) {
+		t.Errorf("expected active global warning gauge, got: %s", body)
+	}
+}

--- a/server/migrations/351_maintenance_banner.down.sql
+++ b/server/migrations/351_maintenance_banner.down.sql
@@ -1,0 +1,1 @@
+-- Rollback: see docs/runbooks/migrations.md

--- a/server/migrations/351_maintenance_banner.down.sql
+++ b/server/migrations/351_maintenance_banner.down.sql
@@ -1,1 +1,4 @@
--- Rollback: see docs/runbooks/migrations.md
+DROP TABLE IF EXISTS platform.banners;
+DROP TYPE IF EXISTS platform.banner_scope;
+DROP TYPE IF EXISTS platform.banner_severity;
+ALTER TABLE settings.platform_app_settings DROP COLUMN IF EXISTS maintenance_banner_enabled;

--- a/server/migrations/351_maintenance_banner.sql
+++ b/server/migrations/351_maintenance_banner.sql
@@ -1,0 +1,47 @@
+-- Plan 18.6: Maintenance / outage banner controls.
+
+ALTER TABLE settings.platform_app_settings
+    ADD COLUMN IF NOT EXISTS maintenance_banner_enabled BOOLEAN;
+
+COMMENT ON COLUMN settings.platform_app_settings.maintenance_banner_enabled IS
+    'Plan 18.6: Enables site-wide and org-scoped maintenance banners plus admin banner APIs.';
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'banner_severity') THEN
+        CREATE TYPE platform.banner_severity AS ENUM ('info', 'warning', 'error');
+    END IF;
+END$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'banner_scope') THEN
+        CREATE TYPE platform.banner_scope AS ENUM ('global', 'org');
+    END IF;
+END$$;
+
+CREATE TABLE IF NOT EXISTS platform.banners (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    scope       platform.banner_scope NOT NULL,
+    org_id      UUID REFERENCES tenant.organizations (id) ON DELETE CASCADE,
+    message     TEXT NOT NULL CHECK (length(message) <= 500),
+    severity    platform.banner_severity NOT NULL DEFAULT 'info',
+    cta_text    TEXT,
+    cta_url     TEXT,
+    starts_at   TIMESTAMPTZ,
+    expires_at  TIMESTAMPTZ,
+    is_active   BOOLEAN NOT NULL DEFAULT TRUE,
+    external_id TEXT,
+    created_by  UUID NOT NULL REFERENCES "user".users (id),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT banners_org_scope_check CHECK (
+        (scope = 'global' AND org_id IS NULL) OR (scope = 'org' AND org_id IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_banners_active ON platform.banners (is_active, scope, org_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_banners_external_id
+    ON platform.banners (external_id)
+    WHERE external_id IS NOT NULL AND external_id <> '';

--- a/server/migrations/351_maintenance_banner.sql
+++ b/server/migrations/351_maintenance_banner.sql
@@ -1,5 +1,7 @@
 -- Plan 18.6: Maintenance / outage banner controls.
 
+CREATE SCHEMA IF NOT EXISTS platform;
+
 ALTER TABLE settings.platform_app_settings
     ADD COLUMN IF NOT EXISTS maintenance_banner_enabled BOOLEAN;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements plan 18.6 — maintenance/outage banner controls (global + org scope), Statuspage webhook, admin UI, and public `StatusBanner` component.

## CI fix

**Root cause:** `TestRepairMigration345RenumberCollision_Integration` simulates a pre-renumber demo DB by rewriting `_sqlx_migrations` between two `RunWithFS` calls. CI runs each `./internal/...` package in a **separate `go test` process**, so other packages could call `RunWithFS` during that window and fail with:

`migrations/345_migration_deploy_tracking.sql was modified after apply (version 345 checksum mismatch)`

**Fix:** Add a flock-based integration gate (when `DATABASE_URL` is set) around `RunWithFS`, `RollbackLatest`, and the full repair-345 test so only one package mutates migration state at a time.

## Changes

- Migration `351_maintenance_banner.sql` + `platform.banners` repo
- HTTP: public `GET /api/v1/status/banner`, admin CRUD, Statuspage webhook
- Feature flag `maintenance_banner_enabled`
- Frontend: `StatusBanner`, `AdminBanners` page
- Tests: unit, DB integration, e2e, telemetry gauge
- `server/internal/migrate/integration_gate.go` — cross-process test serialization
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1627-d9b4-7ab6-8abf-fac2b891e64f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1627-d9b4-7ab6-8abf-fac2b891e64f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

