### PR TITLE
docs(cli): add feature parity plans (C01–C40)

### DIFF
--- a/docs/plan/cli/C01-courses.md
+++ b/docs/plan/cli/C01-courses.md
@@ -1,0 +1,135 @@
+# C01 — Courses (expand)
+
+> CLI parity plan. Source: `server/internal/httpserver/courses_routes.go`, `course_syllabus.go`, `course_put_nodb_test.go`. Baseline: `clients/cli/cmd/courses.go`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C01 |
+| **Section** | Course & content authoring |
+| **Severity** | BLOCKER |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | PARTIAL (list, get, create, delete only) |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Platform / CLI |
+| **Depends on** | C40 (framework) |
+| **Unblocks** | C02, C03, C06, C27 |
+
+---
+
+## 1. Problem Statement
+
+The CLI can list, get, create and archive courses but cannot **update** them, toggle publish state, manage the syllabus/settings, clone, or drive blueprint sync. Instructors and platform teams automating course provisioning (bulk term rollover, CI-managed course templates) must fall back to the web UI, breaking scripted workflows and CI/CD of course content.
+
+## 2. Goals
+
+- Full lifecycle: create → configure → publish → clone/rollover → archive/restore from the terminal.
+- Idempotent, scriptable course updates suitable for git-tracked course definitions.
+- Expose syllabus and course settings as get/set for infra-as-code.
+- Support blueprint (master course) associations and sync.
+
+## 3. Non-Goals
+
+- Authoring module/page content (see C02, C05).
+- Enrollment management (see C11).
+- Grading configuration internals beyond course-level scheme pointer (see C06/C07).
+
+## 4. Personas & User Stories
+
+- **As an admin**, I want to `courses update` scheme/dates in bulk so that term rollover is scripted.
+- **As an instructor**, I want to `courses publish`/`unpublish` so I can gate visibility from CI.
+- **As a course designer**, I want to `courses clone` a template into a new term.
+- **As a platform team**, I want `courses syllabus set --file` so syllabi are version-controlled.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `courses update <code>` mapping to `PUT /api/v1/courses/{id}` with flags for title, description, dates, term, grading-scheme, visibility.
+- **FR-2.** MUST add `courses publish <code>` / `courses unpublish <code>`.
+- **FR-3.** MUST add `courses restore <code>` (un-archive) complementing existing `delete`.
+- **FR-4.** MUST add `courses clone <code> --to-term <id> [--name]` mapping to the copy/blueprint route.
+- **FR-5.** SHOULD add `courses syllabus get|set <code>` (`--file`/stdin) via `course_syllabus.go`.
+- **FR-6.** SHOULD add `courses settings get|set <code>` (general settings, features/tools toggles).
+- **FR-7.** SHOULD add `courses hero-image set <code> <path>` and `courses catalog-listing set`.
+- **FR-8.** MAY add `courses blueprint sync <code>` and `courses storage-usage <code>`.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — single-course ops p95 < 500 ms server round-trip.
+- **Security** — reuse Bearer auth; server enforces `course:manage`/instructor scope. 403 → exit 2 with message.
+- **Privacy & Compliance** — no PII beyond what web UI exposes.
+- **Accessibility** — N/A (CLI); ensure `--json` and table output both stable.
+- **Reliability** — update/publish MUST be idempotent (re-publish a published course = success no-op).
+- **Observability** — commands set a `User-Agent: lextures-cli/<ver>` for server-side attribution.
+- **Backward compatibility** — existing `list/get/create/delete` output unchanged.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a course code, *When* `courses update <code> --title X`, *Then* `PUT` succeeds and `get` reflects the change.
+- **AC-2.** *Given* an unpublished course, *When* `courses publish`, *Then* published=true; re-running exits 0.
+- **AC-3.** *Given* `--json`, *When* any verb runs, *Then* output is valid JSON on stdout only.
+- **AC-4.** *Given* a template course, *When* `courses clone --to-term`, *Then* a new course code is printed.
+
+## 8. Data Model
+
+- No new client-side schema. Server tables unchanged; CLI serializes to existing course DTOs.
+- Add a `coursePublic` field parity check test so new flags map to real JSON keys.
+
+## 9. API Surface
+
+- `PUT /api/v1/courses/{id}`, `POST /api/v1/courses/{id}/publish` (or PUT with published flag), `POST /api/v1/courses/{id}/blueprint` (clone/associate), `GET|PUT /api/v1/courses/{id}/syllabus`, `GET|PUT` settings, `PUT /api/v1/courses/{id}/hero-image`, `GET /api/v1/courses/{id}/storage-usage`.
+- Reuse `client.NewRequest` + `doWithRetry`; 4xx → `apiError(resp, 2)`.
+
+## 10. UI / UX
+
+- `lextures courses <verb>` under existing `coursesCmd`. Table default; `--json` raw.
+- Empty/error states: 404 → "course not found"; 403 → permission message; both exit 2.
+- `set` verbs accept `--file -` for stdin piping.
+
+## 11. AI / ML Considerations
+
+- None (course metadata only).
+
+## 12. Integration Points
+
+- Internal: `clients/cli/cmd/courses.go`, `internal/client/client.go`.
+- Server: `courses_routes.go`, `course_syllabus.go`.
+
+## 13. Dependencies & Sequencing
+
+- After: C40 (shared table/JSON/`--file` helpers).
+- Before: C02, C06 rely on stable course addressing by code.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Publish route shape differs from expectation | M | M | Verify against `courses_routes.go` before coding; add nodb test |
+| Clone is async (job) | M | M | Return job id; integrate with C40 `--wait` |
+
+## 15. Rollout Plan
+
+- Feature flag: none needed (additive verbs). Ship behind CLI minor version bump.
+- Sequence: add verbs → tests → docs → release notes.
+- Rollback: verbs are additive; revert command file.
+
+## 16. Test Plan
+
+- **Unit** — flag parsing, path building (mirror `courses_test.go`).
+- **Integration** — httptest server asserting method/path/body per verb.
+- **E2E** — create→update→publish→clone→archive→restore against dev stack.
+- **Security** — 403 path returns exit 2.
+
+## 17. Documentation & Training
+
+- Update CLI README command table; add `docs/guides` recipe for term rollover scripting.
+
+## 18. Open Questions
+
+1. Is publish a dedicated route or a `PUT` field? Confirm in `courses_routes.go`.
+2. Is clone synchronous or job-backed?
+
+## 19. References
+
+- `clients/cli/cmd/courses.go`, `courses_test.go`; `server/internal/httpserver/courses_routes.go`, `course_syllabus.go`.
+- Related: [C02](C02-modules-course-structure.md), [C06](C06-gradebook-final-grades.md), [C40](C40-cli-framework.md).

--- a/docs/plan/cli/C02-modules-course-structure.md
+++ b/docs/plan/cli/C02-modules-course-structure.md
@@ -1,0 +1,130 @@
+# C02 — Modules & course structure
+
+> CLI parity plan. Source: `courses/{id}/structure` (25 routes), `modules`, `items`, `content-pages`, `external-links`, `registerConditionalReleaseRoutes`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C02 |
+| **Section** | Course & content authoring |
+| **Severity** | BLOCKER |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Platform / CLI |
+| **Depends on** | C01, C40 |
+| **Unblocks** | C03, C04, C05 |
+
+---
+
+## 1. Problem Statement
+
+A course's learning structure — modules, ordered items, content pages, prerequisites and conditional-release rules — is the backbone of a course, yet the CLI cannot read or author any of it. Teams that want to define courses as code (git → CI → `lextures`) cannot lay down module skeletons or reorder content programmatically, blocking course templating and mass authoring.
+
+## 2. Goals
+
+- Read the full course structure tree and diff it against a local definition.
+- Create/reorder/delete modules and items non-interactively.
+- Author content pages from Markdown/HTML files.
+- Set prerequisites and conditional-release requirements.
+
+## 3. Non-Goals
+
+- Rich media transcoding (see C33) and file upload internals (existing `files`).
+- Quiz/assignment bodies (C03/C04) — this plan manages their placement in modules only.
+
+## 4. Personas & User Stories
+
+- **As a course designer**, I want `structure get <course>` to export the module tree as JSON.
+- **As a designer**, I want `modules create/reorder` so I can script a course skeleton.
+- **As an author**, I want `pages create --file lesson.md` to publish content pages from disk.
+- **As an instructor**, I want `modules set-requirements` to gate a module behind a prerequisite.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `structure get <course> [--tree]` → `GET /api/v1/courses/{id}/structure`.
+- **FR-2.** MUST add `modules list|create|update|delete <course>` and `modules reorder <course> --order id,id,...`.
+- **FR-3.** MUST add `modules items add|remove|reorder` to place items (assignments, quizzes, pages, files, links) into a module.
+- **FR-4.** MUST add `pages create|update|publish|list|get <course>` mapping to `content-pages` (`--file`, `--title`, `--publish`).
+- **FR-5.** SHOULD add `links add|list <course>` for `external-links`.
+- **FR-6.** SHOULD add `modules set-requirements <course> <module>` and `structure apply --file structure.json` (declarative sync).
+- **FR-7.** MAY support `structure apply --dry-run` to preview diffs.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — `structure get` for a large course p95 < 1 s.
+- **Security** — server enforces course author scope; 403 → exit 2.
+- **Privacy & Compliance** — content pages may hold PII in examples; no special handling beyond auth.
+- **Reliability** — `reorder` and `apply` MUST be idempotent given identical input.
+- **Observability** — `apply` prints a change summary (created/updated/deleted counts).
+- **Maintainability** — new `cmd/modules.go`, `cmd/pages.go`.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a course, *When* `structure get --json`, *Then* the module→item tree is emitted.
+- **AC-2.** *Given* three modules, *When* `modules reorder --order c,a,b`, *Then* `get` reflects new order.
+- **AC-3.** *Given* `lesson.md`, *When* `pages create --file lesson.md --publish`, *Then* a published page id is returned.
+- **AC-4.** *Given* a JSON structure, *When* `structure apply --dry-run`, *Then* a diff is printed and nothing changes server-side.
+
+## 8. Data Model
+
+- No client persistence. Optional local `structure.json` schema documented for `apply`.
+
+## 9. API Surface
+
+- `GET /api/v1/courses/{id}/structure`; `.../modules` CRUD + reorder; `.../items` add/remove/reorder; `.../content-pages` CRUD/publish; `.../external-links`; conditional-release requirement endpoints.
+- Bodies: JSON; `--file` reads Markdown/HTML for page content.
+
+## 10. UI / UX
+
+- `lextures modules ...`, `lextures pages ...`, `lextures structure ...`.
+- `structure apply` shows `+ created / ~ updated / - deleted` summary; `--dry-run` for preview.
+- Errors: 409 on reorder conflict → exit 2 with hint to re-fetch.
+
+## 11. AI / ML Considerations
+
+- None directly (page authoring may embed AI-generated content authored elsewhere).
+
+## 12. Integration Points
+
+- Server structure/modules/content-pages handlers.
+- Internal: new command files under `clients/cli/cmd/`.
+
+## 13. Dependencies & Sequencing
+
+- After: C01 (course addressing), C40 (`--file`, diff/table helpers).
+- Before: C03/C04/C05 use `modules items add` to place their objects.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Structure schema is deeply nested | H | M | Model `structure apply` as thin passthrough; document JSON shape |
+| Item polymorphism (page vs quiz vs file) | M | M | `--type` flag + validation |
+
+## 15. Rollout Plan
+
+- Ship read verbs (`get`, `list`) first, then mutating verbs, then `apply`.
+- Rollback: additive; revert command files.
+
+## 16. Test Plan
+
+- **Unit** — order flag parsing; type validation.
+- **Integration** — httptest asserting reorder body and page create multipart/JSON.
+- **E2E** — build a full course skeleton via CLI, verify in web UI.
+
+## 17. Documentation & Training
+
+- "Courses as code" guide showing `structure get > structure.json` → edit → `structure apply`.
+
+## 18. Open Questions
+
+1. Does the server accept a full declarative structure, or only per-object mutations? (Determines `apply` shape.)
+2. Are content pages Markdown or HTML on the wire?
+
+## 19. References
+
+- `server/internal/httpserver` structure/modules/content-pages handlers; `registerConditionalReleaseRoutes`.
+- Related: [C01](C01-courses.md), [C03](C03-assignments.md), [C05](C05-content-extras.md), [C40](C40-cli-framework.md).

--- a/docs/plan/cli/C03-assignments.md
+++ b/docs/plan/cli/C03-assignments.md
@@ -1,0 +1,126 @@
+# C03 — Assignments (expand)
+
+> CLI parity plan. Source: `courses/{id}/assignments` (45 routes), `assignment_overrides_http.go`, `assignment_submissions_http.go`, `assignment_submission_annotations_http.go`, `assignment_submission_grade_http.go`. Baseline: `clients/cli/cmd/assignments.go`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C03 |
+| **Section** | Assessment & grading |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | PARTIAL (list, get, create, submit) |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Platform / CLI |
+| **Depends on** | C01, C02, C40 |
+| **Unblocks** | C06, C09 |
+
+---
+
+## 1. Problem Statement
+
+The CLI can list/get/create/submit assignments but cannot update or delete them, manage differentiated **overrides** (assign-to / multiple due dates), list submissions, download student work in bulk, or annotate/comment. Graders and course teams cannot script the full assignment lifecycle or bulk-download submissions for offline grading.
+
+## 2. Goals
+
+- Full assignment CRUD and publish state from the CLI.
+- Differentiated assignment overrides (assign-to section/student, alternate due dates).
+- Bulk submission listing and download for offline workflows.
+- Programmatic annotations/comments on submissions.
+
+## 3. Non-Goals
+
+- Score entry / gradebook math (see C06).
+- AI grading agents (see C09); rubrics live under grading settings.
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I want `assignments update/delete` so I can fix or retire tasks via script.
+- **As an instructor**, I want `assignments override` to grant an extension to one student/section.
+- **As a grader**, I want `assignments submissions download --all --out ./subs` for offline grading.
+- **As a TA**, I want `assignments annotate` to attach feedback programmatically.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `assignments update <id>` and `assignments delete <id>` (PUT/DELETE).
+- **FR-2.** MUST add `assignments publish|unpublish <id>`.
+- **FR-3.** MUST add `assignments overrides list|set|delete <id>` mapping to `assignment_overrides_http.go` (`--section`, `--user`, `--due`, `--available-from/until`).
+- **FR-4.** MUST add `assignments submissions list <id>` with filters (`--status`, `--user`, `--late`).
+- **FR-5.** MUST add `assignments submissions get <id> --user <u>` and `submissions download <id> [--all] --out <dir>`.
+- **FR-6.** SHOULD add `assignments submissions annotate` and `submissions comment` (annotations + text feedback).
+- **FR-7.** SHOULD add `assignments grade-history <id>` (assignment_grade_history.go).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — bulk download streams and shows progress; concurrency-limited (reuse upload pattern).
+- **Security** — grading scopes enforced server-side; 403 → exit 2.
+- **Privacy & Compliance** — submission downloads are FERPA-covered student records; command warns and requires `--yes` for `--all` bulk export.
+- **Reliability** — download resumes/skip-existing on re-run.
+- **Observability** — bulk ops print per-file success/failure summary.
+- **Backward compatibility** — existing `submit` unchanged.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* an assignment, *When* `assignments override set --user U --due 2026-09-01`, *Then* that user's due date changes.
+- **AC-2.** *Given* an assignment with 30 submissions, *When* `submissions download --all --out d`, *Then* 30 files land under `d/` with a summary.
+- **AC-3.** *Given* `--all` without `--yes`, *Then* the command refuses and prints the FERPA warning.
+
+## 8. Data Model
+
+- None client-side. Uses existing submission/attachment DTOs.
+
+## 9. API Surface
+
+- `PUT|DELETE /api/v1/courses/{c}/assignments/{a}`; overrides CRUD; `GET .../submissions`; `GET .../submissions/{u}` + attachment download; annotations POST; grade-history GET.
+
+## 10. UI / UX
+
+- Extend `assignmentsCmd`. New sub-group `assignments submissions` and `assignments overrides`.
+- Download shows a progress line per file; `--json` emits a manifest.
+
+## 11. AI / ML Considerations
+
+- None here (AI grading is C09).
+
+## 12. Integration Points
+
+- Server assignment/override/submission handlers.
+- Internal: `clients/cli/cmd/assignments.go`.
+
+## 13. Dependencies & Sequencing
+
+- After: C40 (bulk/progress helpers), C02 (module placement of assignments).
+- Before: C06 (grade entry references submissions), C09.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Attachment download requires signed URLs | M | M | Follow the existing `files download` signed-URL flow |
+| Overrides schema (assign-to sets) complex | M | M | Mirror differentiated-assignments plan 2.15 shapes |
+
+## 15. Rollout Plan
+
+- Ship CRUD + overrides first, then submissions list/download, then annotations.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — override flag combinations; download path safety (no traversal).
+- **Integration** — httptest for overrides body; submissions pagination.
+- **Security** — `--all` gating; 403 handling.
+
+## 17. Documentation & Training
+
+- Recipe: "Bulk-download submissions for offline grading."
+
+## 18. Open Questions
+
+1. Are submission attachments fetched via signed URL or direct stream?
+2. Override target model — section only, or section+student+group?
+
+## 19. References
+
+- `clients/cli/cmd/assignments.go`; `assignment_overrides_http.go`, `assignment_submissions_http.go`, `assignment_submission_annotations_http.go`.
+- Related: [C06](C06-gradebook-final-grades.md), [C09](C09-ai-grading-agents.md).

--- a/docs/plan/cli/C04-quizzes-question-banks.md
+++ b/docs/plan/cli/C04-quizzes-question-banks.md
@@ -1,0 +1,128 @@
+# C04 — Quizzes & question banks
+
+> CLI parity plan. Source: `courses/{id}/quizzes` (35 routes), `registerQuizDeliveryRoutes`, `registerQuizSubmitRoutes`, `registerQuizGradingRoutes`, `registerQuizGradeSyncRoutes`, `registerQuizCodeRunRoutes`. Baseline (partial): `clients/cli/cmd/questions.go`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C04 |
+| **Section** | Assessment & grading |
+| **Severity** | BLOCKER |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | PARTIAL (questions list/create/import only; no quizzes) |
+| **Estimated effort** | L (1–2mo) |
+| **Owner (proposed)** | Assessment / CLI |
+| **Depends on** | C02, C40 |
+| **Unblocks** | C06, C09 |
+
+---
+
+## 1. Problem Statement
+
+The CLI exposes only question-bank list/create/import — there is no way to create or manage **quizzes**, add questions to them, publish, view attempts, or trigger grading (including autograded code questions). Assessment-heavy programs cannot author or operate quizzes from CI or scripts, and cannot export question banks for backup/migration.
+
+## 2. Goals
+
+- Author quizzes and attach questions (from banks or inline) programmatically.
+- Manage quiz settings (time limits, attempts, availability, shuffle).
+- List attempts, grade submissions, sync grades to the gradebook.
+- Round-trip question banks (import already exists; add export).
+
+## 3. Non-Goals
+
+- Live proctoring UX; real-time delivery to students (student-side is a browser flow).
+- Rubric authoring beyond quiz settings (see C07 outcomes/rubrics).
+
+## 4. Personas & User Stories
+
+- **As an author**, I want `quizzes create` + `quizzes questions add` to build a quiz from a bank.
+- **As an instructor**, I want `quizzes publish` and `quizzes attempts list` to operate an exam.
+- **As a grader**, I want `quizzes grade` and `quizzes grade-sync` to push results to the gradebook.
+- **As an admin**, I want `questions export --bank <id>` for backup/migration (QTI).
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `quizzes list|get|create|update|delete <course>` and `quizzes publish|unpublish`.
+- **FR-2.** MUST add `quizzes questions add|remove|list|reorder <quiz>` (reference bank questions or inline).
+- **FR-3.** MUST add `quizzes settings set <quiz>` (time limit, attempts, shuffle, availability window).
+- **FR-4.** MUST add `quizzes attempts list <quiz>` and `quizzes attempts get <quiz> --user <u>`.
+- **FR-5.** MUST add `quizzes grade <quiz>` (trigger/regrade) and `quizzes grade-sync <quiz>` (push to gradebook).
+- **FR-6.** SHOULD add `quizzes code-run <quiz>` diagnostics for autograded code questions.
+- **FR-7.** SHOULD add `questions export --bank <id> [--qti]` complementing existing `questions import`.
+- **FR-8.** MAY add `questions banks list|create` for bank management.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — attempts list paginated; large banks streamed.
+- **Security** — quiz author/grader scopes; attempt data is FERPA-covered → same `--yes` gating as C03 for bulk export.
+- **Reliability** — grade/grade-sync idempotent; regrade safe to re-run.
+- **Observability** — grade-sync prints count synced/failed.
+- **Maintainability** — new `cmd/quizzes.go`; extend `cmd/questions.go`.
+- **Backward compatibility** — `questions import` unchanged.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a bank, *When* `quizzes create` then `quizzes questions add --bank B --count 10`, *Then* the quiz has 10 questions.
+- **AC-2.** *Given* a submitted quiz, *When* `quizzes grade-sync`, *Then* gradebook scores appear (verify via C06 `grades list`).
+- **AC-3.** *Given* `--json`, attempts list emits an array of attempt DTOs.
+- **AC-4.** *Given* a bank, *When* `questions export --qti`, *Then* a valid QTI .zip is produced.
+
+## 8. Data Model
+
+- None client-side. QTI export writes a `.zip`; import already parses QTI.
+
+## 9. API Surface
+
+- Quiz CRUD/publish under `/api/v1/courses/{c}/quizzes`; delivery/submit/grading/grade-sync/code-run route groups; question-bank list/create + export.
+
+## 10. UI / UX
+
+- `lextures quizzes ...` (course-scoped via `--course`), `lextures questions ...`.
+- Table default; `--json` raw. Attempt export gated by `--yes`.
+
+## 11. AI / ML Considerations
+
+- Autograded code questions run server-side sandboxes; CLI only triggers/reads — no model calls from CLI. AI-assisted grading is deferred to C09.
+
+## 12. Integration Points
+
+- Server quiz + grade-sync handlers; gradebook (C06).
+- Internal: `clients/cli/cmd/quizzes.go`, `questions.go`.
+
+## 13. Dependencies & Sequencing
+
+- After: C02 (place quiz in a module), C40.
+- Before: C06 (grade-sync target), C09.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| 35 quiz routes → large surface | H | M | Phase: author → operate → grade; ship incrementally |
+| QTI export fidelity | M | M | Round-trip test import↔export |
+
+## 15. Rollout Plan
+
+- Phase 1 authoring (CRUD/questions/settings), Phase 2 operate (publish/attempts), Phase 3 grade/sync/export.
+- Rollback: additive per phase.
+
+## 16. Test Plan
+
+- **Unit** — question-add modes (bank ref vs inline); settings flags.
+- **Integration** — httptest for grade-sync; QTI export golden file.
+- **E2E** — author→publish→simulate attempt→grade-sync→verify grade.
+
+## 17. Documentation & Training
+
+- "Author a quiz from a question bank in CI" recipe; QTI backup guide.
+
+## 18. Open Questions
+
+1. Can questions be added inline, or only by bank reference?
+2. Is grade-sync automatic on submit or an explicit action?
+
+## 19. References
+
+- `clients/cli/cmd/questions.go`; quiz route groups in `server/internal/httpserver/server.go`.
+- Related: [C02](C02-modules-course-structure.md), [C06](C06-gradebook-final-grades.md), [C09](C09-ai-grading-agents.md).

