### PR TITLE
fix(cli,server): extend CLI auth sessions to 7 days

### DIFF
--- a/clients/cli/internal/auth/manager.go
+++ b/clients/cli/internal/auth/manager.go
@@ -67,13 +67,14 @@ func (m *Manager) Backend() string {
 }
 
 type refreshResponse struct {
-	AccessToken string `json:"access_token"`
-	ExpiresIn   int    `json:"expires_in"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
 }
 
 func (m *Manager) doRefresh(refreshToken string) (*TokenData, error) {
 	body, _ := json.Marshal(map[string]string{"refresh_token": refreshToken})
-	resp, err := http.Post(m.baseURL+"/api/oauth/token/refresh", "application/json", bytes.NewReader(body))
+	resp, err := http.Post(m.baseURL+"/api/v1/auth/refresh", "application/json", bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -88,9 +89,13 @@ func (m *Manager) doRefresh(refreshToken string) (*TokenData, error) {
 	if r.AccessToken == "" {
 		return nil, fmt.Errorf("refresh response missing access_token")
 	}
+	newRefresh := refreshToken
+	if r.RefreshToken != "" {
+		newRefresh = r.RefreshToken
+	}
 	return &TokenData{
 		AccessToken:  r.AccessToken,
-		RefreshToken: refreshToken,
+		RefreshToken: newRefresh,
 		Expiry:       time.Now().Add(time.Duration(r.ExpiresIn) * time.Second),
 	}, nil
 }

--- a/clients/cli/internal/auth/manager_test.go
+++ b/clients/cli/internal/auth/manager_test.go
@@ -117,7 +117,7 @@ func TestManager_Load_ExpiredWithRefreshToken(t *testing.T) {
 	})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/oauth/token/refresh" {
+		if r.URL.Path != "/api/v1/auth/refresh" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		var body map[string]string
@@ -127,8 +127,9 @@ func TestManager_Load_ExpiredWithRefreshToken(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"access_token": "new-token",
-			"expires_in":   3600,
+			"access_token":  "new-token",
+			"refresh_token": "rotated-refresh",
+			"expires_in":    3600,
 		})
 	}))
 	defer srv.Close()
@@ -145,6 +146,9 @@ func TestManager_Load_ExpiredWithRefreshToken(t *testing.T) {
 	saved, _ := store.Load("default")
 	if saved == nil || saved.AccessToken != "new-token" {
 		t.Errorf("refreshed token not saved to store")
+	}
+	if saved.RefreshToken != "rotated-refresh" {
+		t.Errorf("refresh_token = %q, want rotated-refresh", saved.RefreshToken)
 	}
 }
 

--- a/server/internal/auth/jwt.go
+++ b/server/internal/auth/jwt.go
@@ -21,6 +21,8 @@ import (
 const (
 	// AccessTokenTTL is the lifetime of login (Bearer) JWTs (plan 4.8).
 	AccessTokenTTL = 15 * time.Minute
+	// CLIAccessTokenTTL is the lifetime of access JWTs issued via CLI browser auth.
+	CLIAccessTokenTTL = 7 * 24 * time.Hour
 	defaultTokenTTL = AccessTokenTTL
 	mfaPendingTTL     = 60 * time.Second
 	ltiEmbedTicketTTL   = 15 * time.Minute
@@ -139,6 +141,11 @@ func (s *JWTSigner) RevokeToken(ctx context.Context, token string) error {
 
 // Sign creates a login JWT containing sub, email, org_id, org_slug, exp, optional session version (revocation), and optional refresh-token session id (rti).
 func (s *JWTSigner) Sign(ctx context.Context, userID, email string, orgID, orgSlug string, refreshTokenSessionID *uuid.UUID) (string, error) {
+	return s.SignWithTTL(ctx, userID, email, orgID, orgSlug, refreshTokenSessionID, s.ttl)
+}
+
+// SignWithTTL is like Sign but uses ttl instead of the signer's default TTL.
+func (s *JWTSigner) SignWithTTL(ctx context.Context, userID, email string, orgID, orgSlug string, refreshTokenSessionID *uuid.UUID, ttl time.Duration) (string, error) {
 	if !isUUID(userID) || strings.TrimSpace(email) == "" {
 		return "", ErrInvalidToken
 	}
@@ -146,6 +153,9 @@ func (s *JWTSigner) Sign(ctx context.Context, userID, email string, orgID, orgSl
 		return "", ErrInvalidToken
 	}
 	if refreshTokenSessionID != nil && *refreshTokenSessionID == uuid.Nil {
+		return "", ErrInvalidToken
+	}
+	if ttl == 0 {
 		return "", ErrInvalidToken
 	}
 	var sv int64
@@ -175,7 +185,7 @@ func (s *JWTSigner) Sign(ctx context.Context, userID, email string, orgID, orgSl
 		Issued:         unixSeconds(s.now()),
 		JTI:            jti,
 		RTI:            rti,
-		Expires:        unixSeconds(s.now().Add(s.ttl)),
+		Expires:        unixSeconds(s.now().Add(ttl)),
 	})
 }
 

--- a/server/internal/service/authservice/cli_auth.go
+++ b/server/internal/service/authservice/cli_auth.go
@@ -68,12 +68,13 @@ func ApproveCLIAuth(ctx context.Context, pool *pgxpool.Pool, jwt *pauth.JWTSigne
 		return errors.New("user not found")
 	}
 
-	access, refresh, err := issueAccessAndRefresh(ctx, pool, jwt, urow, meta)
+	meta = MergeClientMeta(meta, "cli")
+	access, refresh, err := issueAccessAndRefreshWithAccessTTL(ctx, pool, jwt, urow, meta, pauth.CLIAccessTokenTTL)
 	if err != nil {
 		return err
 	}
 
-	expiresIn := int(pauth.AccessTokenTTL / time.Second)
+	expiresIn := int(pauth.CLIAccessTokenTTL / time.Second)
 	return cliauthsession.Approve(ctx, pool, h[:], access, refresh, expiresIn)
 }
 

--- a/server/internal/service/authservice/refresh.go
+++ b/server/internal/service/authservice/refresh.go
@@ -111,8 +111,12 @@ func MergeClientMeta(meta *ClientMeta, authMethod string) *ClientMeta {
 }
 
 func issueAccessAndRefresh(ctx context.Context, pool *pgxpool.Pool, jwt *pauth.JWTSigner, row *user.Row, meta *ClientMeta) (access, refresh string, err error) {
+	return issueAccessAndRefreshWithAccessTTL(ctx, pool, jwt, row, meta, pauth.AccessTokenTTL)
+}
+
+func issueAccessAndRefreshWithAccessTTL(ctx context.Context, pool *pgxpool.Pool, jwt *pauth.JWTSigner, row *user.Row, meta *ClientMeta, accessTTL time.Duration) (access, refresh string, err error) {
 	if pool == nil {
-		tok, err := jwt.Sign(ctx, row.ID, row.Email, "", "", nil)
+		tok, err := jwt.SignWithTTL(ctx, row.ID, row.Email, "", "", nil, accessTTL)
 		return tok, "", err
 	}
 	tx, err := pool.Begin(ctx)
@@ -120,7 +124,7 @@ func issueAccessAndRefresh(ctx context.Context, pool *pgxpool.Pool, jwt *pauth.J
 		return "", "", err
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
-	a, ref, err := issueAccessAndRefreshTx(ctx, pool, tx, jwt, row, meta, nil)
+	a, ref, err := issueAccessAndRefreshTx(ctx, pool, tx, jwt, row, meta, nil, accessTTL)
 	if err != nil {
 		return "", "", err
 	}
@@ -130,7 +134,7 @@ func issueAccessAndRefresh(ctx context.Context, pool *pgxpool.Pool, jwt *pauth.J
 	return a, ref, nil
 }
 
-func issueAccessAndRefreshTx(ctx context.Context, pool *pgxpool.Pool, tx pgx.Tx, jwt *pauth.JWTSigner, row *user.Row, meta *ClientMeta, rotatedFrom *refreshtoken.Row) (access, refresh string, err error) {
+func issueAccessAndRefreshTx(ctx context.Context, pool *pgxpool.Pool, tx pgx.Tx, jwt *pauth.JWTSigner, row *user.Row, meta *ClientMeta, rotatedFrom *refreshtoken.Row, accessTTL time.Duration) (access, refresh string, err error) {
 	raw := make([]byte, refreshTokenRawBytes)
 	if _, err := rand.Read(raw); err != nil {
 		return "", "", err
@@ -162,7 +166,7 @@ func issueAccessAndRefreshTx(ctx context.Context, pool *pgxpool.Pool, tx pgx.Tx,
 		return "", "", err
 	}
 	rtid := refID
-	tok, err := jwt.Sign(ctx, row.ID, row.Email, orgID, orgSlug, &rtid)
+	tok, err := jwt.SignWithTTL(ctx, row.ID, row.Email, orgID, orgSlug, &rtid, accessTTL)
 	if err != nil {
 		return "", "", err
 	}
@@ -211,7 +215,11 @@ func Refresh(ctx context.Context, pool *pgxpool.Pool, jwt *pauth.JWTSigner, rawR
 	if err := refreshtoken.MarkRevoked(ctx, tx, row.ID, now); err != nil {
 		return RefreshTokenResponse{}, err
 	}
-	access, newRefresh, err := issueAccessAndRefreshTx(ctx, pool, tx, jwt, urow, meta, row)
+	accessTTL := pauth.AccessTokenTTL
+	if row.AuthMethod != nil && *row.AuthMethod == "cli" {
+		accessTTL = pauth.CLIAccessTokenTTL
+	}
+	access, newRefresh, err := issueAccessAndRefreshTx(ctx, pool, tx, jwt, urow, meta, row, accessTTL)
 	if err != nil {
 		return RefreshTokenResponse{}, err
 	}
@@ -221,7 +229,7 @@ func Refresh(ctx context.Context, pool *pgxpool.Pool, jwt *pauth.JWTSigner, rawR
 	return RefreshTokenResponse{
 		AccessToken:  access,
 		RefreshToken: newRefresh,
-		ExpiresIn:    int(pauth.AccessTokenTTL / time.Second),
+		ExpiresIn:    int(accessTTL / time.Second),
 		TokenType:    "Bearer",
 	}, nil
 }


### PR DESCRIPTION
## Summary

Fixes CLI sessions expiring after ~15 minutes and requiring frequent re-login.

- **Wrong refresh endpoint**: CLI called `/api/oauth/token/refresh` (does not exist); now uses `/api/v1/auth/refresh`.
- **Refresh token rotation**: CLI now persists the new `refresh_token` returned on each refresh instead of keeping the revoked one.
- **7-day access tokens**: CLI browser auth issues access tokens with a 7-day TTL (`CLIAccessTokenTTL`), tagged with `auth_method: cli` so refreshes keep the longer lifetime.

## Test plan

- [x] `go test ./internal/auth/...` (CLI)
- [x] `go test ./internal/auth/... ./internal/service/authservice/... -short` (server)
- [ ] Run `lextures auth login`, then `lextures auth status` — expiry should be ~7 days out
- [ ] Wait past 15 minutes (or expire token manually) and run a CLI command — should refresh silently without re-login