### PR TITLE
Speed up mobile CI workflows for iOS and Android

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -27,15 +27,10 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Cache Gradle
-        uses: actions/cache@v4
+      - uses: gradle/actions/setup-gradle@v4
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('clients/android/**/*.gradle.kts', 'clients/android/gradle/libs.versions.toml', 'clients/android/gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
+          build-root-directory: clients/android
+          cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
 
       - name: Accessibility artifacts
         run: ../../scripts/check-mobile-a11y.sh
@@ -43,8 +38,8 @@ jobs:
       - name: I18n artifacts
         run: ../../scripts/check-mobile-i18n.sh
 
-      - name: Lint
-        run: ./gradlew lint --no-daemon
+      - name: Lint, test, and build
+        run: ./gradlew lint test assembleDebug --build-cache --parallel
 
       - name: Upload lint report
         uses: actions/upload-artifact@v4
@@ -53,9 +48,3 @@ jobs:
           name: android-lint-report
           path: clients/android/app/build/reports/lint-results-debug.html
           retention-days: 7
-
-      - name: Test
-        run: ./gradlew test --no-daemon
-
-      - name: Build (debug)
-        run: ./gradlew assembleDebug --no-daemon

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -19,14 +19,31 @@ jobs:
     defaults:
       run:
         working-directory: clients/ios
+    env:
+      DERIVED_DATA_PATH: ${{ github.workspace }}/.cache/DerivedData
     steps:
       - uses: actions/checkout@v4
 
-      - name: Show Xcode version
-        run: xcodebuild -version
+      - name: Cache Xcode DerivedData
+        uses: actions/cache@v4
+        with:
+          path: .cache/DerivedData
+          key: xcode-deriveddata-${{ runner.os }}-${{ hashFiles('clients/ios/Lextures.xcodeproj/project.pbxproj', 'clients/ios/Lextures.xcodeproj/xcshareddata/**') }}
+          restore-keys: |
+            xcode-deriveddata-${{ runner.os }}-
+
+      - name: Cache SwiftLint
+        id: swiftlint-cache
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/swiftlint
+          key: swiftlint-${{ runner.os }}-0.58.2
 
       - name: Install SwiftLint
-        run: brew install swiftlint
+        if: steps.swiftlint-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL "https://github.com/realm/SwiftLint/releases/download/0.58.2/portable_swiftlint.zip" -o /tmp/swiftlint.zip
+          unzip -q -o /tmp/swiftlint.zip -d /usr/local/bin
 
       - name: Lint
         run: swiftlint lint --reporter github-actions-logging
@@ -36,17 +53,6 @@ jobs:
 
       - name: I18n artifacts
         run: ../../scripts/check-mobile-i18n.sh
-
-      - name: Build (simulator)
-        run: |
-          set -o pipefail
-          xcodebuild build \
-            -project Lextures.xcodeproj \
-            -scheme Lextures \
-            -destination 'generic/platform=iOS Simulator' \
-            -configuration Debug \
-            CODE_SIGNING_ALLOWED=NO \
-            | xcpretty
 
       - name: Select iOS Simulator
         id: sim
@@ -61,15 +67,7 @@ jobs:
           xcrun simctl list devices available || true
           exit 1
 
-      - name: Boot iOS Simulator
-        run: |
-          set -euo pipefail
-          name="${{ steps.sim.outputs.name }}"
-          udid="$(xcrun simctl list devices available | grep -F "    $name (" | head -1 | sed -E 's/.*\(([0-9A-F-]+)\).*/\1/')"
-          xcrun simctl boot "$udid" 2>/dev/null || true
-          xcrun simctl bootstatus "$udid" -b
-
-      - name: Test
+      - name: Build and test
         run: |
           set -o pipefail
           log=/tmp/xcodebuild-test.log
@@ -78,8 +76,11 @@ jobs:
             -scheme Lextures \
             -destination "platform=iOS Simulator,name=${{ steps.sim.outputs.name }}" \
             -configuration Debug \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
             CODE_SIGNING_ALLOWED=NO \
-            2>&1 | tee "$log" | xcpretty
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            ONLY_ACTIVE_ARCH=YES \
+            2>&1 | tee "$log"
           code=${PIPESTATUS[0]}
           if [ "$code" -ne 0 ]; then
             grep -E 'Test Case .* failed|TEST FAILED|Executed .* failures' "$log" | tail -30 || true

--- a/clients/android/gradle.properties
+++ b/clients/android/gradle.properties
@@ -1,4 +1,7 @@
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true


### PR DESCRIPTION
## Summary

Mobile CI workflows were taking ~10 minutes each. This PR cuts redundant work and adds caching so typical runs finish much faster.

### Android (`ci-android.yml`)
- Run `lint`, `test`, and `assembleDebug` in a **single Gradle invocation** (shared compilation, one JVM startup)
- Replace hand-rolled cache with **`gradle/actions/setup-gradle@v4`** for dependency and build-cache reuse
- Enable **parallel execution**, **build cache**, and **configuration cache** in `gradle.properties`

### iOS (`ci-ios.yml`)
- Remove the standalone **`xcodebuild build`** step — `xcodebuild test` already compiles
- **Cache DerivedData** for incremental builds across pushes on the same PR
- **Cache SwiftLint** via portable binary instead of `brew install` every run
- Drop manual simulator boot and xcpretty overhead
- Add CI compile flags: `COMPILER_INDEX_STORE_ENABLE=NO`, `ONLY_ACTIVE_ARCH=YES`

## Expected impact

| Workflow | Before | After (warm cache) |
| --- | --- | --- |
| Android | ~10 min | ~3–5 min |
| iOS | ~10 min | ~4–6 min |

First run on a PR may still be slower while caches warm up.

## Test plan

- [ ] Android workflow passes on a PR touching `clients/android/`
- [ ] iOS workflow passes on a PR touching `clients/ios/`
- [ ] Lint report artifact still uploads on Android
- [ ] iOS test failures still surface clearly in the Actions log