--- a/docs/plan/cli/C05-content-extras.md
+++ b/docs/plan/cli/C05-content-extras.md
@@ -1,0 +1,124 @@
+# C05 — Content extras (pages, glossary, H5P, SCORM, external tools, resources)
+
+> CLI parity plan. Source: `courses/{id}` sub-resources `glossary`, `h5p`/`h5p-items`, `scorm`/`scorm-items`, `lti-external-tools`, `external-links`, `textbook-resources`, `library-resources`, `collab-docs`, `whiteboards`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C05 |
+| **Section** | Course & content authoring |
+| **Severity** | MINOR |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Content / CLI |
+| **Depends on** | C02, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+Rich course content — interactive H5P, SCORM packages, glossaries, embedded external (LTI) tools, textbook/library resource links, collaborative docs and whiteboards — cannot be managed from the CLI. Content teams migrating or bulk-loading interactive packages (e.g. dozens of SCORM zips) must click through the UI package by package.
+
+## 2. Goals
+
+- Bulk-import SCORM/H5P packages and link them into modules.
+- Manage course glossary terms as data (get/set from file).
+- Register external LTI tools and resource links per course.
+- Read (and where sensible, create) collab-docs/whiteboards for backup/migration.
+
+## 3. Non-Goals
+
+- Live editing of whiteboards/collab-docs (real-time browser experience).
+- Media transcoding (see C33) beyond triggering it via existing upload.
+
+## 4. Personas & User Stories
+
+- **As a content engineer**, I want `scorm import <zip>` to load a package and get its item id.
+- **As a designer**, I want `glossary set --file glossary.csv` to bulk-load terms.
+- **As an admin**, I want `tools add --url ... --key ...` to register an LTI tool in a course.
+- **As an archivist**, I want `collab-docs export <course>` for backup.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `scorm import <course> <zip>` and `scorm list|get|delete` (+ `scorm-items`).
+- **FR-2.** MUST add `h5p import <course> <package>` and `h5p list|delete` (+ `h5p-items`).
+- **FR-3.** MUST add `glossary list|get|set <course>` (`--file` CSV/JSON) and per-term add/delete.
+- **FR-4.** SHOULD add `tools add|list|remove <course>` for `lti-external-tools` and `external-links`.
+- **FR-5.** SHOULD add `resources link|list <course>` for `textbook-resources`/`library-resources`.
+- **FR-6.** MAY add `collab-docs list|export` and `whiteboards list|export` (read/backup only).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — package import streams uploads with progress (reuse `files upload`).
+- **Security** — content author scope; LTI tool secrets never echoed back in output.
+- **Privacy & Compliance** — collab-doc/whiteboard exports may contain student content → FERPA `--yes` gate on bulk export.
+- **Reliability** — import is resumable/skips-existing by content hash where the server supports it.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a SCORM zip, *When* `scorm import`, *Then* an item id is returned and it appears in `structure get`.
+- **AC-2.** *Given* `glossary.csv`, *When* `glossary set --file`, *Then* terms are created and `glossary list` shows them.
+- **AC-3.** *Given* an LTI tool, *When* `tools add`, *Then* the secret is not printed in `--json` output.
+
+## 8. Data Model
+
+- None client-side. Document CSV/JSON glossary schema.
+
+## 9. API Surface
+
+- SCORM/H5P import + item endpoints; `glossary` CRUD; `lti-external-tools`/`external-links`; `textbook-resources`/`library-resources`; `collab-docs`/`whiteboards` read/export.
+
+## 10. UI / UX
+
+- `lextures scorm|h5p|glossary|tools|resources ...`, all `--course` scoped.
+- Import shows upload progress; `--json` returns created ids.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server content handlers; TUS/upload pipeline (existing `files upload`).
+- Internal: new command files.
+
+## 13. Dependencies & Sequencing
+
+- After: C02 (to link items into modules), C40 (upload/progress/`--file`).
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| SCORM/H5P import is async (transcode/unpack job) | M | M | Return job id; integrate C40 `--wait` |
+| Whiteboard/collab-doc export format proprietary | M | L | Export as opaque JSON blob; document limits |
+
+## 15. Rollout Plan
+
+- Ship SCORM/H5P import + glossary first (highest bulk value), then tools/resources, then read-only exports.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — glossary CSV parsing; secret redaction.
+- **Integration** — package import multipart; item listing.
+- **E2E** — import SCORM → verify in module.
+
+## 17. Documentation & Training
+
+- "Bulk-import SCORM packages" recipe.
+
+## 18. Open Questions
+
+1. Are SCORM/H5P imports synchronous or job-backed?
+2. Is there a stable export format for collab-docs/whiteboards?
+
+## 19. References
+
+- Content sub-resource handlers in `server/internal/httpserver`.
+- Related: [C02](C02-modules-course-structure.md), [C23](C23-lti-developer-keys.md), [C33](C33-accessibility-media-localization.md), [C40](C40-cli-framework.md).

--- a/docs/plan/cli/C06-gradebook-final-grades.md
+++ b/docs/plan/cli/C06-gradebook-final-grades.md
@@ -1,0 +1,126 @@
+# C06 — Gradebook & final grades (expand)
+
+> CLI parity plan. Source: `courses/{id}` `gradebook`, `grading`, `grading-scheme`, `grading-backlog`, `final-grades`, `registerFinalGradeRoutes`, `curves`, what-if. Baseline: `clients/cli/cmd/grades.go`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C06 |
+| **Section** | Assessment & grading |
+| **Severity** | BLOCKER |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | PARTIAL (list, update, export) |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Assessment / CLI |
+| **Depends on** | C03, C04, C40 |
+| **Unblocks** | C07, C31 |
+
+---
+
+## 1. Problem Statement
+
+The CLI can list grades, update a single score and export CSV, but cannot read the full gradebook matrix, post grades in bulk, manage the grading scheme, work the grading backlog, apply curves, or finalize/submit final grades. Registrars and instructors cannot script end-of-term grade posting or curve application — the highest-value grading automation.
+
+## 2. Goals
+
+- Bulk grade import/export round-trip (edit CSV offline → post).
+- Read the whole gradebook as a matrix (students × items).
+- Manage grading scheme and grading backlog from the terminal.
+- Apply curves and finalize/submit final grades.
+
+## 3. Non-Goals
+
+- Rubric/outcome authoring (see C07).
+- AI grading (see C09).
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I want `gradebook export` → edit → `gradebook import` to post many grades at once.
+- **As a registrar**, I want `final-grades submit <course>` to finalize the term.
+- **As an instructor**, I want `grades curve` to apply a curve and preview the effect.
+- **As a TA**, I want `grading-backlog list` to see what still needs grading.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `gradebook get <course>` (matrix; `--json` and CSV).
+- **FR-2.** MUST add `gradebook import <course> --file grades.csv` (bulk upsert) and keep existing `grades export`.
+- **FR-3.** MUST add `grades scheme get|set <course>` (grading-scheme).
+- **FR-4.** MUST add `final-grades list|set|submit <course>` (`registerFinalGradeRoutes`).
+- **FR-5.** SHOULD add `grades curve <course> --assignment <a> --method <linear|sqrt|...>` with `--dry-run`.
+- **FR-6.** SHOULD add `grading-backlog list <course>` and `grades what-if` (student projection).
+- **FR-7.** MAY add `grades history <course> --assignment <a> --user <u>` (assignment_grade_history).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — gradebook matrix for large sections paginated/streamed; p95 < 2 s.
+- **Security** — grade-manage scope; final-grade submit may require elevated role; 403 → exit 2.
+- **Privacy & Compliance** — grades are FERPA records; bulk export gated by `--yes`; audit noted server-side.
+- **Reliability** — bulk import is transactional per row with a summary; idempotent re-post.
+- **Observability** — import prints posted/failed counts with row-level errors.
+- **Backward compatibility** — existing `grades list/update/export` unchanged.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a CSV of scores, *When* `gradebook import`, *Then* scores post and a summary shows counts.
+- **AC-2.** *Given* a course, *When* `final-grades submit`, *Then* final grades are locked/submitted (verify `final-grades list`).
+- **AC-3.** *Given* `grades curve --dry-run`, *Then* projected scores print and nothing changes.
+
+## 8. Data Model
+
+- None client-side. Document the gradebook CSV column contract (student id, item id/title, score).
+
+## 9. API Surface
+
+- `GET .../gradebook`; bulk grade post; `GET|PUT .../grading-scheme`; `final-grades` list/set/submit; `curves`; `grading-backlog`; grade-history.
+
+## 10. UI / UX
+
+- Extend `gradesCmd`; add `gradebook` and `final-grades` sub-groups.
+- CSV is the default interchange for bulk; `--json` for programmatic.
+
+## 11. AI / ML Considerations
+
+- None (AI grading is C09; what-if is deterministic projection).
+
+## 12. Integration Points
+
+- Server gradebook/final-grade/curve handlers; quiz grade-sync (C04).
+- Internal: `clients/cli/cmd/grades.go`.
+
+## 13. Dependencies & Sequencing
+
+- After: C03/C04 (submissions/attempts exist to grade), C40 (`--file`, `--yes`, `--dry-run`).
+- Before: C07 (SBG builds on scheme), C31 (transcripts read final grades).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Final-grade submit irreversible | M | H | Require `--yes`; support `final-grades unlock` if server allows |
+| CSV column drift between export/import | M | M | Share one schema; round-trip test |
+
+## 15. Rollout Plan
+
+- Ship gradebook get/import + scheme first, then final-grades, then curves/what-if.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — CSV parse/serialize round-trip; curve math dry-run.
+- **Integration** — bulk post partial-failure summary.
+- **E2E** — export→edit→import→final submit against dev stack.
+
+## 17. Documentation & Training
+
+- "End-of-term grade posting" and "Apply a curve" recipes.
+
+## 18. Open Questions
+
+1. Is final-grade submission reversible?
+2. Does bulk post accept CSV or JSON on the wire?
+
+## 19. References
+
+- `clients/cli/cmd/grades.go`; `registerFinalGradeRoutes`, gradebook/curve handlers.
+- Related: [C03](C03-assignments.md), [C04](C04-quizzes-question-banks.md), [C07](C07-outcomes-standards-sbg.md), [C31](C31-credentials-transcripts-advising.md).

--- a/docs/plan/cli/C07-outcomes-standards-sbg.md
+++ b/docs/plan/cli/C07-outcomes-standards-sbg.md
@@ -1,0 +1,122 @@
+# C07 — Outcomes, standards & SBG report cards
+
+> CLI parity plan. Source: `courses/{id}/outcomes`, `registerStandardsRoutes`, `registerSBGReportRoutes`, `registerReportCardRoutes`, `course_outcomes_report.go`, `sbg`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C07 |
+| **Section** | Assessment & grading |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Assessment / CLI |
+| **Depends on** | C06, C40 |
+| **Unblocks** | C27, C31 |
+
+---
+
+## 1. Problem Statement
+
+Standards/outcomes alignment, standards-based grading (SBG) and report cards are core to K-12 and outcomes-driven HE, but none are reachable from the CLI. Districts cannot bulk-load standards frameworks, align outcomes to assignments, or export report cards for their SIS/print pipeline.
+
+## 2. Goals
+
+- Import/align standards and outcomes to courses and assignments in bulk.
+- Read outcome mastery and SBG rollups programmatically.
+- Generate/export report cards for a section or student.
+
+## 3. Non-Goals
+
+- Authoring the assignment/quiz that an outcome aligns to (C03/C04).
+- Transcript generation (C31) — report cards here are term progress reports.
+
+## 4. Personas & User Stories
+
+- **As a district admin**, I want `standards import --file framework.json` to load a standards set.
+- **As a curriculum lead**, I want `outcomes align` to map outcomes to assignments in bulk.
+- **As a teacher**, I want `report-cards export --section S` to produce printable report cards.
+- **As an analyst**, I want `outcomes report <course>` to pull mastery data for BI.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `standards list|import|get` (`registerStandardsRoutes`, `--file` framework).
+- **FR-2.** MUST add `outcomes list|create|align|report <course>` (`course_outcomes_report.go`).
+- **FR-3.** MUST add `sbg get <course>` and `report-cards list|get|export <course>` (`--section`, `--user`, `--format pdf|csv|json`).
+- **FR-4.** SHOULD add `outcomes mastery <course> --user <u>` (student rollup).
+- **FR-5.** MAY add `standards align-suggest` (server-suggested alignments) if the endpoint exists.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — report-card export for a section streams; p95 < 3 s per section.
+- **Security** — outcomes-manage / report scope; report cards FERPA-covered → `--yes` on bulk export.
+- **Privacy & Compliance** — student mastery data is FERPA; redact on shared output.
+- **Reliability** — import idempotent by standards code.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a framework file, *When* `standards import`, *Then* standards are created and `standards list` shows them.
+- **AC-2.** *Given* aligned outcomes, *When* `outcomes report --json`, *Then* mastery rollups are emitted.
+- **AC-3.** *Given* a section, *When* `report-cards export --format pdf --out d`, *Then* PDFs are written with a summary.
+
+## 8. Data Model
+
+- None client-side. Document framework import JSON and report-card CSV schema.
+
+## 9. API Surface
+
+- `standards` list/import; `courses/{c}/outcomes` CRUD + align + report; `sbg`; `report-cards` list/get/export.
+
+## 10. UI / UX
+
+- `lextures standards ...`, `lextures outcomes ...`, `lextures report-cards ...`.
+- Export writes files; `--json` for data.
+
+## 11. AI / ML Considerations
+
+- Optional `align-suggest` may be AI-backed server-side; CLI only triggers/reads. No CLI model calls.
+
+## 12. Integration Points
+
+- Server standards/outcomes/SBG/report-card handlers.
+- Internal: new command files.
+
+## 13. Dependencies & Sequencing
+
+- After: C06 (grades feed SBG), C40.
+- Before: C27 (reports include outcomes), C31.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Framework import format (CASE/IMS) complex | M | M | Support the server's native JSON first; note CASE as follow-up |
+| Report-card PDF generation is async | M | M | Return job id; C40 `--wait` |
+
+## 15. Rollout Plan
+
+- Ship standards/outcomes read+import first, then SBG/report-card export.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — framework parse; align mapping.
+- **Integration** — outcomes report shape; report-card export manifest.
+- **E2E** — import→align→export report card.
+
+## 17. Documentation & Training
+
+- "Load a standards framework and align outcomes" recipe.
+
+## 18. Open Questions
+
+1. What framework import format does the server accept (native vs IMS CASE)?
+2. Is report-card export synchronous?
+
+## 19. References
+
+- `registerStandardsRoutes`, `registerSBGReportRoutes`, `registerReportCardRoutes`, `course_outcomes_report.go`.
+- Related: [C06](C06-gradebook-final-grades.md), [C27](C27-reports-exports.md), [C31](C31-credentials-transcripts-advising.md).

--- a/docs/plan/cli/C08-peer-review-evaluations-surveys.md
+++ b/docs/plan/cli/C08-peer-review-evaluations-surveys.md
@@ -1,0 +1,117 @@
+# C08 — Peer review, evaluations & surveys
+
+> CLI parity plan. Source: `registerPeerReviewRoutes` (`peer-review`), `courses/{id}/reviews`/`evaluations`, `admin/evaluation-templates`, `registerSurveyRoutes` (`surveys`). Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C08 |
+| **Section** | Assessment & grading |
+| **Severity** | MINOR |
+| **Markets** | HE / K12 / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Assessment / CLI |
+| **Depends on** | C03, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+Peer review, course/instructor evaluations, evaluation templates and surveys have no CLI presence. Program admins cannot bulk-configure end-of-term evaluations or export survey results for analysis, and instructors cannot script peer-review assignment/allocation.
+
+## 2. Goals
+
+- Configure and allocate peer reviews for an assignment.
+- Manage evaluation templates and launch course/instructor evaluations.
+- Create surveys and export responses for BI.
+
+## 3. Non-Goals
+
+- Building the student response UX (browser flow).
+- Rubric authoring beyond template fields.
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I want `peer-review allocate <assignment>` to assign reviewers.
+- **As a program admin**, I want `evaluations launch --template T --course C` at term end.
+- **As an analyst**, I want `surveys results export <id>` to pull responses.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `peer-review status|allocate|list <assignment>` (`registerPeerReviewRoutes`).
+- **FR-2.** MUST add `evaluation-templates list|create|get` (admin) and `evaluations launch|list|get <course>`.
+- **FR-3.** MUST add `surveys list|create|get|results <id>` with `results export --format csv|json`.
+- **FR-4.** SHOULD add `evaluations results export` for completed evaluations.
+- **FR-5.** MAY add `peer-review reminders send` if the endpoint exists.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — results export paginated/streamed.
+- **Security** — evaluation/survey admin scope; anonymity preserved in exports.
+- **Privacy & Compliance** — evaluations often anonymous → CLI MUST NOT expose respondent identity when the server marks a survey anonymous.
+- **Reliability** — allocation idempotent.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* submissions, *When* `peer-review allocate --per 2`, *Then* each submission gets 2 reviewers.
+- **AC-2.** *Given* a template, *When* `evaluations launch`, *Then* an evaluation id is returned.
+- **AC-3.** *Given* an anonymous survey, *When* `surveys results export`, *Then* no respondent identity is present.
+
+## 8. Data Model
+
+- None client-side.
+
+## 9. API Surface
+
+- `peer-review` status/allocate/list; `admin/evaluation-templates`; `courses/{c}/evaluations`; `surveys` CRUD + results.
+
+## 10. UI / UX
+
+- `lextures peer-review ...`, `lextures evaluations ...`, `lextures surveys ...`.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server peer-review/evaluation/survey handlers.
+
+## 13. Dependencies & Sequencing
+
+- After: C03 (peer review targets submissions), C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Anonymity leakage in export | L | H | Assert server anonymity flag; strip identity fields; test |
+
+## 15. Rollout Plan
+
+- Ship surveys + evaluations first (broader use), then peer-review allocation.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — allocation flag math; anonymity stripping.
+- **Integration** — results export shape.
+- **E2E** — allocate peer review; export survey.
+
+## 17. Documentation & Training
+
+- "Launch end-of-term evaluations" recipe.
+
+## 18. Open Questions
+
+1. Is peer-review allocation server-driven or does the CLI supply pairings?
+
+## 19. References
+
+- `registerPeerReviewRoutes`, `registerSurveyRoutes`, evaluation-template handlers.
+- Related: [C03](C03-assignments.md), [C27](C27-reports-exports.md).

--- a/docs/plan/cli/C09-ai-grading-agents.md
+++ b/docs/plan/cli/C09-ai-grading-agents.md
@@ -1,0 +1,124 @@
+# C09 — AI grading agents
+
+> CLI parity plan. Source: `courses/{id}/grader-agent-templates` (5), `grader-agents`, `course-grading-agents`, `grading_agent_dry_run_ws.go`, `course_grading_settings`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C09 |
+| **Section** | Assessment & grading |
+| **Severity** | MAJOR |
+| **Markets** | HE / K12 / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | AI / CLI |
+| **Depends on** | C03, C06, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+AI grading agents (templates, per-course agents, dry-runs) are a differentiating feature with no CLI access. Course teams cannot version-control grader configs, run dry-runs in CI to validate a rubric-to-agent mapping, or batch-trigger AI grading — forcing manual UI configuration that can't be reviewed or reproduced.
+
+## 2. Goals
+
+- Manage grader-agent templates and per-course agents as version-controlled config.
+- Run a grading agent **dry-run** and inspect results before applying.
+- Trigger AI grading for an assignment and review/accept suggested scores.
+
+## 3. Non-Goals
+
+- Training or fine-tuning models (server/provider concern).
+- Human grade entry (C06) — this plan produces suggestions that flow into it.
+
+## 4. Personas & User Stories
+
+- **As a course team**, I want `grader-agents set --file agent.json` so configs live in git.
+- **As an instructor**, I want `grader-agents dry-run` to preview AI scores on sample submissions.
+- **As a grader**, I want `grader-agents run <assignment>` then review before syncing to the gradebook.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `grader-templates list|get|create` (grader-agent-templates).
+- **FR-2.** MUST add `grader-agents list|get|set|delete <course>` (`--file` config).
+- **FR-3.** MUST add `grader-agents dry-run <course> --assignment <a> [--sample N]` consuming `grading_agent_dry_run_ws.go` (WS stream → printed results).
+- **FR-4.** SHOULD add `grader-agents run <assignment>` and `grader-agents results <assignment>` (suggested scores; `--accept` to sync).
+- **FR-5.** SHOULD surface AI disclosure/model info in output (ties to C29 AI disclosure).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — dry-run streams incremental results over WebSocket; CLI renders progress.
+- **Security** — AI-grading scope; provider keys never exposed.
+- **Privacy & Compliance** — submissions sent to AI are FERPA/PII-sensitive; CLI MUST surface the AI-disclosure notice and honor course AI opt-out.
+- **Reliability** — dry-run has no gradebook side effects; `run` is idempotent per submission.
+- **Cost** — dry-run `--sample` limits token spend; command prints an estimated cost if the server returns one.
+- **Observability** — print model id and token usage per run (from `ai_provider_usage`).
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* an agent config file, *When* `grader-agents set --file`, *Then* the config is stored and `get` matches.
+- **AC-2.** *Given* a dry-run, *Then* streamed suggested scores print and the gradebook is unchanged.
+- **AC-3.** *Given* an AI-opt-out course, *When* any grading agent command runs, *Then* it refuses with a clear message.
+
+## 8. Data Model
+
+- None client-side. Document agent config JSON schema.
+
+## 9. API Surface
+
+- `grader-agent-templates` CRUD; `courses/{c}/grader-agents` CRUD; dry-run WebSocket (`grading_agent_dry_run_ws.go`); run/results; grade-sync into C06.
+
+## 10. UI / UX
+
+- `lextures grader-templates ...`, `lextures grader-agents ...`.
+- WebSocket dry-run renders a live progress line; `--json` collects final results.
+
+## 11. AI / ML Considerations
+
+- Model(s): server-selected via provider settings (C25/C29). CLI passes config, never prompts directly.
+- PII redaction and opt-out enforced server-side; CLI surfaces disclosure text.
+- Cost budget: `--sample` and printed usage.
+
+## 12. Integration Points
+
+- Server grader-agent + AI provider + disclosure handlers; WebSocket client (new in CLI — see C40 WS helper).
+- Internal: new `cmd/grader_agents.go`.
+
+## 13. Dependencies & Sequencing
+
+- After: C03 (submissions), C06 (grade sync), C40 (WS helper).
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| CLI has no WebSocket client yet | H | M | Add shared WS helper in C40; fall back to polling if server offers REST dry-run |
+| Cost overrun on large runs | M | M | Enforce `--sample`; print estimate; require `--yes` for full-class runs |
+
+## 15. Rollout Plan
+
+- Ship templates/agents CRUD + dry-run first, then run/accept.
+- Rollback: additive; dry-run has no side effects.
+
+## 16. Test Plan
+
+- **Unit** — config parse; opt-out gating.
+- **Integration** — WS dry-run stream parsing (mock WS server).
+- **E2E** — set agent → dry-run → run → sync grade.
+
+## 17. Documentation & Training
+
+- "Version-control an AI grader and validate it in CI" recipe.
+
+## 18. Open Questions
+
+1. Is dry-run WebSocket-only, or is there a REST variant?
+2. How is estimated cost surfaced by the server?
+
+## 19. References
+
+- `grading_agent_dry_run_ws.go`, grader-agent handlers; `ai_provider_usage.go`.
+- Related: [C06](C06-gradebook-final-grades.md), [C25](C25-integrations-webhooks-bots.md), [C29](C29-compliance-privacy.md), [C40](C40-cli-framework.md).

--- a/docs/plan/cli/C10-plagiarism-originality.md
+++ b/docs/plan/cli/C10-plagiarism-originality.md
@@ -1,0 +1,115 @@
+# C10 — Plagiarism & originality
+
+> CLI parity plan. Source: `courses/{id}/plagiarism-settings` (3), `originality_http.go`, `webhooks_originality.go`, `registerFERPARoutes` (integrity adjacency). Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C10 |
+| **Section** | Assessment & grading |
+| **Severity** | MAJOR |
+| **Markets** | HE / K12 |
+| **Status (today)** | MISSING |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Integrity / CLI |
+| **Depends on** | C03, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+Originality/plagiarism configuration and report retrieval are UI-only. Institutions with academic-integrity policies cannot standardize plagiarism settings across courses via script, nor pull originality scores/reports for audit.
+
+## 2. Goals
+
+- Configure per-course plagiarism settings consistently across many courses.
+- Trigger originality checks and retrieve scores/reports for submissions.
+
+## 3. Non-Goals
+
+- Implementing a detector (third-party providers do this).
+- Adjudicating integrity cases (a human/process concern).
+
+## 4. Personas & User Stories
+
+- **As an integrity officer**, I want `plagiarism settings set --file policy.json` across courses.
+- **As an instructor**, I want `originality get <assignment> --user U` to pull a report link/score.
+- **As an auditor**, I want `originality list <assignment>` to export scores for a cohort.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `plagiarism settings get|set <course>` (`plagiarism-settings`, `--file`).
+- **FR-2.** MUST add `originality status|get <assignment> --user <u>` and `originality list <assignment>`.
+- **FR-3.** SHOULD add `originality submit <assignment> --user <u>` to (re)trigger a check.
+- **FR-4.** MAY add `originality export <assignment> --out file.csv`.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — list paginated.
+- **Security** — integrity/report scope; provider credentials never printed.
+- **Privacy & Compliance** — originality reports are FERPA records; export gated by `--yes`.
+- **Reliability** — (re)submit idempotent while a check is pending.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a policy file, *When* `plagiarism settings set`, *Then* `get` reflects it.
+- **AC-2.** *Given* a checked submission, *When* `originality get`, *Then* score + report reference print.
+- **AC-3.** *Given* `originality export` without `--yes`, *Then* it refuses.
+
+## 8. Data Model
+
+- None client-side. Document policy JSON schema.
+
+## 9. API Surface
+
+- `courses/{c}/plagiarism-settings` get/set; `originality_http.go` status/get/list/submit. (Inbound `webhooks_originality.go` is server-side, not CLI.)
+
+## 10. UI / UX
+
+- `lextures plagiarism settings ...`, `lextures originality ...`.
+
+## 11. AI / ML Considerations
+
+- Some originality is AI-detection; CLI only reads provider results.
+
+## 12. Integration Points
+
+- Server originality + plagiarism-settings handlers; third-party provider (Turnitin/etc.) via server.
+
+## 13. Dependencies & Sequencing
+
+- After: C03 (submissions), C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Provider variance in report shape | M | M | Normalize to score + report URL; passthrough raw in `--json` |
+
+## 15. Rollout Plan
+
+- Ship settings get/set + originality get/list; add submit/export next.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — policy parse; `--yes` gate.
+- **Integration** — originality get/list shapes.
+- **E2E** — set policy → submit → get score.
+
+## 17. Documentation & Training
+
+- "Standardize plagiarism policy across a term" recipe.
+
+## 18. Open Questions
+
+1. Which providers are enabled, and do their report shapes differ enough to need per-provider handling?
+
+## 19. References
+
+- `originality_http.go`, `webhooks_originality.go`, `plagiarism-settings` handlers.
+- Related: [C03](C03-assignments.md), [C29](C29-compliance-privacy.md).

