### PR TITLE
Add mobile plan stories for course and admin settings parity (M13, M14)

### DIFF
--- a/docs/plan/mobile/M13.1-course-settings-general.md
+++ b/docs/plan/mobile/M13.1-course-settings-general.md
@@ -1,0 +1,192 @@
+# M13.1 — Course Settings Shell + General (Mobile)
+
+> Implementation plan. Source: web `pages/lms/course-settings.tsx` (`general` section) and
+> `components/layout/side-nav-course-settings-links.tsx`. Follows
+> [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M13.1 |
+| **Section** | M13 — Course Settings & Configuration |
+| **Severity** | BLOCKER (for the epic) — there is **no course settings surface at all** on mobile; an instructor cannot rename a course, set a start/end date, publish/unpublish, choose the course home, set the course time zone, or set a hero image from a phone |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING — web has a full `/courses/{code}/settings/*` area gated by `courseItemCreatePermission`; mobile has zero settings screens |
+| **Estimated effort** | M (2–4w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — `PUT /api/v1/courses/{code}`, `PUT /api/v1/courses/{code}/hero-image`, `POST /api/v1/courses/{code}/generate-image`, and the markdown-theme patch all exist |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M0.5 Redesign IA](../completed/mobile/M0.5-redesign-information-architecture.md) (course drawer + Teach context), [M0.2 Offline](../completed/mobile/M0.2-offline-sync.md) (queued writes) |
+| **Unblocks** | Every other M13 story (this is the container + first section) |
+
+## 1. Problem Statement
+
+The web app gives instructors a full course-settings area — basics, scheduling, visibility,
+publishing, course home, time zone, hero image, and reading theme — behind a permission gate.
+On mobile there is **no settings surface whatsoever**, so a teacher away from a laptop cannot
+even fix a course title, publish a draft, or change a due-window. This story delivers the
+**settings shell** (the container, navigation, permission gate, and shared save/unsaved-changes
+pattern that every later M13 section plugs into) plus the **General** section itself.
+
+## 2. Goals
+
+- A **Course Settings** entry in the course drawer, visible only to staff who pass
+  `courseItemCreatePermission` for the course, that opens a sectioned settings area.
+- A reusable **settings section scaffold**: header, save button, unsaved-changes banner,
+  save/saving/saved/error states, and offline-queued writes — shared by all M13 sections.
+- A complete **General** section: title, description, grade level, course time zone,
+  publish/draft toggle, course-home landing (data / calendar / a content page), fixed **or**
+  relative schedule (start/end/visible-from/hidden-after or ISO durations), hero image
+  (generate with AI, upload, reposition), and markdown reading-theme preset/custom.
+- Feature-flag- and course-flag-aware section list (some sections only appear when enabled).
+
+## 3. Non-Goals
+
+- The other settings sections (features, grading, outcomes, etc.) ship as M13.2–M13.12.
+- No new authoring surfaces (modules, question bank) — those stay in their own stories/web.
+- No admin/global settings (that is epic M14).
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I open Course Settings on my phone and rename the course and publish it.
+- **As an instructor**, I set the course start/end dates and choose whether the course home is
+  the dashboard, the calendar, or a specific content page.
+- **As an instructor**, I set the course time zone so due dates are interpreted correctly.
+- **As an instructor**, I generate or upload a hero image and reposition its crop.
+- **As a student**, I never see the settings entry (permission-gated).
+
+## 5. Functional Requirements
+
+- **FR-1.** A **Course Settings** destination MUST appear in the course drawer only when the
+  signed-in user passes `courseItemCreatePermission(courseCode)`; otherwise it MUST be absent
+  and the route MUST redirect back to the course.
+- **FR-2.** The settings area MUST present a **section list** (General, Features, Grading, …)
+  reflecting the web's grouping, hiding sections whose feature/course flags are off (e.g.,
+  Sections, Grading agents, Plagiarism, Accessibility, Translations).
+- **FR-3.** The **General** section MUST edit: title (required), description, grade level,
+  course time zone, published toggle, course-home landing (`data`/`calendar`/`content_page`
+  with a page picker), schedule mode (`fixed` with start/end/visible-from/hidden-after, or
+  `relative` with ISO durations), and markdown reading-theme preset/custom.
+- **FR-4.** The **hero image** MUST support AI generation (prompt → preview → save), upload
+  (image ≤ 10 MB), and crop repositioning, persisting via the hero-image endpoint.
+- **FR-5.** An **unsaved-changes banner** MUST appear when the General form is dirty, with
+  Save and Discard, mirroring the web's `UnsavedChangesBanner`.
+- **FR-6.** All writes MUST show save/saving/saved/error states and MUST queue when offline
+  (M0.2), reconciling on reconnect; MUST show empty/loading/error/offline states throughout.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — settings open < 500 ms p95 from cache; save round-trip < 800 ms p95.
+- **Security** — permission checked client-side for UI **and** server-side on every write;
+  never trust a cached role.
+- **Privacy & Compliance** — no course PII in logs; hero uploads follow storage policy.
+- **Accessibility** — every field labeled; toggles announce state; date pickers and the theme
+  editor are screen-reader operable; ≥44 pt targets; Dynamic Type; reduced motion.
+- **Reliability** — saves are idempotent; partial multi-field save failure surfaces per field;
+  discard restores the last server state exactly.
+- **Internationalization** — dates render in the course time zone with the learner's zone noted;
+  strings externalized; RTL.
+- **Observability** — emit `course_settings_saved` with section = general; error taxonomy logged.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a staff user with permission, *When* the course drawer opens, *Then* a
+  Course Settings entry is present and opens the General section by default.
+- **AC-2.** *Given* a non-permissioned user, *Then* the entry is absent and the route redirects.
+- **AC-3.** *Given* the General form, *When* the title is cleared and Save pressed, *Then* a
+  "Title is required" error shows and nothing is saved.
+- **AC-4.** *Given* course-home = "a content page" with no page chosen, *When* Save, *Then* a
+  validation message asks for a page.
+- **AC-5.** *Given* a generated or uploaded hero image saved, *Then* it appears on the course.
+- **AC-6.** *Given* offline edits, *Then* they queue and sync on reconnect with a staleness note.
+- **AC-7.** Both apps build.
+
+## 8. Data Model
+
+- No server schema changes. Client persists a cached `CoursePublic` for the course and a
+  pending-writes queue entry per settings save (M0.2).
+
+## 9. API Surface
+
+- `PUT /api/v1/courses/{code}` (title, description, published, startsAt, endsAt, visibleFrom,
+  hiddenAt, scheduleMode, relativeEndAfter, relativeHiddenAfter, courseHomeLanding,
+  courseHomeContentItemId, courseTimezone, gradeLevel).
+- `PUT /api/v1/courses/{code}/hero-image` (imageUrl or objectPosition).
+- `POST /api/v1/courses/{code}/generate-image` (prompt → imageUrl).
+- Markdown theme patch (`patchCourseMarkdownTheme`). Verify exact shapes vs. `courses-api.ts`.
+
+## 10. UI / UX
+
+1. Course drawer → **Settings** (staff only) → section list → **General**.
+2. General is a scrolling form of cards: Basic info, Course time zone, Publishing, Course home,
+   Schedule & visibility (fixed/relative segmented control), Hero image, Reading theme.
+3. Hero image: a bottom sheet for Generate (prompt + preview) / Upload / Reposition (drag focal
+   point). Content-page picker is a searchable sheet sourced from course structure.
+4. Sticky **unsaved-changes** banner with Save/Discard.
+5. States: loading skeleton, load error with retry, per-field save error, offline banner.
+
+## 11. AI / ML Considerations
+
+- Hero-image generation calls the existing server generate-image endpoint (model chosen in
+  platform AI settings, M14.7). Mobile only sends the prompt and renders the returned image;
+  no client model. Show a "generated" label; allow discard before save.
+
+## 12. Integration Points
+
+- **iOS:** new `Features/Courses/Settings/CourseSettingsHostView.swift` (section list + gate),
+  `CourseGeneralSettingsView.swift`, `CourseHeroImageEditor.swift`; API additions in
+  `Core/LMS/LMSAPICourses.swift`; reuse `Core/Design` theme, `TimezoneSelector` analog, and the
+  M0.2 write queue. Course-drawer entry via the M0.5 destination registry. Regenerate xcodeproj.
+- **Android:** new `features/courses/settings/CourseSettingsHostScreen.kt`,
+  `CourseGeneralSettingsScreen.kt`, `CourseHeroImageEditor.kt`; `core/lms/LmsApi.kt`,
+  `core/lms/LmsCourseModels.kt`; drawer entry via M0.5; reuse write queue.
+
+## 13. Dependencies & Sequencing
+
+- After [M0.5](../completed/mobile/M0.5-redesign-information-architecture.md) (drawer/Teach
+  context) and [M0.2](../completed/mobile/M0.2-offline-sync.md) (queued writes). Ships first in
+  M13; M13.2–M13.12 reuse this shell.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Settings shown to unauthorized users | L | H | Gate UI + server-check every write; redirect route |
+| Offline save conflicts with a web edit | M | M | Last-write reconcile with a conflict notice; refetch on save |
+| Hero generation cost/abuse | M | M | Server-side model + rate limits; confirm before generate |
+| Schedule mode confusion (fixed vs relative) | M | M | Segmented control + inline explanation, mirror web copy |
+
+## 15. Rollout Plan
+
+- Flag: `mobile_course_settings` (default off). Internal → instructor pilot → GA.
+- Sequence: shell + gate → General fields → hero image → theme editor.
+- Rollback: flag removes the drawer entry and route.
+
+## 16. Test Plan
+
+- **Unit** — dirty detection; title/home validation; ISO-duration parse/format; tz payload.
+- **Integration** — PUT course; hero upload/generate/reposition; theme patch.
+- **E2E** — staff edits title + publishes; sets content-page home; offline edit → sync;
+  non-staff blocked.
+- **Security** — permission gate; server scope; upload type/size limits.
+- **Accessibility** — VoiceOver/TalkBack pass on the form and hero sheet.
+
+## 17. Documentation & Training
+
+- Instructor help-center: "Edit course settings on mobile" (general, schedule, hero, home).
+- Note that advanced sections appear only when their feature is enabled.
+
+## 18. Open Questions
+
+1. Do we surface relative-schedule editing on mobile v1, or fixed-only with a link-out?
+2. Should the reading-theme custom editor be full parity or preset-only on phones?
+3. Exact permission string vs. `courseItemCreatePermission` for co-teachers/TAs.
+
+## 19. References
+
+- Web: `pages/lms/course-settings.tsx`, `components/layout/side-nav-course-settings-links.tsx`,
+  `lib/courses-api.ts`, `lib/markdown-theme.ts`, `lib/hero-image-position.ts`.
+- Related: [M13.2](./M13.2-course-features-tools.md) … [M13.12](./M13.12-course-archived-content.md),
+  [M0.5](../completed/mobile/M0.5-redesign-information-architecture.md).
+</content>

--- a/docs/plan/mobile/M13.10-course-import-export.md
+++ b/docs/plan/mobile/M13.10-course-import-export.md
@@ -1,0 +1,136 @@
+# M13.10 — Course Import / Export & Backup (Mobile)
+
+> Implementation plan. Source: web `pages/lms/course-export-import-section.tsx` (settings
+> **Import / export** tab). Follows [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M13.10 |
+| **Section** | M13 — Course Settings & Configuration |
+| **Severity** | MINOR — course JSON backup/restore is desktop-only; a mobile instructor can't download a backup or restore from one |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING — web Import/export tab downloads the course as JSON and restores from a backup; mobile has none |
+| **Estimated effort** | S (1w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — course export/import endpoints exist (`reports/{type}/export` and the course import endpoint) |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M13.1](./M13.1-course-settings-general.md) (settings shell) |
+| **Unblocks** | On-the-go backup/restore |
+
+## 1. Problem Statement
+
+The **Import / export** tab downloads the full course as a JSON backup and restores a course
+from a backup file. On mobile there's no way to grab a backup before a risky change or restore
+one, so this safety net is laptop-only. Full authoring imports (QTI, Common Cartridge, Canvas)
+remain desktop-bound; this story covers the course's own JSON backup/restore.
+
+## 2. Goals
+
+- **Export** the course as a JSON backup and save/share it via the OS share sheet / Files.
+- **Import/restore** a course from a JSON backup file chosen from the device.
+- Clear warnings and confirmation before a restore overwrites content.
+
+## 3. Non-Goals
+
+- No QTI / Common Cartridge / Canvas import (desktop-bound authoring — link-out).
+- No cross-course content copy tooling (web).
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I download a JSON backup of my course before making big edits.
+- **As an instructor**, I restore a course from a backup file I saved to my phone.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST export the course as JSON via the export endpoint and hand off to the OS share
+  sheet / Files app.
+- **FR-2.** MUST let the user pick a JSON backup from the device and import/restore it, with an
+  explicit confirmation describing the effect.
+- **FR-3.** MUST show progress and success/error states; large files handled gracefully.
+- **FR-4.** MUST link out to the web for QTI/CC/Canvas imports with a "best on a larger screen"
+  affordance.
+- **FR-5.** MUST be staff-gated via the M13.1 shell.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — export streams; import shows progress; avoid loading huge JSON fully in memory.
+- **Security** — server enforces course scope + permission; imported files validated server-side.
+- **Privacy & Compliance** — backups may contain student-authored content; warn before sharing.
+- **Accessibility** — file pickers and confirmations labeled; ≥44 pt.
+- **Reliability** — import is transactional server-side; partial failures reported clearly.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* Export, *Then* a JSON backup is produced and offered to the share sheet.
+- **AC-2.** *Given* a chosen backup, *When* Import is confirmed, *Then* the course restores and a
+  result summary shows.
+- **AC-3.** *Given* an invalid file, *Then* a clear error shows and nothing changes.
+- **AC-4.** *Given* a QTI/CC import intent, *Then* the user is guided to web.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. No offline queue for these (network-dependent, large payloads).
+
+## 9. API Surface
+
+- Export via `POST/GET /api/v1/courses/{code}/reports/{report_type}/export` (JSON backup) and the
+  course import/restore endpoint. Verify exact routes/shapes vs. the web import/export section.
+
+## 10. UI / UX
+
+- Two actions: Export (→ share sheet) and Import (→ document picker → confirm → progress → result).
+- A note + link-out card for QTI/Common Cartridge/Canvas imports.
+- States: idle, exporting, importing (progress), success summary, error.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Courses/Settings/CourseImportExportView.swift`; API in
+  `Core/LMS/LMSAPICourses.swift`; use `UIDocumentPicker` + share sheet.
+- **Android:** `features/courses/settings/CourseImportExportScreen.kt`; Storage Access Framework
+  (`ACTION_OPEN_DOCUMENT` / `ACTION_CREATE_DOCUMENT`); `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M13.1](./M13.1-course-settings-general.md).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Restore overwrites live content | M | H | Explicit confirm + summary; server transactional; recommend export first |
+| Large backups OOM on device | M | M | Stream to/from disk; size guidance |
+| Sharing a backup leaks student PII | M | M | Warn before share; note contents |
+
+## 15. Rollout Plan
+
+- Under `mobile_course_settings`. Internal → pilot → GA.
+- Rollback: flag hides the section.
+
+## 16. Test Plan
+
+- **Unit** — file-pick handling; error mapping.
+- **Integration** — export produces valid JSON; import restores; invalid-file path.
+- **E2E** — export → save → import → course restored; QTI intent → link-out.
+- **Security** — permission + scope; server-side validation of uploads.
+
+## 17. Documentation & Training
+
+- Instructor help-center: "Back up and restore a course on mobile" (+ what backups contain).
+
+## 18. Open Questions
+
+1. Exact export report type / import endpoint shapes to confirm.
+2. Max file size we support on-device before requiring web.
+
+## 19. References
+
+- Web: `pages/lms/course-export-import-section.tsx`.
+- Related: [M13.1](./M13.1-course-settings-general.md).
+</content>

