### PR TITLE
feat: platform People admin and tenant school-code onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://demo.lextures.com/">Live Demo</a>
+  <a href="https://self.lextures.com/">Start studying</a>
 </p>
 <!-- TEXT_SECTION:header:END -->
 

--- a/clients/web/src/components/layout/side-nav-path-utils.ts
+++ b/clients/web/src/components/layout/side-nav-path-utils.ts
@@ -21,6 +21,7 @@ export type SettingsNavView =
   | 'transcripts'
   | 'advising'
   | 'archive'
+  | 'people'
 
 export function settingsViewFromPathname(pathname: string): SettingsNavView {
   if (pathname.startsWith('/settings/ai/system-prompts')) return 'ai-prompts'
@@ -45,7 +46,8 @@ export function settingsViewFromPathname(pathname: string): SettingsNavView {
     raw === 'oer-providers' ||
     raw === 'transcripts' ||
     raw === 'advising' ||
-    raw === 'archive'
+    raw === 'archive' ||
+    raw === 'people'
   )
     return raw
   return 'account'

--- a/clients/web/src/components/layout/side-nav-settings-links.tsx
+++ b/clients/web/src/components/layout/side-nav-settings-links.tsx
@@ -20,6 +20,7 @@ import {
   ShieldCheck,
   Store,
   User,
+  Users,
   Workflow,
   Lock,
 } from 'lucide-react'
@@ -151,6 +152,13 @@ export function SideNavSettingsLinks() {
           )}
           {canManageRbac && (
             <>
+              <SideNavLink
+                to="/settings/people"
+                className={() => (view === 'people' ? sideNavActiveClass : '')}
+                icon={<Users className="h-5 w-5" />}
+              >
+                People
+              </SideNavLink>
               <SideNavLink
                 to="/settings/roles"
                 className={() => (view === 'roles' ? sideNavActiveClass : '')}

--- a/clients/web/src/components/settings/people-panel.tsx
+++ b/clients/web/src/components/settings/people-panel.tsx
@@ -1,0 +1,623 @@
+import { type FormEvent, useCallback, useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import {
+  ArrowLeft,
+  Loader2,
+  MailPlus,
+  Search,
+  Trash2,
+  UserMinus,
+  UserPlus,
+} from 'lucide-react'
+import { formatDateTime } from '../../lib/format'
+import { toastMutationError, toastSaveOk } from '../../lib/lms-toast'
+import {
+  deletePerson,
+  fetchPersonReport,
+  invitePerson,
+  patchPerson,
+  personDisplayName,
+  searchPeople,
+  type PaginatedPeople,
+  type PersonReport,
+} from '../../lib/people-api'
+
+const PAGE_SIZES = [25, 50, 100]
+
+function statusLabel(active: boolean): string {
+  return active ? 'Active' : 'Suspended'
+}
+
+function PersonReportView({
+  report,
+  loading,
+  error,
+  busy,
+  onBack,
+  onSuspend,
+  onReactivate,
+  onDelete,
+}: {
+  report: PersonReport | null
+  loading: boolean
+  error: string | null
+  busy: boolean
+  onBack: () => void
+  onSuspend: () => void
+  onReactivate: () => void
+  onDelete: () => void
+}) {
+  if (loading) {
+    return <p className="mt-6 text-sm text-slate-500 dark:text-neutral-400">Loading report…</p>
+  }
+  if (error) {
+    return (
+      <p role="alert" className="mt-6 text-sm text-red-600 dark:text-red-400">
+        {error}
+      </p>
+    )
+  }
+  if (!report) return null
+
+  const name = personDisplayName(report)
+  const isErased = report.email.endsWith('@erased.invalid')
+
+  return (
+    <div className="mt-6 space-y-6">
+      <button
+        type="button"
+        onClick={onBack}
+        className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 hover:text-slate-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden />
+        Back to search
+      </button>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-neutral-100">{name}</h3>
+            <p className="mt-1 text-sm text-slate-600 dark:text-neutral-400">{report.email}</p>
+            <dl className="mt-4 grid gap-2 text-sm sm:grid-cols-2">
+              <div>
+                <dt className="text-slate-500 dark:text-neutral-500">Organization</dt>
+                <dd className="text-slate-900 dark:text-neutral-100">{report.orgName}</dd>
+              </div>
+              <div>
+                <dt className="text-slate-500 dark:text-neutral-500">Role</dt>
+                <dd className="text-slate-900 dark:text-neutral-100">{report.role || '—'}</dd>
+              </div>
+              <div>
+                <dt className="text-slate-500 dark:text-neutral-500">Status</dt>
+                <dd className="text-slate-900 dark:text-neutral-100">{statusLabel(report.active)}</dd>
+              </div>
+              <div>
+                <dt className="text-slate-500 dark:text-neutral-500">Joined</dt>
+                <dd className="text-slate-900 dark:text-neutral-100">{formatDateTime(report.createdAt)}</dd>
+              </div>
+              <div>
+                <dt className="text-slate-500 dark:text-neutral-500">Last activity</dt>
+                <dd className="text-slate-900 dark:text-neutral-100">
+                  {report.lastActivityAt ? formatDateTime(report.lastActivityAt) : '—'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-slate-500 dark:text-neutral-500">Enrollments</dt>
+                <dd className="text-slate-900 dark:text-neutral-100">{report.enrollmentCount}</dd>
+              </div>
+            </dl>
+          </div>
+          {!isErased ? (
+            <div className="flex flex-wrap gap-2">
+              {report.active ? (
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={onSuspend}
+                  className="inline-flex items-center gap-2 rounded-lg border border-amber-300 px-3 py-2 text-sm font-medium text-amber-800 hover:bg-amber-50 disabled:opacity-50 dark:border-amber-800 dark:text-amber-200 dark:hover:bg-amber-950/40"
+                >
+                  <UserMinus className="h-4 w-4" aria-hidden />
+                  Suspend
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={onReactivate}
+                  className="inline-flex items-center gap-2 rounded-lg border border-emerald-300 px-3 py-2 text-sm font-medium text-emerald-800 hover:bg-emerald-50 disabled:opacity-50 dark:border-emerald-800 dark:text-emerald-200 dark:hover:bg-emerald-950/40"
+                >
+                  <UserPlus className="h-4 w-4" aria-hidden />
+                  Reactivate
+                </button>
+              )}
+              <button
+                type="button"
+                disabled={busy}
+                onClick={onDelete}
+                className="inline-flex items-center gap-2 rounded-lg border border-red-300 px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:text-red-300 dark:hover:bg-red-950/40"
+              >
+                <Trash2 className="h-4 w-4" aria-hidden />
+                Delete account
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <section>
+        <h4 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Enrollments</h4>
+        {report.enrollments.length === 0 ? (
+          <p className="mt-2 text-sm text-slate-500 dark:text-neutral-400">No enrollments.</p>
+        ) : (
+          <div className="mt-3 overflow-x-auto rounded-xl border border-slate-200 dark:border-neutral-800">
+            <table className="min-w-full text-left text-sm">
+              <thead className="bg-slate-50 text-slate-600 dark:bg-neutral-950 dark:text-neutral-400">
+                <tr>
+                  <th scope="col" className="px-4 py-2 font-medium">Course</th>
+                  <th scope="col" className="px-4 py-2 font-medium">Role</th>
+                  <th scope="col" className="px-4 py-2 font-medium">State</th>
+                  <th scope="col" className="px-4 py-2 font-medium">Enrolled</th>
+                </tr>
+              </thead>
+              <tbody>
+                {report.enrollments.map((e) => (
+                  <tr key={`${e.courseId}-${e.role}`} className="border-t border-slate-100 dark:border-neutral-800">
+                    <td className="px-4 py-2">
+                      <span className="font-medium text-slate-900 dark:text-neutral-100">{e.courseTitle}</span>
+                      <span className="ml-2 text-xs text-slate-500 dark:text-neutral-500">{e.courseCode}</span>
+                    </td>
+                    <td className="px-4 py-2">{e.role}</td>
+                    <td className="px-4 py-2">{e.state}</td>
+                    <td className="px-4 py-2">{formatDateTime(e.enrolledAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h4 className="text-sm font-semibold text-slate-900 dark:text-neutral-100">Recent activity</h4>
+        {report.recentActivity.length === 0 ? (
+          <p className="mt-2 text-sm text-slate-500 dark:text-neutral-400">No recorded activity.</p>
+        ) : (
+          <div className="mt-3 overflow-x-auto rounded-xl border border-slate-200 dark:border-neutral-800">
+            <table className="min-w-full text-left text-sm">
+              <thead className="bg-slate-50 text-slate-600 dark:bg-neutral-950 dark:text-neutral-400">
+                <tr>
+                  <th scope="col" className="px-4 py-2 font-medium">When</th>
+                  <th scope="col" className="px-4 py-2 font-medium">Event</th>
+                  <th scope="col" className="px-4 py-2 font-medium">Course</th>
+                </tr>
+              </thead>
+              <tbody>
+                {report.recentActivity.map((a, i) => (
+                  <tr key={`${a.occurredAt}-${i}`} className="border-t border-slate-100 dark:border-neutral-800">
+                    <td className="px-4 py-2 whitespace-nowrap">{formatDateTime(a.occurredAt)}</td>
+                    <td className="px-4 py-2">{a.eventKind.replaceAll('_', ' ')}</td>
+                    <td className="px-4 py-2">
+                      {a.courseTitle}
+                      <span className="ml-2 text-xs text-slate-500">{a.courseCode}</span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}
+
+export function PeoplePanel() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const selectedUserId = searchParams.get('userId')
+
+  const [q, setQ] = useState('')
+  const [submittedQ, setSubmittedQ] = useState('')
+  const [page, setPage] = useState(1)
+  const [perPage, setPerPage] = useState(25)
+  const [data, setData] = useState<PaginatedPeople | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [busyId, setBusyId] = useState<string | null>(null)
+
+  const [report, setReport] = useState<PersonReport | null>(null)
+  const [reportLoading, setReportLoading] = useState(false)
+  const [reportError, setReportError] = useState<string | null>(null)
+
+  const [inviteOpen, setInviteOpen] = useState(false)
+  const [inviteEmail, setInviteEmail] = useState('')
+  const [inviteFirst, setInviteFirst] = useState('')
+  const [inviteLast, setInviteLast] = useState('')
+  const [inviting, setInviting] = useState(false)
+
+  const loadSearch = useCallback(async () => {
+    const query = submittedQ.trim()
+    if (!query) {
+      setData(null)
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      setData(await searchPeople({ q: query, page, perPage }))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Search failed.')
+      setData(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [submittedQ, page, perPage])
+
+  useEffect(() => {
+    void loadSearch()
+  }, [loadSearch])
+
+  const loadReport = useCallback(async (userId: string) => {
+    setReportLoading(true)
+    setReportError(null)
+    try {
+      setReport(await fetchPersonReport(userId))
+    } catch (e) {
+      setReportError(e instanceof Error ? e.message : 'Failed to load report.')
+      setReport(null)
+    } finally {
+      setReportLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!selectedUserId) {
+      setReport(null)
+      setReportError(null)
+      return
+    }
+    void loadReport(selectedUserId)
+  }, [selectedUserId, loadReport])
+
+  function onSearchSubmit(e: FormEvent) {
+    e.preventDefault()
+    setSubmittedQ(q.trim())
+    setPage(1)
+  }
+
+  function openPerson(userId: string) {
+    const next = new URLSearchParams(searchParams)
+    next.set('userId', userId)
+    setSearchParams(next, { replace: false })
+  }
+
+  function closePerson() {
+    const next = new URLSearchParams(searchParams)
+    next.delete('userId')
+    setSearchParams(next, { replace: false })
+  }
+
+  async function onInvite(e: FormEvent) {
+    e.preventDefault()
+    const email = inviteEmail.trim()
+    if (!email) return
+    setInviting(true)
+    try {
+      await invitePerson({
+        email,
+        firstName: inviteFirst.trim() || undefined,
+        lastName: inviteLast.trim() || undefined,
+      })
+      toastSaveOk(`Invitation sent to ${email}.`)
+      setInviteOpen(false)
+      setInviteEmail('')
+      setInviteFirst('')
+      setInviteLast('')
+      setQ(email)
+      setSubmittedQ(email)
+      setPage(1)
+    } catch (err) {
+      toastMutationError(err instanceof Error ? err.message : 'Could not invite user.')
+    } finally {
+      setInviting(false)
+    }
+  }
+
+  async function mutatePerson(userId: string, active: boolean, confirmMsg: string) {
+    if (!window.confirm(confirmMsg)) return
+    setBusyId(userId)
+    try {
+      await patchPerson(userId, { active })
+      toastSaveOk(active ? 'Account reactivated.' : 'Account suspended.')
+      if (selectedUserId === userId) await loadReport(userId)
+      await loadSearch()
+    } catch (e) {
+      toastMutationError(e instanceof Error ? e.message : 'Update failed.')
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  async function removePerson(userId: string, label: string) {
+    const msg = `Permanently delete ${label}? Their profile will be anonymized and they will not be able to sign in. This cannot be undone.`
+    if (!window.confirm(msg)) return
+    setBusyId(userId)
+    try {
+      await deletePerson(userId)
+      toastSaveOk('Account deleted.')
+      closePerson()
+      await loadSearch()
+    } catch (e) {
+      toastMutationError(e instanceof Error ? e.message : 'Delete failed.')
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  if (selectedUserId) {
+    return (
+      <PersonReportView
+        report={report}
+        loading={reportLoading}
+        error={reportError}
+        busy={busyId === selectedUserId}
+        onBack={closePerson}
+        onSuspend={() => {
+          const label = report ? personDisplayName(report) : 'this user'
+          void mutatePerson(selectedUserId, false, `Suspend ${label}? They will not be able to sign in.`)
+        }}
+        onReactivate={() => {
+          void mutatePerson(selectedUserId, true, 'Reactivate this account?')
+        }}
+        onDelete={() => {
+          const label = report ? personDisplayName(report) : 'this user'
+          void removePerson(selectedUserId, label)
+        }}
+      />
+    )
+  }
+
+  return (
+    <div className="mt-6 space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <p className="text-sm text-slate-600 dark:text-neutral-400">
+          Search users by first name, last name, or email. Results are not shown until you search.
+        </p>
+        <button
+          type="button"
+          onClick={() => setInviteOpen(true)}
+          className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-white"
+        >
+          <MailPlus className="h-4 w-4" aria-hidden />
+          Invite user
+        </button>
+      </div>
+
+      <form onSubmit={onSearchSubmit} className="flex flex-wrap items-end gap-3">
+        <label className="flex min-w-[16rem] flex-1 flex-col text-sm">
+          <span className="mb-1 text-slate-600 dark:text-neutral-400">Search</span>
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" aria-hidden />
+            <input
+              type="search"
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder="First name, last name, or email"
+              className="w-full rounded-lg border border-slate-300 py-2 pl-9 pr-3 dark:border-neutral-700 dark:bg-neutral-900"
+            />
+          </div>
+        </label>
+        <label className="flex flex-col text-sm">
+          <span className="mb-1 text-slate-600 dark:text-neutral-400">Page size</span>
+          <select
+            value={perPage}
+            onChange={(e) => {
+              setPerPage(Number(e.target.value))
+              setPage(1)
+            }}
+            className="rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-900"
+          >
+            {PAGE_SIZES.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="submit"
+          disabled={!q.trim() || loading}
+          className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+        >
+          {loading ? 'Searching…' : 'Search'}
+        </button>
+      </form>
+
+      {error ? (
+        <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+          {error}
+        </p>
+      ) : null}
+
+      {!submittedQ.trim() ? (
+        <p className="rounded-xl border border-dashed border-slate-200 px-4 py-8 text-center text-sm text-slate-500 dark:border-neutral-700 dark:text-neutral-400">
+          Enter a name or email above to find users.
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-neutral-800">
+          <table className="min-w-full text-left text-sm">
+            <thead className="bg-slate-50 text-slate-600 dark:bg-neutral-950 dark:text-neutral-400">
+              <tr>
+                <th scope="col" className="px-4 py-2 font-medium">Name</th>
+                <th scope="col" className="px-4 py-2 font-medium">Email</th>
+                <th scope="col" className="px-4 py-2 font-medium">Organization</th>
+                <th scope="col" className="px-4 py-2 font-medium">Role</th>
+                <th scope="col" className="px-4 py-2 font-medium">Status</th>
+                <th scope="col" className="px-4 py-2 font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-slate-500">
+                    <Loader2 className="mx-auto h-5 w-5 animate-spin" aria-hidden />
+                  </td>
+                </tr>
+              ) : !data?.items.length ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-slate-500">
+                    No users matched your search.
+                  </td>
+                </tr>
+              ) : (
+                data.items.map((user) => (
+                  <tr key={user.id} className="border-t border-slate-100 dark:border-neutral-800">
+                    <td className="px-4 py-2">
+                      <button
+                        type="button"
+                        onClick={() => openPerson(user.id)}
+                        className="font-medium text-indigo-600 hover:underline dark:text-indigo-400"
+                      >
+                        {personDisplayName(user)}
+                      </button>
+                    </td>
+                    <td className="px-4 py-2">{user.email}</td>
+                    <td className="px-4 py-2">{user.orgName}</td>
+                    <td className="px-4 py-2">{user.role || '—'}</td>
+                    <td className="px-4 py-2">{statusLabel(user.active)}</td>
+                    <td className="px-4 py-2">
+                      <div className="flex flex-wrap gap-3">
+                        {user.active ? (
+                          <button
+                            type="button"
+                            disabled={busyId === user.id}
+                            onClick={() =>
+                              void mutatePerson(
+                                user.id,
+                                false,
+                                `Suspend ${personDisplayName(user)}? They will not be able to sign in.`,
+                              )
+                            }
+                            className="text-sm text-amber-700 hover:underline disabled:opacity-50 dark:text-amber-400"
+                          >
+                            Suspend
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            disabled={busyId === user.id}
+                            onClick={() => void mutatePerson(user.id, true, 'Reactivate this account?')}
+                            className="text-sm text-emerald-700 hover:underline disabled:opacity-50 dark:text-emerald-400"
+                          >
+                            Reactivate
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          disabled={busyId === user.id}
+                          onClick={() => void removePerson(user.id, personDisplayName(user))}
+                          className="text-sm text-red-600 hover:underline disabled:opacity-50 dark:text-red-400"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {data && data.totalPages > 1 ? (
+        <nav aria-label="People search pagination" className="flex items-center gap-2">
+          <button
+            type="button"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => p - 1)}
+            className="rounded border px-3 py-1 text-sm disabled:opacity-50"
+          >
+            Previous
+          </button>
+          <span className="text-sm text-slate-600 dark:text-neutral-400">
+            Page {data.page} of {data.totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={page >= data.totalPages}
+            onClick={() => setPage((p) => p + 1)}
+            className="rounded border px-3 py-1 text-sm disabled:opacity-50"
+          >
+            Next
+          </button>
+        </nav>
+      ) : null}
+
+      {inviteOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="invite-user-title"
+        >
+          <form
+            onSubmit={(e) => void onInvite(e)}
+            className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-xl dark:border-neutral-700 dark:bg-neutral-900"
+          >
+            <h3 id="invite-user-title" className="text-base font-semibold text-slate-900 dark:text-neutral-100">
+              Invite user
+            </h3>
+            <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+              Creates an account and emails a link to set their password.
+            </p>
+            <div className="mt-4 space-y-3">
+              <label className="block text-sm">
+                <span className="text-slate-600 dark:text-neutral-400">Email</span>
+                <input
+                  type="email"
+                  required
+                  value={inviteEmail}
+                  onChange={(e) => setInviteEmail(e.target.value)}
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-950"
+                />
+              </label>
+              <label className="block text-sm">
+                <span className="text-slate-600 dark:text-neutral-400">First name</span>
+                <input
+                  value={inviteFirst}
+                  onChange={(e) => setInviteFirst(e.target.value)}
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-950"
+                />
+              </label>
+              <label className="block text-sm">
+                <span className="text-slate-600 dark:text-neutral-400">Last name</span>
+                <input
+                  value={inviteLast}
+                  onChange={(e) => setInviteLast(e.target.value)}
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 dark:border-neutral-700 dark:bg-neutral-950"
+                />
+              </label>
+            </div>
+            <div className="mt-6 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setInviteOpen(false)}
+                className="rounded-lg border border-slate-300 px-4 py-2 text-sm dark:border-neutral-700"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={inviting}
+                className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+              >
+                {inviting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : null}
+                Send invite
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/clients/web/src/lib/__tests__/build-search-items.test.ts
+++ b/clients/web/src/lib/__tests__/build-search-items.test.ts
@@ -92,6 +92,7 @@ describe('buildSearchItems', () => {
     expect(items.some((i) => i.path === '/settings/ai/system-prompts')).toBe(true)
     expect(items.some((i) => i.path === '/settings/ai/reports')).toBe(true)
     expect(items.some((i) => i.path === '/settings/archive')).toBe(true)
+    expect(items.some((i) => i.path === '/settings/people')).toBe(true)
   })
 
   it('matches system settings by title (e.g. Global platform)', () => {

--- a/clients/web/src/lib/build-search-items.ts
+++ b/clients/web/src/lib/build-search-items.ts
@@ -229,6 +229,12 @@ export function buildGlobalSearchItems(
   if (canManageRbac) {
     const systemPages: SearchPageDef[] = [
       {
+        title: 'People',
+        subtitle: 'System settings',
+        path: '/settings/people',
+        hint: 'people users search invite suspend delete accounts enrollments activity admin',
+      },
+      {
         title: 'Roles and Permissions',
         subtitle: 'System settings',
         path: '/settings/roles',

--- a/clients/web/src/lib/people-api.ts
+++ b/clients/web/src/lib/people-api.ts
@@ -1,0 +1,131 @@
+import { authorizedFetch } from './api'
+
+export type PersonRow = {
+  id: string
+  email: string
+  firstName: string | null
+  lastName: string | null
+  displayName: string | null
+  orgId: string
+  orgName: string
+  role: string
+  active: boolean
+  createdAt: string
+}
+
+export type PaginatedPeople = {
+  items: PersonRow[]
+  total: number
+  page: number
+  perPage: number
+  totalPages: number
+}
+
+export type PersonEnrollment = {
+  courseId: string
+  courseCode: string
+  courseTitle: string
+  role: string
+  active: boolean
+  state: string
+  enrolledAt: string
+  orgName?: string | null
+}
+
+export type PersonActivity = {
+  eventKind: string
+  courseCode: string
+  courseTitle: string
+  occurredAt: string
+}
+
+export type PersonReport = {
+  id: string
+  email: string
+  firstName: string | null
+  lastName: string | null
+  displayName: string | null
+  orgId: string
+  orgName: string
+  role: string
+  active: boolean
+  createdAt: string
+  lastActivityAt: string | null
+  enrollmentCount: number
+  enrollments: PersonEnrollment[]
+  recentActivity: PersonActivity[]
+}
+
+async function parseJson<T>(res: Response): Promise<T> {
+  const raw: unknown = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    const msg =
+      typeof raw === 'object' && raw !== null && 'message' in raw
+        ? String((raw as { message: string }).message)
+        : res.statusText
+    throw new Error(msg || 'Request failed')
+  }
+  return raw as T
+}
+
+export function personDisplayName(row: {
+  displayName?: string | null
+  firstName?: string | null
+  lastName?: string | null
+  email: string
+}): string {
+  const dn = row.displayName?.trim()
+  if (dn) return dn
+  const full = [row.firstName?.trim(), row.lastName?.trim()].filter(Boolean).join(' ')
+  if (full) return full
+  return row.email
+}
+
+export async function searchPeople(params: {
+  q: string
+  page?: number
+  perPage?: number
+}): Promise<PaginatedPeople> {
+  const sp = new URLSearchParams()
+  sp.set('q', params.q.trim())
+  if (params.page) sp.set('page', String(params.page))
+  if (params.perPage) sp.set('per_page', String(params.perPage))
+  const res = await authorizedFetch(`/api/v1/admin/people?${sp}`)
+  return parseJson(res)
+}
+
+export async function invitePerson(body: {
+  email: string
+  firstName?: string
+  lastName?: string
+  orgId?: string
+  role?: string
+}): Promise<PersonRow> {
+  const res = await authorizedFetch('/api/v1/admin/people/invite', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  return parseJson(res)
+}
+
+export async function fetchPersonReport(userId: string): Promise<PersonReport> {
+  const res = await authorizedFetch(`/api/v1/admin/people/${encodeURIComponent(userId)}/report`)
+  return parseJson(res)
+}
+
+export async function patchPerson(userId: string, body: { active: boolean }): Promise<PersonRow> {
+  const res = await authorizedFetch(`/api/v1/admin/people/${encodeURIComponent(userId)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  return parseJson(res)
+}
+
+export async function deletePerson(userId: string): Promise<void> {
+  const res = await authorizedFetch(`/api/v1/admin/people/${encodeURIComponent(userId)}`, {
+    method: 'DELETE',
+  })
+  await parseJson(res)
+}

--- a/clients/web/src/pages/lms/settings.tsx
+++ b/clients/web/src/pages/lms/settings.tsx
@@ -35,6 +35,7 @@ import { LearningGoalsPanel } from '../../components/onboarding/learning-goals-p
 import { AiGovernancePanel } from '../../components/settings/ai-governance-panel'
 import { AiProviderSettingsPanel } from '../../components/settings/ai-provider-settings-panel'
 import { ArchivedCoursesPanel } from '../../components/settings/archived-courses-panel'
+import { PeoplePanel } from '../../components/settings/people-panel'
 import { AiReportsPanel } from '../../components/settings/ai-reports-panel'
 import { LmsPage } from './lms-page'
 import OrgBranding from './admin/org-branding'
@@ -60,7 +61,8 @@ function isSystemSettingsPath(pathname: string): boolean {
     pathname === '/settings/oer-providers' ||
     pathname === '/settings/transcripts' ||
     pathname === '/settings/advising' ||
-    pathname === '/settings/archive'
+    pathname === '/settings/archive' ||
+    pathname === '/settings/people'
   )
 }
 
@@ -450,7 +452,8 @@ export default function Settings() {
           activeView === 'oer-providers' ||
           activeView === 'transcripts' ||
           activeView === 'advising' ||
-          activeView === 'archive'
+          activeView === 'archive' ||
+          activeView === 'people'
             ? 'max-w-4xl'
             : activeView === 'integrations'
               ? 'max-w-3xl'
@@ -950,6 +953,26 @@ export default function Settings() {
               }
             >
               <ArchivedCoursesPanel />
+            </RequirePermission>
+          </div>
+        )}
+
+        {activeView === 'people' && (
+          <div>
+            <h2 className="text-base font-semibold text-slate-900 dark:text-neutral-100">People</h2>
+            <p className="mt-1 text-sm text-slate-500 dark:text-neutral-400">
+              Search, invite, suspend, and manage user accounts across the platform.
+            </p>
+            <RequirePermission
+              permission={PERM_RBAC_MANAGE}
+              fallback={
+                <p className="mt-6 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-neutral-600 dark:bg-neutral-800/50 dark:text-neutral-300">
+                  You need permission to manage people (
+                  <code className="font-mono text-xs">{PERM_RBAC_MANAGE}</code>).
+                </p>
+              }
+            >
+              <PeoplePanel />
             </RequirePermission>
           </div>
         )}

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -56,6 +56,9 @@ services:
     environment:
       DATABASE_URL: ${DATABASE_URL:?DATABASE_URL is required}
       JWT_SECRET: ${JWT_SECRET}
+      TURNSTILE_SECRET_KEY: ${TURNSTILE_SECRET_KEY:-}
+      # First password Global Admin only when signup email matches (see docs/getting-started.md).
+      BOOTSTRAP_ADMIN_EMAIL: ${BOOTSTRAP_ADMIN_EMAIL:-}
       RUN_MIGRATIONS: "true"
       # Demo DB may retain checksums from migrations 120/135 after follow-up PR edits; align before migrate.
       MIGRATE_REPAIR_CHECKSUMS: "1"

--- a/iac/modules/digitalocean/deploy.tf
+++ b/iac/modules/digitalocean/deploy.tf
@@ -23,6 +23,7 @@ locals {
     "POSTGRES_PASSWORD=${local.deploy_postgres_password}",
     "DATABASE_URL=postgres://studydrift:${urlencode(local.deploy_postgres_password)}@postgres:5432/studydrift?sslmode=disable",
     "JWT_SECRET=${local.deploy_jwt_secret}",
+    "TURNSTILE_SECRET_KEY=${var.deploy_turnstile_secret_key}",
     "LEXTURES_SERVER_IMAGE=${var.deploy_server_image}",
     "LEXTURES_WEB_IMAGE=${var.deploy_web_image}",
     "",

--- a/iac/modules/digitalocean/variables.tf
+++ b/iac/modules/digitalocean/variables.tf
@@ -88,6 +88,13 @@ variable "deploy_jwt_secret" {
   default     = ""
 }
 
+variable "deploy_turnstile_secret_key" {
+  description = "Cloudflare Turnstile secret key for signup CAPTCHA verification (TURNSTILE_SECRET_KEY on the API)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "deploy_registry_host" {
   description = "Registry hostname for docker login before pulling private images (e.g. ghcr.io)."
   type        = string

--- a/iac/modules/oracle/README.md
+++ b/iac/modules/oracle/README.md
@@ -7,7 +7,7 @@ Single Ampere A1 compute instance with attached block storage for small-school d
 
 **Default sizing** targets OCI **Always Free**: `VM.Standard.A1.Flex` with 2 OCPUs and 12 GB RAM, 50 GB boot + 100 GB data volume (150 GB total block storage within the 200 GB free quota).
 
-When `deploy_enabled = true` (default in `iac/production/`), cloud-init also writes `/opt/lextures/docker-compose.deploy.yml` and `.env`, pulls container images, and runs `docker compose up -d --wait` on first boot. Set `deploy_server_image` and `deploy_web_image` in `terraform.tfvars` (Arm64 images required). Generated secrets are available via `terraform output -raw deploy_postgres_password` and `deploy_jwt_secret`.
+When `deploy_enabled = true` (default in `iac/production/`), cloud-init also writes `/opt/lextures/docker-compose.deploy.yml` and `.env`, pulls container images, and runs `docker compose up -d --wait` on first boot. Set `deploy_server_image` and `deploy_web_image` in `terraform.tfvars` (Arm64 images required). Generated secrets are available via `terraform output -raw deploy_postgres_password` and `deploy_jwt_secret`. Set `deploy_turnstile_secret_key` (or `TF_VAR_deploy_turnstile_secret_key`) to pass Cloudflare Turnstile verification to the API as `TURNSTILE_SECRET_KEY`.
 
 **Important:** Always Free resources must be created in the tenancy **home region**. Build and deploy **linux/arm64** container images (Ampere is Arm). If instance creation fails with "out of host capacity", retry another availability domain or upgrade to Pay As You Go (Always Free resources remain free).
 

--- a/iac/modules/oracle/deploy.tf
+++ b/iac/modules/oracle/deploy.tf
@@ -23,6 +23,7 @@ locals {
     "POSTGRES_PASSWORD=${local.deploy_postgres_password}",
     "DATABASE_URL=postgres://studydrift:${urlencode(local.deploy_postgres_password)}@postgres:5432/studydrift?sslmode=disable",
     "JWT_SECRET=${local.deploy_jwt_secret}",
+    "TURNSTILE_SECRET_KEY=${var.deploy_turnstile_secret_key}",
     "LEXTURES_SERVER_IMAGE=${var.deploy_server_image}",
     "LEXTURES_WEB_IMAGE=${var.deploy_web_image}",
     "",

--- a/iac/modules/oracle/variables.tf
+++ b/iac/modules/oracle/variables.tf
@@ -110,6 +110,13 @@ variable "deploy_jwt_secret" {
   default     = ""
 }
 
+variable "deploy_turnstile_secret_key" {
+  description = "Cloudflare Turnstile secret key for signup CAPTCHA verification (TURNSTILE_SECRET_KEY on the API)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "deploy_registry_host" {
   description = "Registry hostname for docker login before pulling private images (e.g. ghcr.io)."
   type        = string

--- a/iac/self/README.md
+++ b/iac/self/README.md
@@ -198,6 +198,8 @@ terraform output -raw deploy_postgres_password   # generated when unset in tfvar
 terraform output -raw deploy_jwt_secret
 ```
 
+Set `deploy_turnstile_secret_key` in `terraform.tfvars` (or export `TF_VAR_deploy_turnstile_secret_key`) so the API receives `TURNSTILE_SECRET_KEY` for signup Turnstile verification.
+
 Changing `deploy_server_image`, `deploy_web_image`, or `deploy_public_origin` replaces the compute instance so cloud-init re-runs (Postgres data persists on the block volume). When `deploy_enabled = true`, Terraform also SSHes after apply and runs `/usr/local/bin/lextures-deploy-app.sh`, failing the apply if `/health` is not ready.
 
 If the server logs `invalid IP-literal` for `DATABASE_URL`, the Postgres volume may have been initialized with an old URL-unsafe password — stop the stack, clear `/mnt/lextures-db/postgres/*`, and re-run `terraform apply`.

--- a/iac/self/main.tf
+++ b/iac/self/main.tf
@@ -117,16 +117,16 @@ module "digitalocean" {
   data_volume_size_gb    = var.digitalocean_data_volume_size_gb
   enable_droplet_backups = var.digitalocean_enable_droplet_backups
 
-  deploy_enabled           = var.deploy_enabled
-  deploy_server_image      = var.deploy_server_image
-  deploy_web_image         = var.deploy_web_image
-  deploy_public_origin     = var.deploy_public_origin
-  deploy_postgres_password = var.deploy_postgres_password
-  deploy_jwt_secret             = var.deploy_jwt_secret
-  deploy_turnstile_secret_key   = var.deploy_turnstile_secret_key
-  deploy_registry_host          = var.deploy_registry_host
-  deploy_registry_username      = var.deploy_registry_username
-  deploy_registry_password      = var.deploy_registry_password
+  deploy_enabled              = var.deploy_enabled
+  deploy_server_image         = var.deploy_server_image
+  deploy_web_image            = var.deploy_web_image
+  deploy_public_origin        = var.deploy_public_origin
+  deploy_postgres_password    = var.deploy_postgres_password
+  deploy_jwt_secret           = var.deploy_jwt_secret
+  deploy_turnstile_secret_key = var.deploy_turnstile_secret_key
+  deploy_registry_host        = var.deploy_registry_host
+  deploy_registry_username    = var.deploy_registry_username
+  deploy_registry_password    = var.deploy_registry_password
 
   tags = [for k, v in var.tags : "${k}:${v}"]
 }
@@ -147,16 +147,16 @@ module "oracle" {
   boot_volume_size_gb = var.oci_boot_volume_size_gb
   data_volume_size_gb = var.oci_data_volume_size_gb
 
-  deploy_enabled           = var.deploy_enabled
-  deploy_server_image      = var.deploy_server_image
-  deploy_web_image         = var.deploy_web_image
-  deploy_public_origin     = var.deploy_public_origin
-  deploy_postgres_password = var.deploy_postgres_password
-  deploy_jwt_secret             = var.deploy_jwt_secret
-  deploy_turnstile_secret_key   = var.deploy_turnstile_secret_key
-  deploy_registry_host          = var.deploy_registry_host
-  deploy_registry_username      = var.deploy_registry_username
-  deploy_registry_password      = var.deploy_registry_password
+  deploy_enabled              = var.deploy_enabled
+  deploy_server_image         = var.deploy_server_image
+  deploy_web_image            = var.deploy_web_image
+  deploy_public_origin        = var.deploy_public_origin
+  deploy_postgres_password    = var.deploy_postgres_password
+  deploy_jwt_secret           = var.deploy_jwt_secret
+  deploy_turnstile_secret_key = var.deploy_turnstile_secret_key
+  deploy_registry_host        = var.deploy_registry_host
+  deploy_registry_username    = var.deploy_registry_username
+  deploy_registry_password    = var.deploy_registry_password
 
   tags = var.tags
 }

--- a/iac/self/main.tf
+++ b/iac/self/main.tf
@@ -122,10 +122,11 @@ module "digitalocean" {
   deploy_web_image         = var.deploy_web_image
   deploy_public_origin     = var.deploy_public_origin
   deploy_postgres_password = var.deploy_postgres_password
-  deploy_jwt_secret        = var.deploy_jwt_secret
-  deploy_registry_host     = var.deploy_registry_host
-  deploy_registry_username = var.deploy_registry_username
-  deploy_registry_password = var.deploy_registry_password
+  deploy_jwt_secret             = var.deploy_jwt_secret
+  deploy_turnstile_secret_key   = var.deploy_turnstile_secret_key
+  deploy_registry_host          = var.deploy_registry_host
+  deploy_registry_username      = var.deploy_registry_username
+  deploy_registry_password      = var.deploy_registry_password
 
   tags = [for k, v in var.tags : "${k}:${v}"]
 }
@@ -151,10 +152,11 @@ module "oracle" {
   deploy_web_image         = var.deploy_web_image
   deploy_public_origin     = var.deploy_public_origin
   deploy_postgres_password = var.deploy_postgres_password
-  deploy_jwt_secret        = var.deploy_jwt_secret
-  deploy_registry_host     = var.deploy_registry_host
-  deploy_registry_username = var.deploy_registry_username
-  deploy_registry_password = var.deploy_registry_password
+  deploy_jwt_secret             = var.deploy_jwt_secret
+  deploy_turnstile_secret_key   = var.deploy_turnstile_secret_key
+  deploy_registry_host          = var.deploy_registry_host
+  deploy_registry_username      = var.deploy_registry_username
+  deploy_registry_password      = var.deploy_registry_password
 
   tags = var.tags
 }

--- a/iac/self/terraform.tfvars.example
+++ b/iac/self/terraform.tfvars.example
@@ -34,8 +34,9 @@
 # deploy_public_origin      = "https://school.example.com"                   # or leave empty for http://<public-ip>
 # deploy_registry_username  = "github-username"                                # required for private ghcr.io images
 # deploy_registry_password  = "ghp_..."                                        # GitHub PAT with read:packages
-# deploy_postgres_password  = ""                                               # auto-generated when empty
-# deploy_jwt_secret         = ""                                               # auto-generated when empty
+# deploy_postgres_password      = ""                                           # auto-generated when empty
+# deploy_jwt_secret             = ""                                           # auto-generated when empty
+# deploy_turnstile_secret_key   = ""                                           # Cloudflare Turnstile secret (signup CAPTCHA); prefer TF_VAR_deploy_turnstile_secret_key
 
 # ---------------------------------------------------------------------------
 # Enterprise (multi-school / district, AWS EKS + managed services)

--- a/iac/self/variables.tf
+++ b/iac/self/variables.tf
@@ -300,6 +300,13 @@ variable "deploy_jwt_secret" {
   default     = ""
 }
 
+variable "deploy_turnstile_secret_key" {
+  description = "Cloudflare Turnstile secret key for signup CAPTCHA verification (TURNSTILE_SECRET_KEY on the API). Set via TF_VAR_deploy_turnstile_secret_key or terraform.tfvars (do not commit)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "deploy_registry_host" {
   description = "Container registry host for docker login (e.g. ghcr.io)."
   type        = string

--- a/server/.env.example
+++ b/server/.env.example
@@ -41,6 +41,9 @@ PUBLIC_WEB_ORIGIN=http://localhost:5173
 # PLATFORM_SECRETS_KEY=   # base64 32-byte AES key for encrypted SMTP password in DB (openssl rand -base64 32)
 # SMTP_HOST= SMTP_PORT=587 SMTP_USER= SMTP_PASSWORD= SMTP_FROM=
 
+# Cloudflare Turnstile (signup CAPTCHA). Secret only — site key is VITE_TURNSTILE_SITE_KEY at web build time.
+# TURNSTILE_SECRET_KEY=
+
 # STRIPE_SECRET_KEY=
 # STRIPE_WEBHOOK_SECRET=
 # STRIPE_MONTHLY_PRICE_ID=

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -116,6 +116,9 @@ type Config struct {
 	// MagicLinkEnrolledOnly when true: only users with an active course enrollment receive a link.
 	MagicLinkEnrolledOnly bool
 
+	// TurnstileSecretKey is the Cloudflare Turnstile secret for signup CAPTCHA server-side verification.
+	TurnstileSecretKey string
+
 	// SessionManagementUIEnabled gates /api/v1/me/sessions and related UI (plan 4.9).
 	SessionManagementUIEnabled bool
 
@@ -812,7 +815,9 @@ func Load() Config {
 		TeamsBotAppID:        firstNonEmptyTrimmed("TEAMS_BOT_APP_ID"),
 		TeamsBotAppPassword:  firstNonEmptyTrimmed("TEAMS_BOT_APP_PASSWORD"),
 
-		StripeSecretKey:      strings.TrimSpace(os.Getenv("STRIPE_SECRET_KEY")),
+		TurnstileSecretKey: strings.TrimSpace(os.Getenv("TURNSTILE_SECRET_KEY")),
+
+		StripeSecretKey: strings.TrimSpace(os.Getenv("STRIPE_SECRET_KEY")),
 		StripeWebhookSecret:  strings.TrimSpace(os.Getenv("STRIPE_WEBHOOK_SECRET")),
 		StripeMonthlyPriceID: strings.TrimSpace(os.Getenv("STRIPE_MONTHLY_PRICE_ID")),
 		StripeAnnualPriceID:  strings.TrimSpace(os.Getenv("STRIPE_ANNUAL_PRICE_ID")),

--- a/server/internal/httpserver/admin.go
+++ b/server/internal/httpserver/admin.go
@@ -557,4 +557,5 @@ func (d Deps) registerAdminRoutes(r chi.Router) {
 	r.Get("/api/v1/admin/reviews", d.handleAdminReviewsList())
 	r.Delete("/api/v1/admin/reviews/{review_id}", d.handleAdminReviewDelete())
 	d.registerAdminTokenRoutes(r)
+	d.registerPlatformPeopleRoutes(r)
 }

--- a/server/internal/httpserver/onboarding_http.go
+++ b/server/internal/httpserver/onboarding_http.go
@@ -94,7 +94,7 @@ func (d Deps) handlePublicOnboardingTrack() http.HandlerFunc {
 		}
 
 		switch req.Program {
-		case "k-12", "higher-ed", "self-learner":
+		case "k-12", "higher-ed", "self-learner", "school":
 		default:
 			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid program value")
 			return

--- a/server/internal/httpserver/platform_people.go
+++ b/server/internal/httpserver/platform_people.go
@@ -1,0 +1,396 @@
+package httpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/lextures/lextures/server/internal/apierr"
+	"github.com/lextures/lextures/server/internal/repos/communication"
+	"github.com/lextures/lextures/server/internal/repos/gdpr"
+	"github.com/lextures/lextures/server/internal/repos/organization"
+	platformpeople "github.com/lextures/lextures/server/internal/repos/platformpeople"
+	"github.com/lextures/lextures/server/internal/repos/rbac"
+	userrepo "github.com/lextures/lextures/server/internal/repos/user"
+	auditservice "github.com/lextures/lextures/server/internal/service/adminaudit"
+	"github.com/lextures/lextures/server/internal/service/authservice"
+	"github.com/lextures/lextures/server/internal/service/coursereviews"
+	"github.com/lextures/lextures/server/internal/service/licensesvc"
+)
+
+func (d Deps) registerPlatformPeopleRoutes(r chi.Router) {
+	r.Get("/api/v1/admin/people", d.handleAdminPeopleSearch())
+	r.Post("/api/v1/admin/people/invite", d.handleAdminPeopleInvite())
+	r.Get("/api/v1/admin/people/{userId}/report", d.handleAdminPeopleReport())
+	r.Patch("/api/v1/admin/people/{userId}", d.handleAdminPeoplePatch())
+	r.Delete("/api/v1/admin/people/{userId}", d.handleAdminPeopleDelete())
+}
+
+func parsePlatformPeopleListParams(r *http.Request) platformpeople.ListParams {
+	p := platformpeople.ListParams{
+		Query: strings.TrimSpace(r.URL.Query().Get("q")),
+	}
+	if v := strings.TrimSpace(r.URL.Query().Get("page")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			p.Page = n
+		}
+	}
+	if v := strings.TrimSpace(r.URL.Query().Get("per_page")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			p.PerPage = n
+		}
+	}
+	if v := strings.TrimSpace(r.URL.Query().Get("perPage")); v != "" && p.PerPage == 0 {
+		if n, err := strconv.Atoi(v); err == nil {
+			p.PerPage = n
+		}
+	}
+	return p
+}
+
+func (d Deps) handleAdminPeopleSearch() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+		params := parsePlatformPeopleListParams(r)
+		if params.Query == "" {
+			writeJSON(w, http.StatusOK, platformpeople.ListResult{Items: []platformpeople.PersonRow{}})
+			return
+		}
+		result, err := platformpeople.Search(r.Context(), d.Pool, params)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to search users.")
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func (d Deps) handleAdminPeopleInvite() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		actor, ok := d.adminRbacUser(w, r)
+		if !ok {
+			return
+		}
+		raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<16))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid body.")
+			return
+		}
+		var body struct {
+			Email     string  `json:"email"`
+			FirstName *string `json:"firstName"`
+			LastName  *string `json:"lastName"`
+			OrgID     *string `json:"orgId"`
+			Role      *string `json:"role"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		email := userrepo.NormalizeEmail(body.Email)
+		if email == "" {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "email is required.")
+			return
+		}
+		ctx := r.Context()
+		existing, err := userrepo.FindByEmail(ctx, d.Pool, email)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to look up user.")
+			return
+		}
+		if existing != nil {
+			apierr.WriteJSON(w, http.StatusConflict, apierr.CodeConflict, "A user with that email already exists.")
+			return
+		}
+
+		orgID, err := d.resolveInviteOrgID(ctx, actor, body.OrgID)
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, err.Error())
+			return
+		}
+
+		firstName := peopleTrimPtr(body.FirstName)
+		lastName := peopleTrimPtr(body.LastName)
+		displayName := strings.TrimSpace(peopleStrVal(firstName) + " " + peopleStrVal(lastName))
+		if displayName == "" {
+			displayName = email
+		}
+
+		ph, err := authservice.PlaceholderPasswordHash()
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to provision user.")
+			return
+		}
+
+		uid, err := platformpeople.InsertUser(ctx, d.Pool, orgID, email, ph, displayName, firstName, lastName)
+		if err != nil {
+			var pe *pgconn.PgError
+			if errors.As(err, &pe) && pe.Code == "23505" {
+				apierr.WriteJSON(w, http.StatusConflict, apierr.CodeConflict, "A user with that email already exists.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to create user.")
+			return
+		}
+
+		role := "student"
+		if body.Role != nil && strings.TrimSpace(*body.Role) != "" {
+			role = strings.TrimSpace(strings.ToLower(*body.Role))
+		}
+		if err := rbac.AssignUserRoleByName(ctx, d.Pool, uid, platformpeople.CliRoleToApp(role)); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to assign role.")
+			return
+		}
+
+		if err := d.licenseService().CheckCanActivate(ctx, uid, orgID); err != nil {
+			if errors.Is(err, licensesvc.ErrSeatLimitReached) {
+				writeSeatLimitError(w)
+				return
+			}
+		}
+
+		if _, err := authservice.RequestPasswordReset(ctx, d.Pool, d.effectiveConfig(), email); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "User created but invite email could not be sent.")
+			return
+		}
+		communication.SendWelcomeMessage(ctx, d.Pool, email)
+
+		d.recordPlatformPeopleAudit(r, actor, &orgID, auditservice.EventUserCreate, uid, raw)
+
+		result, err := platformpeople.Search(ctx, d.Pool, platformpeople.ListParams{Query: email, Page: 1, PerPage: 1})
+		if err != nil || len(result.Items) == 0 {
+			writeJSON(w, http.StatusCreated, map[string]any{"id": uid.String(), "email": email})
+			return
+		}
+		writeJSON(w, http.StatusCreated, result.Items[0])
+	}
+}
+
+func (d Deps) resolveInviteOrgID(ctx context.Context, actor uuid.UUID, orgIDRaw *string) (uuid.UUID, error) {
+	if orgIDRaw != nil && strings.TrimSpace(*orgIDRaw) != "" {
+		oid, err := uuid.Parse(strings.TrimSpace(*orgIDRaw))
+		if err != nil {
+			return uuid.UUID{}, errors.New("Invalid orgId.")
+		}
+		org, err := organization.GetByID(ctx, d.Pool, oid)
+		if err != nil || org == nil {
+			return uuid.UUID{}, errors.New("Organization not found.")
+		}
+		return oid, nil
+	}
+	return organization.OrgIDForUser(ctx, d.Pool, actor)
+}
+
+func (d Deps) handleAdminPeopleReport() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		if _, ok := d.adminRbacUser(w, r); !ok {
+			return
+		}
+		userID, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "userId")))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid user id.")
+			return
+		}
+		rep, err := platformpeople.UserReport(r.Context(), d.Pool, userID)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "User not found.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load user report.")
+			return
+		}
+		writeJSON(w, http.StatusOK, rep)
+	}
+}
+
+func (d Deps) handleAdminPeoplePatch() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.Header().Set("Allow", http.MethodPatch)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		actor, ok := d.adminRbacUser(w, r)
+		if !ok {
+			return
+		}
+		targetID, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "userId")))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid user id.")
+			return
+		}
+		raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<16))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid body.")
+			return
+		}
+		var body struct {
+			Active *bool `json:"active"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid JSON body.")
+			return
+		}
+		if body.Active == nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "active is required.")
+			return
+		}
+		ctx := r.Context()
+		if *body.Active {
+			var orgID uuid.UUID
+			if err := d.Pool.QueryRow(ctx, `SELECT org_id FROM "user".users WHERE id = $1`, targetID).Scan(&orgID); err != nil {
+				if errors.Is(err, pgx.ErrNoRows) {
+					apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "User not found.")
+					return
+				}
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load user.")
+				return
+			}
+			if err := d.licenseService().CheckCanActivate(ctx, targetID, orgID); err != nil {
+				if errors.Is(err, licensesvc.ErrSeatLimitReached) {
+					writeSeatLimitError(w)
+					return
+				}
+				apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to verify seat license.")
+				return
+			}
+		}
+		if err := platformpeople.SetActive(ctx, d.Pool, targetID, *body.Active); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to update user.")
+			return
+		}
+		if !*body.Active {
+			_ = authservice.RevokeAllSessionsForUser(ctx, d.Pool, targetID)
+		}
+		var orgID uuid.UUID
+		_ = d.Pool.QueryRow(ctx, `SELECT org_id FROM "user".users WHERE id = $1`, targetID).Scan(&orgID)
+		eventType := auditservice.EventUserDeactivate
+		if *body.Active {
+			eventType = auditservice.EventUserUpdate
+		}
+		d.recordPlatformPeopleAudit(r, actor, &orgID, eventType, targetID, raw)
+
+		result, err := platformpeople.Search(ctx, d.Pool, platformpeople.ListParams{Query: targetID.String(), Page: 1, PerPage: 1})
+		if err != nil || len(result.Items) == 0 {
+			writeJSON(w, http.StatusOK, map[string]any{"id": targetID.String(), "active": *body.Active})
+			return
+		}
+		writeJSON(w, http.StatusOK, result.Items[0])
+	}
+}
+
+func (d Deps) handleAdminPeopleDelete() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			w.Header().Set("Allow", http.MethodDelete)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			return
+		}
+		actor, ok := d.adminRbacUser(w, r)
+		if !ok {
+			return
+		}
+		targetID, err := uuid.Parse(strings.TrimSpace(chi.URLParam(r, "userId")))
+		if err != nil {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "Invalid user id.")
+			return
+		}
+		if targetID == actor {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "You cannot delete your own account.")
+			return
+		}
+		ctx := r.Context()
+		var orgID uuid.UUID
+		var email string
+		err = d.Pool.QueryRow(ctx, `SELECT org_id, email FROM "user".users WHERE id = $1`, targetID).Scan(&orgID, &email)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				apierr.WriteJSON(w, http.StatusNotFound, apierr.CodeNotFound, "User not found.")
+				return
+			}
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to load user.")
+			return
+		}
+		if platformpeople.IsErased(email) {
+			apierr.WriteJSON(w, http.StatusBadRequest, apierr.CodeInvalidInput, "This account has already been deleted.")
+			return
+		}
+
+		_ = authservice.RevokeAllSessionsForUser(ctx, d.Pool, targetID)
+		if err := platformpeople.SetActive(ctx, d.Pool, targetID, false); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to deactivate user.")
+			return
+		}
+		if err := gdpr.AnonymiseUser(ctx, d.Pool, targetID); err != nil {
+			apierr.WriteJSON(w, http.StatusInternalServerError, apierr.CodeInternal, "Failed to delete user account.")
+			return
+		}
+		_ = coursereviews.AnonymizeReviewerReviews(ctx, d.Pool, targetID)
+
+		d.recordPlatformPeopleAudit(r, actor, &orgID, auditservice.EventUserDeactivate, targetID, nil)
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "id": targetID.String()})
+	}
+}
+
+func (d Deps) recordPlatformPeopleAudit(r *http.Request, actor uuid.UUID, orgID *uuid.UUID, eventType string, targetID uuid.UUID, after []byte) {
+	if !d.effectiveConfig().AdminAuditLogEnabled {
+		return
+	}
+	tt := "user"
+	ip := adminConsoleClientIP(r)
+	ua := r.UserAgent()
+	_, _ = auditservice.Record(r.Context(), d.Pool, auditservice.RecordParams{
+		OrgID:      orgID,
+		EventType:  eventType,
+		ActorID:    actor,
+		ActorIP:    &ip,
+		UserAgent:  &ua,
+		TargetType: &tt,
+		TargetID:   &targetID,
+		AfterValue: after,
+	})
+}
+
+func peopleTrimPtr(s *string) *string {
+	if s == nil {
+		return nil
+	}
+	t := strings.TrimSpace(*s)
+	if t == "" {
+		return nil
+	}
+	return &t
+}
+
+func peopleStrVal(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return strings.TrimSpace(*s)
+}

--- a/server/internal/httpserver/platform_people_nodb_test.go
+++ b/server/internal/httpserver/platform_people_nodb_test.go
@@ -1,0 +1,41 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAdminPeople_UnauthenticatedReturns401(t *testing.T) {
+	d := Deps{}
+	rr := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/admin/people?q=test", nil)
+	d.handleAdminPeopleSearch()(rr, r)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("search status = %d, want 401", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	r = httptest.NewRequest(http.MethodPost, "/api/v1/admin/people/invite", nil)
+	d.handleAdminPeopleInvite()(rr, r)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("invite status = %d, want 401", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	r = httptest.NewRequest(http.MethodGet, "/api/v1/admin/people/00000000-0000-4000-8000-000000000001/report", nil)
+	d.handleAdminPeopleReport()(rr, r)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("report status = %d, want 401", rr.Code)
+	}
+}
+
+func TestAdminPeople_SearchEmptyQueryReturnsEmptyList(t *testing.T) {
+	// Without DB/auth this only verifies the handler shape for empty q when unauthenticated.
+	rr := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/admin/people", nil)
+	Deps{}.handleAdminPeopleSearch()(rr, r)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 without auth", rr.Code)
+	}
+}

--- a/server/internal/repos/platformpeople/repo.go
+++ b/server/internal/repos/platformpeople/repo.go
@@ -1,0 +1,384 @@
+// Package platformpeople provides instance-wide user search and reports for global admins.
+package platformpeople
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const systemUserID = "a0000000-0000-4000-8000-000000000001"
+
+// PersonRow is a search result row.
+type PersonRow struct {
+	ID          string    `json:"id"`
+	Email       string    `json:"email"`
+	FirstName   *string   `json:"firstName"`
+	LastName    *string   `json:"lastName"`
+	DisplayName *string   `json:"displayName"`
+	OrgID       string    `json:"orgId"`
+	OrgName     string    `json:"orgName"`
+	Role        string    `json:"role"`
+	Active      bool      `json:"active"`
+	CreatedAt   time.Time `json:"createdAt"`
+}
+
+// ListParams holds search pagination options.
+type ListParams struct {
+	Query   string
+	Page    int
+	PerPage int
+}
+
+// ListResult is a paginated search response.
+type ListResult struct {
+	Items      []PersonRow `json:"items"`
+	Total      int64       `json:"total"`
+	Page       int         `json:"page"`
+	PerPage    int         `json:"perPage"`
+	TotalPages int         `json:"totalPages"`
+}
+
+func normalizePagination(page, perPage int) (int, int) {
+	if page < 1 {
+		page = 1
+	}
+	switch perPage {
+	case 25, 50, 100:
+	default:
+		perPage = 25
+	}
+	return page, perPage
+}
+
+// Search returns users matching free text across the instance. Requires a non-empty query.
+func Search(ctx context.Context, pool *pgxpool.Pool, p ListParams) (ListResult, error) {
+	q := strings.TrimSpace(p.Query)
+	if q == "" {
+		return ListResult{Items: []PersonRow{}}, nil
+	}
+	page, perPage := normalizePagination(p.Page, p.PerPage)
+	offset := (page - 1) * perPage
+	like := "%" + strings.ToLower(q) + "%"
+
+	rows, err := pool.Query(ctx, `
+WITH matched AS (
+    SELECT
+        u.id,
+        u.email,
+        u.first_name,
+        u.last_name,
+        u.display_name,
+        u.org_id,
+        o.name AS org_name,
+        COALESCE((
+            SELECT ar.name
+            FROM "user".user_app_roles uar
+            JOIN "user".app_roles ar ON ar.id = uar.role_id
+            WHERE uar.user_id = u.id
+            ORDER BY ar.name
+            LIMIT 1
+        ), '') AS role_name,
+        (u.deactivated_at IS NULL AND NOT u.login_blocked) AS active,
+        u.created_at,
+        GREATEST(
+            ts_rank(u.search_vector, websearch_to_tsquery('english', $1)),
+            CASE WHEN similarity(u.email, $1) >= 0.3 THEN similarity(u.email, $1) ELSE 0 END,
+            CASE WHEN similarity(COALESCE(u.first_name, ''), $1) >= 0.3 THEN similarity(COALESCE(u.first_name, ''), $1) ELSE 0 END,
+            CASE WHEN similarity(COALESCE(u.last_name, ''), $1) >= 0.3 THEN similarity(COALESCE(u.last_name, ''), $1) ELSE 0 END,
+            CASE WHEN u.email ILIKE $2 OR COALESCE(u.first_name, '') ILIKE $2
+                OR COALESCE(u.last_name, '') ILIKE $2
+                OR COALESCE(u.display_name, '') ILIKE $2 THEN 0.35 ELSE 0 END
+        ) AS rank
+    FROM "user".users u
+    INNER JOIN tenant.organizations o ON o.id = u.org_id
+    WHERE u.id <> $3::uuid
+      AND (
+          u.search_vector @@ websearch_to_tsquery('english', $1)
+          OR u.email ILIKE $2
+          OR COALESCE(u.first_name, '') ILIKE $2
+          OR COALESCE(u.last_name, '') ILIKE $2
+          OR similarity(u.email, $1) >= 0.3
+          OR similarity(COALESCE(u.first_name, ''), $1) >= 0.3
+          OR similarity(COALESCE(u.last_name, ''), $1) >= 0.3
+          OR similarity(COALESCE(u.display_name, ''), $1) >= 0.3
+      )
+)
+SELECT
+    id::text,
+    email,
+    first_name,
+    last_name,
+    display_name,
+    org_id::text,
+    org_name,
+    role_name,
+    active,
+    created_at,
+    COUNT(*) OVER () AS total
+FROM matched
+ORDER BY rank DESC, email ASC
+LIMIT $4 OFFSET $5
+`, q, like, systemUserID, perPage, offset)
+	if err != nil {
+		return ListResult{}, err
+	}
+	defer rows.Close()
+
+	var items []PersonRow
+	var total int64
+	for rows.Next() {
+		var row PersonRow
+		var roleName string
+		if err := rows.Scan(
+			&row.ID, &row.Email, &row.FirstName, &row.LastName, &row.DisplayName,
+			&row.OrgID, &row.OrgName, &roleName, &row.Active, &row.CreatedAt, &total,
+		); err != nil {
+			return ListResult{}, err
+		}
+		row.Role = appRoleToCli(roleName)
+		items = append(items, row)
+	}
+	if items == nil {
+		items = []PersonRow{}
+	}
+	totalPages := int(total) / perPage
+	if int(total)%perPage != 0 {
+		totalPages++
+	}
+	return ListResult{
+		Items: items, Total: total, Page: page, PerPage: perPage, TotalPages: totalPages,
+	}, rows.Err()
+}
+
+// EnrollmentRow is one course enrollment on a user report.
+type EnrollmentRow struct {
+	CourseID     string  `json:"courseId"`
+	CourseCode   string  `json:"courseCode"`
+	CourseTitle  string  `json:"courseTitle"`
+	Role         string  `json:"role"`
+	Active       bool    `json:"active"`
+	State        string  `json:"state"`
+	EnrolledAt   string  `json:"enrolledAt"`
+	OrgName      *string `json:"orgName,omitempty"`
+}
+
+// ActivityRow is one recent learning-activity event.
+type ActivityRow struct {
+	EventKind  string `json:"eventKind"`
+	CourseCode string `json:"courseCode"`
+	CourseTitle string `json:"courseTitle"`
+	OccurredAt string `json:"occurredAt"`
+}
+
+// Report is the full person report payload.
+type Report struct {
+	ID            string          `json:"id"`
+	Email         string          `json:"email"`
+	FirstName     *string         `json:"firstName"`
+	LastName      *string         `json:"lastName"`
+	DisplayName   *string         `json:"displayName"`
+	OrgID         string          `json:"orgId"`
+	OrgName       string          `json:"orgName"`
+	Role          string          `json:"role"`
+	Active        bool            `json:"active"`
+	CreatedAt     time.Time       `json:"createdAt"`
+	LastActivityAt *time.Time     `json:"lastActivityAt"`
+	EnrollmentCount int64         `json:"enrollmentCount"`
+	Enrollments   []EnrollmentRow `json:"enrollments"`
+	RecentActivity []ActivityRow  `json:"recentActivity"`
+}
+
+// UserReport returns profile, enrollments, and recent activity for one user.
+func UserReport(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) (*Report, error) {
+	var rep Report
+	var roleName string
+	err := pool.QueryRow(ctx, `
+SELECT
+    u.id::text,
+    u.email,
+    u.first_name,
+    u.last_name,
+    u.display_name,
+    u.org_id::text,
+    o.name,
+    COALESCE((
+        SELECT ar.name
+        FROM "user".user_app_roles uar
+        JOIN "user".app_roles ar ON ar.id = uar.role_id
+        WHERE uar.user_id = u.id
+        ORDER BY ar.name
+        LIMIT 1
+    ), '') AS role_name,
+    (u.deactivated_at IS NULL AND NOT u.login_blocked) AS active,
+    u.created_at
+FROM "user".users u
+INNER JOIN tenant.organizations o ON o.id = u.org_id
+WHERE u.id = $1 AND u.id <> $2::uuid
+`, userID, systemUserID).Scan(
+		&rep.ID, &rep.Email, &rep.FirstName, &rep.LastName, &rep.DisplayName,
+		&rep.OrgID, &rep.OrgName, &roleName, &rep.Active, &rep.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	rep.Role = appRoleToCli(roleName)
+
+	_ = pool.QueryRow(ctx, `
+SELECT MAX(occurred_at) FROM "user".user_audit WHERE user_id = $1
+`, userID).Scan(&rep.LastActivityAt)
+
+	_ = pool.QueryRow(ctx, `
+SELECT COUNT(*)::bigint
+FROM course.course_enrollments ce
+WHERE ce.user_id = $1 AND (ce.active OR ce.invitation_pending)
+`, userID).Scan(&rep.EnrollmentCount)
+
+	enrollRows, err := pool.Query(ctx, `
+SELECT
+    c.id::text,
+    c.course_code,
+    c.title,
+    ce.role,
+    ce.active,
+    COALESCE(ce.state::text, 'active'),
+    ce.created_at,
+    ho.name
+FROM course.course_enrollments ce
+INNER JOIN course.courses c ON c.id = ce.course_id
+LEFT JOIN tenant.organizations ho ON ho.id = ce.home_org_id
+WHERE ce.user_id = $1
+ORDER BY ce.created_at DESC
+LIMIT 100
+`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer enrollRows.Close()
+	for enrollRows.Next() {
+		var row EnrollmentRow
+		var enrolledAt time.Time
+		if err := enrollRows.Scan(
+			&row.CourseID, &row.CourseCode, &row.CourseTitle, &row.Role,
+			&row.Active, &row.State, &enrolledAt, &row.OrgName,
+		); err != nil {
+			return nil, err
+		}
+		row.EnrolledAt = enrolledAt.UTC().Format(time.RFC3339)
+		rep.Enrollments = append(rep.Enrollments, row)
+	}
+	if rep.Enrollments == nil {
+		rep.Enrollments = []EnrollmentRow{}
+	}
+
+	actRows, err := pool.Query(ctx, `
+SELECT
+    ua.event_kind,
+    c.course_code,
+    c.title,
+    ua.occurred_at
+FROM "user".user_audit ua
+INNER JOIN course.courses c ON c.id = ua.course_id
+WHERE ua.user_id = $1
+ORDER BY ua.occurred_at DESC
+LIMIT 50
+`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer actRows.Close()
+	for actRows.Next() {
+		var row ActivityRow
+		var at time.Time
+		if err := actRows.Scan(&row.EventKind, &row.CourseCode, &row.CourseTitle, &at); err != nil {
+			return nil, err
+		}
+		row.OccurredAt = at.UTC().Format(time.RFC3339)
+		rep.RecentActivity = append(rep.RecentActivity, row)
+	}
+	if rep.RecentActivity == nil {
+		rep.RecentActivity = []ActivityRow{}
+	}
+	return &rep, nil
+}
+
+// IsErased reports whether the user email has been anonymized.
+func IsErased(email string) bool {
+	return strings.HasSuffix(strings.ToLower(email), "@erased.invalid")
+}
+
+func appRoleToCli(name string) string {
+	switch name {
+	case "Teacher":
+		return "instructor"
+	case "Student":
+		return "student"
+	case "TA":
+		return "ta"
+	case "Global Admin":
+		return "admin"
+	default:
+		if name == "" {
+			return ""
+		}
+		return strings.ToLower(name)
+	}
+}
+
+func CliRoleToApp(role string) string {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case "instructor":
+		return "Teacher"
+	case "student":
+		return "Student"
+	case "ta":
+		return "TA"
+	case "admin":
+		return "Global Admin"
+	default:
+		return role
+	}
+}
+
+// InsertUser creates a user in the given organization.
+func InsertUser(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	orgID uuid.UUID,
+	email, passwordHash, displayName string,
+	firstName, lastName *string,
+) (uuid.UUID, error) {
+	var uid uuid.UUID
+	err := pool.QueryRow(ctx, `
+INSERT INTO "user".users (email, password_hash, display_name, first_name, last_name, org_id)
+VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING id
+`, email, passwordHash, displayName, firstName, lastName, orgID).Scan(&uid)
+	return uid, err
+}
+
+// SetActive toggles login access for a user.
+func SetActive(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, active bool) error {
+	if active {
+		_, err := pool.Exec(ctx, `
+UPDATE "user".users SET deactivated_at = NULL, login_blocked = FALSE WHERE id = $1
+`, userID)
+		return err
+	}
+	tag, err := pool.Exec(ctx, `
+UPDATE "user".users
+SET deactivated_at = COALESCE(deactivated_at, NOW()), login_blocked = TRUE
+WHERE id = $1
+`, userID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("platformpeople: user not found")
+	}
+	return nil
+}

--- a/www/src/components/home/hero-section.tsx
+++ b/www/src/components/home/hero-section.tsx
@@ -28,8 +28,8 @@ export function HeroSection() {
             audit trails into one platform.
           </p>
           <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
-            <a href={SITE_LINKS.demo} className="btn-primary" target="_blank" rel="noopener noreferrer">
-              Try the demo
+            <a href={SITE_LINKS.selfLearner} className="btn-primary" target="_blank" rel="noopener noreferrer">
+              Start studying
             </a>
             <a href="/docs" className="btn-secondary">
               Read the docs →

--- a/www/src/components/site-footer.tsx
+++ b/www/src/components/site-footer.tsx
@@ -7,7 +7,7 @@ const NAV_COLUMNS = [
       { label: 'Features', href: '/#features' },
       { label: 'Pricing', href: '/pricing' },
       { label: 'Documentation', href: '/docs' },
-      { label: 'Live demo', href: SITE_LINKS.demo },
+      { label: 'Start studying', href: SITE_LINKS.selfLearner },
     ],
   },
   {

--- a/www/src/content/legal/privacy-policy.md
+++ b/www/src/content/legal/privacy-policy.md
@@ -73,9 +73,9 @@ Lextures offers optional AI-assisted features (tutoring, feedback suggestions, c
 
 Before content is sent to AI providers, Lextures applies **PII redaction** and institutional policy controls where configured. Prompts should not include unnecessary sensitive data. Your institution may disable AI features or specific providers.
 
-**Opt-out:** You can opt out of AI processing in **Settings → Account → AI processing**, or avoid AI tools entirely. Institutions can disable AI at the organization level. See the [AI usage disclosure](https://demo.lextures.com/ai-disclosure) page for model cards and retention details. Contact your administrator or **privacy@lextures.com** for questions.
+**Opt-out:** You can opt out of AI processing in **Settings → Account → AI processing**, or avoid AI tools entirely. Institutions can disable AI at the organization level. See the [AI usage disclosure](https://self.lextures.com/ai-disclosure) page for model cards and retention details. Contact your administrator or **privacy@lextures.com** for questions.
 
-For a full list of infrastructure and service sub-processors, see our [Trust Center](https://demo.lextures.com/trust).
+For a full list of infrastructure and service sub-processors, see our [Trust Center](https://self.lextures.com/trust).
 
 ## Data Retention
 

--- a/www/src/lib/api-base.ts
+++ b/www/src/lib/api-base.ts
@@ -1,4 +1,4 @@
 import { APP_ORIGIN } from './site-links'
 
-/** API origin for www pages that call the Lextures backend (defaults to the hosted demo app). */
+/** API origin for www pages that call the Lextures backend (defaults to the self-learner app). */
 export const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? APP_ORIGIN).replace(/\/$/, '')

--- a/www/src/lib/school-code.ts
+++ b/www/src/lib/school-code.ts
@@ -1,0 +1,37 @@
+const SCHOOL_CODE_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/
+
+const RESERVED_SCHOOL_CODES = new Set([
+  'admin',
+  'api',
+  'app',
+  'default',
+  'demo',
+  'login',
+  'magic-link',
+  'mfa',
+  'self',
+  'signup',
+  'www',
+])
+
+export function normalizeSchoolCode(raw: string): string {
+  return raw.trim().toLowerCase()
+}
+
+export function schoolCodeError(code: string): string | null {
+  const normalized = normalizeSchoolCode(code)
+  if (!normalized) return 'Enter your school code.'
+  if (normalized.length < 2) return 'School codes are at least 2 characters.'
+  if (normalized.length > 32) return 'School codes are at most 32 characters.'
+  if (!SCHOOL_CODE_PATTERN.test(normalized)) {
+    return 'Use lowercase letters, numbers, and hyphens only.'
+  }
+  if (RESERVED_SCHOOL_CODES.has(normalized)) {
+    return 'That code is reserved.'
+  }
+  return null
+}
+
+export function isValidSchoolCode(code: string): boolean {
+  return schoolCodeError(code) === null
+}

--- a/www/src/lib/site-links.ts
+++ b/www/src/lib/site-links.ts
@@ -1,7 +1,17 @@
-export const APP_ORIGIN = 'https://demo.lextures.com'
+export const DEMO_ORIGIN = 'https://demo.lextures.com'
+export const SELF_LEARNER_ORIGIN = 'https://self.lextures.com'
+export const TENANT_HOST_SUFFIX = 'lextures.com'
+
+/** Primary hosted app origin (self-learner instance). */
+export const APP_ORIGIN = SELF_LEARNER_ORIGIN
+
+export function tenantOrigin(schoolCode: string) {
+  return `https://${schoolCode}.${TENANT_HOST_SUFFIX}/`
+}
 
 export const SITE_LINKS = {
-  demo: `${APP_ORIGIN}/`,
+  demo: `${DEMO_ORIGIN}/`,
+  selfLearner: `${SELF_LEARNER_ORIGIN}/`,
   github: 'https://github.com/StudyDrift/lextures',
   institutionInquiryEmail: 'chase@lextures.com',
   privacy: '/privacy',

--- a/www/src/pages/get-started-page.tsx
+++ b/www/src/pages/get-started-page.tsx
@@ -1,12 +1,12 @@
-import { ArrowLeft, BookOpen, BrainCircuit, GraduationCap, Search } from 'lucide-react'
+import { ArrowLeft, BrainCircuit, GraduationCap, KeyRound } from 'lucide-react'
 import { useState } from 'react'
 import { Header } from '../components/header'
 import { SiteFooter } from '../components/site-footer'
-
-const LOGIN_URL = 'https://demo.lextures.com/'
+import { isValidSchoolCode, normalizeSchoolCode, schoolCodeError } from '../lib/school-code'
+import { SITE_LINKS, TENANT_HOST_SUFFIX, tenantOrigin } from '../lib/site-links'
 
 // Fire-and-forget — never awaited, never surfaces errors to the user.
-function trackOnboarding(program: string, schoolName?: string) {
+function trackOnboarding(program: string, schoolCode?: string) {
   try {
     const apiBase = import.meta.env.VITE_API_BASE_URL ?? ''
     navigator.sendBeacon(
@@ -14,7 +14,7 @@ function trackOnboarding(program: string, schoolName?: string) {
       new Blob(
         [JSON.stringify({
           program,
-          school_name: schoolName ?? '',
+          school_name: schoolCode ?? '',
           language: navigator.language ?? '',
           timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? '',
           screen_width: window.screen.width,
@@ -29,31 +29,41 @@ function trackOnboarding(program: string, schoolName?: string) {
   }
 }
 
-type Program = 'k-12' | 'higher-ed' | 'self-learner'
-type Step = 'program' | 'school'
+type Path = 'self-learner' | 'school'
+type Step = 'choose' | 'school-code'
 
-const PROGRAMS = [
+const PATHS = [
   {
-    id: 'k-12' as Program,
-    icon: BookOpen,
-    title: 'K–12',
-    description: "I'm a student or teacher at a primary or secondary school.",
-  },
-  {
-    id: 'higher-ed' as Program,
-    icon: GraduationCap,
-    title: 'Higher Education',
-    description: "I'm a student or instructor at a college or university.",
-  },
-  {
-    id: 'self-learner' as Program,
+    id: 'self-learner' as Path,
     icon: BrainCircuit,
-    title: 'Self-Learner',
+    title: 'Self-learner',
     description: "I'm studying independently, for a certification, or on my own schedule.",
+  },
+  {
+    id: 'school' as Path,
+    icon: GraduationCap,
+    title: 'School',
+    description: "I'm a student or educator at a school that uses Lextures.",
   },
 ]
 
-function ProgramStep({ onSelect }: { onSelect: (p: Program) => void }) {
+const fieldClass =
+  'block w-full rounded-xl border border-slate-200 bg-white py-3 text-base text-slate-900 shadow-sm outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20'
+
+function BackButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="mb-8 flex items-center gap-1.5 text-sm font-medium text-slate-500 transition-colors hover:text-slate-900"
+    >
+      <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
+      Back
+    </button>
+  )
+}
+
+function ChooseStep({ onSelect }: { onSelect: (path: Path) => void }) {
   return (
     <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-24 lg:px-8">
       <div className="text-center">
@@ -61,17 +71,17 @@ function ProgramStep({ onSelect }: { onSelect: (p: Program) => void }) {
           How are you using Lextures?
         </h1>
         <p className="mt-3 text-base leading-relaxed text-slate-500">
-          Select the option that best describes you so we can point you in the right direction.
+          Choose the option that matches how you sign in.
         </p>
       </div>
 
-      <div className="mt-12 grid gap-4 sm:grid-cols-3">
-        {PROGRAMS.map(({ id, icon: Icon, title, description }) => (
+      <div className="mx-auto mt-12 grid max-w-2xl gap-4 sm:grid-cols-2">
+        {PATHS.map(({ id, icon: Icon, title, description }) => (
           <button
             key={id}
             type="button"
             onClick={() => onSelect(id)}
-            className="group flex flex-col items-start gap-4 rounded-2xl border border-slate-200 bg-white p-6 text-left shadow-[0_1px_3px_rgba(28,25,23,0.05)] transition-all duration-150 hover:border-accent hover:shadow-[0_4px_16px_rgba(15,118,110,0.12)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 cursor-pointer"
+            className="group flex cursor-pointer flex-col items-start gap-4 rounded-2xl border border-slate-200 bg-white p-6 text-left shadow-[0_1px_3px_rgba(28,25,23,0.05)] transition-all duration-150 hover:border-accent hover:shadow-[0_4px_16px_rgba(15,118,110,0.12)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
           >
             <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 ring-1 ring-indigo-200 transition-colors group-hover:bg-accent group-hover:text-white">
               <Icon className="h-5 w-5" aria-hidden />
@@ -87,57 +97,78 @@ function ProgramStep({ onSelect }: { onSelect: (p: Program) => void }) {
   )
 }
 
-function SchoolStep({ program, onBack }: { program: 'k-12' | 'higher-ed'; onBack: () => void }) {
-  const [query, setQuery] = useState('')
-
-  const isK12 = program === 'k-12'
-  const label = isK12 ? 'school' : 'institution'
-  const placeholder = isK12 ? 'e.g. Lincoln Middle School' : 'e.g. University of Michigan'
+function SchoolCodeStep({ onBack }: { onBack: () => void }) {
+  const [code, setCode] = useState('')
+  const normalizedCode = normalizeSchoolCode(code)
+  const error = code ? schoolCodeError(code) : null
+  const previewHost = normalizedCode ? `${normalizedCode}.${TENANT_HOST_SUFFIX}` : `your-school.${TENANT_HOST_SUFFIX}`
 
   function handleContinue() {
-    if (!query.trim()) return
-    trackOnboarding(program, query.trim())
-    window.location.href = LOGIN_URL
+    if (!isValidSchoolCode(code)) return
+    const schoolCode = normalizeSchoolCode(code)
+    trackOnboarding('school', schoolCode)
+    window.location.href = tenantOrigin(schoolCode)
   }
 
   return (
     <div className="mx-auto max-w-lg px-4 py-16 sm:px-6 sm:py-24 lg:px-8">
-      <button
-        type="button"
-        onClick={onBack}
-        className="mb-8 flex items-center gap-1.5 text-sm font-medium text-slate-500 transition-colors hover:text-slate-900"
-      >
-        <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
-        Back
-      </button>
+      <BackButton onClick={onBack} />
 
       <h1 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
-        Find your {label}
+        Enter your school code
       </h1>
       <p className="mt-3 text-base leading-relaxed text-slate-500">
-        Enter the name of your {label} so your account is connected to the right place.
+        Your school or district provides a short code for sign-in. Enter it below and we&apos;ll take
+        you to your school&apos;s Lextures site.
       </p>
 
       <div className="mt-10 space-y-4">
-        <div className="relative">
-          <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3.5">
-            <Search className="h-4 w-4 text-slate-400" aria-hidden />
+        <div>
+          <label htmlFor="school-code" className="sr-only">
+            School code
+          </label>
+          <div className="relative">
+            <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3.5">
+              <KeyRound className="h-4 w-4 text-slate-400" aria-hidden />
+            </div>
+            <input
+              id="school-code"
+              type="text"
+              autoFocus
+              autoComplete="organization"
+              spellCheck={false}
+              value={code}
+              onChange={e => setCode(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleContinue()}
+              placeholder="e.g. example"
+              className={`${fieldClass} pl-10 pr-4 placeholder-stone-400`}
+              aria-invalid={error ? true : undefined}
+              aria-describedby="school-code-help school-code-preview"
+            />
           </div>
-          <input
-            type="text"
-            autoFocus
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && handleContinue()}
-            placeholder={placeholder}
-            className="block w-full rounded-xl border border-slate-200 bg-white py-3 pl-10 pr-4 text-base text-slate-900 placeholder-stone-400 shadow-sm outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
-          />
+          <p id="school-code-help" className="mt-2 text-sm text-slate-500">
+            Example: <span className="font-medium text-slate-700">example</span> opens{' '}
+            <span className="font-medium text-slate-700">example.lextures.com</span>.
+          </p>
+          {error && (
+            <p className="mt-2 text-sm text-red-600" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <div
+          id="school-code-preview"
+          className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600"
+        >
+          You&apos;ll go to{' '}
+          <span className="font-medium text-slate-900">{previewHost}</span>
         </div>
 
         <button
           type="button"
           onClick={handleContinue}
-          disabled={!query.trim()}
+          disabled={!isValidSchoolCode(code)}
           className="btn-primary w-full justify-center py-3 text-base disabled:cursor-not-allowed disabled:opacity-40"
         >
           Continue
@@ -148,17 +179,15 @@ function SchoolStep({ program, onBack }: { program: 'k-12' | 'higher-ed'; onBack
 }
 
 export function GetStartedPage() {
-  const [step, setStep] = useState<Step>('program')
-  const [program, setProgram] = useState<Program | null>(null)
+  const [step, setStep] = useState<Step>('choose')
 
-  function handleProgramSelect(p: Program) {
-    if (p === 'self-learner') {
+  function handleChoose(path: Path) {
+    if (path === 'self-learner') {
       trackOnboarding('self-learner')
-      window.location.href = LOGIN_URL
+      window.location.href = SITE_LINKS.selfLearner
       return
     }
-    setProgram(p)
-    setStep('school')
+    setStep('school-code')
   }
 
   return (
@@ -166,15 +195,8 @@ export function GetStartedPage() {
       <Header />
 
       <main className="flex min-h-[calc(100vh-4rem)] items-start justify-center">
-        {step === 'program' && (
-          <ProgramStep onSelect={handleProgramSelect} />
-        )}
-        {step === 'school' && program && program !== 'self-learner' && (
-          <SchoolStep
-            program={program}
-            onBack={() => setStep('program')}
-          />
-        )}
+        {step === 'choose' && <ChooseStep onSelect={handleChoose} />}
+        {step === 'school-code' && <SchoolCodeStep onBack={() => setStep('choose')} />}
       </main>
 
       <SiteFooter />

--- a/www/src/pages/pricing-page.tsx
+++ b/www/src/pages/pricing-page.tsx
@@ -58,8 +58,8 @@ const FAQS = [
     a: 'Institutions receive a dedicated environment — hosted by us or on infrastructure you control — with SSO, provisioning, and support scoped to your rollout. Use the request information form on the pricing page to describe your enrollment and integration needs.',
   },
   {
-    q: 'When will self-learner accounts be available?',
-    a: 'Individual hosted accounts for independent learners are coming soon. Until then, self-host the stack for free or use an institution account if your school provides access.',
+    q: 'How do self-learner accounts work?',
+    a: 'Sign up at self.lextures.com for a hosted individual account with adaptive practice and spaced-repetition review. You can also self-host the stack for free or use an institution account if your school provides access.',
   },
   {
     q: 'Does AI cost extra?',
@@ -138,8 +138,8 @@ export function PricingPage() {
           </h1>
           <p className="mx-auto mt-5 max-w-[680px] text-[18px] leading-relaxed" style={{ color: 'var(--text-soft)' }}>
             Lextures is AGPL-3.0 open source. Run it yourself on Postgres, open a university or
-            district account for production hosting and support, or — soon — subscribe as an
-            independent learner.
+            district account for production hosting and support, or sign up as an independent
+            learner at self.lextures.com.
           </p>
         </div>
       </section>
@@ -170,8 +170,6 @@ export function PricingPage() {
 
             <PricingCard
               label="Self-learner"
-              badge="Coming soon"
-              muted
               price={
                 <p className="font-display text-2xl font-semibold" style={{ color: 'var(--ink)' }}>
                   Individual accounts
@@ -180,14 +178,9 @@ export function PricingPage() {
               description="For certification prep, language study, and independent learners who want adaptive practice without running their own server."
               features={SELF_LEARNER_FEATURES}
               cta={
-                <button
-                  type="button"
-                  disabled
-                  className="btn-secondary w-full justify-center disabled:cursor-not-allowed disabled:opacity-50"
-                  aria-disabled="true"
-                >
-                  Coming soon
-                </button>
+                <a href={SITE_LINKS.selfLearner} className="btn-primary w-full justify-center">
+                  Sign up at self.lextures.com
+                </a>
               }
             />
 

--- a/www/src/pages/self-learner-page.tsx
+++ b/www/src/pages/self-learner-page.tsx
@@ -46,8 +46,8 @@ export function SelfLearnerPage() {
       <AudienceHero
         eyebrow="Self-learner"
         title="An adaptive study system that runs without a classroom"
-        lead="Create or enroll in courses, practice with IRT-routed quizzes, and clear spaced-repetition reviews from your phone. Self-host the full stack for free, or use the hosted demo with optional paid tiers."
-        primaryHref="/get-started"
+        lead="Create or enroll in courses, practice with IRT-routed quizzes, and clear spaced-repetition reviews from your phone. Self-host the full stack for free, or sign up at self.lextures.com with optional paid tiers."
+        primaryHref={SITE_LINKS.selfLearner}
         primaryLabel="Start studying"
         secondaryHref="/pricing"
         secondaryLabel="Hosted pricing"
@@ -76,18 +76,18 @@ export function SelfLearnerPage() {
           <p className="text-[15px] leading-relaxed" style={{ color: 'var(--text-soft)' }}>
             <strong style={{ color: 'var(--ink-nav)' }}>Self-host:</strong> clone the repo and run
             without course or student limits.{' '}
-            <strong style={{ color: 'var(--ink-nav)' }}>Hosted demo:</strong> free tier limits apply
-            on demo.lextures.com; see pricing for details. Public course catalog and paid enrollment
+            <strong style={{ color: 'var(--ink-nav)' }}>Hosted:</strong> free tier limits apply
+            on self.lextures.com; see pricing for details. Public course catalog and paid enrollment
             require your administrator to enable those platform features.
           </p>
         </div>
       </section>
 
       <AudienceCta
-        title="Try it on the hosted demo or your own server"
-        body="Sign up on demo.lextures.com to start immediately, or follow the self-hosting guide to run Lextures on your hardware with full control."
-        primaryHref="/get-started"
-        primaryLabel="Get started"
+        title="Try it on self.lextures.com or your own server"
+        body="Sign up on self.lextures.com to start immediately, or follow the self-hosting guide to run Lextures on your hardware with full control."
+        primaryHref={SITE_LINKS.selfLearner}
+        primaryLabel="Open self.lextures.com"
         secondaryHref={SITE_LINKS.github}
         secondaryLabel="View on GitHub"
       />


### PR DESCRIPTION
## Summary

- **Platform People admin**: New `/api/v1/admin/people` endpoints (search, invite, report, patch, delete) plus a Settings → People panel for Global Admins with `rbac:manage`. Supports searching users, inviting by email, viewing per-user reports, suspending/reactivating, and deleting accounts.
- **Tenant onboarding**: Redesigns the marketing get-started flow into self-learner vs school paths. School users enter a validated school code and are redirected to `https://{code}.lextures.com/`. Adds `www/src/lib/school-code.ts` for client-side validation.
- **Site links**: Points primary app CTAs at `self.lextures.com` instead of `demo.lextures.com`; keeps demo as a separate origin.
- **Deploy/IaC**: Wires `BOOTSTRAP_ADMIN_EMAIL` into `docker-compose.deploy.yml`, adds `TURNSTILE_SECRET_KEY` to server config and self-hosted Terraform (DigitalOcean + Oracle modules), and documents both in `.env.example` and `iac/self`.

## Test plan

- [x] `go test ./internal/httpserver/... -short` passes
- [x] `npm run typecheck` in `clients/web/` passes
- [ ] Manual: Global Admin opens Settings → People, searches for a user, views report, invites a new user
- [ ] Manual: Marketing get-started → School path → enter valid school code → redirects to tenant subdomain
- [ ] Manual: Self-learner path redirects to `self.lextures.com`