--- a/docs/plan/cli/C11-enrollments-sections.md
+++ b/docs/plan/cli/C11-enrollments-sections.md
@@ -1,0 +1,125 @@
+# C11 — Enrollments & sections
+
+> CLI parity plan. Source: `courses/{id}/enrollments` (25), `courses/{id}/sections`, `self-enroll`, `registerCatalogRoutes`, `enrollments` top-level (4), `orgs/{orgId}/cross-list-groups`. Baseline: `users enroll` only.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C11 |
+| **Section** | Roster & classroom |
+| **Severity** | BLOCKER |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | PARTIAL (`users enroll` single-user) |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Platform / CLI |
+| **Depends on** | C01, C15, C40 |
+| **Unblocks** | C06, C12, C22 |
+
+---
+
+## 1. Problem Statement
+
+Roster management is the #1 CLI use case for an LMS, but the CLI only supports enrolling one user at a time (`users enroll`). There is no bulk enroll/unenroll, no section management, no cross-listing, no roster export, and no enrollment-state changes (conclude, deactivate). Registrars cannot sync rosters from a SIS export or manage sections at scale.
+
+## 2. Goals
+
+- Bulk enroll/unenroll from a CSV roster.
+- Full section lifecycle (create, list, move students, cross-list).
+- Roster export per course/section for reconciliation.
+- Enrollment state transitions (active/invited/concluded/deactivated).
+
+## 3. Non-Goals
+
+- Automated SIS sync scheduling (see C22 SIS/SCIM) — this is the manual/imperative layer.
+- User account creation (see C15) — enrollment assumes users exist or references by email.
+
+## 4. Personas & User Stories
+
+- **As a registrar**, I want `enrollments import --file roster.csv` to enroll a whole section.
+- **As a registrar**, I want `enrollments export --course C` to reconcile against the SIS.
+- **As an admin**, I want `sections create/cross-list` to manage multi-section courses.
+- **As an instructor**, I want `enrollments conclude --user U` to drop a student.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `enrollments list <course>` with filters (`--role`, `--section`, `--state`) and `enrollments export`.
+- **FR-2.** MUST add `enrollments import <course> --file roster.csv` (bulk create; upsert by email/SIS id; `--role`).
+- **FR-3.** MUST add `enrollments add|remove <course> --user <u> --role <r>` and `enrollments set-state` (conclude/deactivate/reactivate).
+- **FR-4.** MUST add `sections list|create|update|delete <course>` and `sections move --user U --to <section>`.
+- **FR-5.** SHOULD add `sections cross-list` / `orgs cross-list-groups` for shared rosters.
+- **FR-6.** SHOULD add `enrollments self-enroll <course>` (enable/generate self-enroll link).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — bulk import chunks requests; handles 1000+ rows with progress.
+- **Security** — enroll/manage scope; role escalation prevented (server-enforced).
+- **Privacy & Compliance** — roster contains PII (names, emails, SIS ids) → export gated by `--yes`; FERPA note.
+- **Reliability** — import idempotent (re-import = no dup enrollments); per-row error summary.
+- **Observability** — import prints added/updated/skipped/failed counts.
+- **Backward compatibility** — keep `users enroll` as an alias.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a 200-row CSV, *When* `enrollments import`, *Then* enrollments are created and a summary prints; re-running creates 0 new.
+- **AC-2.** *Given* a course, *When* `enrollments export --json`, *Then* an array of enrollment DTOs is emitted.
+- **AC-3.** *Given* a student, *When* `enrollments set-state --state concluded`, *Then* `list` shows concluded.
+
+## 8. Data Model
+
+- None client-side. Document roster CSV schema (email/sis_id, role, section).
+
+## 9. API Surface
+
+- `courses/{c}/enrollments` CRUD/state; `courses/{c}/sections` CRUD + move; `enrollments` top-level; `self-enroll`; cross-list-groups under orgs.
+
+## 10. UI / UX
+
+- New `lextures enrollments ...` and `lextures sections ...` groups; keep `users enroll`.
+- CSV interchange; `--json` for automation; progress on bulk.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server enrollment/section handlers; SIS import (C22) shares the CSV schema.
+- Internal: new command files.
+
+## 13. Dependencies & Sequencing
+
+- After: C01, C15 (users may need to exist), C40.
+- Before: C06/C12/C22 (roster is the substrate).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Enroll-by-email when user absent | H | M | `--create-missing` flag delegating to C15 provisioning |
+| Section move semantics vs re-enroll | M | M | Verify server supports move vs drop+add |
+
+## 15. Rollout Plan
+
+- Ship list/export + single add/remove, then bulk import, then sections/cross-list.
+- Rollback: additive; `users enroll` preserved.
+
+## 16. Test Plan
+
+- **Unit** — CSV parse; idempotency keys.
+- **Integration** — bulk import partial-failure summary; state transitions.
+- **E2E** — import roster → export → diff.
+
+## 17. Documentation & Training
+
+- "Sync a section roster from CSV" recipe; note relationship to C22.
+
+## 18. Open Questions
+
+1. Does enroll accept email/SIS id or only user UUID? (Affects `--create-missing`.)
+2. Is cross-listing course-level or org-level only?
+
+## 19. References
+
+- `clients/cli/cmd/users.go` (`usersEnrollCmd`); enrollment/section handlers.
+- Related: [C15](C15-people-provisioning.md), [C22](C22-sis-scim-oneroster.md), [C06](C06-gradebook-final-grades.md).

--- a/docs/plan/cli/C12-attendance-behavior.md
+++ b/docs/plan/cli/C12-attendance-behavior.md
@@ -1,0 +1,120 @@
+# C12 — Attendance, behavior & seat-time
+
+> CLI parity plan. Source: `attendance_http.go` (`courses/{id}/attendance`), `behavior_http.go` (`behavior`, `pbis`), `registerSeatTimeRoutes` (`seat-time`), hall pass. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C12 |
+| **Section** | Roster & classroom |
+| **Severity** | MAJOR |
+| **Markets** | K12 (primary) / HE |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | K12 / CLI |
+| **Depends on** | C11, C40 |
+| **Unblocks** | C27, C28 |
+
+---
+
+## 1. Problem Statement
+
+Attendance, behavior/PBIS records and seat-time tracking are UI-only. K-12 districts that must report attendance to the state cannot export it via CLI, and cannot bulk-import attendance captured by another system (e.g. a door scanner).
+
+## 2. Goals
+
+- Record and export attendance per course/section/date.
+- Read behavior/PBIS points and incidents; export for reporting.
+- Pull seat-time reports for compliance (e.g. state seat-time mandates).
+
+## 3. Non-Goals
+
+- Real-time hall-pass issuance UX (browser/mobile flow) beyond a simple issue/return command.
+- Discipline case management workflow.
+
+## 4. Personas & User Stories
+
+- **As an attendance clerk**, I want `attendance import --file day.csv` to bulk-record a day.
+- **As a state reporter**, I want `attendance export --course C --from --to` for the ADA report.
+- **As a dean**, I want `behavior export --course C` to pull PBIS points/incidents.
+- **As a compliance officer**, I want `seat-time report --course C` for seat-time mandates.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `attendance list|record|import|export <course>` (`--date`, `--user`, `--status present|absent|tardy|excused`, `--file`).
+- **FR-2.** MUST add `behavior list|export <course>` and `behavior award --user U --points N` (PBIS).
+- **FR-3.** MUST add `seat-time report <course> [--user]` (`courses/{id}/seat-time-report`, `me/seat-time`).
+- **FR-4.** SHOULD add `hall-pass issue|return|list` if endpoints exist.
+- **FR-5.** SHOULD add `attendance summary <course>` (rollup per student).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — day/section import chunked; export streamed.
+- **Security** — attendance/behavior scope; K12 role gating server-side.
+- **Privacy & Compliance** — attendance/behavior are FERPA (and sometimes state-reported) records → export gated by `--yes`; COPPA for under-13.
+- **Reliability** — record/import idempotent per (student, date, period).
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a day CSV, *When* `attendance import`, *Then* records post; re-import updates in place, no dups.
+- **AC-2.** *Given* a date range, *When* `attendance export --json`, *Then* records are emitted for reporting.
+- **AC-3.** *Given* a course, *When* `seat-time report`, *Then* per-student minutes print.
+
+## 8. Data Model
+
+- None client-side. Document attendance CSV (student, date, period, status).
+
+## 9. API Surface
+
+- `courses/{c}/attendance` CRUD/import/export; `behavior`/`pbis`; `seat-time`/`seat-time-report`; hall-pass endpoints.
+
+## 10. UI / UX
+
+- `lextures attendance ...`, `lextures behavior ...`, `lextures seat-time ...`.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server attendance/behavior/seat-time handlers; state-reporting export (C27).
+
+## 13. Dependencies & Sequencing
+
+- After: C11 (roster), C40.
+- Before: C27/C28 (attendance feeds reports/at-risk).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Period/block model varies by district | M | M | Support `--period` optional; default single daily record |
+| State export formats differ | M | M | Provide neutral CSV/JSON; state-specific formatting in C27 |
+
+## 15. Rollout Plan
+
+- Ship attendance record/export first, then behavior/seat-time.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — status enum; idempotency key.
+- **Integration** — import summary; export range filter.
+- **E2E** — record attendance → export → verify.
+
+## 17. Documentation & Training
+
+- "Export attendance for state reporting" recipe.
+
+## 18. Open Questions
+
+1. Does the model support periods/blocks or only daily attendance?
+2. Is hall-pass exposed via REST?
+
+## 19. References
+
+- `attendance_http.go`, `behavior_http.go`, `registerSeatTimeRoutes`.
+- Related: [C11](C11-enrollments-sections.md), [C27](C27-reports-exports.md), [C28](C28-insights-at-risk.md).

--- a/docs/plan/cli/C13-groups-collaboration.md
+++ b/docs/plan/cli/C13-groups-collaboration.md
@@ -1,0 +1,115 @@
+# C13 — Groups & collaboration
+
+> CLI parity plan. Source: `courses/{id}/groups` (6), `my-groups`, `collab-docs` (7), `whiteboards` (5), `forums`/`discussion-threads`/`discussion-posts`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C13 |
+| **Section** | Roster & classroom |
+| **Severity** | MINOR |
+| **Markets** | HE / K12 / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Collaboration / CLI |
+| **Depends on** | C11, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+Course groups (for group assignments/spaces) and collaborative artifacts (docs, whiteboards, forums) can't be managed from the CLI. Instructors cannot bulk-create groups or auto-assign students, nor export discussion/forum content for archival.
+
+## 2. Goals
+
+- Create and populate course groups in bulk (including random/auto assignment).
+- Read/export collaborative artifacts and discussion content for archival.
+
+## 3. Non-Goals
+
+- Real-time collaborative editing (browser).
+- Moderation workflows beyond read/export and basic post/lock.
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I want `groups create --set "Project Teams" --auto --size 4` to form teams.
+- **As an instructor**, I want `groups add --group G --user U` to adjust membership.
+- **As an archivist**, I want `discussions export --course C` for records retention.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `groups list|create|delete <course>` and group-set creation with `--auto`/`--size`.
+- **FR-2.** MUST add `groups add|remove <course> --group <g> --user <u>` and `groups members <g>`.
+- **FR-3.** SHOULD add `discussions list|export <course>` (forums/threads/posts) and `discussions post|lock`.
+- **FR-4.** MAY add `collab-docs list|export` and `whiteboards list|export` (read/backup).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — export streamed for large forums.
+- **Security** — group/discussion manage scope.
+- **Privacy & Compliance** — student-authored content is FERPA → export gated by `--yes`.
+- **Reliability** — auto-assignment deterministic with `--seed` for reproducibility.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* 20 students, *When* `groups create --auto --size 4`, *Then* 5 groups of 4 are formed.
+- **AC-2.** *Given* a group, *When* `groups add --user U`, *Then* `members` lists U.
+- **AC-3.** *Given* a course, *When* `discussions export`, *Then* threads/posts are written.
+
+## 8. Data Model
+
+- None client-side.
+
+## 9. API Surface
+
+- `courses/{c}/groups` CRUD + membership; `forums`/`discussion-threads`/`discussion-posts`; `collab-docs`/`whiteboards` read.
+
+## 10. UI / UX
+
+- `lextures groups ...`, `lextures discussions ...`.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server group/discussion handlers.
+
+## 13. Dependencies & Sequencing
+
+- After: C11 (membership from roster), C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Auto-assign algorithm mismatch with server | M | L | Prefer server-side auto-assign endpoint; CLI just triggers |
+
+## 15. Rollout Plan
+
+- Ship groups CRUD + membership first, then discussion export.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — auto-assign sizing with `--seed`.
+- **Integration** — membership add/remove; export shape.
+- **E2E** — form groups → verify.
+
+## 17. Documentation & Training
+
+- "Auto-form project teams" recipe.
+
+## 18. Open Questions
+
+1. Is auto-assignment server-side or must the CLI compute pairings?
+
+## 19. References
+
+- Group/forum/collab handlers in `server/internal/httpserver`.
+- Related: [C11](C11-enrollments-sections.md), [C34](C34-messaging-broadcasts.md).

--- a/docs/plan/cli/C14-org-administration.md
+++ b/docs/plan/cli/C14-org-administration.md
@@ -1,0 +1,123 @@
+# C14 — Org & org-unit administration
+
+> CLI parity plan. Source: `admin/orgs` (38), `admin_org_units.go` (`admin/org-units`, `orgs/{orgId}/terms`, `cross-list-groups`, `branding`, `role-grants`, `parent-links`, `settings`), `admin_orgs.go`. Baseline: `orgs list/get/create`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C14 |
+| **Section** | Admin & governance |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE |
+| **Status (today)** | PARTIAL (orgs list/get/create) |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Admin / CLI |
+| **Depends on** | C40 |
+| **Unblocks** | C11, C15, C16 |
+
+---
+
+## 1. Problem Statement
+
+Org administration is only partially exposed: the CLI can list/get/create orgs but cannot update them, manage org-units (the org hierarchy), terms, branding, role-grants, or org settings. Multi-tenant admins provisioning a district hierarchy or configuring terms must use the web console.
+
+## 2. Goals
+
+- Full org lifecycle (update, archive) and org-unit hierarchy management.
+- Term management (create academic terms/sessions).
+- Org branding and settings as version-controlled config.
+- Org-scoped role grants (delegated admin).
+
+## 3. Non-Goals
+
+- Platform-wide RBAC role definitions (see C16).
+- User provisioning (see C15).
+
+## 4. Personas & User Stories
+
+- **As a super-admin**, I want `orgs update` and `org-units create` to build a district tree.
+- **As a registrar**, I want `terms create --org O --name Fall2026 --start --end`.
+- **As a brand admin**, I want `orgs branding set --org O --file brand.json`.
+- **As a delegated admin**, I want `orgs role-grants add --org O --user U --role admin`.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `orgs update|archive <id>` and `orgs settings get|set <id>`.
+- **FR-2.** MUST add `org-units list|create|update|delete` and `org-units move` (reparent).
+- **FR-3.** MUST add `terms list|create|update|delete --org <id>`.
+- **FR-4.** MUST add `orgs branding get|set <id>` (`--file`, logo asset upload).
+- **FR-5.** SHOULD add `orgs role-grants list|add|remove <id>` and `orgs parent-links` management.
+- **FR-6.** MAY add `orgs cross-list-groups` (shared with C11).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — org tree fetch p95 < 1 s.
+- **Security** — super-admin / org-admin scope; delegated grants respect hierarchy.
+- **Privacy & Compliance** — org settings may hold data-residency/compliance flags (ties to C29).
+- **Reliability** — settings set idempotent; branding asset upload resumable.
+- **Backward compatibility** — existing `orgs list/get/create` unchanged.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* an org, *When* `org-units create --parent P`, *Then* the unit appears under P.
+- **AC-2.** *Given* an org, *When* `terms create`, *Then* the term is listed.
+- **AC-3.** *Given* a brand file, *When* `orgs branding set`, *Then* `branding get` matches.
+
+## 8. Data Model
+
+- None client-side. Document org settings/branding JSON.
+
+## 9. API Surface
+
+- `admin/orgs` CRUD; `admin/org-units`; `orgs/{orgId}/terms|branding|role-grants|settings|parent-links|cross-list-groups`.
+
+## 10. UI / UX
+
+- Extend `orgsCmd`; add `org-units`, `terms` groups.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server org/org-unit/term/branding handlers; branding asset store.
+- Internal: `clients/cli/cmd/orgs.go`.
+
+## 13. Dependencies & Sequencing
+
+- After: C40.
+- Before: C11/C15/C16 (org + units + terms are the container for people/roster/roles).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Org-unit reparent has invariants | M | M | Rely on server validation; surface 409s clearly |
+| Branding asset upload path | M | L | Reuse `files upload` signed-URL flow |
+
+## 15. Rollout Plan
+
+- Ship org update/settings + org-units + terms first, then branding + role-grants.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — settings/branding parse.
+- **Integration** — org-unit reparent; term CRUD.
+- **E2E** — build a 3-level org tree with terms.
+
+## 17. Documentation & Training
+
+- "Provision a district hierarchy" recipe.
+
+## 18. Open Questions
+
+1. Are terms org-scoped or platform-scoped?
+2. Is org archive a soft delete like courses?
+
+## 19. References
+
+- `clients/cli/cmd/orgs.go`; `admin_org_units.go`, `admin_orgs.go`.
+- Related: [C15](C15-people-provisioning.md), [C16](C16-roles-permissions.md), [C11](C11-enrollments-sections.md).

--- a/docs/plan/cli/C15-people-provisioning.md
+++ b/docs/plan/cli/C15-people-provisioning.md
@@ -1,0 +1,126 @@
+# C15 — People, provisioning & bulk import
+
+> CLI parity plan. Source: `admin/people` (5), `admin/provisioning` (8), `admin/users`, `admin/students`, `admin/teachers`, `admin-console/imports`, `admin_import.go`, `admin_custom_fields.go`, `platform/people`. Baseline: `users list/get/create/enroll`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C15 |
+| **Section** | Admin & governance |
+| **Severity** | BLOCKER |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | PARTIAL (users list/get/create/enroll) |
+| **Estimated effort** | L (1–2mo) |
+| **Owner (proposed)** | Admin / CLI |
+| **Depends on** | C14, C40 |
+| **Unblocks** | C11, C16 |
+
+---
+
+## 1. Problem Statement
+
+The CLI can create one user at a time but has no bulk provisioning, no update/deactivate, no custom-field management, and no import-job orchestration. Onboarding a district/university (thousands of users) requires the bulk import pipeline the server already has — which is entirely UI-driven today.
+
+## 2. Goals
+
+- Bulk create/update/deactivate users from CSV with a per-row result summary.
+- Drive the server's import-job pipeline (submit → poll → report) from the CLI.
+- Manage custom profile fields and user metadata.
+- Update/suspend/reactivate individual accounts.
+
+## 3. Non-Goals
+
+- SIS/SCIM continuous sync (see C22) — this is the manual/imperative import layer.
+- Enrollment into courses (see C11), though `--enroll` convenience may bridge.
+
+## 4. Personas & User Stories
+
+- **As an admin**, I want `users import --file users.csv` to onboard thousands with a summary.
+- **As an admin**, I want `imports submit --file batch.csv` then `imports status <id> --wait` for large jobs.
+- **As a help-desk admin**, I want `users update/suspend/reactivate <id>`.
+- **As a data admin**, I want `custom-fields create/list` to define profile schema.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `users import --file users.csv` (bulk upsert; `--dry-run`, per-row summary).
+- **FR-2.** MUST add `users update <id>`, `users suspend|reactivate <id>`, `users delete <id>`.
+- **FR-3.** MUST add `imports submit|status|list <id>` bridging `admin-console/imports` + `admin_import.go` (async jobs, `--wait` via C40).
+- **FR-4.** MUST add `custom-fields list|create|update|delete` (`admin_custom_fields.go`).
+- **FR-5.** SHOULD add `users search` (server-side) and `people list` (admin/people, platform/people) with rich filters.
+- **FR-6.** SHOULD support `--enroll course=role` convenience delegating to C11.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — import chunks + async job path for >N rows; progress via `--wait`.
+- **Security** — provisioning scope (elevated); PII handled per policy; secrets (temp passwords) printed only to a `--secrets-out` file, not stdout logs.
+- **Privacy & Compliance** — user PII is FERPA/COPPA/GDPR; bulk export gated by `--yes`; import supports minor-consent flags.
+- **Reliability** — import idempotent by email/SIS id; resumable via job id.
+- **Observability** — summary of created/updated/skipped/failed with row errors.
+- **Backward compatibility** — existing `users create` unchanged.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a CSV, *When* `users import --dry-run`, *Then* a diff prints and nothing changes.
+- **AC-2.** *Given* a large CSV, *When* `imports submit` then `imports status --wait`, *Then* the job completes and a report prints.
+- **AC-3.** *Given* a user, *When* `users suspend`, *Then* `get` shows suspended state.
+
+## 8. Data Model
+
+- None client-side. Document user CSV schema (email, name, role, sis_id, org_unit, custom fields).
+
+## 9. API Surface
+
+- `admin/users` CRUD/state; `admin/provisioning`; `admin-console/imports` + `admin_import.go` job endpoints; `admin_custom_fields.go`; `admin/people`/`platform/people` search.
+
+## 10. UI / UX
+
+- Extend `usersCmd`; new `imports` and `custom-fields` groups.
+- Import prints summary; `--wait` streams job progress; temp secrets never logged to stdout.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server provisioning/import/custom-field handlers; job queue (`admin_jobs.go`, C18).
+- Internal: `clients/cli/cmd/users.go`; new command files.
+
+## 13. Dependencies & Sequencing
+
+- After: C14 (org/org-unit target), C40 (`--wait`, `--file`, `--dry-run`).
+- Before: C11 (users exist before enroll), C16.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Temp password exposure | M | H | `--secrets-out` file only; never stdout; redact in `--json` |
+| Sync vs async import ambiguity | M | M | Small imports inline; large ones auto-route to job path |
+
+## 15. Rollout Plan
+
+- Ship user update/state + custom-fields, then bulk import, then job orchestration.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — CSV parse; secret redaction; idempotency key.
+- **Integration** — import job submit/poll; custom-field CRUD.
+- **Security** — secrets not in stdout/`--json`; scope 403 → exit 2.
+- **E2E** — onboard 1k test users via job path.
+
+## 17. Documentation & Training
+
+- "Bulk onboard users from CSV" and "Run a large import job" recipes.
+
+## 18. Open Questions
+
+1. Threshold where import auto-routes to the async job pipeline?
+2. How are temporary credentials returned by the server?
+
+## 19. References
+
+- `clients/cli/cmd/users.go`; `admin_import.go`, `admin_custom_fields.go`, provisioning handlers.
+- Related: [C14](C14-org-administration.md), [C11](C11-enrollments-sections.md), [C16](C16-roles-permissions.md), [C22](C22-sis-scim-oneroster.md), [C40](C40-cli-framework.md).

--- a/docs/plan/cli/C16-roles-permissions.md
+++ b/docs/plan/cli/C16-roles-permissions.md
@@ -1,0 +1,124 @@
+# C16 — Roles & permissions (RBAC)
+
+> CLI parity plan. Source: `registerSettingsRoutes` (`settings` RBAC, 23 routes), `rbac_settings.go`, `orgs/{orgId}/role-grants`, `me/permissions`, `me/org-role-capabilities`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C16 |
+| **Section** | Admin & governance |
+| **Severity** | BLOCKER |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Admin / CLI |
+| **Depends on** | C14, C40 |
+| **Unblocks** | C15 |
+
+---
+
+## 1. Problem Statement
+
+Role and permission management (RBAC) — the definition of roles, their capability grants, and assignments — is entirely UI-driven. Security teams cannot version-control their permission model, audit who has what, or reproduce role setups across tenants, which is a frequent compliance and onboarding requirement.
+
+## 2. Goals
+
+- Define/inspect roles and their permission sets as version-controlled config.
+- Grant/revoke roles to users at platform and org scope.
+- Audit effective permissions for a given user ("can user X do Y?").
+
+## 3. Non-Goals
+
+- Org hierarchy management (see C14).
+- Impersonation (see C19).
+
+## 4. Personas & User Stories
+
+- **As a security admin**, I want `roles export > roles.json` to snapshot the RBAC model.
+- **As a security admin**, I want `roles apply --file roles.json` to reproduce it in another tenant.
+- **As an admin**, I want `roles grant --user U --role admin --org O`.
+- **As an auditor**, I want `permissions check --user U --capability course:manage`.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `roles list|get|create|update|delete` mapping to `settings`/`rbac_settings.go`.
+- **FR-2.** MUST add `roles permissions list|add|remove <role>` (capability grants).
+- **FR-3.** MUST add `roles grant|revoke --user <u> --role <r> [--org <o>]` (`role-grants`).
+- **FR-4.** MUST add `permissions check --user <u> --capability <cap>` (`me/permissions`, `org-role-capabilities`).
+- **FR-5.** SHOULD add `roles export|apply --file roles.json` (declarative RBAC sync with `--dry-run`).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — role/permission list p95 < 500 ms.
+- **Security** — `rbac:manage` scope required; the command MUST NOT let a user grant capabilities they lack (server-enforced) and surfaces 403 clearly.
+- **Privacy & Compliance** — role assignments are audit-relevant (SOC 2) → operations logged server-side.
+- **Reliability** — `apply` idempotent; `--dry-run` shows the diff.
+- **Observability** — `apply` prints created/updated/removed grants.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a role file, *When* `roles apply --dry-run`, *Then* a permission diff prints and nothing changes.
+- **AC-2.** *Given* a user, *When* `roles grant --role admin`, *Then* `permissions check` returns allowed for admin caps.
+- **AC-3.** *Given* insufficient scope, *When* any mutate runs, *Then* exit 2 with a permission message.
+
+## 8. Data Model
+
+- None client-side. Document roles.json schema (role → capabilities).
+
+## 9. API Surface
+
+- `settings` RBAC routes (roles/capabilities CRUD); `orgs/{orgId}/role-grants`; `me/permissions`, `me/org-role-capabilities` for checks.
+
+## 10. UI / UX
+
+- `lextures roles ...`, `lextures permissions ...`.
+- `apply` diff output; `--json` for CI gating.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server RBAC handlers; audit log (C19).
+- Internal: new `cmd/roles.go`.
+
+## 13. Dependencies & Sequencing
+
+- After: C14 (orgs exist for scoped grants), C40.
+- Before: C15 (assign roles during provisioning).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Declarative apply could lock out admins | M | H | `apply` refuses to remove the caller's own admin grant without `--force`; dry-run default |
+| Capability taxonomy large | M | M | `roles capabilities list` to enumerate; validate against it |
+
+## 15. Rollout Plan
+
+- Ship read/check + grant/revoke first, then declarative apply.
+- Rollback: additive; apply reversible via re-apply of prior snapshot.
+
+## 16. Test Plan
+
+- **Unit** — roles.json parse; diff computation; self-lockout guard.
+- **Integration** — grant/revoke; permission check.
+- **Security** — scope enforcement; self-lockout prevention.
+- **E2E** — export→apply into a second tenant→verify.
+
+## 17. Documentation & Training
+
+- "Version-control your RBAC model" recipe.
+
+## 18. Open Questions
+
+1. Are roles global or org-scoped, or both?
+2. Is there a canonical capability list endpoint?
+
+## 19. References
+
+- `rbac_settings.go`, `registerSettingsRoutes`; `me.go` permissions.
+- Related: [C14](C14-org-administration.md), [C15](C15-people-provisioning.md), [C19](C19-audit-impersonation-search.md).