--- a/docs/plan/mobile/M13.11-course-blueprint-sync.md
+++ b/docs/plan/mobile/M13.11-course-blueprint-sync.md
@@ -1,0 +1,132 @@
+# M13.11 — Course Blueprint (Curriculum Sync) (Mobile)
+
+> Implementation plan. Source: web `pages/lms/course-blueprint-settings.tsx` (settings
+> **Blueprint** tab). Follows [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M13.11 |
+| **Section** | M13 — Course Settings & Configuration |
+| **Severity** | MINOR — district curriculum blueprint linking + push sync is desktop-only |
+| **Markets** | K12 / HE |
+| **Status (today)** | MISSING — web Blueprint tab links child courses, pushes structural updates, and reviews sync history; mobile has none |
+| **Estimated effort** | S (1w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — `GET/POST/PATCH/DELETE /api/v1/courses/{code}/blueprint` exist |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M13.1](./M13.1-course-settings-general.md) (settings shell) |
+| **Unblocks** | On-the-go visibility/control of district curriculum sync |
+
+## 1. Problem Statement
+
+A district **blueprint** course links child courses and pushes structural updates to them, with
+a sync history for auditing. This is web-only, so a curriculum lead can't see linked children,
+trigger a push, or review sync results from a phone. Given pushes affect many courses, at least
+**visibility + a guarded push** on mobile is valuable.
+
+## 2. Goals
+
+- **View** blueprint status: whether this course is a blueprint or child, and linked children.
+- **Link/unlink** child courses (guarded).
+- **Push** structural updates to children (with confirmation) and review **sync history**.
+
+## 3. Non-Goals
+
+- No content authoring of the blueprint itself (modules/items — web).
+- No cross-district sharing config (admin — consortium/M14).
+
+## 4. Personas & User Stories
+
+- **As a curriculum lead**, I check which sections are linked to a blueprint from my phone.
+- **As a curriculum lead**, I push an approved structural update to child courses.
+- **As a curriculum lead**, I review the last sync to confirm it applied cleanly.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST show blueprint state (blueprint/child) and the list of linked children.
+- **FR-2.** MUST link/unlink children via the blueprint endpoints, guarded with confirmation.
+- **FR-3.** MUST trigger a **push** with an explicit confirmation and show progress/result.
+- **FR-4.** MUST show **sync history** read-only.
+- **FR-5.** MUST show empty/loading/error/offline states; pushes require connectivity.
+- **FR-6.** MUST be staff-gated via the M13.1 shell.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — status < 800 ms p95; history paginates.
+- **Security** — server enforces blueprint scope + permission; pushes authorized server-side.
+- **Reliability** — push is idempotent/queued server-side; result surfaced clearly.
+- **Accessibility** — child list + history labeled; ≥44 pt.
+- **Internationalization** — timestamps localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a blueprint course, *Then* linked children and state render.
+- **AC-2.** *Given* a push confirmed, *Then* it runs and the result/history updates.
+- **AC-3.** *Given* link/unlink, *Then* the child list updates and is reversible.
+- **AC-4.** *Given* offline, *Then* push is disabled with a clear reason; read views show cache.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Cache blueprint status + children + history (read-only offline).
+
+## 9. API Surface
+
+- `GET /api/v1/courses/{code}/blueprint`, `POST` (link/push), `PATCH`, `DELETE` (unlink).
+  Verify exact semantics vs. the web blueprint section.
+
+## 10. UI / UX
+
+- Status header (blueprint/child) → children list (link/unlink) → Push action (confirm →
+  progress) → Sync history list.
+- States: not-a-blueprint (info), loading, error, offline (push disabled).
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Courses/Settings/CourseBlueprintSettingsView.swift`; API in
+  `Core/LMS/LMSAPICourses.swift`.
+- **Android:** `features/courses/settings/CourseBlueprintSettingsScreen.kt`; `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M13.1](./M13.1-course-settings-general.md).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Accidental push overwrites child edits | M | H | Explicit confirm + summary of what pushes; server rules; history/undo where available |
+| Unlink strands children | L | M | Confirm; reversible; server validates |
+
+## 15. Rollout Plan
+
+- Under `mobile_course_settings`. Internal → curriculum-lead pilot → GA.
+- Rollback: flag hides the section.
+
+## 16. Test Plan
+
+- **Unit** — state parsing; gating; offline-disable push.
+- **Integration** — link/unlink; push; history fetch.
+- **E2E** — link child → push → history shows result; offline read.
+- **Security** — permission + blueprint scope.
+
+## 17. Documentation & Training
+
+- Curriculum-admin help-center: "Manage a blueprint and push updates on mobile."
+
+## 18. Open Questions
+
+1. Is push safe to expose on mobile, or view + history only with push on web?
+2. Exact push/sync-history payload shapes.
+
+## 19. References
+
+- Web: `pages/lms/course-blueprint-settings.tsx`.
+- Related: [M13.1](./M13.1-course-settings-general.md).
+</content>

--- a/docs/plan/mobile/M13.12-course-archived-content.md
+++ b/docs/plan/mobile/M13.12-course-archived-content.md
@@ -1,0 +1,126 @@
+# M13.12 — Course Archived Content (Mobile)
+
+> Implementation plan. Source: web `pages/lms/course-archived-content-section.tsx` (settings
+> **Archived** tab). Follows [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M13.12 |
+| **Section** | M13 — Course Settings & Configuration |
+| **Severity** | MINOR — archived module items can't be reviewed or restored on mobile |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING — web Archived tab lists module items archived from the outline and restores them; mobile has none |
+| **Estimated effort** | XS (≤1d) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — course archived-content list + restore endpoints exist |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M13.1](./M13.1-course-settings-general.md) (settings shell) |
+| **Unblocks** | Restoring accidentally-archived items on the go |
+
+## 1. Problem Statement
+
+When an instructor archives a module item from the outline, it lands in the course's **Archived**
+list and can be restored. On mobile there's no archived view, so an item archived by mistake
+(easy to do on a small screen) can't be recovered until the instructor is at a computer.
+
+## 2. Goals
+
+- **List** archived module items for the course with type and archived-at metadata.
+- **Restore** an archived item back into the outline.
+- Show an empty state when nothing is archived.
+
+## 3. Non-Goals
+
+- No permanent deletion here (mirror web behavior; deletion, if any, is separate/guarded).
+- No archiving flow itself (that lives in the module outline / M3 stories).
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I restore a page I archived by accident from my phone.
+- **As an instructor**, I review what's archived before cleaning up a course.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST list archived items (title, type, archived date), paginated if long.
+- **FR-2.** MUST restore an item via the restore endpoint and reflect it live (item leaves the
+  archived list and returns to the outline).
+- **FR-3.** MUST show empty/loading/error/offline states; restore queues offline (M0.2).
+- **FR-4.** MUST be staff-gated via the M13.1 shell.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — list < 600 ms p95.
+- **Security** — server enforces course scope + permission.
+- **Accessibility** — list rows + restore action labeled; ≥44 pt.
+- **Internationalization** — dates localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* archived items, *Then* they list with type + date.
+- **AC-2.** *Given* Restore, *Then* the item returns to the outline and leaves the archived list.
+- **AC-3.** *Given* nothing archived, *Then* an empty state shows.
+- **AC-4.** *Given* offline, *Then* restore queues and syncs.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Cache archived list per course; queue restore writes (M0.2).
+
+## 9. API Surface
+
+- Reuse the course archived-content list + restore endpoints. Verify shapes vs. the web archived
+  section.
+
+## 10. UI / UX
+
+- Simple list of archived items, each with a Restore button; confirm on restore.
+- States: empty (nothing archived), loading, error, offline pending.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Courses/Settings/CourseArchivedContentView.swift`; API in
+  `Core/LMS/LMSAPICourses.swift`; reuse M3 outline models.
+- **Android:** `features/courses/settings/CourseArchivedContentScreen.kt`; `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M13.1](./M13.1-course-settings-general.md). Smallest M13 story — good first landing.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Restore places item unexpectedly in the outline | L | M | Mirror web placement rules; show where it landed |
+
+## 15. Rollout Plan
+
+- Under `mobile_course_settings`. Internal → pilot → GA.
+- Rollback: flag hides the section.
+
+## 16. Test Plan
+
+- **Unit** — list mapping; restore optimistic update.
+- **Integration** — archived list; restore.
+- **E2E** — restore item → appears in outline; offline queue.
+- **Security** — permission + scope.
+
+## 17. Documentation & Training
+
+- Instructor help-center: "Restore archived course items on mobile."
+
+## 18. Open Questions
+
+1. Does web allow permanent delete from here? If so, do we mirror it (guarded) or omit on mobile?
+2. Exact archived-content endpoint shape.
+
+## 19. References
+
+- Web: `pages/lms/course-archived-content-section.tsx`.
+- Related: [M13.1](./M13.1-course-settings-general.md).
+</content>

--- a/docs/plan/mobile/M13.2-course-features-tools.md
+++ b/docs/plan/mobile/M13.2-course-features-tools.md
@@ -1,0 +1,139 @@
+# M13.2 — Course Features, Tools & Caption Policy (Mobile)
+
+> Implementation plan. Source: web `pages/lms/course-features-section.tsx`,
+> `course-caption-policy-section.tsx`, `course-consortium-settings-section.tsx` (settings
+> **Features** tab). Follows [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M13.2 |
+| **Section** | M13 — Course Settings & Configuration |
+| **Severity** | MAJOR — instructors can't turn course tools on/off on mobile, so the course menu can't be tailored (e.g., enable Discussions, Groups, Sections) away from a laptop |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING — web Features tab toggles tools + caption policy + consortium; mobile has none |
+| **Estimated effort** | S (1w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — `PATCH /api/v1/courses/{code}/features`, `PATCH /api/v1/courses/{code}/caption-policy`, and consortium endpoints exist |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M13.1](./M13.1-course-settings-general.md) (settings shell) |
+| **Unblocks** | [M13.3](./M13.3-course-sections-cross-listing.md) (Sections toggle lives here) |
+
+## 1. Problem Statement
+
+The **Features** tab controls which course tools appear in the course menu (discussions,
+groups, sections, live, etc.), the course's **caption policy** for media, and — where enabled —
+**consortium sharing**. None of this is editable on mobile, so an instructor can't shape the
+course experience from a phone. Because the **Sections** feature toggle lives here, M13.3 is
+blocked until this ships.
+
+## 2. Goals
+
+- A **Features** section listing each course tool with an on/off toggle and a short description,
+  matching the web's tool list, persisted via the features endpoint.
+- A **Caption policy** control (media caption requirement level) editable and saved.
+- A **Consortium sharing** panel when the `ffConsortiumSharing` flag is on.
+- Immediate reflection of toggles in the course drawer/menu.
+
+## 3. Non-Goals
+
+- No creation of the underlying tool content (that's each tool's own story).
+- No platform-level feature definitions (admin — M14.6).
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I enable Discussions and Groups for my course from my phone.
+- **As an instructor**, I require captions on uploaded media via the caption policy.
+- **As a consortium lead**, I share/unshare the course with partner orgs (flag on).
+
+## 5. Functional Requirements
+
+- **FR-1.** The section MUST list course tools with toggles + descriptions and persist changes
+  via `PATCH /api/v1/courses/{code}/features`, reflecting them in the drawer immediately.
+- **FR-2.** MUST expose the **caption policy** control and persist via the caption-policy PATCH.
+- **FR-3.** MUST show the **consortium** panel only when `ffConsortiumSharing` is enabled.
+- **FR-4.** MUST show save/saving/saved/error states and queue writes offline (M0.2).
+- **FR-5.** MUST be gated to staff with course settings permission (via M13.1 shell).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — toggle save < 600 ms p95; optimistic UI with rollback on failure.
+- **Security** — server enforces course scope + permission on each PATCH.
+- **Accessibility** — toggles announce state and label; ≥44 pt; Dynamic Type.
+- **Reliability** — idempotent PATCH; optimistic updates roll back on error.
+- **Internationalization** — tool names/descriptions localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* the Features section, *When* a tool is toggled on, *Then* it persists and
+  the course drawer shows the tool.
+- **AC-2.** *Given* a caption policy change, *Then* it saves and applies to new media uploads.
+- **AC-3.** *Given* `ffConsortiumSharing` off, *Then* the consortium panel is absent.
+- **AC-4.** *Given* offline, *Then* toggles queue and sync; UI reflects pending state.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Cache the course feature map; queue PATCH writes (M0.2).
+
+## 9. API Surface
+
+- `PATCH /api/v1/courses/{code}/features`, `PATCH /api/v1/courses/{code}/caption-policy`,
+  consortium settings endpoints. Verify shapes vs. the web feature/caption/consortium sections.
+
+## 10. UI / UX
+
+- A grouped list of toggle rows (tool name, description, switch). Caption policy as a segmented
+  control or picker. Consortium as a separate card (flagged).
+- States: loading, error with retry, offline pending badge on rows.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Courses/Settings/CourseFeaturesSettingsView.swift`; API in
+  `Core/LMS/LMSAPICourses.swift`; drawer refresh hook. Reuse M13.1 scaffold.
+- **Android:** `features/courses/settings/CourseFeaturesSettingsScreen.kt`; `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M13.1](./M13.1-course-settings-general.md). Ships before
+  [M13.3](./M13.3-course-sections-cross-listing.md) (which needs the Sections toggle).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Toggling a tool off hides existing content confusingly | M | M | Confirm on disable; explain effect; reversible |
+| Drawer/menu out of sync after toggle | M | L | Invalidate nav cache on save |
+
+## 15. Rollout Plan
+
+- Under `mobile_course_settings`. Internal → instructor pilot → GA.
+- Rollback: flag hides the settings area.
+
+## 16. Test Plan
+
+- **Unit** — feature-map diff; optimistic rollback.
+- **Integration** — features PATCH; caption-policy PATCH; consortium flag gating.
+- **E2E** — enable a tool → appears in drawer; offline toggle → sync.
+- **Security** — permission + scope on PATCH.
+
+## 17. Documentation & Training
+
+- Instructor help-center: "Turn course tools on or off, and set your caption policy, on mobile."
+
+## 18. Open Questions
+
+1. Which tools are safe to toggle from mobile vs. desktop-only (e.g., ones needing extra config)?
+2. Caption policy levels and their exact values to mirror.
+
+## 19. References
+
+- Web: `pages/lms/course-features-section.tsx`, `course-caption-policy-section.tsx`,
+  `course-consortium-settings-section.tsx`.
+- Related: [M13.1](./M13.1-course-settings-general.md), [M13.3](./M13.3-course-sections-cross-listing.md).
+</content>

