### PR TITLE
feat(admin): Custom fields on users, courses, and enrollments (18.7)

### DIFF
--- a/clients/web/src/app.tsx
+++ b/clients/web/src/app.tsx
@@ -155,6 +155,7 @@ export default function App() {
               <Route index element={<Pages.AdminOverview />} />
               <Route path="users" element={<Pages.AdminUsers />} />
               <Route path="import" element={<Pages.AdminImport />} />
+              <Route path="custom-fields" element={<Pages.AdminCustomFields />} />
               <Route path="courses" element={<Pages.AdminCourses />} />
               <Route path="integrations" element={<Pages.AdminIntegrations />} />
               <Route path="banners" element={<Pages.AdminBanners />} />

--- a/clients/web/src/components/settings/platform-feature-definitions.ts
+++ b/clients/web/src/components/settings/platform-feature-definitions.ts
@@ -102,6 +102,12 @@ const PLATFORM_FEATURE_DEFINITIONS_UNSORTED: PlatformFeatureDefinition[] = [
       'Enables site-wide and org-scoped maintenance/outage banners with admin publishing and Statuspage webhook integration (plan 18.6).',
   },
   {
+    key: 'customFieldsEnabled',
+    label: 'Custom fields',
+    description:
+      'Enables org admins to define custom metadata fields on users, courses, and enrollments with visibility controls (plan 18.7).',
+  },
+  {
     key: 'ffZapierConnector',
     label: 'Zapier / Make connector',
     description: 'Enable REST-hook webhook subscriptions from Zapier and Make.com automation platforms.',

--- a/clients/web/src/components/settings/platform-settings-panel.tsx
+++ b/clients/web/src/components/settings/platform-settings-panel.tsx
@@ -75,6 +75,7 @@ function emptyForm(): PlatformSettingsPayload {
     adminSearchEnabled: false,
     emailTemplateEditorEnabled: false,
     maintenanceBannerEnabled: true,
+    customFieldsEnabled: false,
     ffZapierConnector: false,
     ffAdvisingIntegration: false,
     ffResearchConsent: false,

--- a/clients/web/src/components/settings/platform-settings-types.ts
+++ b/clients/web/src/components/settings/platform-settings-types.ts
@@ -53,6 +53,7 @@ export type PlatformSettingsPayload = {
   adminSearchEnabled: boolean
   emailTemplateEditorEnabled: boolean
   maintenanceBannerEnabled: boolean
+  customFieldsEnabled: boolean
   ffZapierConnector: boolean
   ffAdvisingIntegration: boolean
   ffResearchConsent: boolean

--- a/clients/web/src/context/platform-features-context.tsx
+++ b/clients/web/src/context/platform-features-context.tsx
@@ -68,6 +68,7 @@ export type PlatformFeatures = {
   adminSearchEnabled: boolean
   emailTemplateEditorEnabled: boolean
   maintenanceBannerEnabled: boolean
+  customFieldsEnabled: boolean
   ffZapierConnector: boolean
   ffCatalogIntegration: boolean
   ffEnrollmentStateMachine: boolean
@@ -166,6 +167,7 @@ const defaultFeatures: PlatformFeatures = {
   adminSearchEnabled: false,
   emailTemplateEditorEnabled: false,
   maintenanceBannerEnabled: true,
+  customFieldsEnabled: false,
   ffZapierConnector: false,
   ffCatalogIntegration: false,
   ffEnrollmentStateMachine: false,
@@ -263,6 +265,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
   adminSearchEnabled: false,
   emailTemplateEditorEnabled: false,
   maintenanceBannerEnabled: true,
+  customFieldsEnabled: false,
   ffZapierConnector: false,
     ffCatalogIntegration: false,
     ffEnrollmentStateMachine: false,
@@ -367,6 +370,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           adminSearchEnabled: data.adminSearchEnabled === true,
           emailTemplateEditorEnabled: data.emailTemplateEditorEnabled === true,
           maintenanceBannerEnabled: data.maintenanceBannerEnabled !== false,
+          customFieldsEnabled: data.customFieldsEnabled === true,
           ffZapierConnector: data.ffZapierConnector === true,
           ffCatalogIntegration: data.ffCatalogIntegration === true,
           ffEnrollmentStateMachine: data.ffEnrollmentStateMachine === true,
@@ -428,6 +432,7 @@ export function PlatformFeaturesProvider({ children }: { children: ReactNode }) 
           adminSearchEnabled: next.adminSearchEnabled === true,
           emailTemplateEditorEnabled: next.emailTemplateEditorEnabled === true,
           maintenanceBannerEnabled: next.maintenanceBannerEnabled !== false,
+          customFieldsEnabled: next.customFieldsEnabled === true,
           ffZapierConnector: next.ffZapierConnector === true,
           ffCatalogIntegration: next.ffCatalogIntegration === true,
           ffEnrollmentStateMachine: next.ffEnrollmentStateMachine === true,

--- a/clients/web/src/lazy-pages.ts
+++ b/clients/web/src/lazy-pages.ts
@@ -96,6 +96,7 @@ export const AdminSettingsPage = lazy(() => import('./pages/admin/AdminSettings'
 export const AdminAuditLog = lazy(() => import('./pages/admin/AdminAuditLog'))
 export const AdminIntegrations = lazy(() => import('./pages/admin/AdminIntegrations'))
 export const AdminImport = lazy(() => import('./pages/admin/AdminImport'))
+export const AdminCustomFields = lazy(() => import('./pages/admin/AdminCustomFields'))
 export const AdminBanners = lazy(() => import('./pages/admin/AdminBanners'))
 export const AdminSearchResults = lazy(() => import('./pages/admin/AdminSearchResults'))
 export const AttendanceExport = lazy(() => import('./pages/admin/AttendanceExport'))

--- a/clients/web/src/lib/custom-fields-api.ts
+++ b/clients/web/src/lib/custom-fields-api.ts
@@ -1,0 +1,104 @@
+import { authorizedFetch } from './api'
+
+export type CustomFieldEntityType = 'user' | 'course' | 'enrollment'
+
+export type CustomFieldDefinition = {
+  id: string
+  orgId: string
+  entityType: CustomFieldEntityType
+  key: string
+  label: string
+  fieldType: 'text' | 'number' | 'boolean' | 'date' | 'select'
+  selectOptions?: string[]
+  isRequired: boolean
+  visibility: 'admin_only' | 'instructor' | 'student'
+  sortOrder: number
+  createdAt: string
+}
+
+export type CreateCustomFieldInput = {
+  entityType: CustomFieldEntityType
+  key: string
+  label: string
+  fieldType: CustomFieldDefinition['fieldType']
+  selectOptions?: string[]
+  isRequired?: boolean
+  visibility?: CustomFieldDefinition['visibility']
+  sortOrder?: number
+}
+
+function orgQuery(orgId: string) {
+  return orgId ? `?orgId=${encodeURIComponent(orgId)}` : ''
+}
+
+export async function listCustomFieldDefinitions(
+  orgId: string,
+  entityType: CustomFieldEntityType,
+): Promise<CustomFieldDefinition[]> {
+  const res = await authorizedFetch(
+    `/api/v1/admin-console/custom-fields?entity_type=${entityType}${orgId ? `&orgId=${encodeURIComponent(orgId)}` : ''}`,
+  )
+  if (!res.ok) throw new Error(await res.text())
+  return res.json() as Promise<CustomFieldDefinition[]>
+}
+
+export async function createCustomFieldDefinition(
+  orgId: string,
+  input: CreateCustomFieldInput,
+): Promise<CustomFieldDefinition> {
+  const res = await authorizedFetch(`/api/v1/admin-console/custom-fields${orgQuery(orgId)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  if (!res.ok) throw new Error(await res.text())
+  return res.json() as Promise<CustomFieldDefinition>
+}
+
+export async function updateCustomFieldDefinition(
+  orgId: string,
+  fieldId: string,
+  patch: Partial<CreateCustomFieldInput>,
+): Promise<CustomFieldDefinition> {
+  const res = await authorizedFetch(
+    `/api/v1/admin-console/custom-fields/${fieldId}${orgQuery(orgId)}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    },
+  )
+  if (!res.ok) throw new Error(await res.text())
+  return res.json() as Promise<CustomFieldDefinition>
+}
+
+export async function deleteCustomFieldDefinition(orgId: string, fieldId: string): Promise<void> {
+  const res = await authorizedFetch(
+    `/api/v1/admin-console/custom-fields/${fieldId}${orgQuery(orgId)}`,
+    { method: 'DELETE' },
+  )
+  if (!res.ok) throw new Error(await res.text())
+}
+
+export async function reorderCustomFieldDefinitions(
+  orgId: string,
+  entityType: CustomFieldEntityType,
+  fieldIds: string[],
+): Promise<CustomFieldDefinition[]> {
+  const res = await authorizedFetch(
+    `/api/v1/admin-console/custom-fields/reorder${orgQuery(orgId)}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ entityType, fieldIds }),
+    },
+  )
+  if (!res.ok) throw new Error(await res.text())
+  return res.json() as Promise<CustomFieldDefinition[]>
+}
+
+export async function downloadUsersExport(orgId: string): Promise<Blob> {
+  const res = await authorizedFetch(`/api/v1/admin-console/users/export${orgQuery(orgId)}`)
+  if (!res.ok) throw new Error(await res.text())
+  return res.blob()
+}

--- a/clients/web/src/lib/platform-features.ts
+++ b/clients/web/src/lib/platform-features.ts
@@ -54,6 +54,7 @@ export type PlatformFeaturesSnapshot = {
   adminSearchEnabled?: boolean
   emailTemplateEditorEnabled?: boolean
   maintenanceBannerEnabled?: boolean
+  customFieldsEnabled?: boolean
   ffZapierConnector?: boolean
   ffCatalogIntegration?: boolean
   ffEnrollmentStateMachine?: boolean
@@ -144,6 +145,7 @@ const defaults: PlatformFeaturesSnapshot = {
   adminSearchEnabled: false,
   emailTemplateEditorEnabled: false,
   maintenanceBannerEnabled: true,
+  customFieldsEnabled: false,
   ffZapierConnector: false,
   ffCatalogIntegration: false,
   ffEnrollmentStateMachine: false,

--- a/clients/web/src/pages/admin/AdminCustomFields.tsx
+++ b/clients/web/src/pages/admin/AdminCustomFields.tsx
@@ -1,0 +1,343 @@
+import { useCallback, useEffect, useId, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { GripVertical, Plus, Trash2 } from 'lucide-react'
+import { usePlatformFeatures } from '../../context/platform-features-context'
+import {
+  createCustomFieldDefinition,
+  deleteCustomFieldDefinition,
+  listCustomFieldDefinitions,
+  reorderCustomFieldDefinitions,
+  type CreateCustomFieldInput,
+  type CustomFieldDefinition,
+  type CustomFieldEntityType,
+} from '../../lib/custom-fields-api'
+
+const ENTITY_TABS: { id: CustomFieldEntityType; label: string }[] = [
+  { id: 'user', label: 'Users' },
+  { id: 'course', label: 'Courses' },
+  { id: 'enrollment', label: 'Enrollments' },
+]
+
+const FIELD_TYPES = ['text', 'number', 'boolean', 'date', 'select'] as const
+const VISIBILITY_OPTIONS = [
+  { value: 'admin_only', label: 'Admin only' },
+  { value: 'instructor', label: 'Instructor' },
+  { value: 'student', label: 'Student' },
+] as const
+
+export default function AdminCustomFieldsPage() {
+  const titleId = useId()
+  const formId = useId()
+  const [searchParams] = useSearchParams()
+  const orgId = searchParams.get('orgId') ?? ''
+  const { customFieldsEnabled, adminConsoleEnabled, loading: featuresLoading } = usePlatformFeatures()
+
+  const [entityType, setEntityType] = useState<CustomFieldEntityType>('user')
+  const [fields, setFields] = useState<CustomFieldDefinition[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+  const [form, setForm] = useState<CreateCustomFieldInput>({
+    entityType: 'user',
+    key: '',
+    label: '',
+    fieldType: 'text',
+    selectOptions: [],
+    isRequired: false,
+    visibility: 'admin_only',
+  })
+
+  const loadFields = useCallback(async () => {
+    if (!orgId) return
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await listCustomFieldDefinitions(orgId, entityType)
+      setFields(data)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load custom fields')
+    } finally {
+      setLoading(false)
+    }
+  }, [orgId, entityType])
+
+  useEffect(() => {
+    void loadFields()
+  }, [loadFields])
+
+  useEffect(() => {
+    setForm((f) => ({ ...f, entityType }))
+  }, [entityType])
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault()
+    if (!orgId) return
+    setError(null)
+    try {
+      const options =
+        form.fieldType === 'select'
+          ? (form.selectOptions ?? []).map((s) => s.trim()).filter(Boolean)
+          : undefined
+      await createCustomFieldDefinition(orgId, { ...form, selectOptions: options })
+      setDrawerOpen(false)
+      setForm({
+        entityType,
+        key: '',
+        label: '',
+        fieldType: 'text',
+        selectOptions: [],
+        isRequired: false,
+        visibility: 'admin_only',
+      })
+      await loadFields()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create field')
+    }
+  }
+
+  async function handleDelete(fieldId: string) {
+    if (!orgId || !window.confirm('Delete this custom field? Existing values are retained but hidden.')) return
+    try {
+      await deleteCustomFieldDefinition(orgId, fieldId)
+      await loadFields()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete field')
+    }
+  }
+
+  async function handleReorder(from: number, to: number) {
+    if (from === to || !orgId) return
+    const next = [...fields]
+    const [moved] = next.splice(from, 1)
+    next.splice(to, 0, moved)
+    setFields(next)
+    try {
+      const updated = await reorderCustomFieldDefinitions(
+        orgId,
+        entityType,
+        next.map((f) => f.id),
+      )
+      setFields(updated)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to reorder fields')
+      await loadFields()
+    }
+  }
+
+  if (featuresLoading) {
+    return <p className="text-sm text-slate-500">Loading…</p>
+  }
+  if (!adminConsoleEnabled || !customFieldsEnabled) {
+    return (
+      <div className="mx-auto max-w-lg text-center">
+        <h1 className="text-lg font-semibold">Custom fields unavailable</h1>
+        <p className="mt-2 text-sm text-slate-600">Enable the custom fields platform feature to use this page.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <header className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 id={titleId} className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+            Custom fields
+          </h1>
+          <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+            Define org metadata fields for users, courses, and enrollments.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+          onClick={() => setDrawerOpen(true)}
+        >
+          <Plus className="h-4 w-4" aria-hidden />
+          Add field
+        </button>
+      </header>
+
+      <div role="tablist" aria-label="Entity type" className="mb-4 flex gap-1 border-b border-slate-200 dark:border-neutral-800">
+        {ENTITY_TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={entityType === tab.id}
+            className={`px-4 py-2 text-sm font-medium ${
+              entityType === tab.id
+                ? 'border-b-2 border-indigo-600 text-indigo-700 dark:text-indigo-300'
+                : 'text-slate-600 hover:text-slate-900 dark:text-slate-400'
+            }`}
+            onClick={() => setEntityType(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {error ? (
+        <p role="alert" className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">
+          {error}
+        </p>
+      ) : null}
+
+      {loading ? (
+        <p className="text-sm text-slate-500">Loading fields…</p>
+      ) : fields.length === 0 ? (
+        <p className="text-sm text-slate-500">No custom fields defined for {entityType} yet.</p>
+      ) : (
+        <ul className="divide-y divide-slate-200 rounded-lg border border-slate-200 dark:divide-neutral-800 dark:border-neutral-800">
+          {fields.map((field, index) => (
+            <li
+              key={field.id}
+              draggable
+              onDragStart={() => setDragIndex(index)}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={() => {
+                if (dragIndex !== null) void handleReorder(dragIndex, index)
+                setDragIndex(null)
+              }}
+              className="flex items-center gap-3 px-3 py-3"
+            >
+              <button
+                type="button"
+                className="cursor-grab text-slate-400 hover:text-slate-600"
+                aria-label={`Reorder ${field.label}`}
+              >
+                <GripVertical className="h-4 w-4" aria-hidden />
+              </button>
+              <div className="min-w-0 flex-1">
+                <p className="font-medium text-slate-900 dark:text-slate-100">{field.label}</p>
+                <p className="text-xs text-slate-500">
+                  {field.key} · {field.fieldType} · {field.visibility.replace('_', ' ')}
+                  {field.isRequired ? ' · required' : ''}
+                </p>
+              </div>
+              <button
+                type="button"
+                className="rounded p-2 text-slate-500 hover:bg-red-50 hover:text-red-700"
+                aria-label={`Delete ${field.label}`}
+                onClick={() => void handleDelete(field.id)}
+              >
+                <Trash2 className="h-4 w-4" aria-hidden />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {drawerOpen ? (
+        <div className="fixed inset-0 z-40 flex justify-end bg-black/30" role="presentation">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={formId}
+            className="h-full w-full max-w-md overflow-y-auto bg-white p-6 shadow-xl dark:bg-neutral-950"
+          >
+            <h2 id={formId} className="text-lg font-semibold">
+              Add custom field
+            </h2>
+            <form className="mt-4 space-y-4" onSubmit={(e) => void handleCreate(e)}>
+              <label className="block text-sm">
+                <span className="font-medium">Key</span>
+                <input
+                  required
+                  pattern="[a-z][a-z0-9_]*"
+                  className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+                  value={form.key}
+                  onChange={(e) => setForm({ ...form, key: e.target.value })}
+                  placeholder="student_id"
+                />
+              </label>
+              <label className="block text-sm">
+                <span className="font-medium">Label</span>
+                <input
+                  required
+                  className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+                  value={form.label}
+                  onChange={(e) => setForm({ ...form, label: e.target.value })}
+                />
+              </label>
+              <label className="block text-sm">
+                <span className="font-medium">Type</span>
+                <select
+                  className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+                  value={form.fieldType}
+                  onChange={(e) =>
+                    setForm({ ...form, fieldType: e.target.value as CreateCustomFieldInput['fieldType'] })
+                  }
+                >
+                  {FIELD_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {form.fieldType === 'select' ? (
+                <label className="block text-sm">
+                  <span className="font-medium">Options (comma-separated)</span>
+                  <input
+                    className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+                    value={(form.selectOptions ?? []).join(', ')}
+                    onChange={(e) =>
+                      setForm({
+                        ...form,
+                        selectOptions: e.target.value.split(',').map((s) => s.trim()),
+                      })
+                    }
+                    placeholder="Math, Science"
+                  />
+                </label>
+              ) : null}
+              <label className="block text-sm">
+                <span className="font-medium">Visibility</span>
+                <select
+                  className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+                  value={form.visibility}
+                  onChange={(e) =>
+                    setForm({
+                      ...form,
+                      visibility: e.target.value as CreateCustomFieldInput['visibility'],
+                    })
+                  }
+                >
+                  {VISIBILITY_OPTIONS.map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={form.isRequired ?? false}
+                  onChange={(e) => setForm({ ...form, isRequired: e.target.checked })}
+                />
+                Required
+              </label>
+              <div className="flex gap-2 pt-2">
+                <button
+                  type="submit"
+                  className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                >
+                  Save
+                </button>
+                <button
+                  type="button"
+                  className="rounded-lg border border-slate-300 px-4 py-2 text-sm dark:border-neutral-700"
+                  onClick={() => setDrawerOpen(false)}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/clients/web/src/pages/admin/AdminLayout.tsx
+++ b/clients/web/src/pages/admin/AdminLayout.tsx
@@ -8,6 +8,7 @@ import {
   Plug,
   ScrollText,
   Settings,
+  SlidersHorizontal,
   Users,
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
@@ -27,9 +28,10 @@ const baseNavItems = [
 ]
 
 const importNavItem = { to: '/org-admin/import', label: 'Import', icon: FileUp, end: false as const }
+const customFieldsNavItem = { to: '/org-admin/custom-fields', label: 'Custom fields', icon: SlidersHorizontal, end: false as const }
 
 export default function AdminLayout() {
-  const { adminConsoleEnabled, bulkCsvImportEnabled, maintenanceBannerEnabled } = usePlatformFeatures()
+  const { adminConsoleEnabled, bulkCsvImportEnabled, customFieldsEnabled, maintenanceBannerEnabled } = usePlatformFeatures()
   const [searchParams] = useSearchParams()
   const orgId = searchParams.get('orgId')
   const [canAccess, setCanAccess] = useState<boolean | null>(null)
@@ -73,6 +75,10 @@ export default function AdminLayout() {
     let items = [...baseNavItems]
     if (bulkCsvImportEnabled) {
       items = [...items.slice(0, 2), importNavItem, ...items.slice(2)]
+    }
+    if (customFieldsEnabled) {
+      const insertAt = bulkCsvImportEnabled ? 3 : 2
+      items = [...items.slice(0, insertAt), customFieldsNavItem, ...items.slice(insertAt)]
     }
     if (maintenanceBannerEnabled) {
       const integrationsIdx = items.findIndex((i) => i.to === '/org-admin/integrations')

--- a/docs/completed/18-admin-experience/18.7-custom-fields.md
+++ b/docs/completed/18-admin-experience/18.7-custom-fields.md
@@ -10,7 +10,7 @@
 | **Section** | Admin Experience |
 | **Severity** | MAJOR |
 | **Markets** | K12, HE |
-| **Status (today)** | MISSING |
+| **Status (today)** | IMPLEMENTED |
 | **Estimated effort** | M (2–4 w) |
 | **Owner (proposed)** | Platform / Backend team |
 | **Depends on** | 18.1 (Admin console shell), 5.1 (Org entity) |
@@ -18,7 +18,17 @@
 
 ---
 
-## 1. Problem Statement
+## Implementation notes
+
+Shipped on branch `fix/custom-fields-153d` (migration `354_custom_fields.sql`):
+
+- **API:** `GET/POST/PUT/DELETE /api/v1/admin-console/custom-fields` for schema CRUD; `PUT .../reorder` for sort order; `GET/PATCH /api/v1/admin-console/users/:id?include=custom_fields` for values; `GET /api/v1/admin-console/users/export` CSV export with custom field columns; `GET /api/v1/me?include=custom_fields` with visibility filtering.
+- **Storage:** `tenant.custom_field_definitions` table; JSONB `custom_fields` columns on users, courses, enrollments with GIN indexes.
+- **CSV import:** Extra columns matching defined field keys are parsed and validated during bulk user import (plan 18.2 extension).
+- **UI:** `/org-admin/custom-fields` (`AdminCustomFields.tsx`) gated by `customFieldsEnabled` platform flag (requires `adminConsoleEnabled`).
+- **Tests:** `server/internal/service/customfields/service_test.go`, `admin_custom_fields_nodb_test.go`, `e2e/tests/custom-fields.spec.ts`.
+
+---
 
 Every district and institution has internal metadata fields that do not fit the standard Lextures data model: student ID numbers, grade levels, department codes, disability flags, Title I eligibility, or SIS-specific attributes. Currently there is no way to attach arbitrary key-value data to users, courses, or enrollments without modifying the core schema. This blocks institutional adoption because customers cannot populate, search, or export their own data fields from within Lextures.
 

--- a/docs/completed/18-admin-experience/18.7-custom-fields.md
+++ b/docs/completed/18-admin-experience/18.7-custom-fields.md
@@ -30,6 +30,8 @@ Shipped on branch `fix/custom-fields-153d` (migration `354_custom_fields.sql`):
 
 ---
 
+## 1. Problem Statement
+
 Every district and institution has internal metadata fields that do not fit the standard Lextures data model: student ID numbers, grade levels, department codes, disability flags, Title I eligibility, or SIS-specific attributes. Currently there is no way to attach arbitrary key-value data to users, courses, or enrollments without modifying the core schema. This blocks institutional adoption because customers cannot populate, search, or export their own data fields from within Lextures.
 
 ## 2. Goals

--- a/e2e/tests/custom-fields.spec.ts
+++ b/e2e/tests/custom-fields.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Custom fields (plan 18.7)
+ */
+import { execSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test, expect } from '@playwright/test'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:8080'
+const PASSWORD = process.env.E2E_ADMIN_PASSWORD ?? 'E2eTestPass1!'
+
+function uniqueEmail(prefix = 'e2e-custom-fields') {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}@test.invalid`
+}
+
+function authHeaders(token: string) {
+  return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+}
+
+function databaseUrl(): string {
+  return (
+    process.env.DATABASE_URL ??
+    process.env.E2E_DATABASE_URL ??
+    'postgres://studydrift:studydrift@localhost:5432/studydrift?sslmode=disable'
+  )
+}
+
+async function apiSignup(email: string) {
+  const res = await fetch(`${API_BASE}/api/v1/auth/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: PASSWORD, display_name: 'E2E User' }),
+  })
+  if (!res.ok && res.status !== 409) {
+    throw new Error(`signup failed: ${await res.text()}`)
+  }
+}
+
+async function apiLogin(email: string) {
+  const res = await fetch(`${API_BASE}/api/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: PASSWORD }),
+  })
+  if (!res.ok) throw new Error(`login failed: ${await res.text()}`)
+  return (await res.json()) as { access_token: string }
+}
+
+async function bootstrapGlobalAdmin(email: string) {
+  execSync(`go run ./cmd/bootstrap-admin -email=${email}`, {
+    cwd: path.join(repoRoot, 'server'),
+    env: { ...process.env, DATABASE_URL: databaseUrl() },
+    stdio: 'pipe',
+  })
+}
+
+async function enableCustomFields(token: string) {
+  const res = await fetch(`${API_BASE}/api/v1/settings/platform`, {
+    method: 'PUT',
+    headers: authHeaders(token),
+    body: JSON.stringify({
+      adminConsoleEnabled: true,
+      customFieldsEnabled: true,
+      bulkCsvImportEnabled: true,
+      adminAuditLogEnabled: true,
+    }),
+  })
+  if (!res.ok) {
+    test.skip(true, `could not enable custom fields: ${await res.text()}`)
+  }
+}
+
+test.describe('Admin custom fields API', () => {
+  test('CustomFields: disabled feature returns 404', async () => {
+    const email = uniqueEmail('disabled')
+    await apiSignup(email)
+    const { access_token } = await apiLogin(email)
+    const res = await fetch(`${API_BASE}/api/v1/admin-console/custom-fields?entity_type=user`, {
+      headers: authHeaders(access_token),
+    })
+    if (res.status === 200 || res.status === 403) {
+      test.skip(true, 'custom fields already enabled globally')
+    }
+    expect(res.status).toBe(404)
+  })
+
+  test('CustomFields: define field, set value, retrieve with include', async () => {
+    const email = uniqueEmail('admin')
+    await apiSignup(email)
+    await bootstrapGlobalAdmin(email)
+    const { access_token } = await apiLogin(email)
+    await enableCustomFields(access_token)
+
+    const createRes = await fetch(`${API_BASE}/api/v1/admin-console/custom-fields`, {
+      method: 'POST',
+      headers: authHeaders(access_token),
+      body: JSON.stringify({
+        entityType: 'user',
+        key: 'student_id',
+        label: 'Student ID',
+        fieldType: 'text',
+        visibility: 'admin_only',
+      }),
+    })
+    expect(createRes.status).toBe(201)
+
+    const meRes = await fetch(`${API_BASE}/api/v1/me`, { headers: authHeaders(access_token) })
+    expect(meRes.ok).toBeTruthy()
+    const me = (await meRes.json()) as { id: string; org?: { id: string } }
+    const userId = me.id
+
+    const patchRes = await fetch(`${API_BASE}/api/v1/admin-console/users/${userId}`, {
+      method: 'PATCH',
+      headers: authHeaders(access_token),
+      body: JSON.stringify({ customFields: { student_id: '12345' } }),
+    })
+    expect(patchRes.status).toBe(200)
+
+    const getRes = await fetch(
+      `${API_BASE}/api/v1/admin-console/users/${userId}?include=custom_fields`,
+      { headers: authHeaders(access_token) },
+    )
+    expect(getRes.ok).toBeTruthy()
+    const user = (await getRes.json()) as { customFields?: Record<string, string> }
+    expect(user.customFields?.student_id).toBe('12345')
+  })
+
+  test('CustomFields: select validation returns 422', async () => {
+    const email = uniqueEmail('select')
+    await apiSignup(email)
+    await bootstrapGlobalAdmin(email)
+    const { access_token } = await apiLogin(email)
+    await enableCustomFields(access_token)
+
+    await fetch(`${API_BASE}/api/v1/admin-console/custom-fields`, {
+      method: 'POST',
+      headers: authHeaders(access_token),
+      body: JSON.stringify({
+        entityType: 'user',
+        key: 'department',
+        label: 'Department',
+        fieldType: 'select',
+        selectOptions: ['Math', 'Science'],
+        visibility: 'admin_only',
+      }),
+    })
+
+    const me = (await (await fetch(`${API_BASE}/api/v1/me`, { headers: authHeaders(access_token) })).json()) as {
+      id: string
+    }
+
+    const patchRes = await fetch(`${API_BASE}/api/v1/admin-console/users/${me.id}`, {
+      method: 'PATCH',
+      headers: authHeaders(access_token),
+      body: JSON.stringify({ customFields: { department: 'History' } }),
+    })
+    expect(patchRes.status).toBe(422)
+  })
+})

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -334,6 +334,8 @@ type Config struct {
 	EmailTemplateEditorEnabled bool
 	// MaintenanceBannerEnabled gates site-wide / org maintenance banners and banner admin APIs (plan 18.6).
 	MaintenanceBannerEnabled bool
+	// CustomFieldsEnabled gates org-admin custom field definitions and values (plan 18.7).
+	CustomFieldsEnabled bool
 	// DataResidencyEnabled gates per-tenant region pinning enforcement and the data residency compliance admin API (plan 10.12).
 	DataResidencyEnabled bool
 	// AiDisclosureEnabled gates AI opt-out, gateway enforcement, inference logging, and disclosure APIs (plan 10.17). Defaults to true.

--- a/server/internal/httpserver/admin_console.go
+++ b/server/internal/httpserver/admin_console.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lextures/lextures/server/internal/repos/orgroles"
 	"github.com/lextures/lextures/server/internal/repos/rbac"
 	auditservice "github.com/lextures/lextures/server/internal/service/adminaudit"
+	cfsvc "github.com/lextures/lextures/server/internal/service/customfields"
 )
 
 func (d Deps) adminConsoleEnabled(w http.ResponseWriter) bool {
@@ -136,6 +137,7 @@ func (d Deps) registerAdminConsoleRoutes(r chi.Router) {
 	r.Get("/api/v1/me/admin-console-capabilities", d.handleMeAdminConsoleCapabilities())
 	d.registerAdminImportRoutes(r)
 	d.registerAdminEmailTemplateRoutes(r)
+	d.registerAdminCustomFieldRoutes(r)
 }
 
 func (d Deps) handleMeAdminConsoleCapabilities() http.HandlerFunc {
@@ -309,8 +311,9 @@ func (d Deps) handleAdminConsoleUserPatch() http.HandlerFunc {
 			return
 		}
 		var body struct {
-			Active *bool   `json:"active"`
-			Role   *string `json:"role"`
+			Active       *bool          `json:"active"`
+			Role         *string        `json:"role"`
+			CustomFields map[string]any `json:"customFields"`
 		}
 		if err := json.Unmarshal(raw, &body); err != nil {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
@@ -377,10 +380,45 @@ ON CONFLICT DO NOTHING
 			d.recordAdminConsoleAudit(r, actor, &orgID, auditservice.EventRoleGrant, "user", &targetID, nil, raw)
 		}
 
+		if len(body.CustomFields) > 0 {
+			if !d.effectiveConfig().CustomFieldsEnabled {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Custom fields are not enabled.")
+				return
+			}
+			_, valErrs, err := d.customFieldsService().PatchUserCustomFields(ctx, orgID, targetID, body.CustomFields)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to update custom fields.")
+				return
+			}
+			if len(valErrs) > 0 {
+				apierr.WriteJSON(w, http.StatusUnprocessableEntity, apierr.CodeInvalidInput, valErrs.Error())
+				return
+			}
+		}
+
 		result, err := adminconsole.ListUsers(ctx, d.Pool, orgID, adminconsole.ListParams{Page: 1, PerPage: 1, Query: targetID.String()})
 		if err != nil || len(result.Items) == 0 {
-			writeJSON(w, http.StatusOK, map[string]any{"id": targetID.String()})
+			out := map[string]any{"id": targetID.String()}
+			if queryIncludes(r, "custom_fields") && d.effectiveConfig().CustomFieldsEnabled {
+				fields, ferr := d.customFieldsService().UserCustomFieldsForViewer(ctx, orgID, targetID, cfsvc.ViewerAdmin)
+				if ferr == nil {
+					out["customFields"] = fields
+				}
+			}
+			writeJSON(w, http.StatusOK, out)
 			return
+		}
+		item := result.Items[0]
+		if queryIncludes(r, "custom_fields") && d.effectiveConfig().CustomFieldsEnabled {
+			fields, ferr := d.customFieldsService().UserCustomFieldsForViewer(ctx, orgID, targetID, cfsvc.ViewerAdmin)
+			if ferr == nil {
+				writeJSON(w, http.StatusOK, map[string]any{
+					"id": item.ID, "email": item.Email, "displayName": item.DisplayName,
+					"role": item.Role, "orgRole": item.OrgRole, "active": item.Active,
+					"createdAt": item.CreatedAt, "customFields": fields,
+				})
+				return
+			}
 		}
 		writeJSON(w, http.StatusOK, result.Items[0])
 	}

--- a/server/internal/httpserver/admin_custom_fields.go
+++ b/server/internal/httpserver/admin_custom_fields.go
@@ -1,0 +1,475 @@
+package httpserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/lextures/lextures/server/internal/apierr"
+	cfrepo "github.com/lextures/lextures/server/internal/repos/customfields"
+	cfsvc "github.com/lextures/lextures/server/internal/service/customfields"
+	auditservice "github.com/lextures/lextures/server/internal/service/adminaudit"
+)
+
+func (d Deps) customFieldsEnabled(w http.ResponseWriter) bool {
+	if !d.effectiveConfig().CustomFieldsEnabled {
+		apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Custom fields are not enabled.")
+		return false
+	}
+	if !d.adminConsoleEnabled(w) {
+		return false
+	}
+	return true
+}
+
+func (d Deps) customFieldsService() cfsvc.Service {
+	return cfsvc.Service{Pool: d.Pool}
+}
+
+func (d Deps) registerAdminCustomFieldRoutes(r chi.Router) {
+	r.Get("/api/v1/admin-console/custom-fields", d.handleAdminCustomFieldsList())
+	r.Post("/api/v1/admin-console/custom-fields", d.handleAdminCustomFieldsCreate())
+	r.Put("/api/v1/admin-console/custom-fields/reorder", d.handleAdminCustomFieldsReorder())
+	r.Put("/api/v1/admin-console/custom-fields/{fieldId}", d.handleAdminCustomFieldsUpdate())
+	r.Delete("/api/v1/admin-console/custom-fields/{fieldId}", d.handleAdminCustomFieldsDelete())
+	r.Get("/api/v1/admin-console/users/export", d.handleAdminConsoleUsersExport())
+	r.Get("/api/v1/admin-console/users/{userId}", d.handleAdminConsoleUserGet())
+}
+
+type customFieldDefinitionJSON struct {
+	ID            string   `json:"id"`
+	OrgID         string   `json:"orgId"`
+	EntityType    string   `json:"entityType"`
+	Key           string   `json:"key"`
+	Label         string   `json:"label"`
+	FieldType     string   `json:"fieldType"`
+	SelectOptions []string `json:"selectOptions,omitempty"`
+	IsRequired    bool     `json:"isRequired"`
+	Visibility    string   `json:"visibility"`
+	SortOrder     int      `json:"sortOrder"`
+	CreatedAt     string   `json:"createdAt"`
+}
+
+func toCustomFieldDefinitionJSON(d cfrepo.Definition) customFieldDefinitionJSON {
+	opts := d.SelectOptions
+	if opts == nil {
+		opts = []string{}
+	}
+	return customFieldDefinitionJSON{
+		ID: d.ID.String(), OrgID: d.OrgID.String(), EntityType: string(d.EntityType),
+		Key: d.Key, Label: d.Label, FieldType: string(d.FieldType), SelectOptions: opts,
+		IsRequired: d.IsRequired, Visibility: string(d.Visibility), SortOrder: d.SortOrder,
+		CreatedAt: d.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+	}
+}
+
+func queryIncludes(r *http.Request, name string) bool {
+	for _, part := range strings.Split(r.URL.Query().Get("include"), ",") {
+		if strings.TrimSpace(part) == name {
+			return true
+		}
+	}
+	return false
+}
+
+func customfieldsValidVisibility(v cfrepo.Visibility) bool {
+	switch v {
+	case cfrepo.VisibilityAdminOnly, cfrepo.VisibilityInstructor, cfrepo.VisibilityStudent:
+		return true
+	default:
+		return false
+	}
+}
+
+func customfieldsFormatExportValue(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case bool:
+		if val {
+			return "true"
+		}
+		return "false"
+	case float64:
+		return strconv.FormatFloat(val, 'f', -1, 64)
+	default:
+		b, _ := json.Marshal(val)
+		return string(b)
+	}
+}
+
+func (d Deps) recordCustomFieldAudit(r *http.Request, actor, orgID uuid.UUID, eventType string, targetID uuid.UUID, before, after []byte) {
+	targetType := "custom_field_definition"
+	d.recordAdminConsoleAudit(r, actor, &orgID, eventType, targetType, &targetID, before, after)
+}
+
+func (d Deps) handleAdminCustomFieldsList() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.customFieldsEnabled(w) {
+			return
+		}
+		_, orgID, _, ok := d.adminConsoleAccess(w, r, false)
+		if !ok {
+			return
+		}
+		entityType, err := cfsvc.ParseEntityType(r.URL.Query().Get("entity_type"))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		defs, err := cfrepo.ListDefinitions(r.Context(), d.Pool, orgID, entityType)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to list custom fields.")
+			return
+		}
+		out := make([]customFieldDefinitionJSON, 0, len(defs))
+		for _, def := range defs {
+			out = append(out, toCustomFieldDefinitionJSON(def))
+		}
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+func (d Deps) handleAdminCustomFieldsCreate() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.customFieldsEnabled(w) {
+			return
+		}
+		actor, orgID, _, ok := d.adminConsoleAccess(w, r, true)
+		if !ok {
+			return
+		}
+		raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<16))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid body.")
+			return
+		}
+		var body struct {
+			EntityType    string   `json:"entityType"`
+			Key           string   `json:"key"`
+			Label         string   `json:"label"`
+			FieldType     string   `json:"fieldType"`
+			SelectOptions []string `json:"selectOptions"`
+			IsRequired    bool     `json:"isRequired"`
+			Visibility    string   `json:"visibility"`
+			SortOrder     *int     `json:"sortOrder"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		entityType, err := cfsvc.ParseEntityType(body.EntityType)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		fieldType := cfrepo.FieldType(strings.TrimSpace(body.FieldType))
+		visibility := cfrepo.Visibility(strings.TrimSpace(body.Visibility))
+		if visibility == "" {
+			visibility = cfrepo.VisibilityAdminOnly
+		}
+		if errs := cfsvc.ValidateDefinitionInput(body.Key, body.Label, fieldType, body.SelectOptions); len(errs) > 0 {
+			apierr.WriteJSON(w, http.StatusUnprocessableEntity, apierr.CodeInvalidInput, errs.Error())
+			return
+		}
+		if !customfieldsValidVisibility(visibility) {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid visibility.")
+			return
+		}
+		sortOrder := 0
+		if body.SortOrder != nil {
+			sortOrder = *body.SortOrder
+		}
+		def, err := cfrepo.CreateDefinition(r.Context(), d.Pool, cfrepo.CreateParams{
+			OrgID: orgID, EntityType: entityType, Key: strings.TrimSpace(body.Key),
+			Label: strings.TrimSpace(body.Label), FieldType: fieldType,
+			SelectOptions: body.SelectOptions, IsRequired: body.IsRequired,
+			Visibility: visibility, SortOrder: sortOrder,
+		})
+		if err == cfrepo.ErrDuplicateKey {
+			apierr.WriteJSON(w, http.StatusConflict, apierr.CodeConflict, "A custom field with this key already exists.")
+			return
+		}
+		if err == cfrepo.ErrMaxFields {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Maximum custom fields per entity type reached.")
+			return
+		}
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to create custom field.")
+			return
+		}
+		d.recordCustomFieldAudit(r, actor, orgID, auditservice.EventCustomFieldDefinitionChange, def.ID, nil, raw)
+		writeJSON(w, http.StatusCreated, toCustomFieldDefinitionJSON(def))
+	}
+}
+
+func (d Deps) handleAdminCustomFieldsUpdate() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.customFieldsEnabled(w) {
+			return
+		}
+		actor, orgID, _, ok := d.adminConsoleAccess(w, r, true)
+		if !ok {
+			return
+		}
+		fieldID, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "fieldId")))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid field id.")
+			return
+		}
+		before, _ := cfrepo.GetDefinition(r.Context(), d.Pool, orgID, fieldID)
+		raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<16))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid body.")
+			return
+		}
+		var body struct {
+			Label         *string   `json:"label"`
+			FieldType     *string   `json:"fieldType"`
+			SelectOptions *[]string `json:"selectOptions"`
+			IsRequired    *bool     `json:"isRequired"`
+			Visibility    *string   `json:"visibility"`
+			SortOrder     *int      `json:"sortOrder"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		var fieldType *cfrepo.FieldType
+		if body.FieldType != nil {
+			ft := cfrepo.FieldType(strings.TrimSpace(*body.FieldType))
+			fieldType = &ft
+		}
+		var visibility *cfrepo.Visibility
+		if body.Visibility != nil {
+			v := cfrepo.Visibility(strings.TrimSpace(*body.Visibility))
+			if !customfieldsValidVisibility(v) {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid visibility.")
+				return
+			}
+			visibility = &v
+		}
+		def, err := cfrepo.UpdateDefinition(r.Context(), d.Pool, orgID, fieldID, cfrepo.UpdateParams{
+			Label: body.Label, FieldType: fieldType, SelectOptions: body.SelectOptions,
+			IsRequired: body.IsRequired, Visibility: visibility, SortOrder: body.SortOrder,
+		})
+		if err == cfrepo.ErrNotFound {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Custom field not found.")
+			return
+		}
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to update custom field.")
+			return
+		}
+		var beforeRaw []byte
+		if before.ID != uuid.Nil {
+			beforeRaw, _ = json.Marshal(toCustomFieldDefinitionJSON(before))
+		}
+		d.recordCustomFieldAudit(r, actor, orgID, auditservice.EventCustomFieldDefinitionChange, def.ID, beforeRaw, raw)
+		writeJSON(w, http.StatusOK, toCustomFieldDefinitionJSON(def))
+	}
+}
+
+func (d Deps) handleAdminCustomFieldsDelete() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.customFieldsEnabled(w) {
+			return
+		}
+		actor, orgID, _, ok := d.adminConsoleAccess(w, r, true)
+		if !ok {
+			return
+		}
+		fieldID, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "fieldId")))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid field id.")
+			return
+		}
+		before, _ := cfrepo.GetDefinition(r.Context(), d.Pool, orgID, fieldID)
+		if err := cfrepo.SoftDeleteDefinition(r.Context(), d.Pool, orgID, fieldID); err == cfrepo.ErrNotFound {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "Custom field not found.")
+			return
+		} else if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to delete custom field.")
+			return
+		}
+		var beforeRaw []byte
+		if before.ID != uuid.Nil {
+			beforeRaw, _ = json.Marshal(toCustomFieldDefinitionJSON(before))
+		}
+		d.recordCustomFieldAudit(r, actor, orgID, auditservice.EventCustomFieldDefinitionChange, fieldID, beforeRaw, nil)
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (d Deps) handleAdminCustomFieldsReorder() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.customFieldsEnabled(w) {
+			return
+		}
+		_, orgID, _, ok := d.adminConsoleAccess(w, r, true)
+		if !ok {
+			return
+		}
+		raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<16))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid body.")
+			return
+		}
+		var body struct {
+			EntityType string   `json:"entityType"`
+			FieldIDs   []string `json:"fieldIds"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		entityType, err := cfsvc.ParseEntityType(body.EntityType)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		ids := make([]uuid.UUID, 0, len(body.FieldIDs))
+		for _, s := range body.FieldIDs {
+			id, err := uuid.Parse(strings.TrimSpace(s))
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid field id in fieldIds.")
+				return
+			}
+			ids = append(ids, id)
+		}
+		if err := cfrepo.ReorderDefinitions(r.Context(), d.Pool, orgID, entityType, ids); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+		defs, err := cfrepo.ListDefinitions(r.Context(), d.Pool, orgID, entityType)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to list custom fields.")
+			return
+		}
+		out := make([]customFieldDefinitionJSON, 0, len(defs))
+		for _, def := range defs {
+			out = append(out, toCustomFieldDefinitionJSON(def))
+		}
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+func (d Deps) handleAdminConsoleUserGet() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, orgID, _, ok := d.adminConsoleAccess(w, r, false)
+		if !ok {
+			return
+		}
+		targetID, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "userId")))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid user id.")
+			return
+		}
+		ctx := r.Context()
+		var targetOrg uuid.UUID
+		var email, firstName, lastName string
+		var displayName *string
+		var active bool
+		var createdAt string
+		err = d.Pool.QueryRow(ctx, `
+SELECT org_id, email, COALESCE(first_name,''), COALESCE(last_name,''), display_name,
+       (deactivated_at IS NULL AND NOT login_blocked), created_at::text
+FROM "user".users WHERE id = $1
+`, targetID).Scan(&targetOrg, &email, &firstName, &lastName, &displayName, &active, &createdAt)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "User not found.")
+			return
+		}
+		if targetOrg != orgID {
+			apierr.WriteJSON(w, http.StatusForbidden, apierr.CodeForbidden, "You do not have permission for this action.")
+			return
+		}
+		out := map[string]any{
+			"id": targetID.String(), "email": email, "displayName": displayName,
+			"firstName": firstName, "lastName": lastName, "active": active, "createdAt": createdAt,
+		}
+		if queryIncludes(r, "custom_fields") && d.effectiveConfig().CustomFieldsEnabled {
+			fields, err := d.customFieldsService().UserCustomFieldsForViewer(ctx, orgID, targetID, cfsvc.ViewerAdmin)
+			if err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load custom fields.")
+				return
+			}
+			out["customFields"] = fields
+		}
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+func (d Deps) handleAdminConsoleUsersExport() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.customFieldsEnabled(w) {
+			return
+		}
+		_, orgID, _, ok := d.adminConsoleAccess(w, r, false)
+		if !ok {
+			return
+		}
+		ctx := r.Context()
+		defs, err := cfrepo.ListDefinitions(ctx, d.Pool, orgID, cfrepo.EntityUser)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load custom fields.")
+			return
+		}
+		rows, err := d.Pool.Query(ctx, `
+SELECT email, COALESCE(first_name,''), COALESCE(last_name,''), custom_fields
+FROM "user".users
+WHERE org_id = $1 AND id <> 'a0000000-0000-4000-8000-000000000001'::uuid
+ORDER BY email
+`, orgID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to export users.")
+			return
+		}
+		defer rows.Close()
+
+		var buf bytes.Buffer
+		header := []string{"email", "first_name", "last_name"}
+		for _, def := range defs {
+			header = append(header, def.Label)
+		}
+		buf.WriteString(strings.Join(header, ",") + "\n")
+
+		for rows.Next() {
+			var email, firstName, lastName string
+			var rawFields []byte
+			if err := rows.Scan(&email, &firstName, &lastName, &rawFields); err != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to export users.")
+				return
+			}
+			fields := map[string]any{}
+			if len(rawFields) > 0 {
+				_ = json.Unmarshal(rawFields, &fields)
+			}
+			line := []string{csvEscapeField(email), csvEscapeField(firstName), csvEscapeField(lastName)}
+			for _, def := range defs {
+				val := ""
+				if v, ok := fields[def.Key]; ok && v != nil {
+					val = customfieldsFormatExportValue(v)
+				}
+				line = append(line, csvEscapeField(val))
+			}
+			buf.WriteString(strings.Join(line, ",") + "\n")
+		}
+		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+		w.Header().Set("Content-Disposition", `attachment; filename="users-export.csv"`)
+		_, _ = w.Write(buf.Bytes())
+	}
+}
+
+func csvEscapeField(s string) string {
+	if strings.ContainsAny(s, ",\"\n\r") {
+		return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+	}
+	return s
+}

--- a/server/internal/httpserver/admin_custom_fields_nodb_test.go
+++ b/server/internal/httpserver/admin_custom_fields_nodb_test.go
@@ -1,0 +1,39 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lextures/lextures/server/internal/config"
+)
+
+func TestCustomFields_Disabled(t *testing.T) {
+	d := Deps{Config: config.Config{CustomFieldsEnabled: false, AdminConsoleEnabled: true}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin-console/custom-fields?entity_type=user", nil)
+	w := httptest.NewRecorder()
+	d.handleAdminCustomFieldsList()(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status: %d body %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCustomFields_AdminConsoleDisabled(t *testing.T) {
+	d := Deps{Config: config.Config{CustomFieldsEnabled: true, AdminConsoleEnabled: false}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin-console/custom-fields?entity_type=user", nil)
+	w := httptest.NewRecorder()
+	d.handleAdminCustomFieldsList()(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status: %d", w.Code)
+	}
+}
+
+func TestCustomFields_Unauthenticated(t *testing.T) {
+	d := Deps{Config: config.Config{CustomFieldsEnabled: true, AdminConsoleEnabled: true}}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin-console/custom-fields", nil)
+	w := httptest.NewRecorder()
+	d.handleAdminCustomFieldsCreate()(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status: %d", w.Code)
+	}
+}

--- a/server/internal/httpserver/admin_import.go
+++ b/server/internal/httpserver/admin_import.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lextures/lextures/server/internal/repos/userimport"
 	"github.com/lextures/lextures/server/internal/service/clamav"
 	"github.com/lextures/lextures/server/internal/service/csvimport"
+	cfrepo "github.com/lextures/lextures/server/internal/repos/customfields"
 )
 
 const (
@@ -187,7 +188,21 @@ func (d Deps) handleAdminImportUpload() http.HandlerFunc {
 		dryRun := strings.EqualFold(strings.TrimSpace(r.FormValue("dry_run")), "true") ||
 			strings.EqualFold(strings.TrimSpace(r.FormValue("dryRun")), "true")
 
-		parsed, err := csvimport.ParseCSV(strings.NewReader(string(data)), profile)
+		var customDefs []csvimport.CustomFieldDef
+		if d.effectiveConfig().CustomFieldsEnabled {
+			defs, derr := cfrepo.ListDefinitions(ctx, d.Pool, orgID, cfrepo.EntityUser)
+			if derr != nil {
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load custom fields.")
+				return
+			}
+			for _, def := range defs {
+				customDefs = append(customDefs, csvimport.CustomFieldDef{
+					Key: def.Key, FieldType: string(def.FieldType), Options: def.SelectOptions,
+				})
+			}
+		}
+
+		parsed, err := csvimport.ParseCSVWithCustomFields(strings.NewReader(string(data)), profile, customDefs)
 		if err != nil {
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
 			return

--- a/server/internal/httpserver/custom_fields_viewer.go
+++ b/server/internal/httpserver/custom_fields_viewer.go
@@ -1,0 +1,58 @@
+package httpserver
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/lextures/lextures/server/internal/repos/orgroles"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+	cfsvc "github.com/lextures/lextures/server/internal/service/customfields"
+)
+
+func (d Deps) customFieldsViewerLevel(ctx context.Context, userID, orgID uuid.UUID) (cfsvc.ViewerLevel, error) {
+	if d.Pool == nil {
+		return cfsvc.ViewerStudent, nil
+	}
+	return customFieldsViewerLevel(ctx, d.Pool, userID, orgID)
+}
+
+func customFieldsViewerLevel(ctx context.Context, pool *pgxpool.Pool, userID, orgID uuid.UUID) (cfsvc.ViewerLevel, error) {
+	ga, err := rbac.UserHasPermission(ctx, pool, userID, permGlobalRBACManage)
+	if err != nil {
+		return cfsvc.ViewerStudent, err
+	}
+	if ga {
+		return cfsvc.ViewerAdmin, nil
+	}
+	admin, err := orgroles.UserHasRole(ctx, pool, userID, orgID, orgroles.RoleOrgAdmin)
+	if err != nil {
+		return cfsvc.ViewerStudent, err
+	}
+	if admin {
+		return cfsvc.ViewerAdmin, nil
+	}
+	viewer, err := orgroles.UserHasRole(ctx, pool, userID, orgID, orgroles.RoleOrgViewer)
+	if err != nil {
+		return cfsvc.ViewerStudent, err
+	}
+	if viewer {
+		return cfsvc.ViewerAdmin, nil
+	}
+	var teacher bool
+	err = pool.QueryRow(ctx, `
+SELECT EXISTS (
+  SELECT 1 FROM "user".user_app_roles uar
+  INNER JOIN "user".app_roles ar ON ar.id = uar.role_id
+  WHERE uar.user_id = $1 AND ar.name IN ('Teacher', 'Instructor')
+)
+`, userID).Scan(&teacher)
+	if err != nil {
+		return cfsvc.ViewerStudent, err
+	}
+	if teacher {
+		return cfsvc.ViewerInstructor, nil
+	}
+	return cfsvc.ViewerStudent, nil
+}

--- a/server/internal/httpserver/me.go
+++ b/server/internal/httpserver/me.go
@@ -203,6 +203,7 @@ func (d Deps) handleGetMe() http.HandlerFunc {
 		DisplayName   *string            `json:"displayName"`
 		Org           *orgInfo           `json:"org,omitempty"`
 		Impersonating *impersonationInfo `json:"impersonating,omitempty"`
+		CustomFields  map[string]any     `json:"customFields,omitempty"`
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		userID, ok := d.meUserID(w, r)
@@ -225,6 +226,15 @@ func (d Deps) handleGetMe() http.HandlerFunc {
 SELECT name, slug FROM tenant.organizations WHERE id = $1
 `, orgID).Scan(&name, &slug); err == nil {
 				out.Org = &orgInfo{ID: orgID.String(), Name: name, Slug: slug}
+			}
+		}
+		if queryIncludes(r, "custom_fields") && d.effectiveConfig().CustomFieldsEnabled {
+			level, err := d.customFieldsViewerLevel(r.Context(), userID, orgID)
+			if err == nil {
+				fields, ferr := d.customFieldsService().UserCustomFieldsForViewer(r.Context(), orgID, userID, level)
+				if ferr == nil && len(fields) > 0 {
+					out.CustomFields = fields
+				}
 			}
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/server/internal/httpserver/platform_features.go
+++ b/server/internal/httpserver/platform_features.go
@@ -113,6 +113,7 @@ type platformFeaturesJSON struct {
 	AdminSearchEnabled           bool `json:"adminSearchEnabled"`
 	EmailTemplateEditorEnabled   bool `json:"emailTemplateEditorEnabled"`
 	MaintenanceBannerEnabled     bool `json:"maintenanceBannerEnabled"`
+	CustomFieldsEnabled          bool `json:"customFieldsEnabled"`
 	OpenRouterConfigured         bool `json:"openRouterConfigured"`
 	RagNotebookEnabled   bool `json:"ragNotebookEnabled"`
 	AiStudyBuddyEnabled  bool `json:"aiStudyBuddyEnabled"`
@@ -240,6 +241,7 @@ func platformFeaturesFromConfig(cfg config.Config) platformFeaturesJSON {
 		AdminSearchEnabled:           cfg.AdminSearchEnabled,
 		EmailTemplateEditorEnabled:   cfg.EmailTemplateEditorEnabled,
 		MaintenanceBannerEnabled:     cfg.MaintenanceBannerEnabled,
+		CustomFieldsEnabled:          cfg.CustomFieldsEnabled,
 	}
 }
 

--- a/server/internal/httpserver/settings_platform.go
+++ b/server/internal/httpserver/settings_platform.go
@@ -114,6 +114,7 @@ type platformSettingsJSON struct {
 	AdminSearchEnabled              bool `json:"adminSearchEnabled"`
 	EmailTemplateEditorEnabled      bool `json:"emailTemplateEditorEnabled"`
 	MaintenanceBannerEnabled        bool `json:"maintenanceBannerEnabled"`
+	CustomFieldsEnabled             bool `json:"customFieldsEnabled"`
 	DataResidencyEnabled            bool `json:"dataResidencyEnabled"`
 	RTLEnabled                      bool `json:"rtlEnabled"`
 	SecurityDisclosureModuleEnabled bool `json:"securityDisclosureModuleEnabled"`
@@ -331,6 +332,7 @@ func (d Deps) handleGetPlatformSettings() http.HandlerFunc {
 			AdminSearchEnabled:              merged.AdminSearchEnabled,
 			EmailTemplateEditorEnabled:      merged.EmailTemplateEditorEnabled,
 			MaintenanceBannerEnabled:        merged.MaintenanceBannerEnabled,
+			CustomFieldsEnabled:             merged.CustomFieldsEnabled,
 			DataResidencyEnabled:            merged.DataResidencyEnabled,
 			RTLEnabled:                      merged.RTLEnabled,
 			SecurityDisclosureModuleEnabled: merged.SecurityDisclosureModuleEnabled,
@@ -521,6 +523,7 @@ type putPlatformBody struct {
 	AdminSearchEnabled              *bool `json:"adminSearchEnabled"`
 	EmailTemplateEditorEnabled      *bool `json:"emailTemplateEditorEnabled"`
 	MaintenanceBannerEnabled        *bool `json:"maintenanceBannerEnabled"`
+	CustomFieldsEnabled             *bool `json:"customFieldsEnabled"`
 	DataResidencyEnabled            *bool `json:"dataResidencyEnabled"`
 	BackupModuleEnabled             *bool `json:"backupModuleEnabled"`
 	RTLEnabled                      *bool `json:"rtlEnabled"`
@@ -861,6 +864,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 		setBool("adminsearchenabled", body.AdminSearchEnabled, func(v bool) { wr.AdminSearchEnabled = &v })
 		setBool("emailtemplateeditorenabled", body.EmailTemplateEditorEnabled, func(v bool) { wr.EmailTemplateEditorEnabled = &v })
 		setBool("maintenancebannerenabled", body.MaintenanceBannerEnabled, func(v bool) { wr.MaintenanceBannerEnabled = &v })
+		setBool("customfieldsenabled", body.CustomFieldsEnabled, func(v bool) { wr.CustomFieldsEnabled = &v })
 		setBool("dataresidencyenabled", body.DataResidencyEnabled, func(v bool) { wr.DataResidencyEnabled = &v })
 		setBool("rtlenabled", body.RTLEnabled, func(v bool) { wr.RTLEnabled = &v })
 		setBool("securitydisclosuremoduleenabled", body.SecurityDisclosureModuleEnabled, func(v bool) { wr.SecurityDisclosureModuleEnabled = &v })
@@ -1032,6 +1036,7 @@ func (d Deps) handlePutPlatformSettings() http.HandlerFunc {
 			AdminSearchEnabled:              merged.AdminSearchEnabled,
 			EmailTemplateEditorEnabled:      merged.EmailTemplateEditorEnabled,
 			MaintenanceBannerEnabled:        merged.MaintenanceBannerEnabled,
+			CustomFieldsEnabled:             merged.CustomFieldsEnabled,
 			DataResidencyEnabled:            merged.DataResidencyEnabled,
 			RTLEnabled:                      merged.RTLEnabled,
 			SecurityDisclosureModuleEnabled: merged.SecurityDisclosureModuleEnabled,

--- a/server/internal/repos/customfields/repo.go
+++ b/server/internal/repos/customfields/repo.go
@@ -1,0 +1,336 @@
+// Package customfields provides persistence for org custom field definitions and entity values (plan 18.7).
+package customfields
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const MaxDefinitionsPerEntity = 50
+
+// EntityType is the parent entity for a custom field definition.
+type EntityType string
+
+const (
+	EntityUser       EntityType = "user"
+	EntityCourse     EntityType = "course"
+	EntityEnrollment EntityType = "enrollment"
+)
+
+// FieldType is the value type for a custom field.
+type FieldType string
+
+const (
+	FieldText    FieldType = "text"
+	FieldNumber  FieldType = "number"
+	FieldBoolean FieldType = "boolean"
+	FieldDate    FieldType = "date"
+	FieldSelect  FieldType = "select"
+)
+
+// Visibility controls which roles may read a custom field value.
+type Visibility string
+
+const (
+	VisibilityAdminOnly  Visibility = "admin_only"
+	VisibilityInstructor Visibility = "instructor"
+	VisibilityStudent    Visibility = "student"
+)
+
+var (
+	ErrNotFound      = errors.New("customfields: definition not found")
+	ErrDuplicateKey  = errors.New("customfields: duplicate key")
+	ErrMaxFields     = errors.New("customfields: maximum field count reached")
+	ErrReservedKey   = errors.New("customfields: reserved key")
+)
+
+// Definition is an org custom field schema row.
+type Definition struct {
+	ID            uuid.UUID
+	OrgID         uuid.UUID
+	EntityType    EntityType
+	Key           string
+	Label         string
+	FieldType     FieldType
+	SelectOptions []string
+	IsRequired    bool
+	Visibility    Visibility
+	SortOrder     int
+	DeletedAt     *time.Time
+	CreatedAt     time.Time
+}
+
+// CreateParams holds input for a new definition.
+type CreateParams struct {
+	OrgID         uuid.UUID
+	EntityType    EntityType
+	Key           string
+	Label         string
+	FieldType     FieldType
+	SelectOptions []string
+	IsRequired    bool
+	Visibility    Visibility
+	SortOrder     int
+}
+
+// UpdateParams holds mutable definition fields.
+type UpdateParams struct {
+	Label         *string
+	FieldType     *FieldType
+	SelectOptions *[]string
+	IsRequired    *bool
+	Visibility    *Visibility
+	SortOrder     *int
+}
+
+func scanDefinition(row pgx.Row) (Definition, error) {
+	var d Definition
+	var selectOpts []string
+	var deletedAt *time.Time
+	err := row.Scan(
+		&d.ID, &d.OrgID, &d.EntityType, &d.Key, &d.Label, &d.FieldType,
+		&selectOpts, &d.IsRequired, &d.Visibility, &d.SortOrder, &deletedAt, &d.CreatedAt,
+	)
+	if err != nil {
+		return Definition{}, err
+	}
+	d.SelectOptions = selectOpts
+	d.DeletedAt = deletedAt
+	return d, nil
+}
+
+const definitionColumns = `
+id, org_id, entity_type, key, label, field_type, select_options,
+is_required, visibility, sort_order, deleted_at, created_at
+`
+
+// ListDefinitions returns active definitions for an org and entity type ordered by sort_order.
+func ListDefinitions(ctx context.Context, pool *pgxpool.Pool, orgID uuid.UUID, entityType EntityType) ([]Definition, error) {
+	rows, err := pool.Query(ctx, `
+SELECT `+definitionColumns+`
+FROM tenant.custom_field_definitions
+WHERE org_id = $1 AND entity_type = $2 AND deleted_at IS NULL
+ORDER BY sort_order ASC, created_at ASC
+`, orgID, entityType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Definition
+	for rows.Next() {
+		d, err := scanDefinition(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// GetDefinition loads one active definition by id scoped to org.
+func GetDefinition(ctx context.Context, pool *pgxpool.Pool, orgID, id uuid.UUID) (Definition, error) {
+	row := pool.QueryRow(ctx, `
+SELECT `+definitionColumns+`
+FROM tenant.custom_field_definitions
+WHERE id = $1 AND org_id = $2 AND deleted_at IS NULL
+`, id, orgID)
+	d, err := scanDefinition(row)
+	if err == pgx.ErrNoRows {
+		return Definition{}, ErrNotFound
+	}
+	return d, err
+}
+
+// CountDefinitions returns the number of active definitions for org+entity.
+func CountDefinitions(ctx context.Context, pool *pgxpool.Pool, orgID uuid.UUID, entityType EntityType) (int, error) {
+	var n int
+	err := pool.QueryRow(ctx, `
+SELECT COUNT(*)::int FROM tenant.custom_field_definitions
+WHERE org_id = $1 AND entity_type = $2 AND deleted_at IS NULL
+`, orgID, entityType).Scan(&n)
+	return n, err
+}
+
+// CreateDefinition inserts a new custom field definition.
+func CreateDefinition(ctx context.Context, pool *pgxpool.Pool, p CreateParams) (Definition, error) {
+	n, err := CountDefinitions(ctx, pool, p.OrgID, p.EntityType)
+	if err != nil {
+		return Definition{}, err
+	}
+	if n >= MaxDefinitionsPerEntity {
+		return Definition{}, ErrMaxFields
+	}
+	row := pool.QueryRow(ctx, `
+INSERT INTO tenant.custom_field_definitions (
+  org_id, entity_type, key, label, field_type, select_options,
+  is_required, visibility, sort_order
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+RETURNING `+definitionColumns,
+		p.OrgID, p.EntityType, p.Key, p.Label, p.FieldType, p.SelectOptions,
+		p.IsRequired, p.Visibility, p.SortOrder,
+	)
+	d, err := scanDefinition(row)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return Definition{}, ErrDuplicateKey
+		}
+		return Definition{}, err
+	}
+	return d, nil
+}
+
+// UpdateDefinition updates mutable fields on an active definition.
+func UpdateDefinition(ctx context.Context, pool *pgxpool.Pool, orgID, id uuid.UUID, p UpdateParams) (Definition, error) {
+	cur, err := GetDefinition(ctx, pool, orgID, id)
+	if err != nil {
+		return Definition{}, err
+	}
+	label := cur.Label
+	if p.Label != nil {
+		label = *p.Label
+	}
+	fieldType := cur.FieldType
+	if p.FieldType != nil {
+		fieldType = *p.FieldType
+	}
+	selectOpts := cur.SelectOptions
+	if p.SelectOptions != nil {
+		selectOpts = *p.SelectOptions
+	}
+	isRequired := cur.IsRequired
+	if p.IsRequired != nil {
+		isRequired = *p.IsRequired
+	}
+	visibility := cur.Visibility
+	if p.Visibility != nil {
+		visibility = *p.Visibility
+	}
+	sortOrder := cur.SortOrder
+	if p.SortOrder != nil {
+		sortOrder = *p.SortOrder
+	}
+	row := pool.QueryRow(ctx, `
+UPDATE tenant.custom_field_definitions SET
+  label = $3,
+  field_type = $4,
+  select_options = $5,
+  is_required = $6,
+  visibility = $7,
+  sort_order = $8
+WHERE id = $1 AND org_id = $2 AND deleted_at IS NULL
+RETURNING `+definitionColumns,
+		id, orgID, label, fieldType, selectOpts, isRequired, visibility, sortOrder,
+	)
+	d, err := scanDefinition(row)
+	if err == pgx.ErrNoRows {
+		return Definition{}, ErrNotFound
+	}
+	return d, err
+}
+
+// SoftDeleteDefinition marks a definition as deleted.
+func SoftDeleteDefinition(ctx context.Context, pool *pgxpool.Pool, orgID, id uuid.UUID) error {
+	tag, err := pool.Exec(ctx, `
+UPDATE tenant.custom_field_definitions SET deleted_at = NOW()
+WHERE id = $1 AND org_id = $2 AND deleted_at IS NULL
+`, id, orgID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ReorderDefinitions updates sort_order for each id in order.
+func ReorderDefinitions(ctx context.Context, pool *pgxpool.Pool, orgID uuid.UUID, entityType EntityType, ids []uuid.UUID) error {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	for i, id := range ids {
+		tag, err := tx.Exec(ctx, `
+UPDATE tenant.custom_field_definitions SET sort_order = $4
+WHERE id = $1 AND org_id = $2 AND entity_type = $3 AND deleted_at IS NULL
+`, id, orgID, entityType, i)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("customfields: definition %s not found for reorder", id)
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+// GetUserCustomFields loads raw JSONB custom fields for a user.
+func GetUserCustomFields(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) (map[string]any, error) {
+	return getEntityCustomFields(ctx, pool, `"user".users`, userID)
+}
+
+// SetUserCustomFields writes custom fields JSONB for a user in org.
+func SetUserCustomFields(ctx context.Context, pool *pgxpool.Pool, orgID, userID uuid.UUID, fields map[string]any) error {
+	return setEntityCustomFields(ctx, pool, `"user".users`, orgID, userID, fields)
+}
+
+// GetCourseCustomFields loads raw JSONB custom fields for a course.
+func GetCourseCustomFields(ctx context.Context, pool *pgxpool.Pool, courseID uuid.UUID) (map[string]any, error) {
+	return getEntityCustomFields(ctx, pool, `course.courses`, courseID)
+}
+
+// SetCourseCustomFields writes custom fields JSONB for a course in org.
+func SetCourseCustomFields(ctx context.Context, pool *pgxpool.Pool, orgID, courseID uuid.UUID, fields map[string]any) error {
+	return setEntityCustomFields(ctx, pool, `course.courses`, orgID, courseID, fields)
+}
+
+func getEntityCustomFields(ctx context.Context, pool *pgxpool.Pool, table string, id uuid.UUID) (map[string]any, error) {
+	var raw []byte
+	err := pool.QueryRow(ctx, fmt.Sprintf(`SELECT custom_fields FROM %s WHERE id = $1`, table), id).Scan(&raw)
+	if err == pgx.ErrNoRows {
+		return map[string]any{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]any{}
+	if len(raw) > 0 && string(raw) != "{}" {
+		if err := json.Unmarshal(raw, &out); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func setEntityCustomFields(ctx context.Context, pool *pgxpool.Pool, table string, orgID, id uuid.UUID, fields map[string]any) error {
+	raw, err := json.Marshal(fields)
+	if err != nil {
+		return err
+	}
+	tag, err := pool.Exec(ctx, fmt.Sprintf(`
+UPDATE %s SET custom_fields = $2::jsonb WHERE id = $1 AND org_id = $3
+`, table), id, raw, orgID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr interface{ Code() string }
+	if errors.As(err, &pgErr) {
+		return pgErr.Code() == "23505"
+	}
+	return false
+}

--- a/server/internal/repos/platformconfig/features.go
+++ b/server/internal/repos/platformconfig/features.go
@@ -140,6 +140,7 @@ func applyPlatformBools(out *config.Config, db *Row, def Defaults) {
 	out.AdminSearchEnabled = mergeBool(db.AdminSearchEnabled, false)
 	out.EmailTemplateEditorEnabled = mergeBool(db.EmailTemplateEditorEnabled, false)
 	out.MaintenanceBannerEnabled = mergeBool(db.MaintenanceBannerEnabled, true)
+	out.CustomFieldsEnabled = mergeBool(db.CustomFieldsEnabled, false)
 	out.DataResidencyEnabled = mergeBool(db.DataResidencyEnabled, false)
 	out.AiDisclosureEnabled = mergeBool(db.AiDisclosureEnabled, def.AiDisclosureEnabled)
 	out.RTLEnabled = mergeBool(db.RTLEnabled, false)

--- a/server/internal/repos/platformconfig/patch.go
+++ b/server/internal/repos/platformconfig/patch.go
@@ -131,6 +131,7 @@ func patch(ctx context.Context, pool *pgxpool.Pool, w *Write) error {
 	addBool("admin_search_enabled", w.AdminSearchEnabled)
 	addBool("email_template_editor_enabled", w.EmailTemplateEditorEnabled)
 	addBool("maintenance_banner_enabled", w.MaintenanceBannerEnabled)
+	addBool("custom_fields_enabled", w.CustomFieldsEnabled)
 	addBool("data_residency_enabled", w.DataResidencyEnabled)
 	addBool("ai_disclosure_enabled", w.AiDisclosureEnabled)
 	addBool("rtl_enabled", w.RTLEnabled)

--- a/server/internal/repos/platformconfig/platformconfig.go
+++ b/server/internal/repos/platformconfig/platformconfig.go
@@ -96,6 +96,7 @@ type Row struct {
 	AdminSearchEnabled              *bool
 	EmailTemplateEditorEnabled      *bool
 	MaintenanceBannerEnabled        *bool
+	CustomFieldsEnabled             *bool
 	DataResidencyEnabled            *bool
 	AiDisclosureEnabled             *bool
 	RTLEnabled                      *bool
@@ -266,6 +267,7 @@ type Write struct {
 	AdminSearchEnabled              *bool
 	EmailTemplateEditorEnabled      *bool
 	MaintenanceBannerEnabled        *bool
+	CustomFieldsEnabled             *bool
 	DataResidencyEnabled            *bool
 	AiDisclosureEnabled             *bool
 	RTLEnabled                      *bool
@@ -434,6 +436,7 @@ SELECT
 	admin_search_enabled,
 	email_template_editor_enabled,
 	maintenance_banner_enabled,
+	custom_fields_enabled,
 	data_residency_enabled,
 	ai_disclosure_enabled,
 	rtl_enabled,
@@ -595,6 +598,7 @@ WHERE id = 1
 		&r.AdminSearchEnabled,
 		&r.EmailTemplateEditorEnabled,
 		&r.MaintenanceBannerEnabled,
+		&r.CustomFieldsEnabled,
 		&r.DataResidencyEnabled,
 		&r.AiDisclosureEnabled,
 		&r.RTLEnabled,
@@ -807,6 +811,7 @@ INSERT INTO settings.platform_app_settings (
 	admin_search_enabled,
 	email_template_editor_enabled,
 	maintenance_banner_enabled,
+	custom_fields_enabled,
 	data_residency_enabled,
 	ai_disclosure_enabled,
 	rtl_enabled,
@@ -973,6 +978,7 @@ ON CONFLICT (id) DO UPDATE SET
 	admin_search_enabled = COALESCE(EXCLUDED.admin_search_enabled, settings.platform_app_settings.admin_search_enabled),
 	email_template_editor_enabled = COALESCE(EXCLUDED.email_template_editor_enabled, settings.platform_app_settings.email_template_editor_enabled),
 	maintenance_banner_enabled = COALESCE(EXCLUDED.maintenance_banner_enabled, settings.platform_app_settings.maintenance_banner_enabled),
+	custom_fields_enabled = COALESCE(EXCLUDED.custom_fields_enabled, settings.platform_app_settings.custom_fields_enabled),
 	data_residency_enabled = COALESCE(EXCLUDED.data_residency_enabled, settings.platform_app_settings.data_residency_enabled),
 	rtl_enabled = COALESCE(EXCLUDED.rtl_enabled, settings.platform_app_settings.rtl_enabled),
 	ai_disclosure_enabled = COALESCE(EXCLUDED.ai_disclosure_enabled, settings.platform_app_settings.ai_disclosure_enabled),
@@ -1132,6 +1138,7 @@ ON CONFLICT (id) DO UPDATE SET
 		w.AdminSearchEnabled,
 		w.EmailTemplateEditorEnabled,
 		w.MaintenanceBannerEnabled,
+		w.CustomFieldsEnabled,
 		w.DataResidencyEnabled,
 		w.AiDisclosureEnabled,
 		w.RTLEnabled,

--- a/server/internal/service/adminaudit/service.go
+++ b/server/internal/service/adminaudit/service.go
@@ -41,6 +41,7 @@ const (
 	EventUserDeactivate       = "user_deactivate"
 	EventCourseArchive        = "course_archive"
 	EventOrgSettingsChange    = "org_settings_change"
+	EventCustomFieldDefinitionChange = "custom_field_definition_change"
 )
 
 var ErrNotFound = errors.New("adminaudit: event not found")

--- a/server/internal/service/csvimport/parse.go
+++ b/server/internal/service/csvimport/parse.go
@@ -20,12 +20,13 @@ type RowError struct {
 
 // ParsedRow is a validated user row ready for import.
 type ParsedRow struct {
-	RowNumber  int
-	Email      string
-	FirstName  string
-	LastName   string
-	Role       string
-	ExternalID string
+	RowNumber    int
+	Email        string
+	FirstName    string
+	LastName     string
+	Role         string
+	ExternalID   string
+	CustomFields map[string]any
 }
 
 // ParseResult holds parsed rows and validation errors.
@@ -55,6 +56,18 @@ func ParseMergeStrategy(s string) (MergeStrategy, error) {
 
 // ParseCSV reads and validates a user import CSV.
 func ParseCSV(r io.Reader, profile Profile) (*ParseResult, error) {
+	return ParseCSVWithCustomFields(r, profile, nil)
+}
+
+// CustomFieldDef is a minimal view of a custom field definition for CSV parsing.
+type CustomFieldDef struct {
+	Key       string
+	FieldType string
+	Options   []string
+}
+
+// ParseCSVWithCustomFields reads CSV and maps columns matching custom field keys.
+func ParseCSVWithCustomFields(r io.Reader, profile Profile, customDefs []CustomFieldDef) (*ParseResult, error) {
 	raw, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("read csv: %w", err)
@@ -89,7 +102,7 @@ func ParseCSV(r io.Reader, profile Profile) (*ParseResult, error) {
 		if rowEmpty(rec) {
 			continue
 		}
-		parsed, errs := parseRecord(rowNum, rec, idx, colMap)
+		parsed, errs := parseRecord(rowNum, rec, idx, colMap, customDefs)
 		if len(errs) > 0 {
 			res.Errors = append(res.Errors, errs...)
 			continue
@@ -128,7 +141,7 @@ func getCol(rec []string, idx map[string]int, names ...string) string {
 	return ""
 }
 
-func parseRecord(rowNum int, rec []string, idx map[string]int, colMap map[string][]string) (ParsedRow, []RowError) {
+func parseRecord(rowNum int, rec []string, idx map[string]int, colMap map[string][]string, customDefs []CustomFieldDef) (ParsedRow, []RowError) {
 	var errs []RowError
 	email := getCol(rec, idx, colMap["email"]...)
 	if email == "" {
@@ -147,13 +160,22 @@ func parseRecord(rowNum int, rec []string, idx map[string]int, colMap map[string
 	if len(errs) > 0 {
 		return ParsedRow{}, errs
 	}
+	customFields := map[string]any{}
+	for _, def := range customDefs {
+		raw := getCol(rec, idx, def.Key)
+		if raw == "" {
+			continue
+		}
+		customFields[def.Key] = raw
+	}
 	return ParsedRow{
-		RowNumber:  rowNum,
-		Email:      strings.ToLower(email),
-		FirstName:  first,
-		LastName:   last,
-		Role:       role,
-		ExternalID: extID,
+		RowNumber:    rowNum,
+		Email:        strings.ToLower(email),
+		FirstName:    first,
+		LastName:     last,
+		Role:         role,
+		ExternalID:   extID,
+		CustomFields: customFields,
 	}, nil
 }
 

--- a/server/internal/service/csvimport/service.go
+++ b/server/internal/service/csvimport/service.go
@@ -16,6 +16,8 @@ import (
 	"github.com/lextures/lextures/server/internal/repos/user"
 	"github.com/lextures/lextures/server/internal/service/adminaudit"
 	"github.com/lextures/lextures/server/internal/service/authservice"
+	cfrepo "github.com/lextures/lextures/server/internal/repos/customfields"
+	cfsvc "github.com/lextures/lextures/server/internal/service/customfields"
 )
 
 const batchSize = 500
@@ -137,6 +139,10 @@ func processOneRow(ctx context.Context, pool *pgxpool.Pool, p ProcessParams, row
 				return RowOutcome{RowNumber: row.RowNumber, Email: row.Email, Outcome: "error", Detail: err.Error()},
 					[]RowError{{Row: row.RowNumber, Column: "email", Message: err.Error(), Code: "create_failed"}}
 			}
+			if cfErrs := applyUserCustomFields(ctx, pool, p.OrgID, uid, row); len(cfErrs) > 0 {
+				return RowOutcome{RowNumber: row.RowNumber, Email: row.Email, Outcome: "error", Detail: "custom field validation failed"},
+					cfErrs
+			}
 			outcome.Outcome = "created"
 			_ = recordUserAudit(ctx, pool, p.OrgID, p.ActorID, adminaudit.EventUserCreate, uid, nil, rowSnapshot(row))
 			return outcome, nil
@@ -161,6 +167,10 @@ func processOneRow(ctx context.Context, pool *pgxpool.Pool, p ProcessParams, row
 	if err := updateUser(ctx, pool, p.OrgID, existing.ID, row); err != nil {
 		return RowOutcome{RowNumber: row.RowNumber, Email: row.Email, Outcome: "error", Detail: err.Error()},
 			[]RowError{{Row: row.RowNumber, Column: "email", Message: err.Error(), Code: "update_failed"}}
+	}
+	if cfErrs := applyUserCustomFields(ctx, pool, p.OrgID, existing.ID, row); len(cfErrs) > 0 {
+		return RowOutcome{RowNumber: row.RowNumber, Email: row.Email, Outcome: "error", Detail: "custom field validation failed"},
+			cfErrs
 	}
 	outcome.Outcome = "updated"
 	_ = recordUserAudit(ctx, pool, p.OrgID, p.ActorID, adminaudit.EventUserUpdate, existing.ID, before, rowSnapshot(row))
@@ -401,6 +411,51 @@ func recordUserAudit(ctx context.Context, pool *pgxpool.Pool, orgID, actorID uui
 		AfterValue:  after,
 	})
 	return err
+}
+
+func applyUserCustomFields(ctx context.Context, pool *pgxpool.Pool, orgID, userID uuid.UUID, row ParsedRow) []RowError {
+	if len(row.CustomFields) == 0 {
+		return nil
+	}
+	defs, err := cfrepo.ListDefinitions(ctx, pool, orgID, cfrepo.EntityUser)
+	if err != nil {
+		return []RowError{{Row: row.RowNumber, Column: "custom_fields", Message: err.Error(), Code: "internal"}}
+	}
+	defByKey := make(map[string]cfrepo.Definition, len(defs))
+	for _, d := range defs {
+		defByKey[d.Key] = d
+	}
+	coerced := make(map[string]any, len(row.CustomFields))
+	for key, raw := range row.CustomFields {
+		def, ok := defByKey[key]
+		if !ok {
+			return []RowError{{Row: row.RowNumber, Column: key, Message: "unknown custom field column", Code: "unknown_field"}}
+		}
+		rawStr, _ := raw.(string)
+		val, err := cfsvc.CoerceCSVValue(def, rawStr)
+		if err != nil {
+			return []RowError{{Row: row.RowNumber, Column: key, Message: err.Error(), Code: "invalid_value"}}
+		}
+		if val != nil {
+			coerced[key] = val
+		}
+	}
+	existing, err := cfrepo.GetUserCustomFields(ctx, pool, userID)
+	if err != nil {
+		return []RowError{{Row: row.RowNumber, Column: "custom_fields", Message: err.Error(), Code: "internal"}}
+	}
+	merged := cfsvc.MergePatch(existing, coerced)
+	if errs := cfsvc.ValidateValues(defs, merged); len(errs) > 0 {
+		out := make([]RowError, 0, len(errs))
+		for _, e := range errs {
+			out = append(out, RowError{Row: row.RowNumber, Column: e.Key, Message: e.Message, Code: "invalid_value"})
+		}
+		return out
+	}
+	if err := cfrepo.SetUserCustomFields(ctx, pool, orgID, userID, merged); err != nil {
+		return []RowError{{Row: row.RowNumber, Column: "custom_fields", Message: err.Error(), Code: "update_failed"}}
+	}
+	return nil
 }
 
 // WriteResultCSV writes per-row outcomes to path.

--- a/server/internal/service/customfields/service.go
+++ b/server/internal/service/customfields/service.go
@@ -1,0 +1,329 @@
+// Package customfields implements validation and visibility filtering for org metadata fields (plan 18.7).
+package customfields
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	cfrepo "github.com/lextures/lextures/server/internal/repos/customfields"
+)
+
+var (
+	keyPattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+	// reservedKeys blocks custom field keys that collide with core CSV/API columns.
+	reservedKeys = map[string]struct{}{
+		"email": {}, "first_name": {}, "last_name": {}, "role": {}, "external_id": {},
+		"display_name": {}, "id": {}, "org_id": {}, "active": {}, "created_at": {},
+		"course_code": {}, "title": {}, "status": {}, "term_id": {},
+	}
+)
+
+// ValidationError describes one invalid custom field value.
+type ValidationError struct {
+	Key     string `json:"key"`
+	Message string `json:"message"`
+}
+
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Key, e.Message)
+}
+
+// ValidationErrors is a collection of field validation failures (HTTP 422).
+type ValidationErrors []ValidationError
+
+func (v ValidationErrors) Error() string {
+	if len(v) == 0 {
+		return "validation failed"
+	}
+	return v[0].Error()
+}
+
+// ViewerLevel is the caller's read access tier for custom field visibility.
+type ViewerLevel int
+
+const (
+	ViewerStudent ViewerLevel = iota
+	ViewerInstructor
+	ViewerAdmin
+)
+
+// Service coordinates custom field schema and value operations.
+type Service struct {
+	Pool *pgxpool.Pool
+}
+
+// ValidateKey checks a proposed field key slug.
+func ValidateKey(key string) error {
+	key = strings.TrimSpace(key)
+	if !keyPattern.MatchString(key) {
+		return fmt.Errorf("key must be snake_case starting with a letter")
+	}
+	if _, ok := reservedKeys[key]; ok {
+		return cfrepo.ErrReservedKey
+	}
+	return nil
+}
+
+// ValidateDefinitionInput validates create/update definition input.
+func ValidateDefinitionInput(key, label string, fieldType cfrepo.FieldType, selectOptions []string) ValidationErrors {
+	var errs ValidationErrors
+	if err := ValidateKey(key); err != nil {
+		errs = append(errs, ValidationError{Key: "key", Message: err.Error()})
+	}
+	if strings.TrimSpace(label) == "" {
+		errs = append(errs, ValidationError{Key: "label", Message: "label is required"})
+	}
+	switch fieldType {
+	case cfrepo.FieldText, cfrepo.FieldNumber, cfrepo.FieldBoolean, cfrepo.FieldDate:
+	case cfrepo.FieldSelect:
+		if len(selectOptions) == 0 {
+			errs = append(errs, ValidationError{Key: "selectOptions", Message: "select options are required for select fields"})
+		}
+	default:
+		errs = append(errs, ValidationError{Key: "fieldType", Message: "invalid field type"})
+	}
+	return errs
+}
+
+// ValidateValues checks incoming values against active definitions.
+func ValidateValues(defs []cfrepo.Definition, values map[string]any) ValidationErrors {
+	var errs ValidationErrors
+	activeKeys := make(map[string]cfrepo.Definition, len(defs))
+	for _, d := range defs {
+		activeKeys[d.Key] = d
+	}
+	for key, val := range values {
+		def, ok := activeKeys[key]
+		if !ok {
+			errs = append(errs, ValidationError{Key: key, Message: "unknown custom field"})
+			continue
+		}
+		if err := validateOneValue(def, val); err != nil {
+			errs = append(errs, ValidationError{Key: key, Message: err.Error()})
+		}
+	}
+	for _, def := range defs {
+		if !def.IsRequired {
+			continue
+		}
+		val, ok := values[def.Key]
+		if !ok || val == nil || val == "" {
+			errs = append(errs, ValidationError{Key: def.Key, Message: "required field is missing"})
+		}
+	}
+	return errs
+}
+
+func validateOneValue(def cfrepo.Definition, val any) error {
+	if val == nil {
+		return nil
+	}
+	switch def.FieldType {
+	case cfrepo.FieldText:
+		if _, ok := val.(string); !ok {
+			return errors.New("must be a string")
+		}
+	case cfrepo.FieldNumber:
+		switch val.(type) {
+		case float64, int, int64:
+		default:
+			return errors.New("must be a number")
+		}
+	case cfrepo.FieldBoolean:
+		if _, ok := val.(bool); !ok {
+			return errors.New("must be a boolean")
+		}
+	case cfrepo.FieldDate:
+		s, ok := val.(string)
+		if !ok {
+			return errors.New("must be a date string (YYYY-MM-DD)")
+		}
+		if _, err := time.Parse("2006-01-02", s); err != nil {
+			return errors.New("must be a date string (YYYY-MM-DD)")
+		}
+	case cfrepo.FieldSelect:
+		s, ok := val.(string)
+		if !ok {
+			return errors.New("must be a string")
+		}
+		found := false
+		for _, opt := range def.SelectOptions {
+			if opt == s {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("value must be one of: %s", strings.Join(def.SelectOptions, ", "))
+		}
+	default:
+		return errors.New("unsupported field type")
+	}
+	return nil
+}
+
+// FilterByVisibility returns only fields visible to the viewer level.
+func FilterByVisibility(defs []cfrepo.Definition, values map[string]any, level ViewerLevel) map[string]any {
+	if values == nil {
+		return map[string]any{}
+	}
+	defByKey := make(map[string]cfrepo.Definition, len(defs))
+	for _, d := range defs {
+		defByKey[d.Key] = d
+	}
+	out := make(map[string]any)
+	for key, val := range values {
+		def, ok := defByKey[key]
+		if !ok {
+			continue
+		}
+		if visibleTo(def.Visibility, level) {
+			out[key] = val
+		}
+	}
+	return out
+}
+
+func visibleTo(v cfrepo.Visibility, level ViewerLevel) bool {
+	switch v {
+	case cfrepo.VisibilityAdminOnly:
+		return level >= ViewerAdmin
+	case cfrepo.VisibilityInstructor:
+		return level >= ViewerInstructor
+	case cfrepo.VisibilityStudent:
+		return true
+	default:
+		return false
+	}
+}
+
+// MergePatch merges patch values into existing custom fields, removing keys set to null.
+func MergePatch(existing, patch map[string]any) map[string]any {
+	out := make(map[string]any, len(existing)+len(patch))
+	for k, v := range existing {
+		out[k] = v
+	}
+	for k, v := range patch {
+		if v == nil {
+			delete(out, k)
+		} else {
+			out[k] = normalizeJSONValue(v)
+		}
+	}
+	return out
+}
+
+func normalizeJSONValue(v any) any {
+	switch n := v.(type) {
+	case float64:
+		if n == float64(int64(n)) {
+			return int64(n)
+		}
+		return n
+	case json.Number:
+		if i, err := n.Int64(); err == nil {
+			return i
+		}
+		if f, err := n.Float64(); err == nil {
+			return f
+		}
+		return n.String()
+	default:
+		return v
+	}
+}
+
+// ListDefinitions loads active definitions for org+entity.
+func (s Service) ListDefinitions(ctx context.Context, orgID uuid.UUID, entityType cfrepo.EntityType) ([]cfrepo.Definition, error) {
+	return cfrepo.ListDefinitions(ctx, s.Pool, orgID, entityType)
+}
+
+// PatchUserCustomFields validates and merges custom field values on a user.
+func (s Service) PatchUserCustomFields(ctx context.Context, orgID, userID uuid.UUID, patch map[string]any) (map[string]any, ValidationErrors, error) {
+	defs, err := cfrepo.ListDefinitions(ctx, s.Pool, orgID, cfrepo.EntityUser)
+	if err != nil {
+		return nil, nil, err
+	}
+	existing, err := cfrepo.GetUserCustomFields(ctx, s.Pool, userID)
+	if err != nil {
+		return nil, nil, err
+	}
+	merged := MergePatch(existing, patch)
+	if errs := ValidateValues(defs, merged); len(errs) > 0 {
+		return nil, errs, nil
+	}
+	if err := cfrepo.SetUserCustomFields(ctx, s.Pool, orgID, userID, merged); err != nil {
+		return nil, nil, err
+	}
+	return merged, nil, nil
+}
+
+// UserCustomFieldsForViewer returns filtered custom fields for a user.
+func (s Service) UserCustomFieldsForViewer(ctx context.Context, orgID, userID uuid.UUID, level ViewerLevel) (map[string]any, error) {
+	defs, err := cfrepo.ListDefinitions(ctx, s.Pool, orgID, cfrepo.EntityUser)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := cfrepo.GetUserCustomFields(ctx, s.Pool, userID)
+	if err != nil {
+		return nil, err
+	}
+	return FilterByVisibility(defs, raw, level), nil
+}
+
+// ParseEntityType normalizes entity_type query param.
+func ParseEntityType(s string) (cfrepo.EntityType, error) {
+	switch cfrepo.EntityType(strings.TrimSpace(s)) {
+	case cfrepo.EntityUser, cfrepo.EntityCourse, cfrepo.EntityEnrollment:
+		return cfrepo.EntityType(strings.TrimSpace(s)), nil
+	default:
+		return "", fmt.Errorf("invalid entity_type %q", s)
+	}
+}
+
+// NormalizeSelectValue coerces CSV string values for validation.
+func NormalizeSelectValue(s string) any {
+	return strings.TrimSpace(s)
+}
+
+// CoerceCSVValue converts a CSV string to the typed value for validation/storage.
+func CoerceCSVValue(def cfrepo.Definition, raw string) (any, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	switch def.FieldType {
+	case cfrepo.FieldText, cfrepo.FieldSelect, cfrepo.FieldDate:
+		return raw, nil
+	case cfrepo.FieldNumber:
+		if i, err := strconv.ParseInt(raw, 10, 64); err == nil {
+			return i, nil
+		}
+		f, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return nil, errors.New("must be a number")
+		}
+		return f, nil
+	case cfrepo.FieldBoolean:
+		switch strings.ToLower(raw) {
+		case "true", "1", "yes":
+			return true, nil
+		case "false", "0", "no":
+			return false, nil
+		default:
+			return nil, errors.New("must be true or false")
+		}
+	default:
+		return raw, nil
+	}
+}

--- a/server/internal/service/customfields/service_test.go
+++ b/server/internal/service/customfields/service_test.go
@@ -1,0 +1,102 @@
+package customfields
+
+import (
+	"testing"
+
+	cfrepo "github.com/lextures/lextures/server/internal/repos/customfields"
+)
+
+func TestValidateKey(t *testing.T) {
+	tests := []struct {
+		key   string
+		valid bool
+	}{
+		{"student_id", true},
+		{"grade_level", true},
+		{"StudentId", false},
+		{"1bad", false},
+		{"email", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		err := ValidateKey(tc.key)
+		if tc.valid && err != nil {
+			t.Errorf("ValidateKey(%q) = %v, want nil", tc.key, err)
+		}
+		if !tc.valid && err == nil {
+			t.Errorf("ValidateKey(%q) = nil, want error", tc.key)
+		}
+	}
+}
+
+func TestValidateValuesSelect(t *testing.T) {
+	defs := []cfrepo.Definition{{
+		Key: "department", FieldType: cfrepo.FieldSelect, SelectOptions: []string{"Math", "Science"},
+	}}
+	errs := ValidateValues(defs, map[string]any{"department": "History"})
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %v", errs)
+	}
+	errs = ValidateValues(defs, map[string]any{"department": "Math"})
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+}
+
+func TestFilterByVisibility(t *testing.T) {
+	defs := []cfrepo.Definition{
+		{Key: "title_one", Visibility: cfrepo.VisibilityAdminOnly},
+		{Key: "section", Visibility: cfrepo.VisibilityInstructor},
+		{Key: "nickname", Visibility: cfrepo.VisibilityStudent},
+	}
+	values := map[string]any{"title_one": true, "section": "A", "nickname": "Sam"}
+
+	student := FilterByVisibility(defs, values, ViewerStudent)
+	if _, ok := student["title_one"]; ok {
+		t.Error("student should not see admin_only field")
+	}
+	if _, ok := student["section"]; ok {
+		t.Error("student should not see instructor field")
+	}
+	if student["nickname"] != "Sam" {
+		t.Error("student should see student field")
+	}
+
+	instructor := FilterByVisibility(defs, values, ViewerInstructor)
+	if _, ok := instructor["title_one"]; ok {
+		t.Error("instructor should not see admin_only field")
+	}
+	if instructor["section"] != "A" {
+		t.Error("instructor should see instructor field")
+	}
+
+	admin := FilterByVisibility(defs, values, ViewerAdmin)
+	if admin["title_one"] != true {
+		t.Error("admin should see admin_only field")
+	}
+}
+
+func TestMergePatch(t *testing.T) {
+	existing := map[string]any{"a": "1", "b": "2"}
+	patch := map[string]any{"b": "updated", "c": "3", "d": nil}
+	merged := MergePatch(existing, patch)
+	if merged["a"] != "1" || merged["b"] != "updated" || merged["c"] != "3" {
+		t.Fatalf("unexpected merge: %v", merged)
+	}
+	if _, ok := merged["d"]; ok {
+		t.Error("nil patch value should remove key")
+	}
+}
+
+func TestCoerceCSVValue(t *testing.T) {
+	boolDef := cfrepo.Definition{FieldType: cfrepo.FieldBoolean}
+	v, err := CoerceCSVValue(boolDef, "yes")
+	if err != nil || v != true {
+		t.Fatalf("bool yes: %v %v", v, err)
+	}
+	numDef := cfrepo.Definition{FieldType: cfrepo.FieldNumber}
+	v, err = CoerceCSVValue(numDef, "42")
+	if err != nil || v != int64(42) {
+		t.Fatalf("number 42: %v %v", v, err)
+	}
+}

--- a/server/migrations/354_custom_fields.down.sql
+++ b/server/migrations/354_custom_fields.down.sql
@@ -1,0 +1,19 @@
+-- Rollback plan 18.7 custom fields.
+
+DROP INDEX IF EXISTS course.course_enrollments_custom_fields_gin;
+DROP INDEX IF EXISTS course.courses_custom_fields_gin;
+DROP INDEX IF EXISTS "user".users_custom_fields_gin;
+
+ALTER TABLE course.course_enrollments DROP COLUMN IF EXISTS custom_fields;
+ALTER TABLE course.courses DROP COLUMN IF EXISTS custom_fields;
+ALTER TABLE "user".users DROP COLUMN IF EXISTS custom_fields;
+
+DROP INDEX IF EXISTS tenant.idx_custom_field_definitions_org_entity;
+DROP INDEX IF EXISTS tenant.cfd_org_entity_key;
+DROP TABLE IF EXISTS tenant.custom_field_definitions;
+
+DROP TYPE IF EXISTS tenant.custom_field_visibility;
+DROP TYPE IF EXISTS tenant.custom_field_type;
+DROP TYPE IF EXISTS tenant.custom_field_entity;
+
+ALTER TABLE settings.platform_app_settings DROP COLUMN IF EXISTS custom_fields_enabled;

--- a/server/migrations/354_custom_fields.sql
+++ b/server/migrations/354_custom_fields.sql
@@ -1,0 +1,81 @@
+-- Plan 18.7: Custom fields / metadata on user, course, and enrollment.
+
+ALTER TABLE settings.platform_app_settings
+    ADD COLUMN IF NOT EXISTS custom_fields_enabled BOOLEAN;
+
+COMMENT ON COLUMN settings.platform_app_settings.custom_fields_enabled IS
+    'Plan 18.7: Enables org-admin custom field definitions and values on users, courses, and enrollments.';
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'custom_field_entity') THEN
+        CREATE TYPE tenant.custom_field_entity AS ENUM ('user', 'course', 'enrollment');
+    END IF;
+END$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'custom_field_type') THEN
+        CREATE TYPE tenant.custom_field_type AS ENUM ('text', 'number', 'boolean', 'date', 'select');
+    END IF;
+END$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'custom_field_visibility') THEN
+        CREATE TYPE tenant.custom_field_visibility AS ENUM ('admin_only', 'instructor', 'student');
+    END IF;
+END$$;
+
+CREATE TABLE IF NOT EXISTS tenant.custom_field_definitions (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id          UUID NOT NULL REFERENCES tenant.organizations (id) ON DELETE CASCADE,
+    entity_type     tenant.custom_field_entity NOT NULL,
+    key             TEXT NOT NULL CHECK (key ~ '^[a-z][a-z0-9_]*$'),
+    label           TEXT NOT NULL,
+    field_type      tenant.custom_field_type NOT NULL,
+    select_options  TEXT[],
+    is_required     BOOLEAN NOT NULL DEFAULT false,
+    visibility      tenant.custom_field_visibility NOT NULL DEFAULT 'admin_only',
+    sort_order      INT NOT NULL DEFAULT 0,
+    deleted_at      TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS cfd_org_entity_key
+    ON tenant.custom_field_definitions (org_id, entity_type, key)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_custom_field_definitions_org_entity
+    ON tenant.custom_field_definitions (org_id, entity_type, sort_order)
+    WHERE deleted_at IS NULL;
+
+ALTER TABLE "user".users
+    ADD COLUMN IF NOT EXISTS custom_fields JSONB NOT NULL DEFAULT '{}';
+
+ALTER TABLE course.courses
+    ADD COLUMN IF NOT EXISTS custom_fields JSONB NOT NULL DEFAULT '{}';
+
+ALTER TABLE course.course_enrollments
+    ADD COLUMN IF NOT EXISTS custom_fields JSONB NOT NULL DEFAULT '{}';
+
+CREATE INDEX IF NOT EXISTS users_custom_fields_gin
+    ON "user".users USING GIN (custom_fields);
+
+CREATE INDEX IF NOT EXISTS courses_custom_fields_gin
+    ON course.courses USING GIN (custom_fields);
+
+CREATE INDEX IF NOT EXISTS course_enrollments_custom_fields_gin
+    ON course.course_enrollments USING GIN (custom_fields);
+
+COMMENT ON TABLE tenant.custom_field_definitions IS
+    'Org-scoped custom field schema definitions for users, courses, and enrollments (plan 18.7).';
+
+COMMENT ON COLUMN "user".users.custom_fields IS
+    'JSONB map of custom field key to value (plan 18.7).';
+
+COMMENT ON COLUMN course.courses.custom_fields IS
+    'JSONB map of custom field key to value (plan 18.7).';
+
+COMMENT ON COLUMN course.course_enrollments.custom_fields IS
+    'JSONB map of custom field key to value (plan 18.7).';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements plan 18.7 — org-scoped custom field definitions and values on users, courses, and enrollments.

- **Migration 354:** `tenant.custom_field_definitions` table, JSONB `custom_fields` columns on users/courses/enrollments with GIN indexes, and `custom_fields_enabled` platform flag.
- **Admin API:** CRUD + reorder for field schemas under `/api/v1/admin-console/custom-fields`; user value read/write via `GET/PATCH /api/v1/admin-console/users/:id?include=custom_fields`; CSV export at `/api/v1/admin-console/users/export`.
- **Visibility:** `admin_only`, `instructor`, and `student` levels enforced at query layer; `GET /api/v1/me?include=custom_fields` filters by caller role.
- **CSV import:** Bulk user import recognizes columns matching defined custom field keys (18.2 extension).
- **UI:** `/org-admin/custom-fields` page with entity tabs, drag-to-reorder, and add-field drawer.

## Testing

- `go test ./internal/service/customfields/ -short`
- `go test ./internal/httpserver/ -run CustomFields -short`
- `npm run typecheck` and `npm run lint` in `clients/web/`
- `e2e/tests/custom-fields.spec.ts`

## Feature flag

Enable via Settings → Global platform: `customFieldsEnabled` (requires `adminConsoleEnabled`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1691-62b3-7588-baaa-fcf53978153d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1691-62b3-7588-baaa-fcf53978153d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