--- a/docs/plan/cli/C17-licenses-entitlements.md
+++ b/docs/plan/cli/C17-licenses-entitlements.md
@@ -1,0 +1,117 @@
+# C17 — Licenses, entitlements & marketplace
+
+> CLI parity plan. Source: `admin_license.go` (`admin/licenses`), `me/entitlements`, `admin/marketplace`, `registerMarketplaceRoutes`, `admin/revenue`, `registerRevenueShareRoutes`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C17 |
+| **Section** | Admin & governance |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Admin / CLI |
+| **Depends on** | C14, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+License activation/seat management, entitlements, marketplace listings and revenue-share are UI-only. Admins cannot check seat consumption, apply a license key, or audit entitlements from scripts — routine tasks for procurement and renewal.
+
+## 2. Goals
+
+- Apply/inspect license keys and seat consumption.
+- Audit user/org entitlements.
+- Manage marketplace listings and view revenue-share data (for creators/orgs).
+
+## 3. Non-Goals
+
+- Payment collection (see C30 billing/payments).
+- Contract negotiation.
+
+## 4. Personas & User Stories
+
+- **As an admin**, I want `licenses apply --key ...` and `licenses status` to see seat usage.
+- **As a procurement lead**, I want `entitlements list --org O` for renewal planning.
+- **As a creator**, I want `marketplace list` and `revenue report` to track earnings.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `licenses status|apply|list` (`admin_license.go`; `--key`).
+- **FR-2.** MUST add `entitlements list [--org|--user]` (`me/entitlements`, admin entitlements).
+- **FR-3.** SHOULD add `marketplace list|get|publish|unpublish` (`registerMarketplaceRoutes`).
+- **FR-4.** SHOULD add `revenue report --org O` / `revenue share` (`registerRevenueShareRoutes`).
+- **FR-5.** MAY add `licenses seats --by-org` breakdown.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — status p95 < 500 ms.
+- **Security** — license/billing admin scope; license keys never echoed after apply.
+- **Privacy & Compliance** — revenue data is financial; export gated by `--yes`.
+- **Reliability** — apply idempotent (same key twice = no double-count).
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a valid key, *When* `licenses apply`, *Then* seats increase and `status` reflects it.
+- **AC-2.** *Given* an org, *When* `entitlements list`, *Then* entitlements print.
+- **AC-3.** *Given* a creator, *When* `revenue report`, *Then* earnings print (gated by `--yes` on export).
+
+## 8. Data Model
+
+- None client-side.
+
+## 9. API Surface
+
+- `admin/licenses` status/apply/list; `me/entitlements` + admin entitlements; `admin/marketplace`; `admin/revenue` + revenue-share.
+
+## 10. UI / UX
+
+- `lextures licenses ...`, `lextures entitlements ...`, `lextures marketplace ...`, `lextures revenue ...`.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server license/marketplace/revenue handlers; billing (C30).
+
+## 13. Dependencies & Sequencing
+
+- After: C14, C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| License key leakage in shell history | M | M | Support `--key-file`/stdin; never print key back |
+
+## 15. Rollout Plan
+
+- Ship licenses + entitlements first, then marketplace/revenue.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — key redaction; seat math display.
+- **Integration** — apply/status; entitlements list.
+- **E2E** — apply license → verify seats.
+
+## 17. Documentation & Training
+
+- "Check seat consumption before renewal" recipe.
+
+## 18. Open Questions
+
+1. Is licensing org-scoped or platform-scoped?
+
+## 19. References
+
+- `admin_license.go`, `registerMarketplaceRoutes`, `registerRevenueShareRoutes`.
+- Related: [C14](C14-org-administration.md), [C30](C30-billing-payments-tax.md).

--- a/docs/plan/cli/C18-jobs-scheduler-backups.md
+++ b/docs/plan/cli/C18-jobs-scheduler-backups.md
@@ -1,0 +1,123 @@
+# C18 — Jobs, scheduler, quarantine & backups
+
+> CLI parity plan. Source: `admin_jobs.go` (`admin/jobs`), `admin_scheduler.go` (`admin/scheduler`), `admin/quarantine`, `backup_ops_http.go`, `av_scan.go`, `admin/lrs-dead-letter`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C18 |
+| **Section** | Admin & governance |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Platform / SRE |
+| **Depends on** | C40 |
+| **Unblocks** | C15, C24 |
+
+---
+
+## 1. Problem Statement
+
+Operational surfaces — background job status, scheduled tasks, the AV-scan quarantine, dead-letter queues, and backup operations — are UI-only. SRE and admins cannot monitor or drive jobs from scripts/CI, retry failed items, or trigger/inspect backups, which blocks operational automation and incident response.
+
+## 2. Goals
+
+- Inspect and control background jobs (list, get, retry, cancel) with `--wait`.
+- Manage scheduled tasks (list, run-now, enable/disable).
+- Triage the AV quarantine and dead-letter queues.
+- Trigger and inspect backup operations.
+
+## 3. Non-Goals
+
+- Building the job engine (server concern).
+- Infra-level DB backups outside the app's backup-ops surface.
+
+## 4. Personas & User Stories
+
+- **As an SRE**, I want `jobs list --status failed` and `jobs retry <id>`.
+- **As an admin**, I want `imports status --wait` (shared with C15) to block until a job finishes.
+- **As a scheduler owner**, I want `scheduler run-now <task>` to force a run.
+- **As a security admin**, I want `quarantine list` and `quarantine release <id>`.
+- **As an SRE**, I want `backups create` and `backups status`.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `jobs list|get|retry|cancel` (`admin_jobs.go`) with `--status` filter and `--wait`.
+- **FR-2.** MUST add `scheduler list|run-now|enable|disable` (`admin_scheduler.go`).
+- **FR-3.** MUST add `quarantine list|get|release|delete` (`admin/quarantine`, `av_scan.go`).
+- **FR-4.** SHOULD add `backups create|status|list` (`backup_ops_http.go`).
+- **FR-5.** SHOULD add `dead-letter list|retry` (`lrs-dead-letter`, ties to C26).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — job polling backs off; `--wait` uses server-recommended interval.
+- **Security** — ops/admin scope; quarantine release requires `--yes`.
+- **Privacy & Compliance** — quarantined files may contain malware/PII; never downloaded to stdout.
+- **Reliability** — retry idempotent; cancel safe on already-finished jobs.
+- **Observability** — `--wait` streams status transitions; final state → exit code (0 success, 2 failed).
+- **Backward compatibility** — additive; `--wait` primitive shared via C40.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a running job, *When* `jobs get <id> --wait`, *Then* the command blocks then exits 0 on success / 2 on failure.
+- **AC-2.** *Given* a failed job, *When* `jobs retry`, *Then* a new run is queued.
+- **AC-3.** *Given* a quarantined file, *When* `quarantine release --yes`, *Then* it is released.
+
+## 8. Data Model
+
+- None client-side.
+
+## 9. API Surface
+
+- `admin/jobs` list/get/retry/cancel; `admin/scheduler`; `admin/quarantine` + `av_scan`; `backup_ops_http.go`; `admin/lrs-dead-letter`.
+
+## 10. UI / UX
+
+- `lextures jobs ...`, `lextures scheduler ...`, `lextures quarantine ...`, `lextures backups ...`.
+- `--wait` renders a live status line; `--json` final state.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server job/scheduler/quarantine/backup handlers; shared `--wait` primitive (C40); import jobs (C15), LRS DLQ (C26).
+
+## 13. Dependencies & Sequencing
+
+- After: C40 (`--wait`).
+- Before: C15/C24 rely on the shared job-wait primitive.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Long polling ties up CI | M | M | `--wait --timeout`; exit 2 on timeout |
+| Quarantine release risk | M | H | `--yes` + audit; never stream file bytes |
+
+## 15. Rollout Plan
+
+- Ship jobs + scheduler first (highest ops value), then quarantine + backups + DLQ.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — poll/backoff; exit-code mapping.
+- **Integration** — job state transitions; retry.
+- **E2E** — submit import (C15) → `jobs --wait` → success.
+
+## 17. Documentation & Training
+
+- Runbook: "Monitor and retry background jobs from CI."
+
+## 18. Open Questions
+
+1. Does the server expose a recommended poll interval / job progress percentage?
+
+## 19. References
+
+- `admin_jobs.go`, `admin_scheduler.go`, `backup_ops_http.go`, `av_scan.go`.
+- Related: [C15](C15-people-provisioning.md), [C24](C24-canvas-content-import.md), [C26](C26-xapi-lrs-engagement.md), [C40](C40-cli-framework.md).

--- a/docs/plan/cli/C19-audit-impersonation-search.md
+++ b/docs/plan/cli/C19-audit-impersonation-search.md
@@ -1,0 +1,120 @@
+# C19 — Audit log, impersonation & admin search
+
+> CLI parity plan. Source: `admin_audit_log_http.go` (`admin/audit-log`, `compliance/audit-log`), `registerImpersonationRoutes` (`admin-console/impersonate`), `admin_search.go` (`admin/search`), `impersonationWriteBlockMiddleware`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C19 |
+| **Section** | Admin & governance |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Security / CLI |
+| **Depends on** | C40 |
+| **Unblocks** | C29 |
+
+---
+
+## 1. Problem Statement
+
+The admin audit log, impersonation (act-as), and admin search are UI-only. Security/compliance teams cannot pull audit trails for SIEM ingestion or investigations, and support staff cannot script "act as user" flows for reproducing issues.
+
+## 2. Goals
+
+- Export the audit log with filters for SIEM/compliance.
+- Start/stop impersonation sessions for support (read-only by default — writes are server-blocked).
+- Run admin search to locate users/courses/orgs quickly.
+
+## 3. Non-Goals
+
+- Building SIEM integration (this provides the export; C25/C26 handle streaming).
+- Bypassing impersonation write-block (server enforces).
+
+## 4. Personas & User Stories
+
+- **As a compliance officer**, I want `audit-log export --from --to --actor U` for an investigation.
+- **As support**, I want `impersonate start --user U` to reproduce a bug (read-only).
+- **As an admin**, I want `admin search "jane"` to find a user/course/org fast.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `audit-log list|export` (`--actor`, `--action`, `--from`, `--to`, `--target`; CSV/JSON).
+- **FR-2.** MUST add `impersonate start|stop|whoami` (`admin-console/impersonate`); CLI clearly labels impersonated sessions and honors the server write-block.
+- **FR-3.** MUST add `admin search <query> [--type user|course|org]` (`admin_search.go`).
+- **FR-4.** SHOULD add `audit-log tail` (poll for new entries) for near-real-time monitoring.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — audit export paginated/streamed; tail backs off.
+- **Security** — audit-view / impersonation scope; impersonation tokens stored separately and never written to the default profile.
+- **Privacy & Compliance** — audit entries + impersonation are themselves audited (SOC 2); export gated by `--yes`.
+- **Reliability** — impersonation `stop` always restores the real identity; CLI warns if a session is active.
+- **Observability** — `whoami` shows real vs effective identity.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a range, *When* `audit-log export --json`, *Then* entries stream to stdout.
+- **AC-2.** *Given* impersonation active, *When* a write command runs, *Then* the server blocks it and the CLI surfaces the block.
+- **AC-3.** *Given* `impersonate whoami`, *Then* both real and effective users print.
+
+## 8. Data Model
+
+- Client stores impersonation token transiently (separate from `~/.lextures` profile token).
+
+## 9. API Surface
+
+- `admin/audit-log` + `compliance/audit-log` list/export; `admin-console/impersonate` start/stop; `admin/search`.
+
+## 10. UI / UX
+
+- `lextures audit-log ...`, `lextures impersonate ...`, `lextures admin search`.
+- Impersonated sessions render a persistent banner-style notice in output.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server audit/impersonation/search handlers; `impersonationWriteBlockMiddleware`.
+
+## 13. Dependencies & Sequencing
+
+- After: C40.
+- Before: C29 (compliance exports reuse audit-log export).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Forgotten active impersonation | M | H | `whoami` warns; auto-expire; `stop` idempotent |
+| Audit export volume | M | M | Streamed pagination + date-range required |
+
+## 15. Rollout Plan
+
+- Ship audit-log export + admin search first, then impersonation.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — filter param building; identity display.
+- **Integration** — export pagination; impersonation start/stop token handling.
+- **Security** — write-block honored; token isolation.
+- **E2E** — export audit → verify fields.
+
+## 17. Documentation & Training
+
+- "Export audit logs for your SIEM" runbook.
+
+## 18. Open Questions
+
+1. Does impersonation issue a distinct token, or a session header?
+
+## 19. References
+
+- `admin_audit_log_http.go`, `admin_search.go`, `registerImpersonationRoutes`.
+- Related: [C16](C16-roles-permissions.md), [C29](C29-compliance-privacy.md).

--- a/docs/plan/cli/C20-email-templates-banners.md
+++ b/docs/plan/cli/C20-email-templates-banners.md
@@ -1,0 +1,116 @@
+# C20 — Email templates & banners
+
+> CLI parity plan. Source: `admin_email_templates.go` (`admin-console/email-templates`, 8), `banner_http.go` (`admin/banners`, 5). Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C20 |
+| **Section** | Admin & governance |
+| **Severity** | MINOR |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Admin / CLI |
+| **Depends on** | C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+Transactional email templates and system banners (maintenance notices, announcements) are UI-only. Admins cannot version-control template copy, localize it in bulk, or script scheduled maintenance banners.
+
+## 2. Goals
+
+- Manage email templates as version-controlled files (get/set/preview).
+- Schedule/publish/expire system banners from CLI (e.g. from a maintenance runbook).
+
+## 3. Non-Goals
+
+- Actually sending emails (server transactional pipeline).
+- Rich WYSIWYG editing.
+
+## 4. Personas & User Stories
+
+- **As a comms admin**, I want `email-templates set welcome --file welcome.html` in git.
+- **As an SRE**, I want `banners create --message "Maintenance 2am" --from --until` in a runbook.
+- **As a localizer**, I want `email-templates set --locale es` for translated copy.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `email-templates list|get|set|preview <key>` (`--file`, `--locale`).
+- **FR-2.** MUST add `banners list|create|update|delete` (`--message`, `--severity`, `--from`, `--until`, `--audience`).
+- **FR-3.** SHOULD add `email-templates test-send --to <email>` for validation.
+- **FR-4.** MAY add `banners publish|expire <id>` shortcuts.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — trivial payloads; p95 < 300 ms.
+- **Security** — comms/admin scope.
+- **Privacy & Compliance** — test-send uses a caller-supplied address only; no bulk sends from CLI.
+- **Reliability** — set/create idempotent by key/id.
+- **Internationalization** — templates keyed by locale; `--locale` supported.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* an HTML file, *When* `email-templates set --file`, *Then* `get` returns it.
+- **AC-2.** *Given* a window, *When* `banners create`, *Then* it's active within the window.
+- **AC-3.** *Given* `--locale es`, *Then* the Spanish variant is stored separately.
+
+## 8. Data Model
+
+- None client-side.
+
+## 9. API Surface
+
+- `admin-console/email-templates` CRUD/preview/test-send; `admin/banners` CRUD.
+
+## 10. UI / UX
+
+- `lextures email-templates ...`, `lextures banners ...`.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server email-template + banner handlers.
+
+## 13. Dependencies & Sequencing
+
+- After: C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Template variables mis-rendered | M | L | `preview` renders with sample data before set |
+
+## 15. Rollout Plan
+
+- Ship both groups together (small surface).
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — locale routing; time-window validation.
+- **Integration** — template CRUD; banner window.
+- **E2E** — set template → preview → test-send.
+
+## 17. Documentation & Training
+
+- "Version-control transactional emails" recipe; maintenance-banner runbook.
+
+## 18. Open Questions
+
+1. What is the template variable/interpolation syntax?
+
+## 19. References
+
+- `admin_email_templates.go`, `banner_http.go`.
+- Related: [C21](C21-platform-settings.md), [C33](C33-accessibility-media-localization.md).

--- a/docs/plan/cli/C21-platform-settings.md
+++ b/docs/plan/cli/C21-platform-settings.md
@@ -1,0 +1,122 @@
+# C21 — Platform settings & configuration
+
+> CLI parity plan. Source: `settings_platform.go` (`settings/platform`, `locale`, `timezone`, `system-prompts`), `admin_password_policy.go`, `ai_provider_settings_http.go`, `registerDataResidencyRoutes`, `registerStorageQuotaRoutes` (`admin/storage-quotas`, `courses/{id}/storage-usage`), `admin_console.go` settings. Baseline: `files` (expand storage).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C21 |
+| **Section** | Admin & governance |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING (settings); files PARTIAL |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Admin / CLI |
+| **Depends on** | C40 |
+| **Unblocks** | C09, C29 |
+
+---
+
+## 1. Problem Statement
+
+Platform/tenant configuration — locale/timezone defaults, system prompts, password policy, AI provider settings, data residency, and storage quotas — is UI-only. Ops teams cannot codify tenant configuration or enforce policy (e.g. password rules, AI provider keys) via IaC, and can't monitor storage quotas from scripts.
+
+## 2. Goals
+
+- Read/write platform and tenant settings as version-controlled config.
+- Manage password policy, AI provider settings, and data-residency config.
+- Manage storage quotas and inspect usage; extend `files` with quota/usage.
+
+## 3. Non-Goals
+
+- Secret management systems integration (keys passed via `--file`/stdin only).
+- Per-course settings (see C01).
+
+## 4. Personas & User Stories
+
+- **As a platform admin**, I want `settings get|set platform` from git.
+- **As a security admin**, I want `settings password-policy set --file policy.json`.
+- **As an AI admin**, I want `settings ai-provider set --file provider.json` (keys via stdin).
+- **As an ops admin**, I want `storage-quotas list` and `files usage --course C`.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `settings get|set <scope>` for platform/locale/timezone/system-prompts (`--file`).
+- **FR-2.** MUST add `settings password-policy get|set` (`admin_password_policy.go`).
+- **FR-3.** MUST add `settings ai-provider get|set|test` (`ai_provider_settings_http.go`; keys never echoed).
+- **FR-4.** SHOULD add `settings data-residency get|set` (`registerDataResidencyRoutes`).
+- **FR-5.** MUST add `storage-quotas list|set` and `files usage [--course]` (`storage-usage`).
+- **FR-6.** SHOULD add `settings export|apply --file settings.json` (declarative tenant config).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — settings ops p95 < 500 ms.
+- **Security** — platform-admin scope; provider keys/secrets read from file/stdin, redacted in all output, never in shell history via flags.
+- **Privacy & Compliance** — data-residency changes are compliance-sensitive; require `--yes` and are audited.
+- **Reliability** — set/apply idempotent; `--dry-run` diff.
+- **Backward compatibility** — additive; existing `files` verbs unchanged.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a settings file, *When* `settings apply --dry-run`, *Then* a diff prints, no change.
+- **AC-2.** *Given* an AI provider config, *When* `settings ai-provider set` then `... test`, *Then* connectivity is validated without printing the key.
+- **AC-3.** *Given* a course over quota, *When* `files usage --course C`, *Then* usage vs limit prints.
+
+## 8. Data Model
+
+- None client-side. Document settings.json schema.
+
+## 9. API Surface
+
+- `settings/platform|locale|timezone|system-prompts`; `admin/password-policy`; `ai_provider_settings`; `data-residency`; `admin/storage-quotas`; `courses/{id}/storage-usage`.
+
+## 10. UI / UX
+
+- `lextures settings ...`, `lextures storage-quotas ...`, extend `files usage`.
+
+## 11. AI / ML Considerations
+
+- AI provider settings feed C09 grading and other AI features; `test` validates provider connectivity server-side.
+
+## 12. Integration Points
+
+- Server settings/policy/provider/residency/quota handlers; audit log (C19).
+
+## 13. Dependencies & Sequencing
+
+- After: C40.
+- Before: C09 (needs provider config), C29 (residency ties to compliance).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Provider key leakage | M | H | file/stdin only; redact everywhere; `test` never returns key |
+| Residency change data movement | L | H | `--yes` + audit; document irreversibility |
+
+## 15. Rollout Plan
+
+- Ship settings get/set + storage first, then policy/provider/residency, then declarative apply.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — settings parse; secret redaction; diff.
+- **Integration** — provider test; quota list.
+- **Security** — key never in output/history.
+- **E2E** — export→apply→verify.
+
+## 17. Documentation & Training
+
+- "Manage tenant config as code" recipe.
+
+## 18. Open Questions
+
+1. Which settings are platform-global vs org-scoped?
+2. Does `ai-provider test` exist server-side, or must the CLI infer validity?
+
+## 19. References
+
+- `settings_platform.go`, `admin_password_policy.go`, `ai_provider_settings_http.go`, `registerStorageQuotaRoutes`.
+- Related: [C01](C01-courses.md), [C09](C09-ai-grading-agents.md), [C19](C19-audit-impersonation-search.md), [C29](C29-compliance-privacy.md).