--- a/docs/plan/mobile/M13.3-course-sections-cross-listing.md
+++ b/docs/plan/mobile/M13.3-course-sections-cross-listing.md
@@ -1,0 +1,143 @@
+# M13.3 — Course Sections & Cross-Listing (Mobile)
+
+> Implementation plan. Source: web `pages/lms/course-sections-settings.tsx`,
+> `course-cross-listing-settings.tsx` (settings **Sections** tab). Follows
+> [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M13.3 |
+| **Section** | M13 — Course Settings & Configuration |
+| **Severity** | MAJOR — multi-section teachers can't manage sections, rosters, or per-section due dates on mobile; cross-listing is desktop-only |
+| **Markets** | K12 / HE |
+| **Status (today)** | MISSING — web Sections tab manages sections + per-section overrides + cross-listing; mobile has none |
+| **Estimated effort** | M (2–4w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — `/api/v1/sections` (list/create/update) and cross-listing endpoints exist; requires `sectionsEnabled` on the course |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M13.1](./M13.1-course-settings-general.md), [M13.2](./M13.2-course-features-tools.md) (Sections toggle), [M11.4 Course People](./M11.4-course-people-roster.md) (roster reuse) |
+| **Unblocks** | Per-section due-date overrides visible/editable on mobile |
+
+## 1. Problem Statement
+
+Teaching sections (rosters, meeting groupings, and per-section assignment due-date overrides)
+and cross-listing (combining enrollments across courses) are configured only on the web. A
+teacher managing several sections from a phone can't create a section, move students, or set a
+section's due dates — the daily reality of K-12 and large HE courses.
+
+## 2. Goals
+
+- A **Sections** screen to create/rename sections and see each section's roster count.
+- **Per-section assignment due-date overrides** viewable and editable.
+- **Roster management** (assign/move students to a section) reusing M11.4 people components.
+- **Cross-listing** view (link/unlink child course sections), respecting course scope.
+- Correct gating: the screen requires the course's **Sections** feature enabled (M13.2).
+
+## 3. Non-Goals
+
+- No SIS-driven section provisioning (admin/integration — web).
+- No bulk CSV import of section rosters (web).
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I create a "Period 3" section and add students to it.
+- **As an instructor**, I give one section a later due date for an assignment.
+- **As a department lead**, I cross-list two lab sections into one course.
+
+## 5. Functional Requirements
+
+- **FR-1.** The screen MUST list sections with rosters; if the course's Sections feature is off,
+  MUST show guidance to enable it in Features (M13.2) and no editing controls.
+- **FR-2.** MUST create/rename sections via the sections endpoints and reflect changes live.
+- **FR-3.** MUST show per-section assignment **due-date overrides** and allow editing them.
+- **FR-4.** MUST allow assigning/moving a student to a section (reuse M11.4 roster).
+- **FR-5.** MUST surface **cross-listing** (link/unlink), scope-checked, with clear warnings.
+- **FR-6.** MUST show empty/loading/error/offline states; writes queue offline (M0.2).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — section list < 700 ms p95; roster paginates.
+- **Security** — server enforces course/section scope on every write.
+- **Privacy & Compliance** — FERPA: only in-scope roster; no cross-section leakage; no PII in logs.
+- **Accessibility** — roster rows and date pickers screen-reader operable; ≥44 pt.
+- **Reliability** — override edits are idempotent; cross-listing changes confirm before applying.
+- **Internationalization** — due dates in course time zone; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* Sections enabled, *When* a section is created, *Then* it persists and appears.
+- **AC-2.** *Given* an assignment, *When* a section due-date override is set, *Then* students in
+  that section see the overridden date.
+- **AC-3.** *Given* Sections disabled, *Then* the screen prompts to enable it and shows no editors.
+- **AC-4.** *Given* a cross-list action, *Then* it confirms, applies, and is reversible.
+- **AC-5.** *Given* offline, *Then* writes queue and sync.
+- **AC-6.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Cache section list + overrides per course; queue writes (M0.2).
+
+## 9. API Surface
+
+- Reuse `/api/v1/sections` (GET/POST/PUT) and cross-listing endpoints; per-section due-date
+  overrides via the assignment/section override endpoints. Verify shapes vs. the web sections
+  component when implementing.
+
+## 10. UI / UX
+
+- Sections list (name + roster count) → section detail (roster, due-date overrides).
+- Roster uses M11.4 rows; add/move via a picker sheet.
+- Cross-listing as a distinct card with explicit link/unlink confirmations.
+- States: disabled-gate, loading, error, offline.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Courses/Settings/CourseSectionsSettingsView.swift`,
+  `CourseCrossListingView.swift`; API in `Core/LMS/LMSAPICourses.swift`; reuse M11.4 roster views.
+- **Android:** `features/courses/settings/CourseSectionsSettingsScreen.kt`,
+  `CourseCrossListingScreen.kt`; `core/lms/LmsApi.kt`; reuse M11.4 roster.
+
+## 13. Dependencies & Sequencing
+
+- After [M13.2](./M13.2-course-features-tools.md) (enable toggle) and
+  [M11.4](./M11.4-course-people-roster.md) (roster).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Cross-listing merges rosters destructively | L | H | Confirm + reversible; server validates scope |
+| Override date confusion across time zones | M | M | Show course tz; preview effective date |
+
+## 15. Rollout Plan
+
+- Under `mobile_course_settings`. Internal → multi-section pilot → GA.
+- Rollback: flag hides the settings area.
+
+## 16. Test Plan
+
+- **Unit** — override payload; gating when sections disabled.
+- **Integration** — create/rename section; set override; cross-list link/unlink.
+- **E2E** — create section → assign student → set section due date; offline queue.
+- **Security** — scope checks; FERPA roster boundaries.
+
+## 17. Documentation & Training
+
+- Instructor help-center: "Manage sections and per-section due dates on mobile."
+
+## 18. Open Questions
+
+1. Is cross-listing common enough to warrant full mobile editing, or view + link-out only?
+2. Exact per-section due-date override endpoint/shape to confirm.
+
+## 19. References
+
+- Web: `pages/lms/course-sections-settings.tsx`, `course-cross-listing-settings.tsx`.
+- Related: [M13.2](./M13.2-course-features-tools.md), [M11.4](./M11.4-course-people-roster.md).
+</content>

--- a/docs/plan/mobile/M13.4-course-grading-settings.md
+++ b/docs/plan/mobile/M13.4-course-grading-settings.md
@@ -1,0 +1,134 @@
+# M13.4 — Course Grading Settings (Mobile)
+
+> Implementation plan. Source: web `pages/lms/course-grading-settings.tsx` (settings **Grading**
+> tab). Follows [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M13.4 |
+| **Section** | M13 — Course Settings & Configuration |
+| **Severity** | MAJOR — grading scale and weighted assignment groups define how every grade is computed; instructors can't set or fix them on mobile |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING — web Grading tab manages grading scale, weighted groups, and item→group mapping; mobile has none |
+| **Estimated effort** | M (2–4w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — grading-scheme / assignment-group endpoints exist |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M13.1](./M13.1-course-settings-general.md) (settings shell), [M6.1 Grades](../completed/mobile/M6.1-grades-feedback.md) (grade context) |
+| **Unblocks** | Correct mobile grade display when groups/weights change |
+
+## 1. Problem Statement
+
+A course's **grading scale** (letter/percent bands) and **weighted assignment groups** (e.g.,
+Homework 20%, Exams 50%) determine how grades are computed and displayed everywhere. On mobile
+an instructor can view grades but cannot define or adjust the scale, the groups, their weights,
+or which items belong to each group — so setting up or correcting grading requires a laptop.
+
+## 2. Goals
+
+- Edit the **grading scale**: named bands with min/max thresholds.
+- Manage **weighted assignment groups**: create/rename/delete, set weights (validate to 100%).
+- Map **items → groups** (assign each assignment/quiz to a group).
+- Reflect changes in the mobile grades views (M6.1 what-if honors weights).
+
+## 3. Non-Goals
+
+- No gradebook grid editing, curving, or CSV import/export (web/admin).
+- No per-student grade overrides here (that's grading/SpeedGrader).
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I set Exams to 50% and Homework to 20% from my phone.
+- **As an instructor**, I create a "Labs" group and assign three labs to it.
+- **As an instructor**, I define a custom A/B/C band scale for the course.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST edit grading-scale bands (label, lower bound) and persist; validate ordering.
+- **FR-2.** MUST create/rename/delete assignment groups and set weights, warning when weights
+  don't sum to 100%.
+- **FR-3.** MUST map items to groups and persist; unmapped items handled per web behavior.
+- **FR-4.** MUST show save/saving/saved/error states and queue writes offline (M0.2).
+- **FR-5.** MUST be gated to staff via the M13.1 shell.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — settings load < 700 ms p95; weight edits update totals live.
+- **Security** — server enforces course scope + permission on writes.
+- **Accessibility** — numeric inputs labeled; weight total announced; ≥44 pt.
+- **Reliability** — idempotent writes; validation client- and server-side.
+- **Internationalization** — number/percent formatting localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* groups summing to <100%, *Then* a warning shows before/after save.
+- **AC-2.** *Given* a new band added out of order, *Then* validation blocks or reorders it.
+- **AC-3.** *Given* an item mapped to a group, *Then* the grades view reflects the new weight.
+- **AC-4.** *Given* offline edits, *Then* they queue and sync.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Cache scale + groups + mapping per course; queue writes (M0.2).
+
+## 9. API Surface
+
+- Reuse grading-scheme and assignment-group endpoints (see `grading_scheme.go` and the web
+  grading settings component). Verify exact routes/shapes when implementing.
+
+## 10. UI / UX
+
+- Three cards: Grading scale (band list editor), Assignment groups (group list with weight
+  fields + running total), Item mapping (grouped picker).
+- States: loading, error with retry, offline pending, weight-total warning banner.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Courses/Settings/CourseGradingSettingsView.swift`; API in
+  `Core/LMS/LMSAPIGrading.swift`; reuse M6.1 grade models.
+- **Android:** `features/courses/settings/CourseGradingSettingsScreen.kt`; `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M13.1](./M13.1-course-settings-general.md); coordinate with
+  [M6.1](../completed/mobile/M6.1-grades-feedback.md) so what-if honors group weights.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Weight edits silently change all grades | M | H | Show impact preview; confirm; server validates |
+| Band ordering errors | M | M | Client + server validation with clear messages |
+
+## 15. Rollout Plan
+
+- Under `mobile_course_settings`. Internal → instructor pilot → GA.
+- Rollback: flag hides the settings area.
+
+## 16. Test Plan
+
+- **Unit** — weight sum/validation; band ordering; mapping diff.
+- **Integration** — scale save; group CRUD; item mapping.
+- **E2E** — set weights → grades reflect; offline edit → sync.
+- **Security** — permission + scope on writes.
+
+## 17. Documentation & Training
+
+- Instructor help-center: "Set your grading scale and weighted groups on mobile."
+
+## 18. Open Questions
+
+1. Exact grading-scheme + assignment-group endpoint shapes to confirm.
+2. Should item mapping be full editing on mobile or view + reorder only?
+
+## 19. References
+
+- Web: `pages/lms/course-grading-settings.tsx`. Server: `grading_scheme.go`.
+- Related: [M13.1](./M13.1-course-settings-general.md), [M6.1](../completed/mobile/M6.1-grades-feedback.md).
+</content>

--- a/docs/plan/mobile/M13.5-course-outcomes-settings.md
+++ b/docs/plan/mobile/M13.5-course-outcomes-settings.md
@@ -1,0 +1,136 @@
+# M13.5 — Course Outcomes Settings (Mobile)
+
+> Implementation plan. Source: web `pages/lms/course-outcomes-section.tsx` (settings **Outcomes**
+> tab). Follows [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M13.5 |
+| **Section** | M13 — Course Settings & Configuration |
+| **Severity** | MAJOR — learning outcomes and their mappings drive standards-based grading and mastery; instructors can't define or map them on mobile |
+| **Markets** | K12 / HE |
+| **Status (today)** | MISSING — web Outcomes tab defines outcomes, maps items/questions, and reviews class progress; mobile has none (students see mastery via M6.2, but staff can't configure) |
+| **Estimated effort** | M (2–4w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — `GET/POST/PUT/PATCH/DELETE /api/v1/courses/{code}/outcomes` and `/sub-outcomes` exist |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M13.1](./M13.1-course-settings-general.md), [M6.2 Standards & Mastery](../completed/mobile/M6.2-standards-mastery.md) (student view) |
+| **Unblocks** | Instructor-side outcomes configuration on mobile |
+
+## 1. Problem Statement
+
+Learning outcomes — and the mapping of assignments, quizzes, and individual questions to them
+with measurement/intensity levels — are the backbone of standards-based grading and the mastery
+views students already see on mobile (M6.2). Instructors can only define and map them on the
+web, so an outcome can't be added or corrected from a phone, and class-progress review is
+laptop-bound.
+
+## 2. Goals
+
+- **CRUD outcomes** (and sub-outcomes) with title/description and measurement/intensity levels.
+- **Map** assignments, quizzes, and individual questions to outcomes.
+- **Review class progress** per outcome (from grades + attempts) read-only.
+- Feed the same data students see in M6.2 mastery.
+
+## 3. Non-Goals
+
+- No district/standards-framework authoring or import (admin/web).
+- No editing of the standards catalog itself (web).
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I add an outcome and map a quiz question to it from my phone.
+- **As an instructor**, I set an outcome's measurement/intensity level.
+- **As an instructor**, I review which outcomes the class is behind on.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST create/edit/delete outcomes and sub-outcomes via the outcomes endpoints.
+- **FR-2.** MUST map items (assignments/quizzes/questions) to outcomes with measurement +
+  intensity levels, mirroring web semantics.
+- **FR-3.** MUST show a read-only **class progress** view per outcome.
+- **FR-4.** MUST show save/saving/saved/error states; queue writes offline (M0.2).
+- **FR-5.** MUST be staff-gated via the M13.1 shell.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — outcomes list < 700 ms p95; progress aggregates lazy-loaded.
+- **Security** — server enforces course scope + permission.
+- **Privacy & Compliance** — FERPA: class-progress data stays in scope; no PII in logs.
+- **Accessibility** — outcome mapping controls labeled; progress not color-only; ≥44 pt.
+- **Internationalization** — localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a new outcome, *When* saved, *Then* it appears and is mappable.
+- **AC-2.** *Given* a question mapped to an outcome, *Then* mastery (M6.2) reflects it.
+- **AC-3.** *Given* class progress, *Then* per-outcome status renders with text (not color-only).
+- **AC-4.** *Given* offline, *Then* edits queue and sync.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Cache outcomes + mappings + progress per course; queue writes (M0.2).
+
+## 9. API Surface
+
+- `GET/POST/PUT/PATCH/DELETE /api/v1/courses/{code}/outcomes`,
+  `POST /api/v1/courses/{code}/outcomes/{id}/sub-outcomes`; mapping + progress endpoints.
+  Verify shapes vs. the web outcomes section.
+
+## 10. UI / UX
+
+- Outcomes list → outcome detail (edit + mappings) → progress tab.
+- Mapping via a searchable item/question picker with measurement/intensity selectors.
+- States: empty (no outcomes), loading, error, offline pending.
+
+## 11. AI / ML Considerations
+
+- None (mapping is manual). If the web offers AI suggestions, defer to web for v1.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Courses/Settings/CourseOutcomesSettingsView.swift`; API in
+  `Core/LMS/LMSAPIOutcomes.swift`; reuse M6.2 mastery models.
+- **Android:** `features/courses/settings/CourseOutcomesSettingsScreen.kt`; `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M13.1](./M13.1-course-settings-general.md); pairs with
+  [M6.2](../completed/mobile/M6.2-standards-mastery.md).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Deleting an outcome orphans mappings | M | M | Confirm + cascade rules mirror web; reversible where possible |
+| Question-level mapping too fiddly on phones | M | M | Coarse map on mobile; deep map link-out if needed |
+
+## 15. Rollout Plan
+
+- Under `mobile_course_settings`. Internal → instructor pilot → GA.
+- Rollback: flag hides the settings area.
+
+## 16. Test Plan
+
+- **Unit** — outcome CRUD payloads; mapping diff.
+- **Integration** — outcomes endpoints; mapping; progress render.
+- **E2E** — add outcome → map question → mastery reflects; offline queue.
+- **Security** — permission + scope; FERPA on progress.
+
+## 17. Documentation & Training
+
+- Instructor help-center: "Define outcomes and map them to work on mobile."
+
+## 18. Open Questions
+
+1. How deep should question-level mapping go on a phone vs. link-out?
+2. Exact measurement/intensity vocab + progress endpoint shapes.
+
+## 19. References
+
+- Web: `pages/lms/course-outcomes-section.tsx`, `course-outcomes-report.tsx`.
+- Related: [M13.1](./M13.1-course-settings-general.md), [M6.2](../completed/mobile/M6.2-standards-mastery.md).
+</content>

--- a/docs/plan/mobile/M13.6-course-grading-agents.md
+++ b/docs/plan/mobile/M13.6-course-grading-agents.md
@@ -1,0 +1,132 @@
+# M13.6 — Course Grading Agents (Mobile)
+
+> Implementation plan. Source: web `pages/lms/course-grading-agents-section.tsx` (settings
+> **Grading agents** tab, flag `graderAgentEnabled`). Follows [../_TEMPLATE.md](../_TEMPLATE.md),
+> mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M13.6 |
+| **Section** | M13 — Course Settings & Configuration |
+| **Severity** | MINOR — AI grading agents are a power feature; instructors can't review/edit their config on mobile |
+| **Markets** | HE / SL / K12 |
+| **Status (today)** | MISSING — web Grading-agents tab (flagged) creates/edits agents; mobile SpeedGrader (`../speed-grader-mobile.md`) can grade but not configure agents |
+| **Estimated effort** | S (1w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — grading-agent config endpoints exist; gated by `graderAgentEnabled` |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M13.1](./M13.1-course-settings-general.md) (settings shell) |
+| **Unblocks** | On-the-go review of grading-agent config |
+
+## 1. Problem Statement
+
+Where the `graderAgentEnabled` flag is on, instructors configure AI **grading agents** per
+course (rubric prompts, which assignments they apply to). This is web-only, so an instructor
+can't review or tweak an agent — or spot a misconfiguration before a batch run — from a phone.
+
+## 2. Goals
+
+- **List** grading agents configured for the course with their target assignments.
+- **View/edit** an agent's configuration (name, instructions/rubric prompt, scope).
+- **Create** a new agent (parity with the web "Create" action) where practical on mobile.
+- Respect the `graderAgentEnabled` flag (section hidden when off).
+
+## 3. Non-Goals
+
+- No running/dry-running the agent here (that's SpeedGrader — see `../speed-grader-mobile.md`).
+- No choosing the underlying model (that's platform AI settings, M14.7).
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I review my essay-grading agent's rubric prompt before class.
+- **As an instructor**, I fix a typo in an agent's instructions from my phone.
+- **As an instructor**, I scope an agent to a specific assignment.
+
+## 5. Functional Requirements
+
+- **FR-1.** The section MUST appear only when `graderAgentEnabled`; otherwise absent.
+- **FR-2.** MUST list agents with scope; MUST open an agent for view/edit.
+- **FR-3.** MUST edit agent config (name, instructions, target assignments) and persist.
+- **FR-4.** SHOULD allow creating an agent (mirroring web's Create), or link-out if too complex.
+- **FR-5.** MUST show save/saving/saved/error states; queue writes offline (M0.2).
+- **FR-6.** MUST be staff-gated via the M13.1 shell.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — list < 700 ms p95.
+- **Security** — server enforces course scope + permission; agent prompts are course-scoped.
+- **Privacy & Compliance** — no student PII embedded in prompts persisted to logs.
+- **Accessibility** — long-text editors labeled and screen-reader operable; ≥44 pt.
+- **Internationalization** — localized chrome; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* the flag off, *Then* the section is absent.
+- **AC-2.** *Given* an agent edited, *When* saved, *Then* config persists and SpeedGrader uses it.
+- **AC-3.** *Given* offline, *Then* edits queue and sync.
+- **AC-4.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Cache agent list/config per course; queue writes (M0.2).
+
+## 9. API Surface
+
+- Reuse grading-agent config endpoints (see the web grading-agents section + grading-agent API).
+  Verify routes/shapes when implementing.
+
+## 10. UI / UX
+
+- Agents list → agent detail (form: name, instructions, scope). Create via a sheet.
+- States: empty (no agents), loading, error, offline pending.
+
+## 11. AI / ML Considerations
+
+- Config only; no inference on mobile. The model used comes from platform AI settings (M14.7).
+  Show which model/agent will run, but don't select it here.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Courses/Settings/CourseGradingAgentsView.swift`; API in
+  `Core/LMS/LMSAPIGrading.swift`.
+- **Android:** `features/courses/settings/CourseGradingAgentsScreen.kt`; `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M13.1](./M13.1-course-settings-general.md). Complements mobile SpeedGrader.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Editing prompts on a phone is error-prone | M | M | Large editor + preview; discard/undo; link-out for heavy edits |
+| Misconfig triggers bad batch grading | L | H | Config only here; running stays in SpeedGrader with confirmation |
+
+## 15. Rollout Plan
+
+- Under `mobile_course_settings` + `graderAgentEnabled`. Internal → pilot → GA.
+- Rollback: flag hides the section.
+
+## 16. Test Plan
+
+- **Unit** — agent config diff; flag gating.
+- **Integration** — list/edit/create agent.
+- **E2E** — edit agent → SpeedGrader run uses it; offline queue.
+- **Security** — permission + scope.
+
+## 17. Documentation & Training
+
+- Instructor help-center: "Review and edit grading agents on mobile."
+
+## 18. Open Questions
+
+1. Is create/edit worth full mobile parity, or view + link-out for authoring?
+2. Exact grading-agent config endpoint shapes.
+
+## 19. References
+
+- Web: `pages/lms/course-grading-agents-section.tsx`. Related: `../speed-grader-mobile.md`,
+  [M13.1](./M13.1-course-settings-general.md), [M14.7](./M14.7-ai-models-prompts-reports.md).
+</content>

--- a/docs/plan/mobile/M13.7-course-plagiarism-settings.md
+++ b/docs/plan/mobile/M13.7-course-plagiarism-settings.md
@@ -1,0 +1,131 @@
+# M13.7 — Course Plagiarism & AI-Authorship Settings (Mobile)
+
+> Implementation plan. Source: web `pages/lms/course-plagiarism-settings-section.tsx` (settings
+> **Plagiarism** tab, flag `ffPlagiarismChecks`). Follows [../_TEMPLATE.md](../_TEMPLATE.md),
+> mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M13.7 |
+| **Section** | M13 — Course Settings & Configuration |
+| **Severity** | MINOR — originality/AI-authorship checking is configured per course; instructors can't set provider or thresholds on mobile |
+| **Markets** | HE / K12 |
+| **Status (today)** | MISSING — web Plagiarism tab (flagged) sets provider + thresholds; mobile has none (students already see originality results via M5.x submissions) |
+| **Estimated effort** | S (1w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — `GET/PATCH /api/v1/courses/{code}/plagiarism` exist; gated by `ffPlagiarismChecks` |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M13.1](./M13.1-course-settings-general.md) (settings shell) |
+| **Unblocks** | On-the-go control of originality checking |
+
+## 1. Problem Statement
+
+Course-wide **plagiarism / AI-authorship** checking — whether it's on, which provider, and the
+alert thresholds — is configured only on the web (behind `ffPlagiarismChecks`). Instructors
+can't enable checking, switch providers, or tune sensitivity from a phone, even though students
+already see originality results in mobile submissions.
+
+## 2. Goals
+
+- **Toggle** plagiarism / AI-authorship checking for the course.
+- **Choose the provider** and set **alert thresholds**.
+- Persist via the plagiarism endpoints; hidden when the flag is off.
+
+## 3. Non-Goals
+
+- No provider account/credential setup (admin — platform integrations, M14.8).
+- No per-submission re-scan controls here (that's the submission view).
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I turn on originality checking for my essay course from my phone.
+- **As an instructor**, I raise the AI-authorship alert threshold to reduce false positives.
+
+## 5. Functional Requirements
+
+- **FR-1.** The section MUST appear only when `ffPlagiarismChecks`; otherwise absent.
+- **FR-2.** MUST load current settings via `GET /api/v1/courses/{code}/plagiarism` and edit
+  provider + thresholds, persisting via `PATCH`.
+- **FR-3.** MUST show save/saving/saved/error states; queue writes offline (M0.2).
+- **FR-4.** MUST be staff-gated via the M13.1 shell.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — load/save < 600 ms p95.
+- **Security** — server enforces course scope + permission.
+- **Privacy & Compliance** — clarify to instructors what is sent to the provider; no PII in logs.
+- **Accessibility** — provider/threshold controls labeled; ≥44 pt.
+- **Internationalization** — localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* the flag off, *Then* the section is absent.
+- **AC-2.** *Given* a provider/threshold change, *When* saved, *Then* it persists and applies.
+- **AC-3.** *Given* offline, *Then* edits queue and sync.
+- **AC-4.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Cache plagiarism config per course; queue writes (M0.2).
+
+## 9. API Surface
+
+- `GET /api/v1/courses/{code}/plagiarism`, `PATCH /api/v1/courses/{code}/plagiarism`.
+  Verify field shapes vs. the web plagiarism section.
+
+## 10. UI / UX
+
+- One card: enable toggle, provider picker, threshold sliders/inputs, and an explanatory note
+  about what's sent to the provider.
+- States: loading, error, offline pending.
+
+## 11. AI / ML Considerations
+
+- AI-authorship detection is provider-side. Present results as **signals, not proof**; mirror
+  the web's framing. No client model.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Courses/Settings/CoursePlagiarismSettingsView.swift`; API in
+  `Core/LMS/LMSAPICourses.swift`.
+- **Android:** `features/courses/settings/CoursePlagiarismSettingsScreen.kt`; `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M13.1](./M13.1-course-settings-general.md).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Over-trusting AI-authorship scores | M | H | "Signal not proof" framing; thresholds explained |
+| Enabling sends content to a third party unexpectedly | M | M | Clear consent/explanation copy before enabling |
+
+## 15. Rollout Plan
+
+- Under `mobile_course_settings` + `ffPlagiarismChecks`. Internal → pilot → GA.
+- Rollback: flag hides the section.
+
+## 16. Test Plan
+
+- **Unit** — config diff; flag gating.
+- **Integration** — GET/PATCH plagiarism.
+- **E2E** — enable + set threshold → persists; offline queue.
+- **Security** — permission + scope.
+
+## 17. Documentation & Training
+
+- Instructor help-center: "Configure originality checking on mobile" + a privacy note.
+
+## 18. Open Questions
+
+1. Exact provider list + threshold fields to mirror.
+2. Do we expose all providers on mobile, or the org default only?
+
+## 19. References
+
+- Web: `pages/lms/course-plagiarism-settings-section.tsx`.
+- Related: [M13.1](./M13.1-course-settings-general.md), [M14.8](./M14.8-integrations-provisioning-admin.md).
+</content>

--- a/docs/plan/mobile/M13.8-course-accessibility-review.md
+++ b/docs/plan/mobile/M13.8-course-accessibility-review.md
@@ -1,0 +1,133 @@
+# M13.8 — Course Accessibility (Alt-Text) Review (Mobile)
+
+> Implementation plan. Source: web `pages/lms/course-accessibility-settings.tsx` (settings
+> **Accessibility** tab, flag `altTextEnforcementEnabled`). Follows
+> [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M13.8 |
+| **Section** | M13 — Course Settings & Configuration |
+| **Severity** | MINOR — accessibility coverage review is desktop-only; instructors can't check or fix missing alt-text on mobile |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING — web Accessibility tab (flagged) reviews image alt-text coverage and flags gaps; mobile has none |
+| **Estimated effort** | S (1w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — accessibility/alt-text coverage endpoints exist; gated by `altTextEnforcementEnabled` |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M13.1](./M13.1-course-settings-general.md) (settings shell) |
+| **Unblocks** | Quick alt-text fixes on mobile; better WCAG posture |
+
+## 1. Problem Statement
+
+The **Accessibility** tab reviews image alt-text coverage across course content and points to
+items still needing accessibility updates (behind `altTextEnforcementEnabled`). On mobile an
+instructor can't see coverage or fix a missing alt-text, so an accessibility gap noticed on a
+phone waits until they're at a computer.
+
+## 2. Goals
+
+- A **coverage summary** (percent of images with alt-text) for the course.
+- A **list of items missing alt-text**, each linking to the content to fix.
+- **Inline alt-text editing** where the content type supports it on mobile.
+
+## 3. Non-Goals
+
+- No full WCAG audit engine or color-contrast checking (web/tooling).
+- No bulk auto-generation of alt-text (defer to web/AI story if any).
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I see my course is 80% covered and which images are missing alt-text.
+- **As an instructor**, I add alt-text to a flagged image from my phone.
+- **As an accessibility coordinator**, I spot-check coverage on the go.
+
+## 5. Functional Requirements
+
+- **FR-1.** The section MUST appear only when `altTextEnforcementEnabled`; otherwise absent.
+- **FR-2.** MUST show a coverage summary and a list of items needing alt-text.
+- **FR-3.** MUST let the user open a flagged item and add/edit alt-text where supported, saving
+  through the item's existing endpoint.
+- **FR-4.** MUST show empty (fully covered)/loading/error/offline states; queue writes (M0.2).
+- **FR-5.** MUST be staff-gated via the M13.1 shell.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — summary < 700 ms p95; list paginates.
+- **Security** — server enforces course scope + permission.
+- **Accessibility** — the review screen itself is exemplary (labels, focus order); ≥44 pt.
+- **Internationalization** — localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* the flag off, *Then* the section is absent.
+- **AC-2.** *Given* items missing alt-text, *Then* they list and each opens to a fixer.
+- **AC-3.** *Given* alt-text added, *When* saved, *Then* coverage updates.
+- **AC-4.** *Given* full coverage, *Then* an empty/success state shows.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Cache coverage + gap list per course; queue writes (M0.2).
+
+## 9. API Surface
+
+- Reuse the accessibility coverage endpoints + the content item's update endpoint for alt-text.
+  Verify shapes vs. the web accessibility section.
+
+## 10. UI / UX
+
+- Coverage header (ring/bar with % + text) → gap list → item fixer (image + alt-text field).
+- States: success/empty (100%), loading, error, offline pending.
+
+## 11. AI / ML Considerations
+
+- If the platform offers AI alt-text suggestions, surface as an optional suggestion the user can
+  accept/edit; otherwise manual. No client model.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Courses/Settings/CourseAccessibilityReviewView.swift`; API in
+  `Core/LMS/LMSAPICourses.swift`.
+- **Android:** `features/courses/settings/CourseAccessibilityReviewScreen.kt`; `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M13.1](./M13.1-course-settings-general.md); complements the cross-cutting a11y work
+  ([M0.3](../completed/mobile/M0.3-accessibility.md)).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Some content types can't be edited on mobile | M | M | Show but link-out those; edit what's supported |
+| Coverage stale after edits | M | L | Refetch coverage after save |
+
+## 15. Rollout Plan
+
+- Under `mobile_course_settings` + `altTextEnforcementEnabled`. Internal → pilot → GA.
+- Rollback: flag hides the section.
+
+## 16. Test Plan
+
+- **Unit** — coverage math; gating.
+- **Integration** — coverage fetch; alt-text save; coverage refresh.
+- **E2E** — fix a flagged image → coverage rises; offline queue.
+- **Security** — permission + scope.
+
+## 17. Documentation & Training
+
+- Instructor help-center: "Check and fix image alt-text on mobile."
+
+## 18. Open Questions
+
+1. Which content types support inline alt-text editing on mobile vs. link-out?
+2. Exact coverage endpoint shape.
+
+## 19. References
+
+- Web: `pages/lms/course-accessibility-settings.tsx`.
+- Related: [M13.1](./M13.1-course-settings-general.md), [M0.3](../completed/mobile/M0.3-accessibility.md).
+</content>

--- a/docs/plan/mobile/M13.9-course-translations-localization.md
+++ b/docs/plan/mobile/M13.9-course-translations-localization.md
@@ -1,0 +1,136 @@
+# M13.9 — Course Translations & Localization (Mobile)
+
+> Implementation plan. Source: web `pages/lms/course-translations-settings.tsx` (settings
+> **Translations** tab, gated by translation-memory feature). Follows
+> [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M13.9 |
+| **Section** | M13 — Course Settings & Configuration |
+| **Severity** | MINOR — multilingual course setup (locale variants, glossary, coverage) is desktop-only |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING — web Translations tab creates locale variants, manages glossary, reviews coverage; mobile has none (learners already get immersive-reader translation via M6.3) |
+| **Estimated effort** | S (1w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — course-translation endpoints (locales, glossary, coverage) exist; gated by translation-memory feature |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M13.1](./M13.1-course-settings-general.md), [M0.4 i18n/RTL](../completed/mobile/M0.4-i18n-rtl.md) |
+| **Unblocks** | Instructor-side localization management on mobile |
+
+## 1. Problem Statement
+
+The **Translations** tab lets instructors create locale variants of a course, manage glossary
+terms, and review translation coverage (behind the translation-memory feature). This is
+web-only, so an instructor can't add a locale or fix a glossary term from a phone, even though
+learners already read translated content via the immersive reader (M6.3).
+
+## 2. Goals
+
+- **Create/manage locale variants** for the course.
+- **Manage glossary terms** (add/edit/delete) used by translations.
+- **Review coverage** per locale (read-only) so instructors know what's translated.
+
+## 3. Non-Goals
+
+- No bulk translation authoring/segment editing of full content (web/TMS).
+- No changing the MT provider (admin — M14.8).
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I add a Spanish locale variant to my course from my phone.
+- **As an instructor**, I fix a glossary term so a key phrase translates correctly.
+- **As an instructor**, I check how much of the course is translated for a locale.
+
+## 5. Functional Requirements
+
+- **FR-1.** The section MUST appear only when the translation-memory feature is enabled.
+- **FR-2.** MUST create/manage locale variants via the course-translation endpoints.
+- **FR-3.** MUST CRUD glossary terms and persist.
+- **FR-4.** MUST show per-locale **coverage** read-only.
+- **FR-5.** MUST show save/saving/saved/error states; queue writes offline (M0.2).
+- **FR-6.** MUST be staff-gated via the M13.1 shell.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — locale/coverage load < 800 ms p95; glossary paginates.
+- **Security** — server enforces course scope + permission.
+- **Accessibility** — locale/glossary editors labeled; ≥44 pt.
+- **Internationalization** — this IS localization; ensure locale names localized; RTL variants.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* the feature off, *Then* the section is absent.
+- **AC-2.** *Given* a new locale variant, *When* created, *Then* it persists and coverage tracks.
+- **AC-3.** *Given* a glossary term edited, *Then* it persists and influences translation.
+- **AC-4.** *Given* offline, *Then* edits queue and sync.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Cache locales + glossary + coverage per course; queue writes (M0.2).
+
+## 9. API Surface
+
+- Reuse course-translation endpoints (locales, glossary, coverage — see `course-translation-api.ts`).
+  Verify shapes when implementing.
+
+## 10. UI / UX
+
+- Locales list (with coverage %) → locale detail. Glossary as a searchable term list with an
+  add/edit sheet.
+- States: empty (no locales), loading, error, offline pending.
+
+## 11. AI / ML Considerations
+
+- Machine translation is server-side. Mobile manages configuration/glossary only; present MT
+  output as editable, not authoritative. No client model.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Courses/Settings/CourseTranslationsSettingsView.swift`; API in
+  `Core/LMS/LMSAPICourses.swift`; reuse M0.4 locale utilities.
+- **Android:** `features/courses/settings/CourseTranslationsSettingsScreen.kt`; `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M13.1](./M13.1-course-settings-general.md); pairs with
+  [M6.3 Immersive Reader](../completed/mobile/M6.3-immersive-reader.md) and
+  [M0.4](../completed/mobile/M0.4-i18n-rtl.md).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Glossary editing on a phone is fiddly | M | M | Simple term/replacement fields; search; link-out for bulk |
+| Locale variant creation triggers large MT jobs | M | M | Confirm; show job/coverage progress |
+
+## 15. Rollout Plan
+
+- Under `mobile_course_settings` + translation-memory feature. Internal → pilot → GA.
+- Rollback: flag hides the section.
+
+## 16. Test Plan
+
+- **Unit** — glossary diff; gating.
+- **Integration** — locale CRUD; glossary CRUD; coverage fetch.
+- **E2E** — add locale → coverage tracks; edit glossary term; offline queue.
+- **Security** — permission + scope.
+
+## 17. Documentation & Training
+
+- Instructor help-center: "Manage course locales and glossary on mobile."
+
+## 18. Open Questions
+
+1. How much glossary/segment editing belongs on mobile vs. link-out?
+2. Exact locale/coverage endpoint shapes.
+
+## 19. References
+
+- Web: `pages/lms/course-translations-settings.tsx`, `lib/course-translation-api.ts`.
+- Related: [M13.1](./M13.1-course-settings-general.md), [M6.3](../completed/mobile/M6.3-immersive-reader.md),
+  [M0.4](../completed/mobile/M0.4-i18n-rtl.md).
+</content>

--- a/docs/plan/mobile/M14.1-account-integrations-api-access.md
+++ b/docs/plan/mobile/M14.1-account-integrations-api-access.md
@@ -1,0 +1,142 @@
+# M14.1 — Account Integrations & API Access (Mobile)
+
+> Implementation plan. Source: web `pages/lms/settings.tsx` (`integrations` view) →
+> `components/settings/integrations-access-keys-panel.tsx`, `calendar-subscriptions-panel.tsx`,
+> `admin-service-tokens-panel.tsx`, `integrations-mcp-panel.tsx`. Follows
+> [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M14.1 |
+| **Section** | M14 — Platform, Org & Account Administration |
+| **Severity** | MINOR — user-level API access keys, calendar subscriptions, and MCP config are desktop-only |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING — web Integrations view manages access keys, calendar (iCal) subscriptions, MCP, and (admin) service tokens; mobile has none |
+| **Estimated effort** | S (1w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — access-key, calendar-subscription, MCP, and service-token endpoints exist |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M1.4 Profile & settings](../completed/mobile/M1.4-settings-accommodations.md) (settings home), [M2.1 Calendar](../completed/mobile/M2.1-calendar-todos.md) (calendar-subscription context) |
+| **Unblocks** | Managing API/MCP/calendar access from a phone |
+| **Permission** | Own access keys/calendar subs/MCP: any authenticated user. **Service tokens: `rbac:manage`** (admin) |
+
+## 1. Problem Statement
+
+The **Integrations** settings view lets a user create API access keys, subscribe external
+calendars (iCal feeds) to their Lextures calendar, configure MCP so AI agents can act on their
+data, and (for admins) manage service tokens. All of this is web-only, so a user can't rotate a
+leaked key, grab their calendar feed URL, or set up MCP from their phone.
+
+## 2. Goals
+
+- **Access keys:** list, create (with scopes), copy once, and revoke.
+- **Calendar subscriptions:** view the user's subscription/feed URLs and add/remove subscriptions.
+- **MCP:** view/configure the user's MCP connection details.
+- **Service tokens (admin only):** list/create/revoke, gated by `rbac:manage`.
+
+## 3. Non-Goals
+
+- No org-wide integration marketplace or webhooks config (admin/web — M14.8).
+- No LTI tool registration (admin — M14.8).
+
+## 4. Personas & User Stories
+
+- **As a user**, I revoke a leaked API key immediately from my phone.
+- **As a user**, I copy my calendar feed URL to subscribe in another app.
+- **As a power user**, I configure MCP so my agent can reach my Lextures data.
+- **As an admin**, I revoke a service token from my phone.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST list access keys and create one, showing the secret **once** with a copy action
+  and a clear "you won't see this again" warning; MUST revoke keys.
+- **FR-2.** MUST show calendar subscription/feed URLs (copy) and add/remove subscriptions.
+- **FR-3.** MUST show/configure MCP connection details for the user.
+- **FR-4.** MUST show the **service tokens** panel only when the user has `rbac:manage`.
+- **FR-5.** MUST show create/revoke confirmations and success/error states; secrets never logged.
+- **FR-6.** MUST live under the mobile Settings home (M1.4), reachable only for the current user.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — lists < 600 ms p95.
+- **Security** — secrets shown once, never persisted to disk or logs; copy uses secure clipboard
+  (auto-clear where supported); revoke is immediate; service tokens admin-gated server-side.
+- **Privacy & Compliance** — treat keys/tokens as credentials; no analytics on their values.
+- **Accessibility** — copy/reveal/revoke controls labeled; ≥44 pt.
+- **Internationalization** — localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* Create key, *Then* the secret shows once with copy + warning and is revocable.
+- **AC-2.** *Given* a calendar subscription URL, *Then* it's copyable; add/remove works.
+- **AC-3.** *Given* a non-admin, *Then* the service-tokens panel is absent.
+- **AC-4.** *Given* MCP config, *Then* connection details render and can be updated.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. No secret is cached beyond the one-time reveal buffer.
+
+## 9. API Surface
+
+- Reuse access-key, calendar-subscription, MCP, and service-token endpoints (see the four
+  integrations panels). Verify routes/shapes when implementing.
+
+## 10. UI / UX
+
+- Settings → Integrations → four cards: Access keys, Calendar subscriptions, MCP, Service tokens
+  (admin). Create flows use bottom sheets; secret reveal is modal with copy + dismiss.
+- States: empty (no keys), loading, error, created-secret modal.
+
+## 11. AI / ML Considerations
+
+- MCP enables AI agents to access user data; present scopes/permissions plainly before enabling.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Settings/IntegrationsView.swift` (+ AccessKeys/CalendarSubs/MCP/ServiceTokens
+  subviews); API in `Core/Networking` / `Core/LMS/LMSAPIAccount.swift`.
+- **Android:** `features/settings/IntegrationsScreen.kt` (+ sub-screens);
+  `core/lms/LmsApi.kt` / account API.
+
+## 13. Dependencies & Sequencing
+
+- After [M1.4](../completed/mobile/M1.4-settings-accommodations.md) (settings home). First M14
+  story — user-facing, no admin dependency.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Secret leaked via clipboard/logs | M | H | One-time reveal; secure clipboard auto-clear; never log |
+| Admin panel shown to non-admins | L | H | Server-check + client gate on `rbac:manage` |
+
+## 15. Rollout Plan
+
+- Flag: `mobile_settings_integrations`. Internal → GA (user-facing parts); service tokens gated.
+- Rollback: flag hides the Integrations entry.
+
+## 16. Test Plan
+
+- **Unit** — one-time reveal logic; admin gating.
+- **Integration** — key create/revoke; calendar sub add/remove; MCP update; service token CRUD.
+- **E2E** — create key → copy → revoke; non-admin lacks service tokens.
+- **Security** — secret handling; admin-only service tokens; clipboard behavior.
+
+## 17. Documentation & Training
+
+- Help-center: "Manage API keys, calendar feeds, and MCP on mobile."
+
+## 18. Open Questions
+
+1. Which access-key scopes are safe to create on mobile?
+2. Should MCP setup be full config or a QR/deep-link handoff to desktop?
+
+## 19. References
+
+- Web: `components/settings/integrations-access-keys-panel.tsx`, `calendar-subscriptions-panel.tsx`,
+  `admin-service-tokens-panel.tsx`, `integrations-mcp-panel.tsx`; `pages/lms/settings.tsx`.
+- Related: [M1.4](../completed/mobile/M1.4-settings-accommodations.md), [M2.1](../completed/mobile/M2.1-calendar-todos.md).
+</content>

--- a/docs/plan/mobile/M14.10-global-archived-courses.md
+++ b/docs/plan/mobile/M14.10-global-archived-courses.md
@@ -1,0 +1,133 @@
+# M14.10 — Global Archived Courses Admin (Mobile)
+
+> Implementation plan. Source: web `pages/lms/settings.tsx` (`archive` view) →
+> `components/settings/archived-courses-panel.tsx`. Follows [../_TEMPLATE.md](../_TEMPLATE.md),
+> mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M14.10 |
+| **Section** | M14 — Platform, Org & Account Administration |
+| **Severity** | MINOR — platform-wide archived-course management (restore/delete) is desktop-only |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING — web Archive view reviews archived courses and restores or permanently deletes them; mobile has none |
+| **Estimated effort** | XS (≤1d) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — archived-courses list + restore/delete endpoints exist |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M1.4 Settings home](../completed/mobile/M1.4-settings-accommodations.md) |
+| **Unblocks** | Admin restore of archived courses on mobile |
+| **Permission** | `rbac:manage` (`PERM_RBAC_MANAGE`) |
+
+## 1. Problem Statement
+
+The admin **Archive** view lists archived courses across the platform and lets an admin restore
+them to the catalog or permanently delete them. It's web-only, so an admin can't restore a
+course archived by mistake — or clear out old ones — from a phone. (This is distinct from the
+per-course archived *items* surface, M13.12.)
+
+## 2. Goals
+
+- **List** archived courses (title, org, archived-at) with search, gated by `rbac:manage`.
+- **Restore** an archived course to the catalog.
+- **Permanent delete** with a strong, explicit confirmation (irreversible).
+
+## 3. Non-Goals
+
+- No course content editing here.
+- No bulk operations on mobile v1.
+
+## 4. Personas & User Stories
+
+- **As an admin**, I restore a course a teacher archived by accident from my phone.
+- **As an admin**, I permanently delete an obsolete archived course after double-confirming.
+
+## 5. Functional Requirements
+
+- **FR-1.** The view MUST require `rbac:manage`; else the permission fallback.
+- **FR-2.** MUST list archived courses with search/pagination.
+- **FR-3.** MUST restore a course via the restore endpoint and reflect it live.
+- **FR-4.** MUST support permanent delete behind a strong confirmation (type-to-confirm or double
+  confirm), clearly marked irreversible.
+- **FR-5.** MUST show loading/error/empty states; actions require connectivity; audited.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — list < 700 ms p95; paginated.
+- **Security** — server-check `rbac:manage`; delete guarded + audited; irreversible action flagged.
+- **Accessibility** — list + destructive actions labeled; ≥44 pt; delete clearly distinguished.
+- **Internationalization** — dates localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a non-admin, *Then* the fallback shows.
+- **AC-2.** *Given* archived courses, *Then* they list and are searchable.
+- **AC-3.** *Given* Restore, *Then* the course returns to the catalog.
+- **AC-4.** *Given* Delete, *Then* a strong confirmation is required before it's permanently
+  removed, and the action is audited.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Transient list cache; deletes are server-authoritative.
+
+## 9. API Surface
+
+- Reuse archived-courses list + restore + delete endpoints. Verify shapes vs. the web archived-
+  courses panel.
+
+## 10. UI / UX
+
+- Searchable list → course row with Restore + Delete. Delete uses a type-to-confirm dialog.
+- States: fallback, loading, empty (nothing archived), error.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Settings/Admin/ArchivedCoursesAdminView.swift`; API in
+  `Core/LMS/LMSAPIAdmin.swift`.
+- **Android:** `features/settings/admin/ArchivedCoursesAdminScreen.kt`; `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M1.4](../completed/mobile/M1.4-settings-accommodations.md). Smallest M14 story.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Accidental permanent delete | M | H | Type-to-confirm; irreversible warning; audit |
+| Restoring a course with stale data | L | M | Mirror web restore semantics; show restored state |
+
+## 15. Rollout Plan
+
+- Flag: `mobile_admin_settings`. Internal → admin pilot → GA (restore first; delete gated behind a
+  stronger confirmation, possibly desktop-only initially).
+- Rollback: flag hides the admin area.
+
+## 16. Test Plan
+
+- **Unit** — gating; delete confirmation logic.
+- **Integration** — list; restore; delete.
+- **E2E** — restore a course → catalog; delete requires strong confirm; non-admin blocked.
+- **Security** — permission; audit; irreversible-action guard.
+
+## 17. Documentation & Training
+
+- Admin help-center: "Restore or delete archived courses on mobile."
+
+## 18. Open Questions
+
+1. Should permanent delete be allowed on mobile at all, or restore-only + delete on web?
+2. Exact archived-courses endpoint shapes.
+
+## 19. References
+
+- Web: `components/settings/archived-courses-panel.tsx`; `pages/lms/settings.tsx`.
+- Related: [M13.12 Course archived content](./M13.12-course-archived-content.md).
+</content>

