### PR TITLE
docs: correct Docker daemon startup note for cloud agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,5 +63,8 @@ If the report shows `NO_FCP`, verify the auth token (`LH_TOKEN`), API availabili
 - `golangci-lint` must be built with Go >= 1.25 to lint this project. Use the latest version.
 - The password-signup endpoint enforces HIBP (Have I Been Pwned) breach checking. Use long, random passwords for test accounts.
 - The pre-commit hook (`.husky/pre-commit`) runs `lint-staged` (ESLint fix) and `tsc -b` from `clients/web/`. This runs automatically on commit if husky is installed.
-- Docker daemon must be started manually with `dockerd &>/var/log/dockerd.log &` before using `docker compose` commands in this VM environment.
+- Docker daemon must be started manually before using `docker compose` (dependencies Postgres + RabbitMQ run as containers). `dockerd` needs root and a writable log path, so start it with `sudo bash -c 'dockerd >/var/log/dockerd.log 2>&1 &'` and wait ~10s for `docker info` to succeed.
+- The `ubuntu` user is added to the `docker` group during setup, so plain `docker`/`docker compose` work in fresh login shells once the daemon is up; the shell that performed the `usermod` still needs `sg docker -c '<cmd>'` (or `sudo`) until a new login picks up the group.
 - The fuse-overlayfs storage driver and iptables-legacy are required for Docker-in-Docker in this environment.
+- Go 1.25 lives at `/usr/local/go/bin` (the system default `go` is 1.22). Setup appends this to `~/.bashrc`; if `go version` shows 1.22, prepend `/usr/local/go/bin` to `PATH`.
+- Run the Go API and web SPA natively (`go run ./cmd/server`, `npm run dev`); only Postgres and RabbitMQ need Docker. The API reads `server/.env` (copy from `server/.env.example`) — it is gitignored, so recreate it if missing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While setting up the development environment, the `## Cursor Cloud specific instructions` Docker startup command in `AGENTS.md` was found to be incorrect for the `ubuntu` user: `dockerd &>/var/log/dockerd.log &` fails with permission errors (dockerd needs root, `/var/log` is not writable by `ubuntu`).

This updates the note to:
- Start `dockerd` with `sudo` and a writable log path, and wait for `docker info`.
- Document that `ubuntu` is added to the `docker` group during setup (plain `docker`/`docker compose` work in fresh shells; the setup shell needs `sg docker -c` until re-login).
- Clarify Go 1.25 lives at `/usr/local/go/bin` (system default is 1.22).
- Note that the Go API + web SPA run natively while only Postgres/RabbitMQ need Docker, and that `server/.env` is gitignored.

## Testing

No code changes. Verified the documented commands by bringing up the full stack:
- Postgres + RabbitMQ via `docker compose up -d postgres rabbitmq` (healthy)
- Go API via `go run ./cmd/server` (migrations applied, `/health/ready` ok)
- Web SPA via `npm run dev` (HTTP 200 on :5173)
- Signed up a new account and created a course end-to-end through the UI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fffc231-236a-4924-9b92-6bf7a05a33a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fffc231-236a-4924-9b92-6bf7a05a33a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