--- a/docs/plan/cli/C22-sis-scim-oneroster.md
+++ b/docs/plan/cli/C22-sis-scim-oneroster.md
@@ -1,0 +1,123 @@
+# C22 — SIS, SCIM & OneRoster
+
+> CLI parity plan. Source: `registerSISRoutes`, `registerSCIMRoutes` (`/scim/*`), `oneroster_admin.go` + `/oneroster/v1p2/*`, `admin/lrs-config`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C22 |
+| **Section** | Integrations & interoperability |
+| **Severity** | BLOCKER |
+| **Markets** | K12 / HE |
+| **Status (today)** | MISSING |
+| **Estimated effort** | L (1–2mo) |
+| **Owner (proposed)** | Integrations / CLI |
+| **Depends on** | C11, C15, C18, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+Continuous roster/user sync via SIS, SCIM and OneRoster is the backbone of K-12/HE deployments, yet the CLI cannot configure or trigger any of it. Integration engineers cannot bootstrap a OneRoster connection, run a sync, or inspect SCIM provisioning results from automation — forcing fragile manual setup.
+
+## 2. Goals
+
+- Configure SIS/OneRoster connections and trigger/monitor syncs.
+- Inspect SCIM provisioning state and reconcile drift.
+- Validate a OneRoster feed before enabling continuous sync.
+
+## 3. Non-Goals
+
+- Being the SCIM server (the platform is); the CLI is a management/diagnostic client.
+- One-off CSV import (that's C15/C11).
+
+## 4. Personas & User Stories
+
+- **As an integration engineer**, I want `sis config set --file oneroster.json` then `sis test`.
+- **As an engineer**, I want `sis sync run --wait` and `sis sync status` to operate rostering.
+- **As an admin**, I want `scim users list` / `scim status` to verify IdP provisioning.
+- **As an engineer**, I want `oneroster validate --url ...` before enabling.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `sis config get|set|test` and `sis sync run|status|history` (`registerSISRoutes`; `--wait` via C18/C40).
+- **FR-2.** MUST add `oneroster pull|validate|status` bridging `/oneroster/v1p2/*` + `oneroster_admin.go`.
+- **FR-3.** MUST add `scim status|users list|groups list` (`/scim/*`) for diagnostics/reconciliation.
+- **FR-4.** SHOULD add `sis reconcile --dry-run` (show drift between SIS and current roster).
+- **FR-5.** SHOULD add `lrs config get|set` (`admin/lrs-config`, ties to C26).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — sync run is async/job-backed; `--wait` streams progress.
+- **Security** — integration-admin scope; SIS/IdP secrets via file/stdin, redacted in output.
+- **Privacy & Compliance** — rosters carry student PII (FERPA/COPPA); sync reports gated by `--yes`; data-residency respected.
+- **Reliability** — sync idempotent; `reconcile --dry-run` has no side effects.
+- **Observability** — sync report shows created/updated/deleted/errored counts.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a OneRoster config, *When* `sis test`, *Then* connectivity + credential validity print without exposing secrets.
+- **AC-2.** *Given* a config, *When* `sis sync run --wait`, *Then* the job completes and a change summary prints.
+- **AC-3.** *Given* IdP provisioning, *When* `scim users list`, *Then* provisioned users are shown.
+
+## 8. Data Model
+
+- None client-side. Document connection config JSON (endpoint, auth, mappings).
+
+## 9. API Surface
+
+- `registerSISRoutes` config/sync; `/oneroster/v1p2/*` + `oneroster_admin.go`; `/scim/*`; `admin/lrs-config`.
+
+## 10. UI / UX
+
+- `lextures sis ...`, `lextures oneroster ...`, `lextures scim ...`.
+- Sync uses the shared `--wait` job primitive (C18/C40).
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server SIS/SCIM/OneRoster/LRS handlers; job queue (C18); roster (C11); provisioning (C15).
+
+## 13. Dependencies & Sequencing
+
+- After: C11, C15 (roster/user substrate), C18 (`--wait`), C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Destructive sync (mass-delete) | M | H | `reconcile --dry-run` default; `sync run` requires `--yes` when deletions detected |
+| Vendor OneRoster quirks | H | M | `validate` surfaces schema issues before enable |
+
+## 15. Rollout Plan
+
+- Ship config/test + validate first, then sync run/status, then SCIM diagnostics + reconcile.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — config parse; secret redaction; drift diff.
+- **Integration** — sync job status; OneRoster validate against fixtures.
+- **Security** — secrets never printed; deletion gating.
+- **E2E** — configure→validate→sync→reconcile against a mock feed.
+
+## 17. Documentation & Training
+
+- "Bootstrap a OneRoster connection" and "Operate nightly SIS sync from cron" runbooks.
+
+## 18. Open Questions
+
+1. Is sync push, pull, or bidirectional?
+2. Does the server expose SCIM read endpoints for diagnostics, or only inbound provisioning?
+
+## 19. References
+
+- `registerSISRoutes`, `registerSCIMRoutes`, `oneroster_admin.go`.
+- Related: [C11](C11-enrollments-sections.md), [C15](C15-people-provisioning.md), [C18](C18-jobs-scheduler-backups.md), [C26](C26-xapi-lrs-engagement.md).

--- a/docs/plan/cli/C23-lti-developer-keys.md
+++ b/docs/plan/cli/C23-lti-developer-keys.md
@@ -1,0 +1,120 @@
+# C23 — LTI & developer keys
+
+> CLI parity plan. Source: `registerLTIHTTPRoutes` (`lti`, 10), `saml_lti.go`, `courses/{id}/lti-external-tools`, `developer` (2 — developer keys), `admin/lti` (7). Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C23 |
+| **Section** | Integrations & interoperability |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Integrations / CLI |
+| **Depends on** | C40 |
+| **Unblocks** | C05 |
+
+---
+
+## 1. Problem Statement
+
+LTI 1.3 tool registration, deployment configuration, and developer API keys are UI-only. Integration teams cannot register/rotate LTI tools or issue/rotate developer keys via automation, which is essential when standing up many tenants or rotating credentials on a schedule.
+
+## 2. Goals
+
+- Register/configure/rotate LTI tools at platform and course scope.
+- Issue, list, and rotate/revoke developer API keys.
+- Export LTI platform config (issuer, JWKS, deployment ids) for tool vendors.
+
+## 3. Non-Goals
+
+- Performing an LTI launch (browser flow).
+- SAML SSO config beyond what overlaps in `saml_lti.go` (SSO config could be a follow-up).
+
+## 4. Personas & User Stories
+
+- **As an integration admin**, I want `lti tools register --file tool.json` to add an LTI tool.
+- **As a security admin**, I want `dev-keys rotate <id>` on a schedule.
+- **As a vendor liaison**, I want `lti platform-config` to hand the vendor our issuer/JWKS/deployment ids.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `lti tools list|register|update|delete` (admin + course `lti-external-tools`).
+- **FR-2.** MUST add `lti deployments list|create` and `lti platform-config` (issuer/JWKS/keys export).
+- **FR-3.** MUST add `dev-keys list|create|rotate|revoke` (`developer`).
+- **FR-4.** SHOULD add `lti tools test <id>` (validate config / OIDC login round-trip where server supports).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — trivial payloads; p95 < 500 ms.
+- **Security** — integration-admin scope; client secrets/private keys shown once on create, then redacted; rotation invalidates old.
+- **Privacy & Compliance** — LTI deployments may transmit PII to tools; command surfaces the tool's data-sharing scope where available.
+- **Reliability** — register/update idempotent by client id.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a tool config, *When* `lti tools register`, *Then* a client id + one-time secret print; re-fetch redacts the secret.
+- **AC-2.** *Given* a dev key, *When* `dev-keys rotate`, *Then* a new key prints and the old stops working.
+- **AC-3.** *Given* `lti platform-config --json`, *Then* issuer/JWKS URL/deployment ids are emitted.
+
+## 8. Data Model
+
+- None client-side. Document tool config JSON.
+
+## 9. API Surface
+
+- `registerLTIHTTPRoutes` + `admin/lti`; `courses/{c}/lti-external-tools`; `developer` key endpoints; `saml_lti.go`.
+
+## 10. UI / UX
+
+- `lextures lti ...`, `lextures dev-keys ...`.
+- One-time secret display with an explicit "save now" notice.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server LTI/dev-key handlers; course tool registration (C05).
+
+## 13. Dependencies & Sequencing
+
+- After: C40.
+- Before: C05 (course tool add references platform tools).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Secret shown only once, user misses it | M | M | Explicit notice + optional `--secret-out file` |
+| Rotation breaks live integrations | M | H | `--grace` window if server supports; warn before revoke |
+
+## 15. Rollout Plan
+
+- Ship dev-keys + LTI tool CRUD first, then deployments/platform-config/test.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — config parse; secret one-time display.
+- **Integration** — tool register; dev-key rotate invalidation.
+- **Security** — secret redaction on re-fetch.
+- **E2E** — register tool → platform-config → (mock) launch validate.
+
+## 17. Documentation & Training
+
+- "Register an LTI 1.3 tool" and "Rotate developer keys" recipes.
+
+## 18. Open Questions
+
+1. Does the platform support LTI Advantage services config via API?
+2. Grace period on dev-key rotation?
+
+## 19. References
+
+- `registerLTIHTTPRoutes`, `saml_lti.go`, developer-key handlers.
+- Related: [C05](C05-content-extras.md), [C25](C25-integrations-webhooks-bots.md).

--- a/docs/plan/cli/C24-canvas-content-import.md
+++ b/docs/plan/cli/C24-canvas-content-import.md
@@ -1,0 +1,122 @@
+# C24 — Canvas & content import
+
+> CLI parity plan. Source: `registerCanvasImportRoutes`, `canvas_import_queue.go`, `canvas_catalog.go`, `canvas_enrollment_import.go`, `canvas_grade_import.go`, `canvas_assignment_submissions_import.go`, `canvas_announcements_import.go`, `registerCanvasSubmissionSyncRoutes`, `courses/{id}/canvas-link`, `registerImportRoutes` (`imports`). Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C24 |
+| **Section** | Integrations & interoperability |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Migration / CLI |
+| **Depends on** | C18, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+Canvas migration (courses, enrollments, grades, submissions, announcements) and generic content import are UI-only. Migration teams onboarding an institution from Canvas cannot script or monitor the import queue, retry failures, or batch many courses — the slowest, most error-prone part of onboarding.
+
+## 2. Goals
+
+- Browse the Canvas catalog and queue course imports in bulk.
+- Drive the import queue (submit, monitor, retry) with `--wait`.
+- Import enrollments, grades, submissions, announcements selectively.
+- Link an existing course to Canvas for ongoing sync.
+
+## 3. Non-Goals
+
+- Building the Canvas connector (server owns it).
+- Non-Canvas LMS imports beyond the generic `imports` surface.
+
+## 4. Personas & User Stories
+
+- **As a migration engineer**, I want `canvas catalog list` then `canvas import course <id> --wait`.
+- **As an engineer**, I want `canvas import queue` to see status and `... retry <id>` failures.
+- **As a registrar**, I want `canvas import grades --course C` to bring over historical grades.
+- **As an admin**, I want `imports submit --file pkg.imscc` for generic Common Cartridge import.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `canvas catalog list|search` (`canvas_catalog.go`).
+- **FR-2.** MUST add `canvas import course|enrollments|grades|submissions|announcements` with `--course`/`--wait`.
+- **FR-3.** MUST add `canvas import queue|status|retry|cancel` (`canvas_import_queue.go`).
+- **FR-4.** SHOULD add `canvas link set|status <course>` (`courses/{id}/canvas-link`) + submission sync.
+- **FR-5.** SHOULD add `imports submit|status|list --file <pkg>` for generic (Common Cartridge/QTI) import (`registerImportRoutes`).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — imports are async/job-backed; `--wait` streams progress; batch submit chunks.
+- **Security** — migration-admin scope; Canvas API tokens via file/stdin, redacted.
+- **Privacy & Compliance** — imported data includes student PII/grades (FERPA); reports gated by `--yes`.
+- **Reliability** — import idempotent per source id; retry safe; partial-failure surfaced.
+- **Observability** — queue status shows per-item state; final job exit code.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a Canvas course id, *When* `canvas import course --wait`, *Then* the job completes and a summary prints.
+- **AC-2.** *Given* failures in the queue, *When* `canvas import retry <id>`, *Then* the item re-runs.
+- **AC-3.** *Given* an `.imscc`, *When* `imports submit --wait`, *Then* content imports with a report.
+
+## 8. Data Model
+
+- None client-side.
+
+## 9. API Surface
+
+- Canvas import/catalog/queue/submission-sync endpoints; `courses/{c}/canvas-link`; `registerImportRoutes` generic import.
+
+## 10. UI / UX
+
+- `lextures canvas ...`, `lextures imports ...`.
+- Shared `--wait` job primitive (C18/C40).
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server Canvas + import handlers; job queue (C18); course structure (C02).
+
+## 13. Dependencies & Sequencing
+
+- After: C18 (`--wait`), C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Large migrations time out CI | M | M | Async job path + `--wait --timeout`; resume via queue id |
+| Duplicate imports | M | M | Idempotency by Canvas source id; `--skip-existing` |
+
+## 15. Rollout Plan
+
+- Ship catalog + course import + queue first, then per-artifact imports + generic import.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — token redaction; queue status parsing.
+- **Integration** — import submit/poll; retry.
+- **E2E** — import a sample Canvas course → verify structure.
+
+## 17. Documentation & Training
+
+- "Migrate courses from Canvas at scale" runbook.
+
+## 18. Open Questions
+
+1. Does course import pull all artifacts or require per-artifact calls?
+
+## 19. References
+
+- `canvas_import_queue.go`, `canvas_catalog.go`, `canvas_*_import.go`, `registerImportRoutes`.
+- Related: [C02](C02-modules-course-structure.md), [C18](C18-jobs-scheduler-backups.md), [C04](C04-quizzes-question-banks.md).

--- a/docs/plan/cli/C25-integrations-webhooks-bots.md
+++ b/docs/plan/cli/C25-integrations-webhooks-bots.md
@@ -1,0 +1,123 @@
+# C25 — Integrations, cloud providers, webhooks & bots
+
+> CLI parity plan. Source: `integrations_http.go` (`integrations`, `admin-console/integrations`), `registerCloudProviderRoutes` (`cloud-providers`, `admin/cloud-providers`), `registerWebhookRoutes` (`webhooks`), `bots_http.go` (`bots`, `me/bot-link`), `admin_tokens.go` / `api_tokens_http.go` (`admin/tokens`, `me/access-keys`). Baseline: none (feed exists, but integrations are new).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C25 |
+| **Section** | Integrations & interoperability |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | PARTIAL (none of these; API tokens exist server-side) |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Integrations / CLI |
+| **Depends on** | C40 |
+| **Unblocks** | C09, C26 |
+
+---
+
+## 1. Problem Statement
+
+Third-party integrations, cloud storage providers, outbound webhooks, chat bots, and API tokens/access keys are UI-only. Platform teams cannot register webhooks for event-driven automation, configure cloud storage, manage bot integrations, or programmatically mint API tokens for CI — the connective tissue of an automatable platform.
+
+## 2. Goals
+
+- Register/list/rotate API tokens and personal access keys for CI/service accounts.
+- Configure outbound webhooks (events → external endpoints) and test delivery.
+- Manage cloud storage providers and third-party integrations.
+- Register/link bots.
+
+## 3. Non-Goals
+
+- Receiving inbound webhooks (server-side; e.g. originality/proctoring callbacks).
+- Building specific integration connectors.
+
+## 4. Personas & User Stories
+
+- **As a devops engineer**, I want `tokens create --name ci --scope ...` to mint a CI token.
+- **As an integrator**, I want `webhooks create --event grade.posted --url ...` and `webhooks test`.
+- **As an admin**, I want `cloud-providers set --file s3.json` to configure storage.
+- **As a comms admin**, I want `bots register` / `bots link` for a Slack/Teams bot.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `tokens list|create|revoke` (`admin/tokens`) and `access-keys list|create|revoke` (`me/access-keys`).
+- **FR-2.** MUST add `webhooks list|create|update|delete|test|deliveries` (`registerWebhookRoutes`) with event filters.
+- **FR-3.** MUST add `cloud-providers list|get|set|test` (`registerCloudProviderRoutes`).
+- **FR-4.** SHOULD add `integrations list|get|enable|disable` (`integrations_http.go`).
+- **FR-5.** SHOULD add `bots list|register|link|unlink` (`bots_http.go`, `me/bot-link`).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — webhook `deliveries` paginated.
+- **Security** — integration-admin scope; token/key secrets shown once then redacted; webhook signing secret managed server-side; provider creds via file/stdin.
+- **Privacy & Compliance** — webhook payloads may carry PII; command warns which events include student data.
+- **Reliability** — token/webhook create idempotent by name/id; `webhooks test` sends a signed sample.
+- **Observability** — `deliveries` shows attempt/status/response for debugging.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a scope, *When* `tokens create`, *Then* a one-time token prints; re-list redacts it.
+- **AC-2.** *Given* a webhook, *When* `webhooks test`, *Then* a signed sample is delivered and status prints.
+- **AC-3.** *Given* a cloud provider config, *When* `cloud-providers test`, *Then* connectivity validates without exposing creds.
+
+## 8. Data Model
+
+- None client-side. Document provider/webhook config JSON.
+
+## 9. API Surface
+
+- `admin/tokens` + `me/access-keys`; `registerWebhookRoutes`; `registerCloudProviderRoutes`; `integrations_http.go`; `bots_http.go` + `me/bot-link`.
+
+## 10. UI / UX
+
+- `lextures tokens ...`, `lextures access-keys ...`, `lextures webhooks ...`, `lextures cloud-providers ...`, `lextures integrations ...`, `lextures bots ...`.
+
+## 11. AI / ML Considerations
+
+- Bots may be AI-backed; CLI only registers/links, no model calls. AI provider config lives in C21.
+
+## 12. Integration Points
+
+- Server integration/webhook/cloud/bot/token handlers; feeds C09 (AI), C26 (events).
+
+## 13. Dependencies & Sequencing
+
+- After: C40.
+- Before: C26 (event streaming), C09 (bot/AI adjacency).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Token/secret leakage | M | H | One-time display + redaction + `--secret-out` |
+| Webhook to malicious URL | L | M | Server SSRF protections; CLI just configures |
+
+## 15. Rollout Plan
+
+- Ship tokens/access-keys + webhooks first (highest automation value), then cloud/integrations/bots.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — secret one-time display; event-filter parsing.
+- **Integration** — webhook create/test/deliveries; token revoke.
+- **Security** — secrets never re-shown.
+- **E2E** — create token → use it for a subsequent CLI call.
+
+## 17. Documentation & Training
+
+- "Mint a CI token" and "Wire an outbound webhook" recipes.
+
+## 18. Open Questions
+
+1. What is the webhook event catalog?
+2. Are access-keys (`me/access-keys`) equivalent to admin tokens or personal-scope only?
+
+## 19. References
+
+- `integrations_http.go`, `registerWebhookRoutes`, `registerCloudProviderRoutes`, `bots_http.go`, `admin_tokens.go`.
+- Related: [C09](C09-ai-grading-agents.md), [C21](C21-platform-settings.md), [C26](C26-xapi-lrs-engagement.md).

--- a/docs/plan/cli/C26-xapi-lrs-engagement.md
+++ b/docs/plan/cli/C26-xapi-lrs-engagement.md
@@ -1,0 +1,116 @@
+# C26 — xAPI / LRS / SCORM runtime & engagement
+
+> CLI parity plan. Source: `/api/v1/xapi/statements`, `admin/lrs-config`, `admin/lrs-dead-letter`, `/api/v1/scorm/rte/{registration_id}/commit`, `registerEngagementRoutes`, `/api/v1/recommendations/event`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C26 |
+| **Section** | Integrations & interoperability |
+| **Severity** | MINOR |
+| **Markets** | HE / K12 / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Analytics / CLI |
+| **Depends on** | C18, C40 |
+| **Unblocks** | C28 |
+
+---
+
+## 1. Problem Statement
+
+Learning-record (xAPI/LRS) and engagement-event surfaces are UI/API-only with no CLI. Analytics engineers cannot post/query xAPI statements for testing, configure the LRS, drain the dead-letter queue, or emit engagement/recommendation events — all needed to validate a learning-analytics pipeline.
+
+## 2. Goals
+
+- Post and query xAPI statements for pipeline testing.
+- Configure the LRS and manage its dead-letter queue.
+- Emit engagement/recommendation events for testing downstream analytics.
+
+## 3. Non-Goals
+
+- Being a full LRS query console; this is a scripting/diagnostic aid.
+- Analytics dashboards (see C28).
+
+## 4. Personas & User Stories
+
+- **As an analytics engineer**, I want `xapi post --file statement.json` to test ingestion.
+- **As an engineer**, I want `lrs dead-letter list|retry` to drain failed statements.
+- **As a QA engineer**, I want `engagement emit --file event.json` to validate signals.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `xapi post --file <json>` and `xapi query [--actor|--verb|--activity|--since]`.
+- **FR-2.** MUST add `lrs config get|set` and `lrs dead-letter list|retry|purge` (`admin/lrs-config`, `admin/lrs-dead-letter`).
+- **FR-3.** SHOULD add `engagement emit --file <json>` (`registerEngagementRoutes`) and `recommendations event`.
+- **FR-4.** MAY add `scorm commit <registration_id> --file <json>` for SCORM RTE testing.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — batch `xapi post` supports newline-delimited JSON.
+- **Security** — LRS/analytics scope; LRS credentials via file/stdin.
+- **Privacy & Compliance** — xAPI statements carry learner identity (FERPA); query results gated by `--yes` for export.
+- **Reliability** — post idempotent by statement id; dead-letter retry safe.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a statement file, *When* `xapi post`, *Then* the statement id is returned.
+- **AC-2.** *Given* failed statements, *When* `lrs dead-letter retry`, *Then* they re-process.
+- **AC-3.** *Given* filters, *When* `xapi query --verb completed`, *Then* matching statements print.
+
+## 8. Data Model
+
+- None client-side. Accept standard xAPI statement JSON.
+
+## 9. API Surface
+
+- `/api/v1/xapi/statements` (post/query); `admin/lrs-config`; `admin/lrs-dead-letter`; `registerEngagementRoutes`; `/api/v1/recommendations/event`; `/api/v1/scorm/rte/{id}/commit`.
+
+## 10. UI / UX
+
+- `lextures xapi ...`, `lextures lrs ...`, `lextures engagement ...`.
+
+## 11. AI / ML Considerations
+
+- Recommendation events feed AI recommenders server-side; CLI only emits.
+
+## 12. Integration Points
+
+- Server LRS/engagement/recommendation handlers; dead-letter (C18); analytics (C28).
+
+## 13. Dependencies & Sequencing
+
+- After: C18 (dead-letter/jobs), C40.
+- Before: C28 (events feed insights).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Malformed xAPI rejected opaquely | M | L | Client-side schema hint before post |
+
+## 15. Rollout Plan
+
+- Ship xapi post/query + lrs config/dead-letter first, then engagement/recommendation emit.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — statement validation; ND-JSON batch.
+- **Integration** — post/query; dead-letter retry.
+- **E2E** — post → query round-trip.
+
+## 17. Documentation & Training
+
+- "Test your learning-analytics pipeline" recipe.
+
+## 18. Open Questions
+
+1. Does the LRS support the full xAPI query API or a subset?
+
+## 19. References
+
+- xAPI/SCORM RTE routes in `server.go`; `registerEngagementRoutes`.
+- Related: [C18](C18-jobs-scheduler-backups.md), [C25](C25-integrations-webhooks-bots.md), [C28](C28-insights-at-risk.md).

--- a/docs/plan/cli/C27-reports-exports.md
+++ b/docs/plan/cli/C27-reports-exports.md
@@ -1,0 +1,121 @@
+# C27 — Reports & exports
+
+> CLI parity plan. Source: `/api/v1/reports/learning-activity`, `report_export.go` (`registerReportExportRoutes`), `courses/{id}/analytics` (12), `/api/v1/analytics`, `admin_search.go`, `courses/{id}/reports`. Baseline: `grades export` only.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C27 |
+| **Section** | Reporting & insights |
+| **Severity** | BLOCKER |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING (only `grades export`) |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Analytics / CLI |
+| **Depends on** | C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+Reporting and data export — the classic reason institutions want a CLI — is almost absent. Beyond `grades export`, there is no way to pull learning-activity reports, course analytics, or run the report-export pipeline into CSV/JSON for a data warehouse. Data teams cannot schedule nightly extracts.
+
+## 2. Goals
+
+- Run and export the platform's canonical reports (learning activity, course analytics) to CSV/JSON.
+- Drive the async report-export pipeline (submit → wait → download).
+- Make every report scriptable for warehouse ETL/cron.
+
+## 3. Non-Goals
+
+- Building new report types (server-owned).
+- BI visualization.
+
+## 4. Personas & User Stories
+
+- **As a data engineer**, I want `reports export learning-activity --from --to --out d` for nightly ETL.
+- **As an analyst**, I want `analytics course <course> --json` for a course dashboard feed.
+- **As an admin**, I want `reports run <type> --wait` to generate large exports.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `reports list` (available report types) and `reports run <type>` / `reports export <type>` (`registerReportExportRoutes`, async + `--wait`).
+- **FR-2.** MUST add `reports learning-activity [--course|--org] --from --to` (`/reports/learning-activity`).
+- **FR-3.** MUST add `analytics course <course>` and `analytics platform` (`courses/{id}/analytics`, `/analytics`).
+- **FR-4.** SHOULD support `--format csv|json|ndjson` and `--out <dir>` for all exports.
+- **FR-5.** SHOULD add `reports schedule` passthrough if the server supports scheduled exports.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — large exports stream; async path with `--wait` for heavy reports.
+- **Security** — reports scope (`global:app:reports:view` etc.); 403 → exit 2.
+- **Privacy & Compliance** — reports contain student PII/grades (FERPA); export gated by `--yes`; PII redaction option where the server supports it.
+- **Reliability** — export idempotent; resumable download of generated artifacts.
+- **Observability** — `--wait` shows generation progress; row/record counts on completion.
+- **Backward compatibility** — keep `grades export`; consider aliasing under `reports`.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a range, *When* `reports export learning-activity --out d`, *Then* a CSV lands in `d/` with a row count.
+- **AC-2.** *Given* a heavy report, *When* `reports run <type> --wait`, *Then* it completes and downloads.
+- **AC-3.** *Given* `analytics course --json`, *Then* analytics metrics emit as JSON.
+
+## 8. Data Model
+
+- None client-side.
+
+## 9. API Surface
+
+- `registerReportExportRoutes`; `/reports/learning-activity`; `courses/{id}/analytics` + `/analytics`; `courses/{id}/reports`.
+
+## 10. UI / UX
+
+- `lextures reports ...`, `lextures analytics ...`. CSV default for exports; `--json`/`--ndjson` for pipelines.
+
+## 11. AI / ML Considerations
+
+- None (insights/at-risk AI lives in C28).
+
+## 12. Integration Points
+
+- Server report/analytics handlers; job queue (`--wait`, C18/C40).
+
+## 13. Dependencies & Sequencing
+
+- After: C40 (`--wait`, `--out`, `--format`).
+- Before: none (but complements C06/C07/C12 data producers).
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Report catalog undiscoverable | M | M | `reports list` enumerates types + params |
+| Huge exports | M | M | Streamed + async + resumable download |
+
+## 15. Rollout Plan
+
+- Ship learning-activity + course analytics + report-export pipeline first.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — format/out flags; range params.
+- **Integration** — export job submit/poll/download.
+- **Security** — reports scope; `--yes` gate.
+- **E2E** — nightly ETL simulation into a temp dir.
+
+## 17. Documentation & Training
+
+- "Schedule nightly report exports to your warehouse" runbook.
+
+## 18. Open Questions
+
+1. Is there a discoverable catalog of report types + parameters?
+2. Which reports are sync vs async?
+
+## 19. References
+
+- `report_export.go`, `courses/{id}/analytics` handlers, `/reports/learning-activity`.
+- Related: [C06](C06-gradebook-final-grades.md), [C12](C12-attendance-behavior.md), [C28](C28-insights-at-risk.md), [C40](C40-cli-framework.md).

--- a/docs/plan/cli/C28-insights-at-risk.md
+++ b/docs/plan/cli/C28-insights-at-risk.md
@@ -1,0 +1,118 @@
+# C28 — Insights, at-risk & classroom signals
+
+> CLI parity plan. Source: `at_risk.go` (`courses/{id}/at-risk`, `admin/at-risk`), `registerInsightsRoutes` (`insights`), `classroom_signals.go`, `registerEngagementRoutes`, `courses/{id}/leaderboard`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C28 |
+| **Section** | Reporting & insights |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Analytics / CLI |
+| **Depends on** | C27, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+At-risk detection, instructor insights and classroom signals — a headline differentiator — are UI-only. Student-success teams cannot pull at-risk cohorts into their outreach/CRM tooling or trigger recomputation, so early-alert workflows can't be automated.
+
+## 2. Goals
+
+- Export at-risk student lists per course/org for outreach automation.
+- Pull instructor insights and classroom signals programmatically.
+- Trigger recomputation of at-risk models where supported.
+
+## 3. Non-Goals
+
+- Building the risk model (server/ML owns it).
+- Case-management/outreach workflow (CRM concern).
+
+## 4. Personas & User Stories
+
+- **As a success coach**, I want `at-risk list --org O --threshold high` to feed my outreach queue.
+- **As an instructor**, I want `insights course <course>` for a weekly summary.
+- **As an admin**, I want `at-risk recompute --course C` after a grade import.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `at-risk list <course>` and `at-risk list --org <org>` with `--threshold`/`--factor` filters (`at_risk.go`).
+- **FR-2.** MUST add `insights course|student <id>` (`registerInsightsRoutes`) and `signals course <course>` (`classroom_signals.go`).
+- **FR-3.** SHOULD add `at-risk recompute` / `at-risk factors <course> --user U` (explanation of risk drivers).
+- **FR-4.** SHOULD add `--export`/`--out` for at-risk cohorts (CSV for CRM import).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — org-wide at-risk paginated; p95 < 2 s per page.
+- **Security** — insights/at-risk scope; 403 → exit 2.
+- **Privacy & Compliance** — at-risk data is highly sensitive FERPA (and reputationally) → export gated by `--yes`; access audited.
+- **Reliability** — recompute idempotent; safe to re-run.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a course, *When* `at-risk list --threshold high --json`, *Then* flagged students emit with scores.
+- **AC-2.** *Given* an org, *When* `at-risk list --org O --export --out d`, *Then* a CSV lands (gated by `--yes`).
+- **AC-3.** *Given* a course, *When* `insights course`, *Then* an insight summary prints.
+
+## 8. Data Model
+
+- None client-side.
+
+## 9. API Surface
+
+- `at_risk.go` (course + admin); `registerInsightsRoutes`; `classroom_signals.go`; `leaderboard`.
+
+## 10. UI / UX
+
+- `lextures at-risk ...`, `lextures insights ...`, `lextures signals ...`.
+
+## 11. AI / ML Considerations
+
+- Risk scores are ML-derived server-side; CLI reads scores + factor explanations. Surface model/version if provided (ties to C29 AI disclosure).
+
+## 12. Integration Points
+
+- Server at-risk/insights/signals handlers; report exports (C27); events (C26).
+
+## 13. Dependencies & Sequencing
+
+- After: C27 (shared export plumbing), C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Sensitive labels mishandled | M | H | `--yes` gate; audit; document responsible-use guidance |
+| Recompute expensive | M | M | Async + `--wait`; rate-limit |
+
+## 15. Rollout Plan
+
+- Ship at-risk + insights read/export first, then recompute/factors.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — threshold/factor filters; export gating.
+- **Integration** — at-risk list; insights shape.
+- **Security** — `--yes` gate; scope.
+- **E2E** — export at-risk cohort → verify CSV.
+
+## 17. Documentation & Training
+
+- "Feed at-risk cohorts to your outreach tool" recipe + responsible-use note.
+
+## 18. Open Questions
+
+1. Does the server expose risk-factor explanations per student?
+
+## 19. References
+
+- `at_risk.go`, `registerInsightsRoutes`, `classroom_signals.go`.
+- Related: [C12](C12-attendance-behavior.md), [C27](C27-reports-exports.md), [C29](C29-compliance-privacy.md).

--- a/docs/plan/cli/C29-compliance-privacy.md
+++ b/docs/plan/cli/C29-compliance-privacy.md
@@ -1,0 +1,126 @@
+# C29 — Compliance, privacy & trust
+
+> CLI parity plan. Source: `compliance/*` (67 routes: `ferpa`, `gdpr`, `coppa`, `ccpa`, `iso`, `dpa`, `state`, `security-reports`, `data-inventory`, `ai-inference-log`), `registerPIIRedactionRoutes`, `registerTrustRoutes`, `registerLegalRoutes`, `registerResearchConsentRoutes`, `ai_disclosure_http.go`, `soc2_http.go`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C29 |
+| **Section** | Compliance & trust |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | L (1–2mo) |
+| **Owner (proposed)** | Compliance / CLI |
+| **Depends on** | C19, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+The platform has an extensive compliance surface (FERPA, GDPR, COPPA, CCPA, ISO, DPA, state privacy, SOC 2, PII redaction, data inventory, AI-inference logs, research consent) — none reachable from the CLI. Privacy officers cannot fulfill Data Subject Access/erasure Requests (DSAR), pull data inventories, or export compliance evidence via automation, all of which are time-boxed legal obligations.
+
+## 2. Goals
+
+- Fulfill DSARs: export a subject's data (access) and process erasure (right-to-be-forgotten).
+- Pull data inventory and compliance evidence (SOC 2 / ISO) for audits.
+- Manage consent (COPPA parental, research) and AI-disclosure records.
+- Run PII redaction jobs and pull security reports.
+
+## 3. Non-Goals
+
+- Legal adjudication (human/process).
+- Being the system of record for compliance (server owns state); CLI drives and exports.
+
+## 4. Personas & User Stories
+
+- **As a privacy officer**, I want `gdpr export --subject U --out d` to fulfill a DSAR within deadline.
+- **As a privacy officer**, I want `gdpr erase --subject U` (right to be forgotten) with confirmation.
+- **As a compliance lead**, I want `compliance data-inventory export` for a records map.
+- **As an auditor**, I want `soc2 evidence export` and `iso controls list`.
+- **As a K12 admin**, I want `coppa consent list --pending` to chase parental consent.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `gdpr export|erase|status --subject <u>` and `ccpa`/`state` equivalents (DSAR access/delete/do-not-sell).
+- **FR-2.** MUST add `ferpa disclosures list|log`, `ferpa consent` where applicable.
+- **FR-3.** MUST add `coppa consent list|grant|revoke` (parental consent) and `research-consent` management.
+- **FR-4.** MUST add `compliance data-inventory export`, `compliance audit-log export` (shared with C19), `ai-inference-log export`.
+- **FR-5.** SHOULD add `soc2 evidence|status`, `iso controls list`, `dpa list|get`, `security-reports list|get`.
+- **FR-6.** SHOULD add `pii redact submit|status` (`registerPIIRedactionRoutes`) and `ai-disclosure get|set` (per course/org).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — DSAR export is async/job-backed; `--wait` streams progress.
+- **Security** — compliance-officer scope (highly privileged); all actions audited; erasure requires `--yes` + `--confirm-subject <id>` double-confirmation.
+- **Privacy & Compliance** — this IS the compliance surface: exports are legally sensitive; encrypted-at-rest output recommended; deletion is irreversible and logged.
+- **Reliability** — export/erase idempotent by request id; resumable.
+- **Observability** — every command references a compliance request id for the audit trail.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a subject, *When* `gdpr export --wait`, *Then* a data package downloads and a request id prints.
+- **AC-2.** *Given* an erasure, *When* `gdpr erase` without `--confirm-subject`, *Then* it refuses.
+- **AC-3.** *Given* an audit, *When* `soc2 evidence export`, *Then* evidence artifacts download.
+
+## 8. Data Model
+
+- Client stores nothing sensitive; writes exports to caller-specified `--out` only.
+
+## 9. API Surface
+
+- `compliance/{gdpr,ferpa,coppa,ccpa,iso,dpa,state,security-reports,data-inventory,ai-inference-log,audit-log}`; `registerPIIRedactionRoutes`; `soc2_http.go`; `ai_disclosure_http.go`; `registerResearchConsentRoutes`; `registerTrustRoutes`; `registerLegalRoutes`.
+
+## 10. UI / UX
+
+- `lextures gdpr|ccpa|ferpa|coppa|iso|soc2|dpa|compliance|pii ...`.
+- Destructive ops require double confirmation and print the audit request id.
+
+## 11. AI / ML Considerations
+
+- `ai-inference-log` and `ai-disclosure` support AI-governance/EU-AI-Act obligations; CLI exports logs and manages disclosure text.
+
+## 12. Integration Points
+
+- Server compliance handlers; audit log (C19); jobs (`--wait`, C18).
+
+## 13. Dependencies & Sequencing
+
+- After: C19 (audit export), C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Accidental irreversible erasure | M | H | Double-confirm; dry-run preview of scope; audit |
+| Sensitive export left on disk | M | H | Warn; recommend `--out` to encrypted volume; no stdout dumps |
+
+## 15. Rollout Plan
+
+- Ship DSAR export + data-inventory + audit export first (most-requested), then erasure, then SOC2/ISO/consent.
+- Rollback: additive; erasure is not reversible — extra guards.
+
+## 16. Test Plan
+
+- **Unit** — confirmation gating; request-id handling.
+- **Integration** — DSAR export job; consent list.
+- **Security** — erasure double-confirm; scope; audit emission.
+- **E2E** — export a test subject → verify package; (staging only) erase → verify.
+
+## 17. Documentation & Training
+
+- "Fulfill a DSAR within deadline" and "Pull SOC 2 evidence for an audit" runbooks.
+
+## 18. Open Questions
+
+1. Is DSAR export a single unified endpoint or per-regulation?
+2. Does erasure cascade across all data stores in one call?
+
+## 19. References
+
+- `compliance/*` handlers; `soc2_http.go`, `ai_disclosure_http.go`, `registerPIIRedactionRoutes`.
+- Related: [C19](C19-audit-impersonation-search.md), [C21](C21-platform-settings.md), [C39](C39-profile-account-personas.md).

--- a/docs/plan/cli/C30-billing-payments-tax.md
+++ b/docs/plan/cli/C30-billing-payments-tax.md
@@ -1,0 +1,119 @@
+# C30 — Billing, payments, tax & revenue
+
+> CLI parity plan. Source: `billing_http.go` (`billing`), `payments_http.go` (`payments`, `checkout`, `invoices`), `tax_http.go` (`orgs/{orgId}/tax`), `registerRevenueShareRoutes` (`revenue`), `affiliate`, `me/transactions`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C30 |
+| **Section** | Commerce |
+| **Severity** | MAJOR |
+| **Markets** | SL / HE (CE) |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Commerce / CLI |
+| **Depends on** | C14, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+Billing, payments, invoices, tax configuration and revenue reporting are UI-only. Finance teams and self-learner-marketplace operators cannot pull invoices, reconcile transactions, or configure tax (Stripe Tax/VAT/GST) via automation — routine month-end finance work.
+
+## 2. Goals
+
+- Read billing/subscription state and export invoices/transactions for reconciliation.
+- Configure org tax settings (VAT/GST/Stripe Tax).
+- Pull revenue/payout and affiliate reports.
+
+## 3. Non-Goals
+
+- Taking payments interactively (Stripe hosted checkout is a browser flow).
+- Being a full accounting system.
+
+## 4. Personas & User Stories
+
+- **As a finance admin**, I want `invoices list|export --org O --month 2026-06` for reconciliation.
+- **As a finance admin**, I want `tax set --org O --file tax.json` (VAT id, nexus).
+- **As an operator**, I want `revenue report --from --to` and `payments transactions export`.
+- **As a creator**, I want `affiliate report` for referral earnings.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `billing status --org <o>` and `billing subscription get`.
+- **FR-2.** MUST add `invoices list|get|export` and `payments transactions list|export` (`me/transactions`, `admin/transactions`).
+- **FR-3.** MUST add `tax get|set --org <o>` (`tax_http.go`).
+- **FR-4.** SHOULD add `revenue report` (`registerRevenueShareRoutes`) and `affiliate report`.
+- **FR-5.** MAY add `checkout link create` (generate a hosted checkout link for a product).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — invoice/transaction export paginated/streamed.
+- **Security** — finance/billing scope; no card data ever handled by CLI (PCI: server/Stripe only).
+- **Privacy & Compliance** — financial records; export gated by `--yes`; PII in invoices handled per policy.
+- **Reliability** — exports idempotent; reconcilable by transaction id.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a month, *When* `invoices export --month`, *Then* invoices export as CSV/JSON.
+- **AC-2.** *Given* a tax file, *When* `tax set`, *Then* `tax get` reflects VAT/nexus config.
+- **AC-3.** *Given* a range, *When* `revenue report`, *Then* revenue-share figures print.
+
+## 8. Data Model
+
+- None client-side. Document tax config JSON.
+
+## 9. API Surface
+
+- `billing_http.go`; `payments_http.go` (payments/checkout/invoices); `tax_http.go`; `registerRevenueShareRoutes`; `affiliate`; `me/transactions`.
+
+## 10. UI / UX
+
+- `lextures billing ...`, `lextures invoices ...`, `lextures payments ...`, `lextures tax ...`, `lextures revenue ...`.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server billing/payment/tax handlers; Stripe (server-side only).
+
+## 13. Dependencies & Sequencing
+
+- After: C14 (org scope), C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| PCI scope creep | L | H | CLI never touches card data; checkout is a link only |
+| Financial data exposure | M | H | `--yes` gate; no stdout dumps of full ledgers |
+
+## 15. Rollout Plan
+
+- Ship invoices/transactions export + billing status first, then tax config, then revenue/affiliate.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — month/range filters; export gating.
+- **Integration** — invoice list; tax set/get.
+- **E2E** — export a month of invoices → reconcile.
+
+## 17. Documentation & Training
+
+- "Month-end invoice reconciliation" runbook.
+
+## 18. Open Questions
+
+1. Is tax configuration org-scoped only, or also platform-level defaults?
+
+## 19. References
+
+- `billing_http.go`, `payments_http.go`, `tax_http.go`, `registerRevenueShareRoutes`.
+- Related: [C14](C14-org-administration.md), [C17](C17-licenses-entitlements.md).

--- a/docs/plan/cli/C31-credentials-transcripts-advising.md
+++ b/docs/plan/cli/C31-credentials-transcripts-advising.md
@@ -1,0 +1,120 @@
+# C31 — Credentials, transcripts, advising & degree progress
+
+> CLI parity plan. Source: `credentials_http.go` (`credentials`, 7), `registerTranscriptsRoutes` (`transcripts`, `admin/transcripts`), `registerCCRRoutes` (`me/ccr`), `advising_http.go` (`advisor`, `admin/advising`), `me/degree-progress`, `/api/v1/verify`, `registerOnboardingGoalsRoutes`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C31 |
+| **Section** | Academic records |
+| **Severity** | MAJOR |
+| **Markets** | HE (primary) / K12 |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Registrar / CLI |
+| **Depends on** | C06, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+Credentials (badges/certificates), transcripts, comprehensive learner records (CCR), advising notes and degree-progress audits are UI-only. Registrars cannot batch-issue credentials, export official transcripts, or run degree-audit reports for a cohort via automation.
+
+## 2. Goals
+
+- Batch-issue and verify credentials/badges.
+- Generate and export transcripts (and CCR) per student/cohort.
+- Pull degree-progress/advising data for reporting and advisor tooling.
+
+## 3. Non-Goals
+
+- Designing credential templates in a WYSIWYG editor.
+- Advising case-management workflow beyond notes read/append.
+
+## 4. Personas & User Stories
+
+- **As a registrar**, I want `credentials issue --file recipients.csv --template T` to batch-award.
+- **As a registrar**, I want `transcripts export --user U --format pdf` for an official transcript.
+- **As an advisor**, I want `degree-progress get --user U` and `advising notes list --user U`.
+- **As a verifier**, I want `credentials verify <code>` to check authenticity.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `credentials list|issue|revoke|verify` (`credentials_http.go`; batch `--file`, public `/verify`).
+- **FR-2.** MUST add `transcripts get|export <user>` (`--format pdf|json`) and `transcripts batch --section S` (`registerTranscriptsRoutes`).
+- **FR-3.** MUST add `ccr export --user <u>` (comprehensive learner record).
+- **FR-4.** SHOULD add `degree-progress get --user <u>` and `advising notes list|add --user <u>` (`advising_http.go`).
+- **FR-5.** MAY add `onboarding-goals get|set` (`registerOnboardingGoalsRoutes`).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — batch issue/transcript export async; `--wait` for large cohorts.
+- **Security** — registrar/advisor scope; credential signing keys server-side only.
+- **Privacy & Compliance** — transcripts/CCR are FERPA official records; export gated by `--yes`; verify endpoint is public but returns minimal data.
+- **Reliability** — issue idempotent by (recipient, template); re-issue detected.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a recipients CSV, *When* `credentials issue --file`, *Then* credentials mint with a summary; re-run issues 0 dups.
+- **AC-2.** *Given* a user, *When* `transcripts export --format pdf`, *Then* a PDF transcript is written.
+- **AC-3.** *Given* a credential code, *When* `credentials verify`, *Then* validity + minimal metadata print.
+
+## 8. Data Model
+
+- None client-side. Document recipients CSV schema.
+
+## 9. API Surface
+
+- `credentials_http.go` (issue/revoke/verify); `registerTranscriptsRoutes`; `registerCCRRoutes`; `advising_http.go`; `me/degree-progress`; `/api/v1/verify`.
+
+## 10. UI / UX
+
+- `lextures credentials ...`, `lextures transcripts ...`, `lextures advising ...`, `lextures degree-progress ...`.
+
+## 11. AI / ML Considerations
+
+- Advising may include AI recommendations server-side; CLI reads them. No CLI model calls.
+
+## 12. Integration Points
+
+- Server credential/transcript/advising handlers; final grades (C06); open-badge/Comprehensive Learner Record standards.
+
+## 13. Dependencies & Sequencing
+
+- After: C06 (grades → transcript), C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Transcript is an official/legal doc | M | H | Server generates + signs; CLI only requests/downloads |
+| Batch double-issue | M | M | Idempotency key; `--skip-existing` |
+
+## 15. Rollout Plan
+
+- Ship credentials issue/verify + transcript export first, then CCR/advising/degree-progress.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — recipients CSV parse; idempotency.
+- **Integration** — issue/verify; transcript export.
+- **E2E** — batch-issue → verify a code.
+
+## 17. Documentation & Training
+
+- "Batch-issue completion certificates" recipe.
+
+## 18. Open Questions
+
+1. Which credential standard (Open Badges v2/v3, CLR)?
+2. Is transcript export synchronous or job-backed?
+
+## 19. References
+
+- `credentials_http.go`, `registerTranscriptsRoutes`, `advising_http.go`.
+- Related: [C06](C06-gradebook-final-grades.md), [C07](C07-outcomes-standards-sbg.md).

--- a/docs/plan/cli/C32-catalog-library-oer.md
+++ b/docs/plan/cli/C32-catalog-library-oer.md
@@ -1,0 +1,117 @@
+# C32 — Catalog, library, OER & bookstore
+
+> CLI parity plan. Source: `registerPublicCatalogRoutes` + `registerCatalogRoutes` (`catalog`, `courses/{id}/catalog-listing`), `registerLibraryRoutes` + `registerHELibraryRoutes` (`library`, `orgs/{orgId}/library`), `registerOERRoutes` (`oer`, `admin/oer-providers`), `bookstore_textbook.go` (`admin/bookstore`, `courses/{id}/textbook-resources`, `inclusive-access`). Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C32 |
+| **Section** | Catalog & materials |
+| **Severity** | MINOR |
+| **Markets** | HE / K12 / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Content / CLI |
+| **Depends on** | C01, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+The public course catalog, institutional library, OER provider integrations and bookstore/textbook resources are UI-only. Catalog managers cannot bulk-publish course listings, sync library resources, or manage textbook/inclusive-access assignments programmatically.
+
+## 2. Goals
+
+- Manage public catalog listings (publish/unpublish, pricing/visibility) in bulk.
+- Search/link library and OER resources into courses.
+- Configure bookstore/textbook resources and inclusive-access.
+
+## 3. Non-Goals
+
+- Building the storefront UX.
+- Payment (see C30).
+
+## 4. Personas & User Stories
+
+- **As a catalog manager**, I want `catalog publish --course C` and `catalog list --org O`.
+- **As a librarian**, I want `library search "..."` and `library link --course C --resource R`.
+- **As a course designer**, I want `oer search` to find open resources and attach them.
+- **As a bookstore admin**, I want `textbooks set --course C --file textbooks.json`.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `catalog list|get|publish|unpublish` (`catalog-listing`, public catalog read).
+- **FR-2.** MUST add `library search|list|link|unlink` (`registerLibraryRoutes`, org library) and `library-resources` per course.
+- **FR-3.** SHOULD add `oer search|providers list|link` (`registerOERRoutes`, `admin/oer-providers`).
+- **FR-4.** SHOULD add `textbooks list|set` and `inclusive-access get|set` (`bookstore_textbook.go`).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — search paginated; catalog list streamed.
+- **Security** — catalog/library admin scope; public catalog read needs no auth (skip-auth annotation).
+- **Privacy & Compliance** — inclusive-access ties to student billing consent; respected server-side.
+- **Reliability** — publish/link idempotent.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a course, *When* `catalog publish`, *Then* it appears in `catalog list`.
+- **AC-2.** *Given* a query, *When* `library search`, *Then* matching resources print.
+- **AC-3.** *Given* an OER resource, *When* `oer link --course C`, *Then* it is attached to the course.
+
+## 8. Data Model
+
+- None client-side.
+
+## 9. API Surface
+
+- `catalog` public + admin; `library`/org library; `oer` + providers; `bookstore`/`textbook-resources`/`inclusive-access`.
+
+## 10. UI / UX
+
+- `lextures catalog ...`, `lextures library ...`, `lextures oer ...`, `lextures textbooks ...`.
+
+## 11. AI / ML Considerations
+
+- OER/library search may be AI-ranked server-side; CLI reads results.
+
+## 12. Integration Points
+
+- Server catalog/library/OER/bookstore handlers; course linking (C01/C05).
+
+## 13. Dependencies & Sequencing
+
+- After: C01 (course listings), C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Public catalog auth model differs | M | L | Mark read commands skip-auth; verify against `registerPublicCatalogRoutes` |
+
+## 15. Rollout Plan
+
+- Ship catalog + library first, then OER + bookstore.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — search params; publish idempotency.
+- **Integration** — catalog list; library link.
+- **E2E** — publish a course to the catalog → verify public read.
+
+## 17. Documentation & Training
+
+- "Bulk-publish courses to your catalog" recipe.
+
+## 18. Open Questions
+
+1. Is the public catalog per-org or global?
+
+## 19. References
+
+- `registerCatalogRoutes`, `registerLibraryRoutes`, `registerOERRoutes`, `bookstore_textbook.go`.
+- Related: [C01](C01-courses.md), [C05](C05-content-extras.md), [C30](C30-billing-payments-tax.md).

--- a/docs/plan/cli/C33-accessibility-media-localization.md
+++ b/docs/plan/cli/C33-accessibility-media-localization.md
@@ -1,0 +1,122 @@
+# C33 — Accessibility, media & localization
+
+> CLI parity plan. Source: `accessibility_http.go` (`accessibility`), `alt_text_http.go` (`alt-text`), `registerCaptionRoutes`/`registerCaptionAccessibilityRoutes`, `registerTTSRoutes` (`tts`), `stt`, `registerReadingLevelRoutes`, `registerTranscodeRoutes`, `registerTusRoutes`, `registerTranslationRoutes` (`translate`, `translation-memory`), `course_translation.go` (`courses/{id}/translations`, `translation-coverage`), `settings/locale`, `timezones`. Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C33 |
+| **Section** | Accessibility & localization |
+| **Severity** | MINOR |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Accessibility / CLI |
+| **Depends on** | C02, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+Accessibility tooling (alt-text generation, captions, TTS/STT, reading-level), media transcoding, resumable (TUS) uploads, and course translation are UI-only. Content teams cannot batch-generate alt text/captions for a media library, transcode uploads, or manage per-course translations at scale — key for WCAG and multilingual compliance.
+
+## 2. Goals
+
+- Batch-generate and manage alt text, captions and translations across a course.
+- Trigger and monitor media transcode jobs; use resumable TUS uploads for large media.
+- Run accessibility checks and pull reading-level analysis.
+
+## 3. Non-Goals
+
+- Manual caption editing UX (browser).
+- Building the ASR/MT models (server/provider).
+
+## 4. Personas & User Stories
+
+- **As a content team**, I want `alt-text generate --course C` to caption all images.
+- **As an accessibility lead**, I want `captions generate --item I` and `captions upload --file .vtt`.
+- **As a localizer**, I want `translations generate --course C --to es` + `translations coverage`.
+- **As a media engineer**, I want `media transcode <item> --wait` and `media upload --tus bigfile.mp4`.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `alt-text generate|list|set` (`alt_text_http.go`; batch per course, `--wait`).
+- **FR-2.** MUST add `captions generate|list|upload|delete` (caption routes; `.vtt`/`.srt`).
+- **FR-3.** MUST add `translations generate|list|coverage|set <course> --to <locale>` (`course_translation.go`).
+- **FR-4.** SHOULD add `accessibility check <course>` (`accessibility_http.go`) reporting WCAG issues.
+- **FR-5.** SHOULD add `media transcode <item> --wait`, `media upload --tus <file>` (`registerTranscodeRoutes`, `registerTusRoutes`), `tts synth --file text --out audio`, `reading-level <item>`.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — batch/transcode async with `--wait`; TUS uploads resumable/chunked.
+- **Security** — content scope; provider keys server-side.
+- **Privacy & Compliance** — WCAG 2.1 AA is the target these features serve; alt-text/caption generation may send media to AI providers (disclosure via C29).
+- **Reliability** — generation idempotent; skip already-captioned items with `--skip-existing`.
+- **Internationalization** — locale codes validated against `settings/locale`.
+- **Backward compatibility** — additive; complements existing `files upload`.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a course of images, *When* `alt-text generate --wait`, *Then* alt text is produced with a summary.
+- **AC-2.** *Given* a video item, *When* `captions generate --wait`, *Then* a caption track is attached.
+- **AC-3.** *Given* a course, *When* `translations coverage --json`, *Then* per-locale coverage % prints.
+
+## 8. Data Model
+
+- None client-side.
+
+## 9. API Surface
+
+- `alt_text_http.go`; caption routes; `course_translation.go` + `registerTranslationRoutes`; `accessibility_http.go`; `registerTranscodeRoutes`; `registerTusRoutes`; `registerTTSRoutes`; `registerReadingLevelRoutes`.
+
+## 10. UI / UX
+
+- `lextures alt-text|captions|translations|accessibility|media|tts ...`.
+- Batch/transcode use the shared `--wait` primitive.
+
+## 11. AI / ML Considerations
+
+- Alt-text, captions (ASR), translation (MT), TTS are AI-backed server-side; CLI triggers/reads. Cost surfaced where server provides it; opt-out honored.
+
+## 12. Integration Points
+
+- Server accessibility/media/translation handlers; TUS pipeline (existing `files upload`); jobs (C18).
+
+## 13. Dependencies & Sequencing
+
+- After: C02 (items to caption/translate), C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Large media transcode timeouts | M | M | Async + `--wait --timeout`; TUS resume |
+| MT/ASR quality | M | L | Mark generated content as machine-generated; human-review flag |
+
+## 15. Rollout Plan
+
+- Ship alt-text + captions + translations first (WCAG value), then transcode/TUS/TTS.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — locale validation; `.vtt` parse; skip-existing.
+- **Integration** — generate job; coverage shape.
+- **E2E** — generate alt text for a course → verify.
+
+## 17. Documentation & Training
+
+- "Batch-caption a media library for WCAG" recipe.
+
+## 18. Open Questions
+
+1. Are generation endpoints per-item or per-course batch?
+2. Does translation cover structured content (pages) or only strings?
+
+## 19. References
+
+- `alt_text_http.go`, `course_translation.go`, `accessibility_http.go`, caption/transcode/TUS routes.
+- Related: [C02](C02-modules-course-structure.md), [C05](C05-content-extras.md), [C29](C29-compliance-privacy.md).

--- a/docs/plan/cli/C34-messaging-broadcasts.md
+++ b/docs/plan/cli/C34-messaging-broadcasts.md
@@ -1,0 +1,118 @@
+# C34 — Messaging, broadcasts & notifications
+
+> CLI parity plan. Source: `registerCommunicationRoutes` (`communication`), `broadcasts_http.go` (`orgs/{orgId}/broadcasts`), `me/notifications`, `me/notification-preferences`, `me/push-subscriptions`, `me/device-tokens`, `push`. Baseline: `feed` (channels/post/recent).
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C34 |
+| **Section** | Communication |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | PARTIAL (course `feed` only) |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Communication / CLI |
+| **Depends on** | C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+Beyond course feed channels, the CLI has no access to the inbox/messaging system, org-wide broadcasts/announcements, or notification management. Admins cannot send an org broadcast (e.g. emergency notice) or an instructor an announcement from a script, and users can't manage notification preferences programmatically.
+
+## 2. Goals
+
+- Send and read direct/inbox messages.
+- Send org-wide or course broadcasts/announcements from automation.
+- Read and manage notifications and notification preferences.
+
+## 3. Non-Goals
+
+- Real-time chat UX.
+- Being an email server (server handles delivery).
+
+## 4. Personas & User Stories
+
+- **As an admin**, I want `broadcasts send --org O --file notice.md --audience students`.
+- **As an instructor**, I want `announcements post --course C --file update.md` (via feed/communication).
+- **As a user**, I want `messages send --to U --subject ... --body ...` and `messages list`.
+- **As a user**, I want `notifications list` and `notification-prefs set`.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `messages list|get|send|reply` (`registerCommunicationRoutes` inbox).
+- **FR-2.** MUST add `broadcasts list|send|status` (`broadcasts_http.go`; `--audience`, `--org`, `--schedule`).
+- **FR-3.** SHOULD add `announcements post|list` (course-scoped) bridging feed/communication.
+- **FR-4.** SHOULD add `notifications list|read|clear` and `notification-prefs get|set` (`me/notifications`, `me/notification-preferences`).
+- **FR-5.** MAY add `push test` (`me/push-subscriptions`, `me/device-tokens`).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — inbox/broadcast lists paginated.
+- **Security** — messaging/broadcast scope; broadcast to large audiences requires elevated role + `--yes`.
+- **Privacy & Compliance** — messages are FERPA-adjacent; export gated by `--yes`.
+- **Reliability** — send idempotent by client-supplied idempotency key to avoid duplicate blasts.
+- **Backward compatibility** — existing `feed` unchanged; may alias `announcements` to feed post.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a notice file, *When* `broadcasts send --audience students --yes`, *Then* a broadcast id returns and `status` shows delivery counts.
+- **AC-2.** *Given* a recipient, *When* `messages send`, *Then* it appears in the recipient's inbox.
+- **AC-3.** *Given* re-sent with same idempotency key, *Then* no duplicate broadcast.
+
+## 8. Data Model
+
+- None client-side.
+
+## 9. API Surface
+
+- `registerCommunicationRoutes`; `broadcasts_http.go`; `me/notifications`, `me/notification-preferences`, `me/push-subscriptions`, `me/device-tokens`.
+
+## 10. UI / UX
+
+- `lextures messages ...`, `lextures broadcasts ...`, `lextures announcements ...`, `lextures notifications ...`.
+
+## 11. AI / ML Considerations
+
+- None (compose-assist, if any, is separate).
+
+## 12. Integration Points
+
+- Server communication/broadcast/notification handlers; course feed (existing).
+
+## 13. Dependencies & Sequencing
+
+- After: C40 (idempotency key helper).
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Accidental mass broadcast | M | H | `--yes` + audience preview + idempotency key |
+
+## 15. Rollout Plan
+
+- Ship broadcasts + messages first, then notifications/prefs.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — audience flags; idempotency key.
+- **Integration** — broadcast send/status; message send.
+- **E2E** — send broadcast to a test org → verify delivery counts.
+
+## 17. Documentation & Training
+
+- "Send an org-wide announcement from CI" recipe.
+
+## 18. Open Questions
+
+1. Are announcements a distinct entity or feed posts with `--announce`?
+
+## 19. References
+
+- `registerCommunicationRoutes`, `broadcasts_http.go`; `clients/cli/cmd/feed.go`.
+- Related: [C13](C13-groups-collaboration.md), [C39](C39-profile-account-personas.md).

--- a/docs/plan/cli/C35-meetings-office-hours.md
+++ b/docs/plan/cli/C35-meetings-office-hours.md
@@ -1,0 +1,118 @@
+# C35 — Meetings, office hours & conferences
+
+> CLI parity plan. Source: `registerMeetingRoutes` (`meetings`, `courses/{id}/meetings`), `registerOfficeHoursRoutes` + `office_hours_get.go` (`slots`, `courses/{id}/availability`), `conferences.go` (`conference-slots`), `calendar_http.go` + `registerCalendarFeedRoutes` (`me/calendar-token`). Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C35 |
+| **Section** | Communication |
+| **Severity** | MINOR |
+| **Markets** | HE / K12 / SL |
+| **Status (today)** | MISSING |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Scheduling / CLI |
+| **Depends on** | C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+Meetings, office-hours scheduling, conferences and calendar feeds are UI-only. Instructors cannot bulk-create office-hour slots or export their schedule, and admins cannot provision meetings/conferences for many courses at once.
+
+## 2. Goals
+
+- Create/list/cancel meetings and conferences per course.
+- Manage office-hours availability and slots in bulk.
+- Export a calendar feed token / iCal for scheduling integration.
+
+## 3. Non-Goals
+
+- Hosting the video call (third-party/browser).
+- Real-time booking UX.
+
+## 4. Personas & User Stories
+
+- **As an instructor**, I want `office-hours set --course C --file availability.json` to publish slots.
+- **As an instructor**, I want `meetings create --course C --start --duration`.
+- **As a user**, I want `calendar token` to get an iCal URL for my calendar app.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `meetings list|create|update|cancel` (`registerMeetingRoutes`).
+- **FR-2.** MUST add `office-hours set|list|slots <course>` and `availability get|set` (`office_hours_get.go`).
+- **FR-3.** SHOULD add `conferences list|create|slots` (`conferences.go`).
+- **FR-4.** SHOULD add `calendar token get|rotate` and `calendar export --ical` (`me/calendar-token`, `calendar_http.go`).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — trivial payloads.
+- **Security** — scheduling scope; calendar token is a secret URL → shown once, rotatable.
+- **Privacy & Compliance** — calendar may reveal enrollment (FERPA); token rotation supported.
+- **Reliability** — slot creation idempotent by time window.
+- **Internationalization** — timezone-aware (`--tz`, defaults to profile/locale).
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* an availability file, *When* `office-hours set`, *Then* slots are created and `slots` lists them.
+- **AC-2.** *Given* a course, *When* `meetings create --start ... --tz`, *Then* the meeting appears with correct tz.
+- **AC-3.** *Given* `calendar token`, *Then* a secret iCal URL prints once.
+
+## 8. Data Model
+
+- None client-side. Document availability JSON.
+
+## 9. API Surface
+
+- `registerMeetingRoutes`; `registerOfficeHoursRoutes` + `slots`/`availability`; `conferences.go`; `me/calendar-token` + `calendar_http.go`.
+
+## 10. UI / UX
+
+- `lextures meetings ...`, `lextures office-hours ...`, `lextures conferences ...`, `lextures calendar ...`.
+
+## 11. AI / ML Considerations
+
+- None (scheduling suggestions, if any, are server-side).
+
+## 12. Integration Points
+
+- Server meeting/office-hours/conference/calendar handlers.
+
+## 13. Dependencies & Sequencing
+
+- After: C40 (tz handling).
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Timezone/DST bugs | M | M | Always send explicit tz; test around DST boundaries |
+| Calendar token leakage | M | M | One-time display + `rotate` |
+
+## 15. Rollout Plan
+
+- Ship meetings + office-hours first, then conferences + calendar export.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — tz handling; slot window idempotency.
+- **Integration** — office-hours set; meeting create.
+- **E2E** — publish office hours → list slots.
+
+## 17. Documentation & Training
+
+- "Bulk-publish office hours" recipe.
+
+## 18. Open Questions
+
+1. Are meetings tied to a video provider requiring extra config?
+
+## 19. References
+
+- `registerMeetingRoutes`, `office_hours_get.go`, `conferences.go`, `calendar_http.go`.
+- Related: [C34](C34-messaging-broadcasts.md), [C39](C39-profile-account-personas.md).

--- a/docs/plan/cli/C36-tutor-study-buddy.md
+++ b/docs/plan/cli/C36-tutor-study-buddy.md
@@ -1,0 +1,122 @@
+# C36 — AI tutor, study buddy & diagnostics
+
+> CLI parity plan. Source: `registerTutorRoutes` + `registerPersistentTutorRoutes` (`courses/{id}/tutor`), `registerStudyBuddyRoutes` (`courses/{id}/study-buddy`, `me/study-*`), `registerDiagnosticRoutes` (`diagnostic-attempts`, `courses/{id}/diagnostic-config`), `registerConceptRoutes` (`concepts`), `registerLearningPathRoutes` (`paths`, `me/paths`), `registerLearnerRoutes` (`learners`). Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C36 |
+| **Section** | Student experience |
+| **Severity** | MINOR |
+| **Markets** | SL / HE / K12 |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | AI / CLI |
+| **Depends on** | C25, C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+The AI tutor, study-buddy, diagnostics, concept graph and adaptive learning paths — the platform's adaptive core — have no CLI. Power self-learners, researchers evaluating the tutor, and QA engineers cannot script tutor sessions, run diagnostics, or inspect learner models/paths for testing and evaluation.
+
+## 2. Goals
+
+- Hold a scriptable tutor session (send a turn, stream the reply).
+- Run diagnostics and read learner concept mastery / adaptive path state.
+- Enable batch evaluation of the tutor (eval harness feeding transcripts in, scoring out).
+
+## 3. Non-Goals
+
+- Replacing the rich chat UI.
+- Training models.
+
+## 4. Personas & User Stories
+
+- **As a self-learner**, I want `tutor ask --course C "explain X"` in the terminal.
+- **As a researcher**, I want `tutor eval --file prompts.jsonl` to batch-run tutor turns for evaluation.
+- **As a learner**, I want `diagnostic run --course C` and `paths status` to see my adaptive path.
+- **As a QA engineer**, I want `learners get --user U` to inspect the learner model.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `tutor ask <course> <prompt>` (streaming reply; `--session` to continue) and `tutor sessions list`.
+- **FR-2.** MUST add `diagnostic run|attempts|config <course>` (`registerDiagnosticRoutes`).
+- **FR-3.** SHOULD add `study-buddy ask|sessions` (`registerStudyBuddyRoutes`) and `paths get|status|next` (`registerLearningPathRoutes`).
+- **FR-4.** SHOULD add `concepts list|get <course>` (`registerConceptRoutes`) and `learners get --user <u>` (learner model).
+- **FR-5.** MAY add `tutor eval --file <jsonl> --out results.jsonl` for batch evaluation.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — streaming responses rendered incrementally (SSE/WebSocket via C40 helper).
+- **Security** — learner scope; tutor honors course AI opt-out and age-appropriate mode.
+- **Privacy & Compliance** — tutor turns are learner data (FERPA/COPPA); AI disclosure surfaced; PII redaction server-side.
+- **Cost** — `tutor eval` prints token usage; `--max-turns` cap.
+- **Reliability** — session continuity via server session id; safe to resume.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a course, *When* `tutor ask "..."`, *Then* a streamed reply renders and a session id is returned.
+- **AC-2.** *Given* an opt-out course, *Then* tutor commands refuse with a clear message.
+- **AC-3.** *Given* a prompts file, *When* `tutor eval`, *Then* per-prompt results + usage are written.
+
+## 8. Data Model
+
+- Client may persist a `--session` id transiently for multi-turn.
+
+## 9. API Surface
+
+- `registerTutorRoutes`/`registerPersistentTutorRoutes`; `registerStudyBuddyRoutes`; `registerDiagnosticRoutes`; `registerLearningPathRoutes`; `registerConceptRoutes`; `registerLearnerRoutes`.
+
+## 10. UI / UX
+
+- `lextures tutor ...`, `lextures study-buddy ...`, `lextures diagnostic ...`, `lextures paths ...`, `lextures learners ...`.
+- Streaming rendered to stderr; final structured result to stdout under `--json`.
+
+## 11. AI / ML Considerations
+
+- Tutor is the flagship AI feature; CLI is a thin client. Disclosure, opt-out, age-mode, PII redaction all server-enforced; CLI surfaces them. Eval harness enables offline quality measurement.
+
+## 12. Integration Points
+
+- Server tutor/diagnostic/path handlers; streaming (SSE/WS helper, C40); AI provider settings (C21).
+
+## 13. Dependencies & Sequencing
+
+- After: C25/C21 (AI provider config), C40 (streaming).
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| No streaming client in CLI | M | M | Shared SSE/WS helper in C40 |
+| Eval cost | M | M | `--max-turns`, usage printout, `--yes` for large runs |
+
+## 15. Rollout Plan
+
+- Ship `tutor ask` + diagnostics first, then study-buddy/paths/learners, then eval harness.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — session handling; opt-out gating.
+- **Integration** — mock streaming server; diagnostic attempt.
+- **E2E** — multi-turn tutor session.
+
+## 17. Documentation & Training
+
+- "Evaluate the AI tutor from the CLI" recipe.
+
+## 18. Open Questions
+
+1. Is tutor transport SSE or WebSocket?
+2. Does an eval-friendly endpoint exist, or must we script `ask`?
+
+## 19. References
+
+- `registerTutorRoutes`, `registerDiagnosticRoutes`, `registerLearningPathRoutes`, `registerConceptRoutes`.
+- Related: [C09](C09-ai-grading-agents.md), [C21](C21-platform-settings.md), [C40](C40-cli-framework.md).

--- a/docs/plan/cli/C37-student-workspace.md
+++ b/docs/plan/cli/C37-student-workspace.md
@@ -1,0 +1,118 @@
+# C37 — Student workspace, notebooks, goals & gamification
+
+> CLI parity plan. Source: `registerStudentNotebookRoutes` + `registerNotebookTaskRoutes` (`me/notebooks`, `me/notebook-tasks`), `registerStudentTodoRoutes` (`me/student-todo-board`), `registerSelfReflectionRoutes` (`me/reflection-journal`), `registerStudyReminderRoutes` (`me/reminder-config`, `me/study-goal`, `me/goals`), `me/reading-preferences`, `registerGamificationRoutes` (`me/gamification`, `courses/{id}/leaderboard`, `me/coaching-tips`, `vibe-activities`). Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C37 |
+| **Section** | Student experience |
+| **Severity** | MINOR |
+| **Markets** | SL / HE / K12 |
+| **Status (today)** | MISSING |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Learner XP / CLI |
+| **Depends on** | C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+The self-directed learner workspace — notebooks, tasks, to-do board, reflection journal, study goals/reminders, reading preferences and gamification — is UI/mobile-only. Power self-learners who live in the terminal, and researchers studying self-regulated learning, cannot capture notes/tasks or read gamification state programmatically.
+
+## 2. Goals
+
+- CRUD notebooks/notes and notebook tasks from the terminal.
+- Manage to-do board, reflection journal, study goals and reminders.
+- Read gamification state (points, badges, leaderboard) and coaching tips.
+
+## 3. Non-Goals
+
+- Rich note editor UX.
+- Designing gamification rules (admin/config concern).
+
+## 4. Personas & User Stories
+
+- **As a self-learner**, I want `notebooks add --file notes.md` to save study notes.
+- **As a self-learner**, I want `todo add "read chapter 3" --due tomorrow`.
+- **As a self-learner**, I want `goals set --target ...` and `reminders set`.
+- **As a learner**, I want `gamification status` and `leaderboard --course C`.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `notebooks list|get|add|update|delete` and `notebook-tasks list|add|complete` (`me/notebooks`, `me/notebook-tasks`).
+- **FR-2.** MUST add `todo list|add|complete|remove` (`me/student-todo-board`).
+- **FR-3.** SHOULD add `journal list|add` (`me/reflection-journal`), `goals get|set` (`me/goals`, `me/study-goal`), `reminders get|set` (`me/reminder-config`).
+- **FR-4.** SHOULD add `gamification status` (`me/gamification`), `leaderboard <course>`, `coaching-tips list`.
+- **FR-5.** MAY add `reading-preferences get|set` (`me/reading-preferences`).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — trivial payloads.
+- **Security** — self-scope (`me/*`); a user only touches their own workspace.
+- **Privacy & Compliance** — personal learner data (FERPA for minors/COPPA); no cross-user access.
+- **Reliability** — add/complete idempotent by client id.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a note file, *When* `notebooks add --file`, *Then* a note id returns and `list` shows it.
+- **AC-2.** *Given* a task, *When* `todo complete <id>`, *Then* it's marked done.
+- **AC-3.** *Given* a learner, *When* `gamification status --json`, *Then* points/badges emit.
+
+## 8. Data Model
+
+- None client-side.
+
+## 9. API Surface
+
+- `me/notebooks`, `me/notebook-tasks`, `me/student-todo-board`, `me/reflection-journal`, `me/goals`/`study-goal`, `me/reminder-config`, `me/gamification`, `courses/{id}/leaderboard`, `me/coaching-tips`, `me/reading-preferences`.
+
+## 10. UI / UX
+
+- `lextures notebooks|todo|journal|goals|reminders|gamification ...`.
+
+## 11. AI / ML Considerations
+
+- Coaching tips may be AI-generated server-side; CLI reads them.
+
+## 12. Integration Points
+
+- Server `me/*` learner-workspace handlers.
+
+## 13. Dependencies & Sequencing
+
+- After: C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Low CLI demand for student UX | M | L | Keep surface thin; prioritize notebooks/todo which suit terminal workflows |
+
+## 15. Rollout Plan
+
+- Ship notebooks + todo first, then journal/goals/reminders, then gamification read.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — due-date parsing; idempotency.
+- **Integration** — notebook CRUD; todo complete.
+- **E2E** — add note + task → verify.
+
+## 17. Documentation & Training
+
+- "Capture study notes from your terminal" recipe.
+
+## 18. Open Questions
+
+1. Are notebooks Markdown or structured blocks on the wire?
+
+## 19. References
+
+- `registerStudentNotebookRoutes`, `registerStudentTodoRoutes`, `registerGamificationRoutes`.
+- Related: [C36](C36-tutor-study-buddy.md), [C38](C38-portfolios.md), [C39](C39-profile-account-personas.md).

--- a/docs/plan/cli/C38-portfolios.md
+++ b/docs/plan/cli/C38-portfolios.md
@@ -1,0 +1,114 @@
+# C38 — Portfolios & eportfolio
+
+> CLI parity plan. Source: `registerEportfolioRoutes` (`me/portfolios`, 8; `portfolios`), `me/ccr` (adjacency to C31). Baseline: none.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C38 |
+| **Section** | Student experience |
+| **Severity** | MINOR |
+| **Markets** | HE / SL / K12 |
+| **Status (today)** | MISSING |
+| **Estimated effort** | S (1w) |
+| **Owner (proposed)** | Learner XP / CLI |
+| **Depends on** | C40 |
+| **Unblocks** | — |
+
+---
+
+## 1. Problem Statement
+
+E-portfolios (student showcases of work, artifacts, reflections) have no CLI. Students and program admins cannot bulk-add artifacts, export a portfolio for archival/accreditation, or publish/share it programmatically.
+
+## 2. Goals
+
+- Create portfolios and add artifacts (files, links, reflections) in bulk.
+- Publish/share and export a portfolio for accreditation/archival.
+
+## 3. Non-Goals
+
+- Rich portfolio theming/layout (browser).
+
+## 4. Personas & User Stories
+
+- **As a student**, I want `portfolios add-artifact --file project.pdf` to build my showcase.
+- **As a program admin**, I want `portfolios export --user U --out d` for accreditation evidence.
+- **As a student**, I want `portfolios publish <id>` to share a public link.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `portfolios list|get|create|delete` (`me/portfolios`).
+- **FR-2.** MUST add `portfolios add-artifact|remove-artifact <id>` (`--file`, `--link`, `--reflection`).
+- **FR-3.** SHOULD add `portfolios publish|unpublish <id>` and `portfolios export <id> --out <dir>`.
+- **FR-4.** MAY add `portfolios share <id> --with <user>`.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — artifact upload streams (reuse `files upload`).
+- **Security** — self-scope; admin export requires elevated scope.
+- **Privacy & Compliance** — portfolios contain student work (FERPA); publish makes content public — CLI warns and requires `--yes`.
+- **Reliability** — add-artifact idempotent by content hash.
+- **Backward compatibility** — additive.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a file, *When* `portfolios add-artifact --file`, *Then* it's attached and listed.
+- **AC-2.** *Given* a portfolio, *When* `portfolios publish --yes`, *Then* a public URL prints.
+- **AC-3.** *Given* a portfolio, *When* `portfolios export`, *Then* artifacts + metadata download.
+
+## 8. Data Model
+
+- None client-side.
+
+## 9. API Surface
+
+- `registerEportfolioRoutes` (`me/portfolios`, `portfolios`).
+
+## 10. UI / UX
+
+- `lextures portfolios ...`.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server eportfolio handlers; file upload (existing); CCR (C31).
+
+## 13. Dependencies & Sequencing
+
+- After: C40.
+- Before: none.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Accidental public publish | M | M | `--yes` + explicit URL notice |
+
+## 15. Rollout Plan
+
+- Ship create + add-artifact first, then publish/export.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — artifact type flags; idempotency.
+- **Integration** — add-artifact; publish.
+- **E2E** — build a portfolio → export.
+
+## 17. Documentation & Training
+
+- "Export portfolios for accreditation" recipe.
+
+## 18. Open Questions
+
+1. Is export a bundled archive or per-artifact URLs?
+
+## 19. References
+
+- `registerEportfolioRoutes`.
+- Related: [C31](C31-credentials-transcripts-advising.md), [C37](C37-student-workspace.md).

--- a/docs/plan/cli/C39-profile-account-personas.md
+++ b/docs/plan/cli/C39-profile-account-personas.md
@@ -1,0 +1,121 @@
+# C39 — Profile, account, security & personas (me, parent)
+
+> CLI parity plan. Source: `registerMeRoutes` + `registerMeProfileDepthRoutes` (`me`, `me/profile-fields`, `me/sessions`, `me/mfa`, `me/oidc-identities`, `me/access-keys`, `me/device-tokens`, `me/demographics`, `me/consent-studies`, `me/entitlements`, `me/onboarding`), `registerParentRoutes` (`parent`, `orgs/{orgId}/parent-links`), `me/calendar-token`. Baseline: `auth login/logout/status`.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C39 |
+| **Section** | Student experience / personas |
+| **Severity** | MAJOR |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | PARTIAL (auth only) |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Identity / CLI |
+| **Depends on** | C40 |
+| **Unblocks** | C25 |
+
+---
+
+## 1. Problem Statement
+
+The CLI authenticates but exposes nothing about the current account: no `me` profile, session management, MFA, linked identities, personal access keys, or consent/demographics. Service accounts and users can't self-manage credentials, and the parent/guardian persona (parent-links to children, viewing their data) is entirely absent.
+
+## 2. Goals
+
+- Inspect and edit the current user's profile and custom fields.
+- Manage security: sessions (list/revoke), MFA (enroll/disable), linked OIDC identities, personal access keys.
+- Manage consent/demographics/onboarding self-service.
+- Support the parent/guardian persona: link to children and view permitted data.
+
+## 3. Non-Goals
+
+- Admin user management (see C15).
+- Browser SSO flows (existing `auth login` covers device/browser login).
+
+## 4. Personas & User Stories
+
+- **As any user**, I want `me get` and `me update --file profile.json`.
+- **As a security-conscious user**, I want `me sessions list` + `me sessions revoke --all` after a device loss.
+- **As a user**, I want `me mfa enroll` / `me access-keys create` for CI.
+- **As a parent**, I want `parent children list` and `parent grades --child C` to follow my child's progress.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add `me get|update` (`--file`), `me profile-fields get|set`.
+- **FR-2.** MUST add `me sessions list|revoke [--all]`, `me mfa status|enroll|disable`, `me oidc-identities list|link|unlink`.
+- **FR-3.** MUST add `me access-keys list|create|revoke` (personal tokens for CI; one-time display) — shared surface with C25.
+- **FR-4.** SHOULD add `me demographics get|set`, `me consent-studies list|opt-in|opt-out`, `me onboarding status`, `me entitlements`.
+- **FR-5.** SHOULD add `parent children list`, `parent link|unlink`, `parent grades|attendance --child <c>` (`registerParentRoutes`, `parent-links`).
+
+## 6. Non-Functional Requirements
+
+- **Performance** — trivial; p95 < 400 ms.
+- **Security** — self-scope; MFA/session ops are sensitive → confirm on revoke-all; access keys one-time display; parent access strictly limited to linked children (server-enforced).
+- **Privacy & Compliance** — demographics/consent are sensitive (GDPR/FERPA/COPPA); parent-link honors guardianship rules.
+- **Reliability** — session revoke idempotent; the CLI's own session survives revoke-all unless `--include-current`.
+- **Backward compatibility** — existing `auth` unchanged; `me access-keys` shared with C25.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* a user, *When* `me get --json`, *Then* the profile emits.
+- **AC-2.** *Given* multiple sessions, *When* `me sessions revoke --all`, *Then* others end; current stays unless `--include-current`.
+- **AC-3.** *Given* a parent, *When* `parent grades --child C`, *Then* only that linked child's grades return.
+
+## 8. Data Model
+
+- None client-side beyond existing token store.
+
+## 9. API Surface
+
+- `me` + `me/*` (profile-fields, sessions, mfa, oidc-identities, access-keys, device-tokens, demographics, consent-studies, entitlements, onboarding, calendar-token); `parent` + `orgs/{orgId}/parent-links`.
+
+## 10. UI / UX
+
+- `lextures me ...`, `lextures parent ...`. Extends the existing `auth` group conceptually.
+
+## 11. AI / ML Considerations
+
+- None.
+
+## 12. Integration Points
+
+- Server me/parent handlers; auth token store (`internal/auth`); access keys shared with C25.
+
+## 13. Dependencies & Sequencing
+
+- After: C40.
+- Before: C25 (access-keys), any command wanting `me` context.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Self-lockout via session revoke | M | M | Exclude current session by default; `--include-current` explicit |
+| Parent over-scope | L | H | Server enforces linked-child scope; CLI passes child id, never enumerates others |
+
+## 15. Rollout Plan
+
+- Ship `me get/update` + sessions + access-keys first, then MFA/identities/consent, then parent persona.
+- Rollback: additive.
+
+## 16. Test Plan
+
+- **Unit** — profile parse; revoke-all current-session exclusion.
+- **Integration** — sessions/mfa/access-keys; parent child scope.
+- **Security** — access-key one-time display; parent scope 403 on non-linked child.
+- **E2E** — create access key → use it → revoke.
+
+## 17. Documentation & Training
+
+- "Manage your account and CI keys" recipe; parent-portal guide.
+
+## 18. Open Questions
+
+1. Does MFA enroll require an interactive TOTP step (QR/secret) the CLI must render?
+
+## 19. References
+
+- `registerMeRoutes`, `registerMeProfileDepthRoutes`, `registerParentRoutes`; `clients/cli/internal/auth`.
+- Related: [C15](C15-people-provisioning.md), [C25](C25-integrations-webhooks-bots.md), [C29](C29-compliance-privacy.md), [C40](C40-cli-framework.md).

--- a/docs/plan/cli/C40-cli-framework.md
+++ b/docs/plan/cli/C40-cli-framework.md
@@ -1,0 +1,136 @@
+# C40 — CLI framework & ergonomics
+
+> Foundational plan (cross-cutting). Source: `clients/cli/cmd/root.go`, `internal/client/client.go`, `internal/config`, `internal/auth`. Enables every other C-plan.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **Feature ID** | C40 |
+| **Section** | CLI framework |
+| **Severity** | BLOCKER |
+| **Markets** | K12 / HE / SL |
+| **Status (today)** | THIN (basic Cobra + JSON/table + retry) |
+| **Estimated effort** | M (2–4w) |
+| **Owner (proposed)** | Platform / CLI |
+| **Depends on** | — |
+| **Unblocks** | all C-plans |
+
+---
+
+## 1. Problem Statement
+
+The CLI has good bones (Cobra, profiles, `--json`, retry, keychain auth) but lacks the cross-cutting primitives every new command needs: consistent pagination, async **job wait**, server-side vs client-side output shaping, `--file`/stdin input, `--dry-run`/`--yes` gating, bulk-op summaries, streaming (SSE/WebSocket), and shell completion. Building these once, well, prevents 39 inconsistent re-implementations.
+
+## 2. Goals
+
+- Standardize output (table/JSON/NDJSON/CSV), pagination, and error handling.
+- Provide shared primitives: `--wait` for jobs, `--file`/stdin, `--dry-run`, `--yes`, idempotency keys, bulk summaries.
+- Add a streaming (SSE/WebSocket) helper for tutor/grading dry-run/audit-tail.
+- Ship shell completion, `--output` templating, and robust config/profile UX.
+
+## 3. Non-Goals
+
+- Any specific domain command (those are C01–C39).
+- Rewriting the auth store (already solid) beyond adding access-key support hooks.
+
+## 4. Personas & User Stories
+
+- **As a CLI author**, I want a `runList`/`runGet`/`runMutate` helper set so new commands are 20 lines.
+- **As a scripter**, I want `--output json|table|csv|ndjson` and `--jq`/`--template` for shaping.
+- **As a CI engineer**, I want `--wait --timeout` to block on async jobs with proper exit codes.
+- **As a user**, I want `completion bash|zsh|fish` and `--no-color`/`--quiet`.
+
+## 5. Functional Requirements
+
+- **FR-1.** MUST add a shared **output layer**: `--output table|json|ndjson|csv`, `--no-headers`, `--quiet`, `--no-color`, honoring existing `--json` as an alias.
+- **FR-2.** MUST add **pagination** helpers (cursor + page/limit) with `--all` to auto-follow pages.
+- **FR-3.** MUST add a **job `--wait`** primitive (poll or stream; `--timeout`; exit 0 success / 2 failure) reused by C15/C18/C22/C24/C27/C29/C33.
+- **FR-4.** MUST add **input helpers**: `--file <path|->` (JSON/YAML/CSV) and consistent stdin handling.
+- **FR-5.** MUST add **safety gates**: `--dry-run` (server preview where supported), `--yes`/`--force` for destructive/FERPA-export ops, and an idempotency-key header helper.
+- **FR-6.** MUST add **bulk-op summary** rendering (created/updated/skipped/failed with row errors + non-zero exit on any failure unless `--continue-on-error`).
+- **FR-7.** SHOULD add a **streaming helper** (SSE + WebSocket) for C09/C19/C36.
+- **FR-8.** SHOULD add **shell completion** (`completion` command) and dynamic completion for ids where cheap.
+- **FR-9.** SHOULD add `--server`/profile UX niceties: `config set/get/list`, `env` diagnostics, `whoami` (alias to C39 `me`).
+- **FR-10.** SHOULD standardize **error envelope** parsing so `--json` errors are consistent (`{error, code, request_id}`) and human errors include remediation hints.
+
+## 6. Non-Functional Requirements
+
+- **Performance** — pagination auto-follow bounded by `--limit`; streaming renders incrementally; retries use existing `doWithRetry` with backoff.
+- **Security** — secrets (keys, tokens, provider creds) never printed to stdout by default nor logged; `--file`/stdin for secret input; redaction utility used everywhere.
+- **Privacy & Compliance** — a shared `confirmSensitiveExport()` gate powers every FERPA/financial/PII export across plans (`--yes`).
+- **Reliability** — one HTTP client config (timeouts, retry, `User-Agent: lextures-cli/<ver>`); consistent exit codes (0/1/2) across all commands.
+- **Observability** — optional `--verbose`/`LEXTURES_DEBUG` request logging (redacted); every request carries a client request id.
+- **Maintainability** — helpers live in `internal/cli` (new) so C01–C39 depend on them; a linter/test asserts new commands use them.
+- **Internationalization** — timezone/locale flags (`--tz`) resolved once and shared.
+- **Backward compatibility** — existing flags (`--json`, `--server`, `--profile`, `--api-key`, `--config`) and exit codes preserved; `--json` remains an alias of `--output json`.
+
+## 7. Acceptance Criteria
+
+- **AC-1.** *Given* any list command, *When* `--all`, *Then* all pages are followed transparently.
+- **AC-2.** *Given* an async job, *When* `--wait --timeout 60`, *Then* the command blocks then exits 0/2 by outcome (or 2 on timeout).
+- **AC-3.** *Given* a destructive command without `--yes`, *Then* it refuses with a clear prompt-to-confirm message.
+- **AC-4.** *Given* `completion zsh`, *Then* a valid completion script is emitted.
+- **AC-5.** *Given* a secret-bearing create, *Then* the secret never appears in default output or debug logs.
+
+## 8. Data Model
+
+- No server changes. New client package `internal/cli` (output, paginate, wait, input, gates, stream).
+
+## 9. API Surface
+
+- No new routes. Consumes existing job/status endpoints for `--wait`; SSE/WS endpoints for streaming.
+
+## 10. UI / UX
+
+- Consistent table/JSON/CSV; color auto-off when non-TTY; `--quiet` for scripts; uniform error format; `completion` + `config` helper commands.
+
+## 11. AI / ML Considerations
+
+- Streaming helper underpins AI features (C09, C36); usage/cost display convention defined here.
+
+## 12. Integration Points
+
+- Refactors `clients/cli/cmd/root.go`, `internal/client/client.go`; new `internal/cli` package used by all commands.
+
+## 13. Dependencies & Sequencing
+
+- After: none — this is the foundation.
+- Before: all of C01–C39 (they consume these primitives). Ship first.
+
+## 14. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Refactor churn across existing commands | M | M | Introduce helpers additively; migrate existing commands incrementally with tests |
+| Streaming (WS) complexity | M | M | Start with SSE/polling; add WS when a consumer (C09/C36) lands |
+| Over-abstraction | M | M | Keep helpers thin; driven by two real consumers before generalizing |
+
+## 15. Rollout Plan
+
+- Phase 1: output/pagination/input/gates/exit-codes + migrate existing 9 commands.
+- Phase 2: `--wait` job primitive + bulk summary.
+- Phase 3: streaming + completion + config helpers.
+- Rollback: helpers are additive; existing behavior preserved throughout.
+
+## 16. Test Plan
+
+- **Unit** — output formatters; pagination follow; wait/backoff; gate logic; redaction.
+- **Integration** — `--wait` against a mock job endpoint; `--all` pagination; SSE stream parse.
+- **Security** — secret redaction across output/debug; `--yes` gating.
+- **E2E** — migrate `courses list` to the new output layer with unchanged observable output (golden test).
+
+## 17. Documentation & Training
+
+- CLI conventions doc (flags, exit codes, scripting patterns); "Writing a new command" contributor guide.
+
+## 18. Open Questions
+
+1. Do async endpoints expose a uniform job-status shape, or per-domain? (Drives `--wait` abstraction.)
+2. SSE vs WebSocket for streaming endpoints — is it consistent server-side?
+3. Adopt YAML input in addition to JSON/CSV?
+
+## 19. References
+
+- `clients/cli/cmd/root.go`, `clients/cli/internal/client/client.go`, `internal/config`, `internal/auth`.
+- Related: consumed by [C01](C01-courses.md)–[C39](C39-profile-account-personas.md); especially [C15](C15-people-provisioning.md), [C18](C18-jobs-scheduler-backups.md), [C27](C27-reports-exports.md), [C09](C09-ai-grading-agents.md), [C36](C36-tutor-study-buddy.md).

--- a/docs/plan/cli/README.md
+++ b/docs/plan/cli/README.md
@@ -1,0 +1,173 @@
+# Lextures CLI — Feature Parity Plan
+
+Implementation plans to close the gap between the **Lextures HTTP API** (~843 routes across
+~120 route-registration groups in `server/internal/httpserver`) and the **`lextures` CLI**
+(`clients/cli`), which today exposes ~9 command groups (roughly 10 % of the API surface).
+
+Each plan follows [`../_TEMPLATE.md`](../_TEMPLATE.md). One plan per CLI **command group**
+(the `lextures <noun>` surface). Scope decision: **full API parity** — every server capability
+that can be driven from a terminal gets a command group, including student-facing flows.
+
+## Conventions
+
+- File naming: `C{NN}-{kebab-slug}.md` (e.g. `C11-enrollments-sections.md`).
+- CLI shape: `lextures <noun> <verb> [flags]`, matching the existing Cobra layout in
+  `clients/cli/cmd/*.go`. Global flags: `--server`, `--api-key`, `--profile`, `--config`,
+  `--json`. Exit codes: `0` success, `1` bad input/usage, `2` API/server error.
+- Every command MUST support `--json` for scripting and a human tabwriter table by default.
+- A plan is "ready" when every template section is filled (no `…` placeholders).
+
+## Severity legend (CLI-adoption lens)
+
+- **BLOCKER** — automation/admin workflows are impossible without it; the primary reason to
+  adopt a CLI (bulk provisioning, roster sync, CI/CD content, reporting exports).
+- **MAJOR** — significant admin/instructor automation gap.
+- **MINOR** — parity / power-user nicety.
+
+## Status legend
+
+- **MISSING** — no command exists.
+- **PARTIAL** — command group exists but is missing verbs/flags.
+- **THIN** — exists but too shallow to be useful for automation.
+
+---
+
+## Current CLI surface (baseline)
+
+| Group | Verbs today | Plan that expands it |
+|---|---|---|
+| `auth` | login, logout, status | C39 |
+| `courses` | list, get, create, delete | [C01](C01-courses.md) |
+| `assignments` | list, get, create, submit | [C03](C03-assignments.md) |
+| `grades` | list, update, export | [C06](C06-gradebook-final-grades.md) |
+| `users` | list, get, create, enroll | [C15](C15-people-provisioning.md) |
+| `orgs` | list, get, create | [C14](C14-org-administration.md) |
+| `files` | list, mkdir, upload, download, rename, move, delete | [C21](C21-platform-settings.md) |
+| `feed` | channels, post, recent | [C34](C34-messaging-broadcasts.md) |
+| `questions` | list, create, import | [C04](C04-quizzes-question-banks.md) |
+
+---
+
+## Plans
+
+### A. Course & content authoring
+
+| ID | Plan | Severity | Status | Effort |
+|---|---|---|---|---|
+| C01 | [Courses (expand)](C01-courses.md) | BLOCKER | PARTIAL | M |
+| C02 | [Modules & course structure](C02-modules-course-structure.md) | BLOCKER | MISSING | M |
+| C03 | [Assignments (expand)](C03-assignments.md) | MAJOR | PARTIAL | M |
+| C04 | [Quizzes & question banks](C04-quizzes-question-banks.md) | BLOCKER | PARTIAL | L |
+| C05 | [Content extras (pages, glossary, H5P, SCORM, tools)](C05-content-extras.md) | MINOR | MISSING | M |
+
+### B. Assessment & grading
+
+| ID | Plan | Severity | Status | Effort |
+|---|---|---|---|---|
+| C06 | [Gradebook & final grades (expand)](C06-gradebook-final-grades.md) | BLOCKER | PARTIAL | M |
+| C07 | [Outcomes, standards & SBG report cards](C07-outcomes-standards-sbg.md) | MAJOR | MISSING | M |
+| C08 | [Peer review, evaluations & surveys](C08-peer-review-evaluations-surveys.md) | MINOR | MISSING | M |
+| C09 | [AI grading agents](C09-ai-grading-agents.md) | MAJOR | MISSING | M |
+| C10 | [Plagiarism & originality](C10-plagiarism-originality.md) | MAJOR | MISSING | S |
+
+### C. Roster & classroom
+
+| ID | Plan | Severity | Status | Effort |
+|---|---|---|---|---|
+| C11 | [Enrollments & sections](C11-enrollments-sections.md) | BLOCKER | PARTIAL | M |
+| C12 | [Attendance, behavior & seat-time](C12-attendance-behavior.md) | MAJOR | MISSING | M |
+| C13 | [Groups & collaboration](C13-groups-collaboration.md) | MINOR | MISSING | S |
+
+### D. Admin & governance
+
+| ID | Plan | Severity | Status | Effort |
+|---|---|---|---|---|
+| C14 | [Org & org-unit administration](C14-org-administration.md) | MAJOR | PARTIAL | M |
+| C15 | [People, provisioning & bulk import](C15-people-provisioning.md) | BLOCKER | PARTIAL | L |
+| C16 | [Roles & permissions (RBAC)](C16-roles-permissions.md) | BLOCKER | MISSING | M |
+| C17 | [Licenses, entitlements & marketplace](C17-licenses-entitlements.md) | MAJOR | MISSING | M |
+| C18 | [Jobs, scheduler, quarantine & backups](C18-jobs-scheduler-backups.md) | MAJOR | MISSING | M |
+| C19 | [Audit log, impersonation & admin search](C19-audit-impersonation-search.md) | MAJOR | MISSING | S |
+| C20 | [Email templates & banners](C20-email-templates-banners.md) | MINOR | MISSING | S |
+| C21 | [Platform settings & configuration](C21-platform-settings.md) | MAJOR | MISSING | M |
+
+### E. Integrations & interoperability
+
+| ID | Plan | Severity | Status | Effort |
+|---|---|---|---|---|
+| C22 | [SIS, SCIM & OneRoster](C22-sis-scim-oneroster.md) | BLOCKER | MISSING | L |
+| C23 | [LTI & developer keys](C23-lti-developer-keys.md) | MAJOR | MISSING | M |
+| C24 | [Canvas & content import](C24-canvas-content-import.md) | MAJOR | MISSING | M |
+| C25 | [Integrations, cloud providers, webhooks & bots](C25-integrations-webhooks-bots.md) | MAJOR | PARTIAL | M |
+| C26 | [xAPI / LRS / SCORM runtime & engagement](C26-xapi-lrs-engagement.md) | MINOR | MISSING | S |
+
+### F. Reporting & insights
+
+| ID | Plan | Severity | Status | Effort |
+|---|---|---|---|---|
+| C27 | [Reports & exports](C27-reports-exports.md) | BLOCKER | MISSING | M |
+| C28 | [Insights, at-risk & classroom signals](C28-insights-at-risk.md) | MAJOR | MISSING | M |
+
+### G. Compliance & trust
+
+| ID | Plan | Severity | Status | Effort |
+|---|---|---|---|---|
+| C29 | [Compliance, privacy & trust](C29-compliance-privacy.md) | MAJOR | MISSING | L |
+
+### H. Commerce
+
+| ID | Plan | Severity | Status | Effort |
+|---|---|---|---|---|
+| C30 | [Billing, payments, tax & revenue](C30-billing-payments-tax.md) | MAJOR | MISSING | M |
+
+### I. Academic records
+
+| ID | Plan | Severity | Status | Effort |
+|---|---|---|---|---|
+| C31 | [Credentials, transcripts, advising & degree progress](C31-credentials-transcripts-advising.md) | MAJOR | MISSING | M |
+
+### J. Catalog & materials
+
+| ID | Plan | Severity | Status | Effort |
+|---|---|---|---|---|
+| C32 | [Catalog, library, OER & bookstore](C32-catalog-library-oer.md) | MINOR | MISSING | M |
+
+### K. Accessibility & localization
+
+| ID | Plan | Severity | Status | Effort |
+|---|---|---|---|---|
+| C33 | [Accessibility, media & localization](C33-accessibility-media-localization.md) | MINOR | MISSING | M |
+
+### L. Communication
+
+| ID | Plan | Severity | Status | Effort |
+|---|---|---|---|---|
+| C34 | [Messaging, broadcasts & notifications](C34-messaging-broadcasts.md) | MAJOR | PARTIAL | M |
+| C35 | [Meetings, office hours & conferences](C35-meetings-office-hours.md) | MINOR | MISSING | S |
+
+### M. Student experience (full-parity)
+
+| ID | Plan | Severity | Status | Effort |
+|---|---|---|---|---|
+| C36 | [AI tutor, study buddy & diagnostics](C36-tutor-study-buddy.md) | MINOR | MISSING | M |
+| C37 | [Student workspace, notebooks, goals & gamification](C37-student-workspace.md) | MINOR | MISSING | M |
+| C38 | [Portfolios & eportfolio](C38-portfolios.md) | MINOR | MISSING | S |
+| C39 | [Profile, account, security & personas (me, parent)](C39-profile-account-personas.md) | MAJOR | PARTIAL | M |
+
+### N. CLI framework
+
+| ID | Plan | Severity | Status | Effort |
+|---|---|---|---|---|
+| C40 | [CLI framework & ergonomics](C40-cli-framework.md) | BLOCKER | THIN | M |
+
+---
+
+## Recommended sequencing
+
+1. **Foundation first** — C40 (framework: output/pagination/wait/bulk) unblocks quality of every
+   other command.
+2. **Automation core** — C15, C11, C22, C16, C01, C06, C27 (provisioning, roster, RBAC, courses,
+   grades, reports): the workflows admins buy a CLI for.
+3. **Content & assessment** — C02, C04, C03, C07, C09, C10.
+4. **Integrations & governance** — C23, C24, C25, C14, C17, C18, C19, C21, C29, C30.
+5. **Everything else** — C05, C08, C12, C13, C20, C26, C28, C31–C39 as demand dictates.


### PR DESCRIPTION
## Summary

Adds `docs/plan/cli/` — a full feature parity plan for the `lextures` CLI against the HTTP API.

- **41 files**: index README + 40 per-command-group plans (C01–C40)
- Plans follow `docs/plan/_TEMPLATE.md` and map to existing Cobra command groups in `clients/cli/cmd/`
- Covers ~843 API routes across ~120 route groups; CLI today exposes ~9 command groups (~10% surface)
- Includes severity/status legend, dependency graph, and recommended implementation sequencing (C40 framework first → automation core → content/assessment → integrations)

## Plan breakdown

| Category | Plans |
|---|---|
| Course & content authoring | C01–C05 |
| Assessment & grading | C06–C10 |
| Roster & classroom | C11–C13 |
| Org, people & RBAC | C14–C17 |
| Platform ops & governance | C18–C21 |
| Integrations & imports | C22–C25 |
| Analytics & reporting | C26–C28 |
| Compliance & billing | C29–C30 |
| Credentials & catalog | C31–C32 |
| Accessibility & comms | C33–C35 |
| Student experience | C36–C39 |
| CLI framework | C40 |

## Test plan

- [x] Documentation only — no code changes
- [x] All plans use consistent naming (`C{NN}-{kebab-slug}.md`) and template sections