--- a/docs/plan/mobile/M14.2-roles-permissions-admin.md
+++ b/docs/plan/mobile/M14.2-roles-permissions-admin.md
@@ -1,0 +1,134 @@
+# M14.2 — Roles & Permissions (RBAC) Admin (Mobile)
+
+> Implementation plan. Source: web `pages/lms/settings.tsx` (`roles` view) →
+> `components/settings/roles-permissions-panel.tsx`. Follows [../_TEMPLATE.md](../_TEMPLATE.md),
+> mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M14.2 |
+| **Section** | M14 — Platform, Org & Account Administration |
+| **Severity** | MINOR — RBAC role/permission management is a desktop-bound admin console; mobile admins get a read/spot-check view + guarded assignment |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING — web Roles view defines permission strings and assigns them to roles; mobile has none |
+| **Estimated effort** | S (1w) native subset; full authoring stays web |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — RBAC endpoints exist (`rbac_settings.go`, `rbac-api.ts`) |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M1.4 Settings home](../completed/mobile/M1.4-settings-accommodations.md) |
+| **Unblocks** | Admin spot-checks/role assignment on mobile |
+| **Permission** | `rbac:manage` (`PERM_RBAC_MANAGE`) |
+
+## 1. Problem Statement
+
+Roles and permissions (defining permission strings and assigning them to roles) are managed only
+on the web. An admin can't review who has what, or make a quick role assignment, from a phone.
+Full permission-matrix authoring is genuinely desktop work, but **review + guarded assignment**
+is a reasonable mobile subset consistent with the plan's admin doctrine.
+
+## 2. Goals
+
+- **Read view** of roles and their permissions (searchable), gated by `rbac:manage`.
+- **Assign/remove a role** to/from a user (guarded), reusing the People search (M14.3).
+- **Link-out** to web for permission-string authoring / bulk matrix editing.
+
+## 3. Non-Goals
+
+- No creating/editing permission strings or the full matrix on mobile (web — link-out).
+- No custom role creation on mobile v1.
+
+## 4. Personas & User Stories
+
+- **As an admin**, I check which permissions the "Teacher" role has from my phone.
+- **As an admin**, I grant a colleague an admin role in a pinch, with confirmation.
+
+## 5. Functional Requirements
+
+- **FR-1.** The view MUST require `rbac:manage`; otherwise show the standard permission fallback.
+- **FR-2.** MUST list roles + their permissions (read), searchable.
+- **FR-3.** SHOULD allow assigning/removing a role for a user (guarded confirm), via RBAC endpoints.
+- **FR-4.** MUST link out to web for permission authoring/matrix editing with "best on a larger
+  screen."
+- **FR-5.** MUST show loading/error/empty states; role writes require connectivity.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — role list < 700 ms p95.
+- **Security** — every read/write server-checks `rbac:manage`; never widen client-side.
+- **Privacy & Compliance** — admin action auditing preserved server-side.
+- **Accessibility** — role/permission lists labeled; ≥44 pt.
+- **Internationalization** — localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a non-admin, *Then* the fallback shows and no data loads.
+- **AC-2.** *Given* an admin, *Then* roles + permissions render read-only and searchable.
+- **AC-3.** *Given* a role assignment confirmed, *Then* it persists and audits.
+- **AC-4.** *Given* an authoring intent, *Then* the user is guided to web.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Read-only cache of roles/permissions for display.
+
+## 9. API Surface
+
+- Reuse RBAC endpoints (`rbac-api.ts`, `rbac_settings.go`) for roles, permissions, and role
+  assignment. Verify shapes when implementing.
+
+## 10. UI / UX
+
+- Roles list → role detail (permissions, read). User → assign role (sheet, confirm).
+- A "manage permissions on web" link-out card.
+- States: fallback (no perm), loading, error, empty.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Settings/Admin/RolesPermissionsView.swift`; API in
+  `Core/LMS/LMSAPIAdmin.swift`; reuse M14.3 people search.
+- **Android:** `features/settings/admin/RolesPermissionsScreen.kt`; `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M1.4](../completed/mobile/M1.4-settings-accommodations.md); pairs with
+  [M14.3 People](./M14.3-people-user-management.md) for assignment.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Over-broad role granted from mobile | M | H | Guarded confirm; server audit; consider blocking self-elevation |
+| Partial mobile view misleads admins | M | M | Clear "read-only / manage on web" framing |
+
+## 15. Rollout Plan
+
+- Flag: `mobile_admin_settings`. Internal → admin pilot → GA (read first, assignment later).
+- Rollback: flag hides the admin area.
+
+## 16. Test Plan
+
+- **Unit** — permission gating; assignment payload.
+- **Integration** — roles read; role assign/remove.
+- **E2E** — admin views roles → assigns role; non-admin blocked.
+- **Security** — server `rbac:manage` on every call; audit.
+
+## 17. Documentation & Training
+
+- Admin help-center: "Review roles and assign them on mobile (author on web)."
+
+## 18. Open Questions
+
+1. Do we allow any role assignment on mobile, or read-only + link-out entirely?
+2. Guardrails against self-privilege-escalation.
+
+## 19. References
+
+- Web: `components/settings/roles-permissions-panel.tsx`; server `rbac_settings.go`; `lib/rbac-api.ts`.
+- Related: [M14.3](./M14.3-people-user-management.md).
+</content>

--- a/docs/plan/mobile/M14.3-people-user-management.md
+++ b/docs/plan/mobile/M14.3-people-user-management.md
@@ -1,0 +1,134 @@
+# M14.3 — People / User Management Admin (Mobile)
+
+> Implementation plan. Source: web `pages/lms/settings.tsx` (`people` view) →
+> `components/settings/people-panel.tsx`. Follows [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M14.3 |
+| **Section** | M14 — Platform, Org & Account Administration |
+| **Severity** | MINOR — platform-wide user management is desktop-only; mobile admins can't search, invite, or suspend accounts |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING — web People view searches, invites, suspends, and manages accounts; mobile has none |
+| **Estimated effort** | S (1w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — people/admin user endpoints exist |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M1.4 Settings home](../completed/mobile/M1.4-settings-accommodations.md) |
+| **Unblocks** | Admin user actions (search/invite/suspend) on mobile; role assignment (M14.2) |
+| **Permission** | `rbac:manage` (`PERM_RBAC_MANAGE`) |
+
+## 1. Problem Statement
+
+The **People** admin view searches, invites, suspends, and manages user accounts across the
+platform. It's web-only, so an admin can't look up a user, send an invite, or suspend a
+compromised account from a phone — exactly the moments when speed matters.
+
+## 2. Goals
+
+- **Search** users across the platform (name/email), gated by `rbac:manage`.
+- **User detail**: profile summary, roles, status, and org membership (read).
+- **Actions**: invite a user, suspend/reactivate, resend invite — each guarded with confirmation.
+- Feed the **role assignment** flow used by M14.2.
+
+## 3. Non-Goals
+
+- No bulk user import/CSV (web/SCIM — M14.8).
+- No deep profile editing of arbitrary users beyond the exposed admin actions.
+
+## 4. Personas & User Stories
+
+- **As an admin**, I search for a user and suspend a compromised account immediately.
+- **As an admin**, I invite a new teacher from my phone.
+- **As an admin**, I check a user's roles and status while away from my desk.
+
+## 5. Functional Requirements
+
+- **FR-1.** The view MUST require `rbac:manage`; otherwise show the permission fallback.
+- **FR-2.** MUST search users with pagination and open a user detail.
+- **FR-3.** MUST support invite, suspend/reactivate, and resend-invite with confirmations.
+- **FR-4.** MUST integrate with role assignment (M14.2) from the user detail.
+- **FR-5.** MUST show loading/error/empty states; writes require connectivity; actions audited.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — search < 700 ms p95; paginated.
+- **Security** — server-check `rbac:manage` on every call; suspend is immediate; audit all actions.
+- **Privacy & Compliance** — FERPA/PII: minimal fields; no PII in logs; least-privilege display.
+- **Accessibility** — search + action controls labeled; ≥44 pt.
+- **Internationalization** — localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a non-admin, *Then* the fallback shows and no data loads.
+- **AC-2.** *Given* a search, *Then* matching users list; a user opens to detail.
+- **AC-3.** *Given* Suspend confirmed, *Then* the account is suspended and audited.
+- **AC-4.** *Given* Invite, *Then* an invite is sent and reflected.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Transient search results; no bulk PII cached.
+
+## 9. API Surface
+
+- Reuse people/admin-user endpoints (search, invite, suspend, reactivate, resend). Verify shapes
+  vs. the web People panel.
+
+## 10. UI / UX
+
+- Search bar → results list → user detail (profile, roles, status, actions). Actions in a menu
+  with confirmations; destructive actions styled distinctly.
+- States: fallback, loading, empty, error.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Settings/Admin/PeopleAdminView.swift`, `UserDetailAdminView.swift`; API in
+  `Core/LMS/LMSAPIAdmin.swift`.
+- **Android:** `features/settings/admin/PeopleAdminScreen.kt`, `UserDetailAdminScreen.kt`;
+  `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M1.4](../completed/mobile/M1.4-settings-accommodations.md); pairs with
+  [M14.2 Roles](./M14.2-roles-permissions-admin.md).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Accidental suspend of the wrong user | M | H | Confirm with name/email echo; reversible reactivate |
+| PII exposure on a shared device | M | M | Minimal fields; biometric lock (M1.2); no PII in logs |
+
+## 15. Rollout Plan
+
+- Flag: `mobile_admin_settings`. Internal → admin pilot → GA.
+- Rollback: flag hides the admin area.
+
+## 16. Test Plan
+
+- **Unit** — gating; action payloads.
+- **Integration** — search; invite; suspend/reactivate.
+- **E2E** — admin searches → suspends → reactivates; non-admin blocked.
+- **Security** — server `rbac:manage`; audit; PII handling.
+
+## 17. Documentation & Training
+
+- Admin help-center: "Find, invite, and suspend users on mobile."
+
+## 18. Open Questions
+
+1. Which admin actions are safe on mobile vs. web-only (e.g., merge/delete)?
+2. Exact people-admin endpoint shapes.
+
+## 19. References
+
+- Web: `components/settings/people-panel.tsx`; `pages/lms/settings.tsx`.
+- Related: [M14.2](./M14.2-roles-permissions-admin.md).
+</content>

--- a/docs/plan/mobile/M14.4-organizations-units-terms.md
+++ b/docs/plan/mobile/M14.4-organizations-units-terms.md
@@ -1,0 +1,134 @@
+# M14.4 — Organizations, Org Units & Academic Terms Admin (Mobile)
+
+> Implementation plan. Source: web `pages/lms/settings.tsx` (`organizations`, `org-units`,
+> `terms` views) → `components/settings/organizations-panel.tsx`, `org-units-panel.tsx`,
+> `terms-settings-panel.tsx`. Follows [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M14.4 |
+| **Section** | M14 — Platform, Org & Account Administration |
+| **Severity** | MINOR — org structure and academic-term management is desktop-bound admin |
+| **Markets** | K12 / HE |
+| **Status (today)** | MISSING — web manages organizations, org units (schools/colleges/departments), and academic terms; mobile has none |
+| **Estimated effort** | S (1w) read + light edit; heavy structure editing stays web |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — organizations / org-units / terms endpoints exist |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M1.4 Settings home](../completed/mobile/M1.4-settings-accommodations.md) |
+| **Unblocks** | Admin review of org structure + term dates on mobile |
+| **Permission** | `rbac:manage` **or** `tenant:org-units:admin` (`PERM_TENANT_ORG_UNITS_ADMIN`) for org-units/terms |
+
+## 1. Problem Statement
+
+Organizations, the org-unit hierarchy (schools/colleges/departments), and academic terms
+(start/end dates) are configured only on the web. An admin can't review the hierarchy or fix a
+term's dates from a phone. Deep restructuring is genuinely desktop work; **review + light edits
+(e.g., a term's dates)** is a sensible mobile subset.
+
+## 2. Goals
+
+- **Read** the organizations list and the org-unit tree, gated by the appropriate permission.
+- **Academic terms**: view terms and add/edit term dates (light edit).
+- **Light org-unit edits** (rename) where safe; link out for deep restructuring.
+
+## 3. Non-Goals
+
+- No large-scale org-unit tree restructuring/moves on mobile (web — link-out).
+- No org provisioning/deprovisioning (web).
+
+## 4. Personas & User Stories
+
+- **As an org-unit admin**, I fix the spring term end date from my phone.
+- **As an admin**, I review the department hierarchy while away from my desk.
+- **As an admin**, I rename a mistyped department.
+
+## 5. Functional Requirements
+
+- **FR-1.** Views MUST require `rbac:manage` (organizations) or `rbac:manage`/`tenant:org-units:admin`
+  (org-units, terms); otherwise the permission fallback.
+- **FR-2.** MUST render the organizations list and org-unit tree (read).
+- **FR-3.** MUST view academic terms and add/edit term dates, persisting via the terms endpoints.
+- **FR-4.** SHOULD allow renaming an org unit; MUST link out for deep restructuring.
+- **FR-5.** MUST show loading/error/empty states; writes require connectivity; actions audited.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — trees/lists < 800 ms p95; large trees lazy-load.
+- **Security** — server-check permission on every call; audit edits.
+- **Accessibility** — tree navigation operable non-visually; date pickers labeled; ≥44 pt.
+- **Internationalization** — term dates localized to org tz; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* insufficient permission, *Then* the fallback shows.
+- **AC-2.** *Given* org units, *Then* the tree renders and is navigable.
+- **AC-3.** *Given* a term date edit, *When* saved, *Then* it persists and audits.
+- **AC-4.** *Given* a deep restructure intent, *Then* the user is guided to web.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Read cache of org/units/terms; light edits go straight to the server.
+
+## 9. API Surface
+
+- Reuse organizations, org-units, and terms endpoints. Verify shapes vs. the three web panels.
+
+## 10. UI / UX
+
+- Tabs/sections: Organizations (list), Org units (tree), Terms (list + date editor).
+- Term editor is a simple form (name, start, end). Org-unit rename inline; "restructure on web"
+  link-out.
+- States: fallback, loading, empty, error.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Settings/Admin/OrgStructureView.swift`, `TermsAdminView.swift`; API in
+  `Core/LMS/LMSAPIAdmin.swift`.
+- **Android:** `features/settings/admin/OrgStructureScreen.kt`, `TermsAdminScreen.kt`;
+  `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M1.4](../completed/mobile/M1.4-settings-accommodations.md).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Term date change shifts many course schedules | M | H | Confirm + explain impact; server validates; audit |
+| Tree edits on mobile misplace units | M | M | Rename-only on mobile; restructure via web |
+
+## 15. Rollout Plan
+
+- Flag: `mobile_admin_settings`. Internal → admin pilot → GA.
+- Rollback: flag hides the admin area.
+
+## 16. Test Plan
+
+- **Unit** — permission gating; term payload.
+- **Integration** — org list; unit tree; term add/edit.
+- **E2E** — edit term dates → persists; non-admin blocked.
+- **Security** — permission on every call; audit.
+
+## 17. Documentation & Training
+
+- Admin help-center: "Review org structure and edit term dates on mobile."
+
+## 18. Open Questions
+
+1. Which org-unit edits are safe on mobile vs. web-only?
+2. Exact terms/org-unit endpoint shapes.
+
+## 19. References
+
+- Web: `components/settings/organizations-panel.tsx`, `org-units-panel.tsx`, `terms-settings-panel.tsx`.
+- Related: [M14.5](./M14.5-org-branding-ai-governance.md).
+</content>

--- a/docs/plan/mobile/M14.5-org-branding-ai-governance.md
+++ b/docs/plan/mobile/M14.5-org-branding-ai-governance.md
@@ -1,0 +1,140 @@
+# M14.5 — Org Branding, AI Governance & AI Provider Admin (Mobile)
+
+> Implementation plan. Source: web `pages/lms/settings.tsx` (`org-branding` view) →
+> `pages/lms/admin/org-branding.tsx`, `components/settings/ai-governance-panel.tsx`,
+> `ai-provider-settings-panel.tsx`. Follows [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M14.5 |
+| **Section** | M14 — Platform, Org & Account Administration |
+| **Severity** | MINOR — org branding, AI governance, and AI provider config are desktop-bound admin |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING — web Org-branding view sets logo/colors/custom domain/email sender, plus AI governance and AI provider settings; mobile has none |
+| **Estimated effort** | S (1w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — org-branding, AI-governance, and AI-provider endpoints exist |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M1.4 Settings home](../completed/mobile/M1.4-settings-accommodations.md) |
+| **Unblocks** | Admin branding/AI-governance review + light edits on mobile |
+| **Permission** | `rbac:manage` **or** `tenant:org-units:admin` (`PERM_TENANT_ORG_UNITS_ADMIN`) |
+
+## 1. Problem Statement
+
+The **Org branding** view controls the logo, colors, optional custom domain, and email sender
+display name, and hosts **AI governance** (org-level AI policy) and **AI provider** settings.
+It's web-only, so an admin can't review or tweak branding, or check the org's AI governance
+posture, from a phone.
+
+## 2. Goals
+
+- **Branding**: view and edit logo, colors, and email sender display name; view custom domain.
+- **AI governance**: view and edit the org's AI policy toggles/limits.
+- **AI provider**: view/configure the org's AI provider settings (secrets handled safely).
+
+## 3. Non-Goals
+
+- No custom-domain DNS/verification flow on mobile (web — link-out).
+- No per-model catalog editing here (that's platform AI models — M14.7).
+
+## 4. Personas & User Stories
+
+- **As an admin**, I update the org logo/colors and email sender name from my phone.
+- **As an admin**, I review the org's AI governance policy and tighten a limit.
+- **As an admin**, I check which AI provider the org uses.
+
+## 5. Functional Requirements
+
+- **FR-1.** The view MUST require `rbac:manage` or `tenant:org-units:admin`; else the fallback.
+- **FR-2.** MUST edit logo (upload), colors, and email sender name; MUST show (read) custom
+  domain with a "configure on web" link-out.
+- **FR-3.** MUST view/edit AI governance settings and persist.
+- **FR-4.** MUST view/configure AI provider settings; secrets shown masked, entered write-only,
+  never displayed back or logged.
+- **FR-5.** MUST show save/saving/saved/error states; branding uploads follow storage policy.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — load < 800 ms p95.
+- **Security** — server-check permission; provider secrets write-only (placeholder pattern like
+  web's `PLATFORM_SECRET_PLACEHOLDER`); no secret in logs; audit edits.
+- **Privacy & Compliance** — AI governance changes audited; document data-handling implications.
+- **Accessibility** — color pickers/uploads labeled; ≥44 pt; contrast preview.
+- **Internationalization** — localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* insufficient permission, *Then* the fallback shows.
+- **AC-2.** *Given* a logo/color/sender edit, *When* saved, *Then* it persists and previews.
+- **AC-3.** *Given* AI governance edits, *Then* they persist and audit.
+- **AC-4.** *Given* a provider secret, *Then* it's write-only, masked, and never displayed back.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. No provider secret cached; branding assets follow storage policy.
+
+## 9. API Surface
+
+- Reuse org-branding, AI-governance, and AI-provider endpoints. Verify shapes vs. the three
+  web panels; mirror the secret placeholder handling.
+
+## 10. UI / UX
+
+- Three cards: Branding (logo upload, color fields, sender name, custom domain read+link-out),
+  AI governance (policy toggles/limits), AI provider (provider picker + masked secret field).
+- States: fallback, loading, error, saved.
+
+## 11. AI / ML Considerations
+
+- AI governance defines org-wide AI policy; present each toggle's effect plainly. Provider
+  settings choose where inference runs; changing them affects all AI features.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Settings/Admin/OrgBrandingView.swift`, `AiGovernanceView.swift`,
+  `AiProviderSettingsView.swift`; API in `Core/LMS/LMSAPIAdmin.swift`.
+- **Android:** `features/settings/admin/OrgBrandingScreen.kt`, `AiGovernanceScreen.kt`,
+  `AiProviderSettingsScreen.kt`; `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M1.4](../completed/mobile/M1.4-settings-accommodations.md); relates to platform AI
+  settings ([M14.7](./M14.7-ai-models-prompts-reports.md)).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Provider secret leaked | M | H | Write-only + masked + placeholder; never log/display back |
+| Branding change breaks contrast/accessibility | M | M | Contrast preview; warn on low-contrast pairs |
+
+## 15. Rollout Plan
+
+- Flag: `mobile_admin_settings`. Internal → admin pilot → GA.
+- Rollback: flag hides the admin area.
+
+## 16. Test Plan
+
+- **Unit** — secret placeholder handling; color validation.
+- **Integration** — branding save; governance save; provider save (masked).
+- **E2E** — edit logo/colors → preview; provider secret write-only; non-admin blocked.
+- **Security** — permission; secret handling; audit.
+
+## 17. Documentation & Training
+
+- Admin help-center: "Edit org branding and review AI governance on mobile."
+
+## 18. Open Questions
+
+1. Do we allow logo upload on mobile, or edit colors/sender only?
+2. Exact governance fields + provider secret semantics to mirror.
+
+## 19. References
+
+- Web: `pages/lms/admin/org-branding.tsx`, `components/settings/ai-governance-panel.tsx`,
+  `ai-provider-settings-panel.tsx`.
+- Related: [M14.4](./M14.4-organizations-units-terms.md), [M14.7](./M14.7-ai-models-prompts-reports.md).
+</content>

--- a/docs/plan/mobile/M14.6-global-platform-config.md
+++ b/docs/plan/mobile/M14.6-global-platform-config.md
@@ -1,0 +1,135 @@
+# M14.6 — Global Platform Configuration Admin (Mobile)
+
+> Implementation plan. Source: web `pages/lms/settings.tsx` (`platform` view) →
+> `components/settings/platform-settings-panel.tsx` (+ `platform-feature-definitions.ts`,
+> `platform-settings-types.ts`). Follows [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M14.6 |
+| **Section** | M14 — Platform, Org & Account Administration |
+| **Severity** | MINOR — global platform configuration (feature flags/definitions, platform secrets) is desktop-bound admin |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING — web Global-platform view edits platform-wide configuration and feature toggles; mobile has none |
+| **Estimated effort** | S (1w) read + guarded flag toggles; secret editing stays web |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — platform settings/features endpoints exist (`settings_platform.go`, `GET /api/v1/platform/features`) |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M1.4 Settings home](../completed/mobile/M1.4-settings-accommodations.md) |
+| **Unblocks** | Emergency flag toggles + config review on mobile |
+| **Permission** | `rbac:manage` (`PERM_RBAC_MANAGE`) |
+
+## 1. Problem Statement
+
+The **Global platform** view edits platform-wide configuration and feature definitions/toggles —
+the switches that gate many features across the app (including several M13/M14 flags). It's
+web-only, so an admin can't flip an emergency feature flag or review platform config from a
+phone. Full config editing (esp. secrets) is desktop work; **review + guarded flag toggles** is
+a high-value mobile subset.
+
+## 2. Goals
+
+- **Read** the platform configuration and feature-definition list, gated by `rbac:manage`.
+- **Toggle** feature flags (guarded), so an admin can enable/disable a feature in an incident.
+- **Link out** to web for editing platform secrets and complex config values.
+
+## 3. Non-Goals
+
+- No editing platform secrets/keys on mobile (web — masked, link-out).
+- No creating new feature definitions on mobile.
+
+## 4. Personas & User Stories
+
+- **As a platform admin**, I disable a misbehaving feature flag from my phone during an incident.
+- **As a platform admin**, I review the current platform config while away from my desk.
+
+## 5. Functional Requirements
+
+- **FR-1.** The view MUST require `rbac:manage`; else the permission fallback.
+- **FR-2.** MUST list feature definitions with current state (from `GET /api/v1/platform/features`)
+  and platform config values (secrets masked/omitted).
+- **FR-3.** MUST toggle a feature flag with a confirmation and reflect it live.
+- **FR-4.** MUST link out to web for secret/complex-config editing.
+- **FR-5.** MUST show loading/error states; toggles require connectivity; changes audited.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — config/flags load < 700 ms p95.
+- **Security** — server-check `rbac:manage`; secrets never sent to the client; audit every toggle.
+- **Reliability** — flag toggles idempotent; show effective state post-toggle.
+- **Accessibility** — flag rows/toggles labeled with current state; ≥44 pt.
+- **Internationalization** — localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a non-admin, *Then* the fallback shows and nothing loads.
+- **AC-2.** *Given* the flags list, *Then* each shows current state.
+- **AC-3.** *Given* a flag toggled + confirmed, *Then* it persists, audits, and reflects live.
+- **AC-4.** *Given* a secret-edit intent, *Then* the user is guided to web.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Read cache of feature list; no secrets cached.
+
+## 9. API Surface
+
+- `GET /api/v1/platform/features` + platform settings read/toggle endpoints (`settings_platform.go`).
+  Verify shapes; ensure secrets are excluded from the mobile payload.
+
+## 10. UI / UX
+
+- Feature flags list (name, description, state toggle) + config values (read, masked). Toggle
+  confirmations spell out the effect. "Edit secrets on web" link-out.
+- States: fallback, loading, error.
+
+## 11. AI / ML Considerations
+
+- None directly (though some flags gate AI features).
+
+## 12. Integration Points
+
+- **iOS:** `Features/Settings/Admin/PlatformSettingsView.swift`; API in
+  `Core/LMS/LMSAPIAdmin.swift`; reuse the platform-features context analog.
+- **Android:** `features/settings/admin/PlatformSettingsScreen.kt`; `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M1.4](../completed/mobile/M1.4-settings-accommodations.md).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Toggling a flag breaks the app for everyone | M | H | Confirm with impact text; audit; easy re-toggle; consider allowlist of mobile-safe flags |
+| Secret leakage via config payload | L | H | Exclude secrets server-side; mask; link-out |
+
+## 15. Rollout Plan
+
+- Flag: `mobile_admin_settings`. Internal → platform-admin pilot → GA (read first, toggles later).
+- Rollback: flag hides the admin area.
+
+## 16. Test Plan
+
+- **Unit** — gating; toggle payload; secret exclusion.
+- **Integration** — features list; flag toggle.
+- **E2E** — admin disables a flag → reflected; non-admin blocked.
+- **Security** — server permission; no secrets to client; audit.
+
+## 17. Documentation & Training
+
+- Admin runbook: "Toggle platform feature flags from mobile during an incident."
+
+## 18. Open Questions
+
+1. Should we allowlist which flags are mobile-toggleable to prevent footguns?
+2. Exact platform-settings read shape (which fields, secret exclusions).
+
+## 19. References
+
+- Web: `components/settings/platform-settings-panel.tsx`, `platform-feature-definitions.ts`;
+  server `settings_platform.go`.
+- Related: [M14.5](./M14.5-org-branding-ai-governance.md), [M14.7](./M14.7-ai-models-prompts-reports.md).
+</content>

--- a/docs/plan/mobile/M14.7-ai-models-prompts-reports.md
+++ b/docs/plan/mobile/M14.7-ai-models-prompts-reports.md
@@ -1,0 +1,150 @@
+# M14.7 — AI Models, System Prompts & Usage Reports Admin (Mobile)
+
+> Implementation plan. Source: web `pages/lms/settings.tsx` (`ai-models`, `ai-prompts`,
+> `ai-reports` views) → `components/image-model-picker.tsx`, `components/settings/ai-reports-panel.tsx`.
+> Follows [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M14.7 |
+| **Section** | M14 — Platform, Org & Account Administration |
+| **Severity** | MINOR — AI model selection, system prompts, and usage reports are desktop-bound admin |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING — web sets AI models (course setup / flashcards / vibe / grader / image), the OpenRouter key, edits system prompts, and views AI usage reports; mobile has none |
+| **Estimated effort** | S (1w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — `GET/PUT /api/v1/settings/ai`, `/settings/ai/models`, `/settings/system-prompts`, AI reports endpoints exist (`settings_ai_reports.go`) |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M1.4 Settings home](../completed/mobile/M1.4-settings-accommodations.md) |
+| **Unblocks** | Reviewing/adjusting AI config + usage on mobile |
+| **Permission** | `rbac:manage` (`PERM_RBAC_MANAGE`) |
+
+## 1. Problem Statement
+
+Admins choose which AI models power each feature (course setup, notebook flashcards, vibe
+activities, grading agent, image generation), set the OpenRouter API key, edit platform system
+prompts, and review AI usage reports — all web-only. So an admin can't swap a model, fix a
+prompt, or check AI spend/usage from a phone.
+
+## 2. Goals
+
+- **Models**: view current model choices per feature and change them from the model list.
+- **API key**: set/clear the OpenRouter key (write-only, masked).
+- **System prompts**: view/edit platform prompts (audited).
+- **AI reports**: view AI usage/spend reports (read-only).
+
+## 3. Non-Goals
+
+- No fine-tuning or model catalog authoring (provider-side).
+- No prompt versioning UI beyond what the web offers.
+
+## 4. Personas & User Stories
+
+- **As an admin**, I switch the grading-agent model from my phone.
+- **As an admin**, I fix a typo in a platform system prompt.
+- **As an admin**, I check this week's AI usage/spend on the go.
+
+## 5. Functional Requirements
+
+- **FR-1.** All three views MUST require `rbac:manage`; else the permission fallback.
+- **FR-2.** **Models**: MUST load current selections via `GET /api/v1/settings/ai`, list options
+  via `/settings/ai/models?kind=text|image`, and save via `PUT /api/v1/settings/ai`; MUST
+  support refresh-from-provider.
+- **FR-3.** **API key**: MUST set/clear the OpenRouter key write-only (placeholder pattern),
+  never displaying it back.
+- **FR-4.** **System prompts**: MUST list prompts, edit content, and save via
+  `/settings/system-prompts/{key}` (audited).
+- **FR-5.** **AI reports**: MUST render usage/spend read-only.
+- **FR-6.** MUST show loading/error/saved states; require connectivity.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — model list load < 1 s p95 (network to provider); reports paginate.
+- **Security** — server-check `rbac:manage`; API key write-only/masked; no key in logs; prompt
+  edits audited.
+- **Privacy & Compliance** — reports may include usage attributable to users; minimal PII; scope-checked.
+- **Accessibility** — pickers + long-text prompt editor operable; ≥44 pt.
+- **Internationalization** — numbers/currency localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a non-admin, *Then* the fallback shows.
+- **AC-2.** *Given* a model change saved, *Then* it persists and the feature uses it.
+- **AC-3.** *Given* the API key field, *Then* it's write-only, masked, and clearable.
+- **AC-4.** *Given* a system-prompt edit saved, *Then* it persists and audits.
+- **AC-5.** *Given* AI reports, *Then* usage/spend renders read-only.
+- **AC-6.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. No API key cached; model list cached transiently.
+
+## 9. API Surface
+
+- `GET/PUT /api/v1/settings/ai`; `GET /api/v1/settings/ai/models?kind=text|image`;
+  `GET /api/v1/settings/system-prompts`, `PUT /api/v1/settings/system-prompts/{key}`;
+  AI reports endpoints (`settings_ai_reports.go`). Mirror the web's secret placeholder handling.
+
+## 10. UI / UX
+
+- Three sub-screens: Models (per-feature pickers + API key + refresh), System prompts (select +
+  editor), AI reports (charts/tables read-only). Long prompt editor uses a full-height sheet.
+- States: fallback, loading, error, saved.
+
+## 11. AI / ML Considerations
+
+- This screen **is** the AI configuration surface. Selecting a model changes cost/behavior across
+  features; show model metadata (context window, price) as the web does. Prompts are platform-wide;
+  changes are audited. No client-side inference here.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Settings/Admin/AiModelsSettingsView.swift`, `SystemPromptsView.swift`,
+  `AiReportsView.swift`; API in `Core/LMS/LMSAPIAdmin.swift`.
+- **Android:** `features/settings/admin/AiModelsSettingsScreen.kt`, `SystemPromptsScreen.kt`,
+  `AiReportsScreen.kt`; `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M1.4](../completed/mobile/M1.4-settings-accommodations.md). The models chosen here power
+  hero generation (M13.1), grading agents (M13.6), vibe activities, and flashcards.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Bad model choice raises cost/breaks a feature | M | M | Show price/metadata; confirm; easy revert |
+| API key leaked | M | H | Write-only + masked + placeholder; never log/display |
+| Prompt edit degrades AI output | M | M | Audited; preview/warning; revert path |
+
+## 15. Rollout Plan
+
+- Flag: `mobile_admin_settings`. Internal → admin pilot → GA.
+- Rollback: flag hides the admin area.
+
+## 16. Test Plan
+
+- **Unit** — model save payload; key placeholder handling; prompt diff.
+- **Integration** — models GET/PUT + refresh; prompt PUT; reports render.
+- **E2E** — change model → feature uses it; edit prompt → audited; non-admin blocked.
+- **Security** — permission; key write-only; audit.
+
+## 17. Documentation & Training
+
+- Admin help-center: "Manage AI models, prompts, and review usage on mobile."
+
+## 18. Open Questions
+
+1. Do we surface all model pickers on mobile, or the most-changed ones + link-out?
+2. Which report views are legible on a phone vs. summary-only.
+
+## 19. References
+
+- Web: `pages/lms/settings.tsx` (`ai-models`/`ai-prompts`/`ai-reports`),
+  `components/image-model-picker.tsx`, `components/settings/ai-reports-panel.tsx`;
+  server `settings_ai_reports.go`.
+- Related: [M13.1](./M13.1-course-settings-general.md), [M13.6](./M13.6-course-grading-agents.md),
+  [M14.5](./M14.5-org-branding-ai-governance.md).
+</content>

--- a/docs/plan/mobile/M14.8-integrations-provisioning-admin.md
+++ b/docs/plan/mobile/M14.8-integrations-provisioning-admin.md
@@ -1,0 +1,143 @@
+# M14.8 — Integrations & Provisioning Admin: LTI, SCIM, Cloud, LRS, OER (Mobile)
+
+> Implementation plan. Source: web `pages/lms/settings.tsx` (`lti-tools`, `scim-provisioning`,
+> `cloud-providers`, `lrs-integrations`, `oer-providers` views) → the matching
+> `components/settings/*-panel.tsx`. Follows [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M14.8 |
+| **Section** | M14 — Platform, Org & Account Administration |
+| **Severity** | MINOR — integration/provisioning admin (LTI registrations, SCIM, cloud storage, LRS/xAPI, OER providers) is desktop-bound |
+| **Markets** | HE / K12 |
+| **Status (today)** | MISSING — web manages LTI tools, SCIM provisioning, cloud providers, LRS integrations, and OER providers; mobile has none |
+| **Estimated effort** | S (1w) read/status + link-out; heavy config stays web |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — LTI/SCIM/cloud/LRS/OER endpoints exist; several gated by feature flags |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M1.4 Settings home](../completed/mobile/M1.4-settings-accommodations.md) |
+| **Unblocks** | Admin status review + light actions for integrations on mobile |
+| **Permission** | `rbac:manage` (`PERM_RBAC_MANAGE`); flags: SCIM (platform SCIM), LRS (`xapiEmissionFeatureEnabled`), OER (`oerLibraryEnabled`) |
+
+## 1. Problem Statement
+
+Registering LTI tools, configuring SCIM user provisioning, cloud storage providers, LRS/xAPI
+targets, and OER providers are all web-only admin surfaces. These are credential-heavy and
+desktop-bound, but an admin often needs to **check status** (is SCIM syncing? is the LRS
+reachable? which LTI tools are registered?) or perform a **light action** (enable/disable a
+provider) from a phone. This story delivers that status/light-action subset with link-out for
+full configuration.
+
+## 2. Goals
+
+- **Status views** for each integration type (LTI tools list, SCIM sync status, cloud providers,
+  LRS targets, OER providers), gated by permission + the relevant flag.
+- **Light actions**: enable/disable a provider or registration where safe (guarded).
+- **Link-out** to web for credential entry and full configuration.
+
+## 3. Non-Goals
+
+- No entering client secrets / SCIM bearer tokens / cloud keys on mobile (web — masked/link-out).
+- No LTI 1.3 key exchange or deployment setup on mobile (web).
+
+## 4. Personas & User Stories
+
+- **As an admin**, I check whether SCIM provisioning is healthy from my phone.
+- **As an admin**, I see which LTI tools are registered before class.
+- **As an admin**, I disable a misbehaving cloud/LRS/OER provider quickly.
+
+## 5. Functional Requirements
+
+- **FR-1.** Each sub-view MUST require `rbac:manage` and its feature flag (SCIM/LRS/OER); absent
+  otherwise.
+- **FR-2.** MUST show a status/list for each: LTI tools (registered tools), SCIM (sync status/last
+  run), cloud providers, LRS targets, OER providers.
+- **FR-3.** SHOULD support enable/disable of a provider/registration with confirmation.
+- **FR-4.** MUST link out to web for adding/editing credentials and full config.
+- **FR-5.** MUST show loading/error/empty states; secrets never shown; actions audited.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — each status view < 800 ms p95.
+- **Security** — server-check permission + flag; secrets excluded from mobile payloads; audit
+  enable/disable.
+- **Privacy & Compliance** — SCIM/LRS involve PII flows; show only status, not payloads/PII.
+- **Accessibility** — status rows + toggles labeled; ≥44 pt.
+- **Internationalization** — timestamps localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* insufficient permission or a disabled flag, *Then* the relevant sub-view is
+  absent/fallback.
+- **AC-2.** *Given* each integration, *Then* its status/list renders (no secrets).
+- **AC-3.** *Given* enable/disable confirmed, *Then* it persists and audits.
+- **AC-4.** *Given* a config-edit intent, *Then* the user is guided to web.
+- **AC-5.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Read cache of statuses; no secrets cached.
+
+## 9. API Surface
+
+- Reuse LTI, SCIM, cloud-providers, LRS, and OER endpoints (see the five web panels). Ensure
+  mobile payloads exclude secrets. Verify shapes + flag gating when implementing.
+
+## 10. UI / UX
+
+- A grouped list: LTI tools, SCIM, Cloud providers, LRS, OER — each a status card that opens a
+  read/status detail with enable/disable + "configure on web" link-out.
+- States: fallback, loading, empty, error.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Settings/Admin/IntegrationsAdminView.swift` (+ LTI/SCIM/Cloud/LRS/OER
+  detail views); API in `Core/LMS/LMSAPIAdmin.swift`.
+- **Android:** `features/settings/admin/IntegrationsAdminScreen.kt` (+ detail screens);
+  `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M1.4](../completed/mobile/M1.4-settings-accommodations.md). Lowest-priority M14 story;
+  ship status views first, light actions later.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Disabling a provider breaks logins/sync | M | H | Confirm + impact text; audit; easy re-enable |
+| Secret exposure via status payload | L | H | Exclude secrets server-side; status-only on mobile |
+
+## 15. Rollout Plan
+
+- Flag: `mobile_admin_settings` (+ per-integration flags). Internal → admin pilot → GA.
+- Rollback: flag hides the admin area.
+
+## 16. Test Plan
+
+- **Unit** — permission/flag gating; secret exclusion.
+- **Integration** — each status fetch; enable/disable.
+- **E2E** — admin views SCIM status → disables an OER provider; non-admin/flag-off blocked.
+- **Security** — permission + flag; no secrets to client; audit.
+
+## 17. Documentation & Training
+
+- Admin runbook: "Check integration status and toggle providers from mobile (configure on web)."
+
+## 18. Open Questions
+
+1. Which enable/disable actions are safe on mobile vs. status-only?
+2. Exact status payload shapes per integration; confirm secret exclusion.
+
+## 19. References
+
+- Web: `components/settings/lti-tools-settings-panel.tsx`, `scim-settings-panel.tsx`,
+  `cloud-providers-panel.tsx`, `lrs-settings-panel.tsx`, `oer-providers-panel.tsx`.
+- Related: [M14.6](./M14.6-global-platform-config.md).
+</content>

--- a/docs/plan/mobile/M14.9-transcripts-advising-config.md
+++ b/docs/plan/mobile/M14.9-transcripts-advising-config.md
@@ -1,0 +1,134 @@
+# M14.9 — Transcripts & Advising Configuration Admin (Mobile)
+
+> Implementation plan. Source: web `pages/lms/settings.tsx` (`transcripts`, `advising` views) →
+> `components/settings/transcripts-settings-panel.tsx`, `advising-settings-panel.tsx`. Follows
+> [../_TEMPLATE.md](../_TEMPLATE.md), mobile-tuned.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | M14.9 |
+| **Section** | M14 — Platform, Org & Account Administration |
+| **Severity** | MINOR — transcript and advising integration configuration is desktop-bound admin (flagged) |
+| **Markets** | HE |
+| **Status (today)** | MISSING — web transcripts + advising settings (behind `ffTranscripts` / `ffAdvisingIntegration`); mobile has none (students already use advising via M7.8) |
+| **Estimated effort** | S (1w) |
+| **Platforms** | iOS (SwiftUI), Android (Compose) |
+| **Backend** | None — transcripts + advising config endpoints exist; gated by feature flags |
+| **Owner (proposed)** | Mobile Platform |
+| **Depends on** | [M1.4 Settings home](../completed/mobile/M1.4-settings-accommodations.md) |
+| **Unblocks** | Admin review/light-edit of transcript + advising config on mobile |
+| **Permission** | `rbac:manage` (`PERM_RBAC_MANAGE`); flags: `ffTranscripts`, `ffAdvisingIntegration` |
+
+## 1. Problem Statement
+
+Where enabled, admins configure **official transcripts** (formats/fields/release policy) and the
+**advising** integration (notes/appointments config the student advising surface in M7.8 relies
+on). Both are web-only, so an admin can't review or tweak them from a phone, even though students
+already use advising on mobile.
+
+## 2. Goals
+
+- **Transcripts**: view/edit transcript configuration (fields, release policy) — flag-gated.
+- **Advising**: view/edit advising integration config — flag-gated.
+- Feed the student advising surface (M7.8) with correct config.
+
+## 3. Non-Goals
+
+- No generating/issuing individual transcripts here (that's a separate flow).
+- No SIS credential entry (web/M14.8).
+
+## 4. Personas & User Stories
+
+- **As a registrar admin**, I review the transcript release policy from my phone.
+- **As an advising admin**, I toggle an advising integration option on the go.
+
+## 5. Functional Requirements
+
+- **FR-1.** Each sub-view MUST require `rbac:manage` **and** its flag (`ffTranscripts` /
+  `ffAdvisingIntegration`); absent otherwise.
+- **FR-2.** MUST load and edit transcript config and persist.
+- **FR-3.** MUST load and edit advising config and persist.
+- **FR-4.** MUST show save/saving/saved/error states; require connectivity; audit edits.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — load/save < 700 ms p95.
+- **Security** — server-check permission + flag; audit edits.
+- **Privacy & Compliance** — transcripts + advising notes are sensitive FERPA data; config only,
+  no student records displayed here; no PII in logs.
+- **Accessibility** — form controls labeled; ≥44 pt.
+- **Internationalization** — localized; RTL.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* insufficient permission or a disabled flag, *Then* the sub-view is absent.
+- **AC-2.** *Given* a transcript config edit saved, *Then* it persists and audits.
+- **AC-3.** *Given* an advising config edit saved, *Then* it persists and M7.8 reflects it.
+- **AC-4.** Both apps build.
+
+## 8. Data Model
+
+- No schema changes. Read/write config only; no student records cached.
+
+## 9. API Surface
+
+- Reuse transcripts + advising config endpoints (`/me/advising/config` and transcript settings
+  endpoints). Verify shapes vs. the two web panels.
+
+## 10. UI / UX
+
+- Two cards (shown only when their flag is on): Transcripts config, Advising config — each a
+  simple form.
+- States: fallback, loading, error, saved.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- **iOS:** `Features/Settings/Admin/TranscriptsSettingsView.swift`, `AdvisingSettingsView.swift`;
+  API in `Core/LMS/LMSAPIAdmin.swift`; relates to M7.8 advising.
+- **Android:** `features/settings/admin/TranscriptsSettingsScreen.kt`, `AdvisingSettingsScreen.kt`;
+  `core/lms/LmsApi.kt`.
+
+## 13. Dependencies & Sequencing
+
+- After [M1.4](../completed/mobile/M1.4-settings-accommodations.md); pairs with
+  [M7.8 Academic advising](../completed/mobile/M7.8-academic-advising.md).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Transcript release policy misconfigured | M | H | Confirm + explain; audit; mirror web validation |
+| Advising config change disrupts student surface | M | M | Validate; audit; M7.8 handles gracefully |
+
+## 15. Rollout Plan
+
+- Flag: `mobile_admin_settings` (+ `ffTranscripts`/`ffAdvisingIntegration`). Internal → pilot → GA.
+- Rollback: flag hides the sub-views.
+
+## 16. Test Plan
+
+- **Unit** — permission/flag gating; config payloads.
+- **Integration** — transcripts config; advising config.
+- **E2E** — edit advising config → M7.8 reflects; flag-off/non-admin blocked.
+- **Security** — permission + flag; audit; FERPA.
+
+## 17. Documentation & Training
+
+- Admin help-center: "Configure transcripts and advising on mobile."
+
+## 18. Open Questions
+
+1. Exact transcript config fields to mirror.
+2. Which advising config options are safe on mobile.
+
+## 19. References
+
+- Web: `components/settings/transcripts-settings-panel.tsx`, `advising-settings-panel.tsx`.
+- Related: [M7.8](../completed/mobile/M7.8-academic-advising.md), [M14.8](./M14.8-integrations-provisioning-admin.md).
+</content>

--- a/docs/plan/mobile/README.md
+++ b/docs/plan/mobile/README.md
@@ -93,6 +93,8 @@ Android unless noted. Epics:
 | **M10** | K-12 & Parent — parent portal, attendance-taking, behavior/PBIS, report cards, conference booking, hall pass, age-appropriate UI |
 | **M11** | Instructor on Mobile — grading depth, take attendance, post announcement, quick authoring caps |
 | **M12** | Portfolios & Credentials — e-portfolio, co-curricular transcript, CCR, certificates wallet |
+| **M13** | Course Settings & Configuration — the full `/courses/{code}/settings/*` area: general, features, sections, grading, outcomes, grading agents, plagiarism, accessibility, translations, import/export, blueprint, archived |
+| **M14** | Platform, Org & Account Administration — the global `/settings/*` area (permission-gated): integrations/API access, roles, people, orgs/units/terms, branding & AI governance, platform config, AI models/prompts/reports, integrations/provisioning, transcripts/advising, archived courses |
 
 ## 5. Full backlog (every web feature → mobile disposition)
 
@@ -184,6 +186,58 @@ covered**, plus the navigation redesign needed to hold them. Added as stories:
 > now hosts it — plus a **More** hub and a header **search** entry. Every story above plugs into
 > that destination-registry contract.
 
+### Newly identified gap stories (2026-07-05 settings parity scan)
+
+A scan of the web **settings** surfaces — the course settings area
+(`pages/lms/course-settings.tsx` + `side-nav-course-settings-links.tsx`) and the global
+settings area (`pages/lms/settings.tsx`) — against the mobile app found that **none of the
+course-settings sections and none of the admin/global-settings views exist on mobile**. Only
+account/profile ([M1.4](../completed/mobile/M1.4-settings-accommodations.md)) and notification
+prefs ([M2.2](../completed/mobile/M2.2-notification-center.md)) were covered. This adds two
+epics. Every course-settings server endpoint already exists (no backend work); global-settings
+endpoints exist and are permission-gated (`rbac:manage` / `tenant:org-units:admin`) plus feature
+flags. Admin-heavy consoles are scoped as **status/review + guarded light actions natively, with
+link-out to web for credential entry and deep authoring**, consistent with the doctrine below.
+
+**M13 — Course Settings & Configuration** (instructor/course-admin; gated by
+`courseItemCreatePermission`; all endpoints exist):
+
+| Story | Web source (settings tab) | Disposition |
+|---|---|---|
+| [M13.1 Settings shell + General](./M13.1-course-settings-general.md) | `general` (basics, home, schedule, visibility, hero, theme, tz, publish) | **P1** (keystone) |
+| [M13.2 Features, tools & caption policy](./M13.2-course-features-tools.md) | `features` (+ caption policy, consortium) | **P1** |
+| [M13.3 Sections & cross-listing](./M13.3-course-sections-cross-listing.md) | `sections` (flag) | **P1** |
+| [M13.4 Grading settings](./M13.4-course-grading-settings.md) | `grading` (scale, weighted groups) | **P1** |
+| [M13.5 Outcomes settings](./M13.5-course-outcomes-settings.md) | `outcomes` | **P1** |
+| [M13.6 Grading agents](./M13.6-course-grading-agents.md) | `grading-agents` (flag) | **P2** |
+| [M13.7 Plagiarism & AI-authorship](./M13.7-course-plagiarism-settings.md) | `plagiarism` (flag) | **P2** |
+| [M13.8 Accessibility (alt-text) review](./M13.8-course-accessibility-review.md) | `accessibility` (flag) | **P2** |
+| [M13.9 Translations & localization](./M13.9-course-translations-localization.md) | `translations` (flag) | **P2** |
+| [M13.10 Import / export & backup](./M13.10-course-import-export.md) | `import-export` | **P2** |
+| [M13.11 Blueprint (curriculum sync)](./M13.11-course-blueprint-sync.md) | `blueprint` | **P2** |
+| [M13.12 Archived content](./M13.12-course-archived-content.md) | `archive` | **P2** |
+
+**M14 — Platform, Org & Account Administration** (global `/settings/*`; permission-gated):
+
+| Story | Web source (settings view) | Permission | Disposition |
+|---|---|---|---|
+| [M14.1 Account integrations & API access](./M14.1-account-integrations-api-access.md) | `integrations` (keys, calendar subs, MCP, service tokens) | user (service tokens: `rbac:manage`) | **P1** (user-facing) |
+| [M14.2 Roles & permissions](./M14.2-roles-permissions-admin.md) | `roles` | `rbac:manage` | **P2** (read + guarded assign) |
+| [M14.3 People / user management](./M14.3-people-user-management.md) | `people` | `rbac:manage` | **P2** |
+| [M14.4 Organizations, units & terms](./M14.4-organizations-units-terms.md) | `organizations`/`org-units`/`terms` | `rbac:manage` / `tenant:org-units:admin` | **P2** |
+| [M14.5 Branding, AI governance & provider](./M14.5-org-branding-ai-governance.md) | `org-branding` | `rbac:manage` / `tenant:org-units:admin` | **P2** |
+| [M14.6 Global platform config](./M14.6-global-platform-config.md) | `platform` | `rbac:manage` | **P2** (read + guarded flag toggle) |
+| [M14.7 AI models, prompts & reports](./M14.7-ai-models-prompts-reports.md) | `ai-models`/`ai-prompts`/`ai-reports` | `rbac:manage` | **P2** |
+| [M14.8 Integrations & provisioning admin](./M14.8-integrations-provisioning-admin.md) | `lti-tools`/`scim-provisioning`/`cloud-providers`/`lrs-integrations`/`oer-providers` (flags) | `rbac:manage` | **P2** (status + link-out) |
+| [M14.9 Transcripts & advising config](./M14.9-transcripts-advising-config.md) | `transcripts`/`advising` (flags) | `rbac:manage` | **P2** |
+| [M14.10 Global archived courses](./M14.10-global-archived-courses.md) | `archive` | `rbac:manage` | **P2** |
+
+> **Sequencing note.** [M13.1](./M13.1-course-settings-general.md) is the keystone for M13 — it
+> lands the course-settings shell (drawer entry, permission gate, save/unsaved-changes scaffold,
+> flag-aware section list) that M13.2–M13.12 plug into. For M14,
+> [M14.1](./M14.1-account-integrations-api-access.md) (user-facing) ships first; the admin views
+> (M14.2–M14.10) share a `mobile_admin_settings` flag and lead with read/status before edit.
+
 ### Stays web-only (reachable via in-app web view)
 
 Authoring and admin surfaces that are desktop-bound and out of scope for native:
@@ -194,6 +248,13 @@ grid editing & curving/CSV (3.11, 3.17 instructor), org/admin consoles (5.x admi
 authoring/import (QTI/Common Cartridge 2.13, Canvas import), proctoring config
 (14.9), evaluation/template authoring (14.7). Mobile links out to these with a
 "best on a larger screen" affordance rather than reimplementing them.
+
+> **Updated by the 2026-07-05 settings scan.** The *settings/config* surfaces themselves are no
+> longer treated as pure web-only: **M13** brings the course-settings area to mobile natively, and
+> **M14** brings the permission-gated global settings to mobile as review/status + guarded light
+> actions. What stays web-only is the **deep authoring and credential entry** behind those
+> settings — SIS/SCIM/cloud/LTI secret entry, custom-domain DNS, permission-matrix authoring,
+> QTI/Common Cartridge import, and template authoring — which M14 links out to.
 
 ## 6. Sequencing / roadmap
 
@@ -212,10 +273,16 @@ authoring/import (QTI/Common Cartridge 2.13, Canvas import), proctoring config
    M7.6 course feed ✅ + M7.7 evaluations, adaptive (M8.2 ✅/M8.3 ✅/M8.4 ✅), self-learner commerce
    (M9.1 ✅/M9.2 ✅/M9.3 ✅), parent (M10.1 ✅/M10.2), accessibility & i18n (M0.3 ✅/M0.4 ✅), settings (M1.4 ✅),
    instructor attendance (M11.1 ✅) + M11.3 instructor insights/at-risk + M11.4 course
-   people/roster.
+   people/roster. **Course settings (M13):** the settings shell + General (M13.1) lands as the
+   keystone, then the high-value instructor sections — Features (M13.2), Sections (M13.3),
+   Grading (M13.4), Outcomes (M13.5). **Account integrations (M14.1)** ships here too (user-facing).
 3. **Wave 3 — Situational (P2).** Lockdown, code exec, behavior/hall-pass,
    age-appropriate UI, e-portfolio/credentials, instructor broadcast, M7.8 advising,
-   M1.5 profile depth (demographics/custom fields/research consent).
+   M1.5 profile depth (demographics/custom fields/research consent). **Remaining course settings
+   (M13.6–M13.12):** grading agents, plagiarism, accessibility, translations, import/export,
+   blueprint, archived. **Admin/global settings (M14.2–M14.10):** roles, people, orgs/units/terms,
+   branding & AI governance, platform config, AI models/prompts/reports, integrations/provisioning,
+   transcripts/advising, archived courses — all behind `mobile_admin_settings`, read/status first.
 
 Each wave ships behind staged store releases (TestFlight / Play internal track →
 pilot cohort → GA). Per-feature server flags gate anything risky.


### PR DESCRIPTION
## Summary

A settings parity scan found that **course settings** (`/courses/{code}/settings/*`) and **global admin settings** (`/settings/*`) have no mobile coverage beyond account profile (M1.4) and notification prefs (M2.2). This PR adds two new epics with 22 implementation stories and updates the mobile README backlog accordingly.

### M13 — Course Settings & Configuration (12 stories)
Instructor/course-admin flows gated by `courseItemCreatePermission`. All server endpoints already exist.

- M13.1 Settings shell + General (P1 keystone)
- M13.2 Features, tools & caption policy (P1)
- M13.3 Sections & cross-listing (P1)
- M13.4 Grading settings (P1)
- M13.5 Outcomes settings (P1)
- M13.6 Grading agents (P2)
- M13.7 Plagiarism & AI-authorship (P2)
- M13.8 Accessibility review (P2)
- M13.9 Translations & localization (P2)
- M13.10 Import / export & backup (P2)
- M13.11 Blueprint sync (P2)
- M13.12 Archived content (P2)

### M14 — Platform, Org & Account Administration (10 stories)
Permission-gated global settings (`rbac:manage` / `tenant:org-units:admin`). Scoped as status/review + guarded light actions natively, with link-out to web for credential entry and deep authoring.

- M14.1 Account integrations & API access (P1, user-facing)
- M14.2 Roles & permissions (P2)
- M14.3 People / user management (P2)
- M14.4 Organizations, units & terms (P2)
- M14.5 Branding, AI governance & provider (P2)
- M14.6 Global platform config (P2)
- M14.7 AI models, prompts & reports (P2)
- M14.8 Integrations & provisioning admin (P2)
- M14.9 Transcripts & advising config (P2)
- M14.10 Global archived courses (P2)

### README updates
- Adds M13 and M14 to the epic table
- Adds disposition tables for both epics with sequencing notes
- Updates the "stays web-only" doctrine: settings/config surfaces move to native mobile; deep authoring and credential entry remain web-only

## Test plan

- [x] Documentation only — no code changes
- [x] All 22 story files follow the mobile story format
- [x] README links resolve to new story files